### PR TITLE
update guardfile to provide rspec focus

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,7 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', cmd: "bin/rspec --fail-fast", all_on_start: true, all_after_pass: false, notification: false do
+default_watch_proc = Proc.new do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
@@ -14,3 +14,15 @@ guard 'rspec', cmd: "bin/rspec --fail-fast", all_on_start: true, all_after_pass:
   watch('config/routes.rb')                           { "spec/routing" }
   watch('app/controllers/application_controller.rb')  { "spec/controllers" }
 end
+
+group :focus do
+  guard 'rspec', cmd: "bin/rspec --tag focus --fail-fast", all_on_start: true, all_after_pass: false, notification: false do
+    default_watch_proc.call
+  end
+end
+
+guard 'rspec', cmd: "bin/rspec --fail-fast", all_on_start: true, all_after_pass: false, notification: false do
+  default_watch_proc.call
+end
+
+scope groups: 'default'


### PR DESCRIPTION
add focus group to isolate examples and ensure default group is run if no command line overrides
https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/command-line/tag-option 
to run the focus specs use: 
bundle exec guard -g focus --no-interactions
