### PR TITLE
Remove random creation of has_many relations

### DIFF
--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -9,8 +9,7 @@ FactoryGirl.define do
 
     factory :collection_with_subjects do
       after(:create) do |col|
-        n = Array(2..100).sample
-        create_list(:subject, n, collections: [col])
+        create_list(:subject, 2, collections: [col])
       end
     end
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -10,22 +10,19 @@ FactoryGirl.define do
 
     factory :project_with_workflows do
       after(:create) do |p|
-        n = Array(2..10).sample
-        create_list(:workflow, n, project: p)
+        create_list(:workflow, 2, project: p)
       end
     end
 
     factory :project_with_subject_sets do
       after(:create) do |p|
-        n = Array(2..10).sample
-        create_list(:subject_set, n, project: p)
+        create_list(:subject_set, 2, project: p)
       end
     end
 
     factory :project_with_subjects do
       after(:create) do |p|
-        n = Array(2..10).sample
-        create_list(:subject_set_with_subjects, n, project: p)
+        create_list(:subject_set_with_subjects, 2, project: p)
       end
     end
   end

--- a/spec/factories/subject_sets.rb
+++ b/spec/factories/subject_sets.rb
@@ -11,15 +11,13 @@ FactoryGirl.define do
 
     factory :subject_set_with_workflows do
       after(:create) do |sg|
-        n = Array(2..10).sample
-        create_list(:workflow, n, subject_sets: [sg])
+        create_list(:workflow, 2, subject_sets: [sg])
       end
     end
 
     factory :subject_set_with_subjects do
       after(:create) do |sg|
-        n = Array(20..100).sample
-        create_list(:set_member_subject, n, subject_set: sg)
+        create_list(:set_member_subject, 2, subject_set: sg)
       end
     end
   end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -10,15 +10,13 @@ FactoryGirl.define do
 
     factory :subject_with_collections do
       after(:create) do |s|
-        n = Array(20..150).sample
-        create_list(:collection, n, subjects: [s])
+        create_list(:collection, 2, subjects: [s])
       end
     end
 
     factory :subject_with_subject_sets do
       after(:create) do |s|
-        n = Array(10..20).sample
-        create_list(:set_member_subject, n, subject: s)
+        create_list(:set_member_subject, 2, subject: s)
       end
     end
   end

--- a/spec/factories/user_groups.rb
+++ b/spec/factories/user_groups.rb
@@ -6,22 +6,19 @@ FactoryGirl.define do
 
     factory :user_group_with_users do
       after(:create) do |ug|
-        n = Array(20..100).sample
-        create_list(:membership, n, user_group: ug)
+        create_list(:membership, 2, user_group: ug)
       end
     end
 
     factory :user_group_with_projects do
       after(:create) do |ug|
-        n = Array(2..10).sample
-        create_list(:project, n, owner: ug)
+        create_list(:project, 2, owner: ug)
       end
     end
 
     factory :user_group_with_collections do
       after(:Create) do |ug|
-        n = Array(2..10).sample
-        create_list(:collections, n, owner: ug)
+        create_list(:collections, 2, owner: ug)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,8 +18,7 @@ FactoryGirl.define do
 
     factory :project_owner do
       after(:create) do |user|
-        n = Array(2..10).sample
-        create_list(:project, n, owner: user)
+        create_list(:project, 2, owner: user)
       end
     end
 
@@ -31,8 +30,7 @@ FactoryGirl.define do
 
     factory :user_with_collections do
       after(:create) do |user|
-        n = Array(2..10).sample
-        create_list(:collection, n, owner: user)
+        create_list(:collection, 2, owner: user)
       end
     end
 

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -16,15 +16,13 @@ FactoryGirl.define do
 
     factory :workflow_with_subject_sets do
       after(:create) do |w|
-        n = Array(2..10).sample
-        create_list(:subject_set, n, workflows: [w])
+        create_list(:subject_set, 2, workflows: [w])
       end
     end
 
     factory :workflow_with_subjects do
       after(:create) do |w|
-        n = Array(2..10).sample
-        create_list(:subject_set_with_subjects, n, workflows: [w])
+        create_list(:subject_set_with_subjects, 2, workflows: [w])
       end
     end
   end


### PR DESCRIPTION
Instead of creating a random number for `has_many` relations, just make 2. Made tests 66% faster on my machine. 

I think I was originally intending them as some sort of performance test, but that's pretty useless in a unit test. 
