### PR TITLE
Destroy instead of delete

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   end
 
-  def delete
+  def destroy
 
   end
 end 

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::CollectionsController < Api::ApiController
 
   end
 
-  def delete
+  def destroy
 
   end
 end 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -47,9 +47,9 @@ class Api::V1::ProjectsController < Api::ApiController
                                                          'description'])
   end
 
-  def delete
+  def destroy
     project = Project.find(params[:id])
-    authorize project, :delete?
+    authorize project, :destroy?
     project.destroy
     deleted_resource_response
   end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
 
   end
 
-  def delete
+  def destroy
 
   end
 end 

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::SubjectsController < Api::ApiController
 
   end
 
-  def delete
+  def destroy
 
   end
 end 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::UsersController < Api::ApiController
 
   def destroy
     user = User.find(params[:id])
-    authorize user, :delete?
+    authorize user, :destroy?
     UserInfoScrubber.scrub_personal_info!(user)
     Activation.disable_instances!([ user ] | user.projects | user.collections | user.memberships)
     deleted_resource_response

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   def destroy
     workflow = Workflow.find params[:id]
-    authorize workflow.project, :delete?
+    authorize workflow.project, :destroy?
     workflow.destroy!
     deleted_resource_response
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -11,7 +11,7 @@ class ApplicationPolicy < Struct.new(:user, :record)
     is_admin?
   end
 
-  def delete?
+  def destroy?
     is_admin?
   end
 

--- a/app/policies/owned_object_policy.rb
+++ b/app/policies/owned_object_policy.rb
@@ -11,7 +11,7 @@ class OwnedObjectPolicy < ApplicationPolicy
     super || is_owner?
   end
 
-  def delete?
+  def destroy?
     super || is_owner?
   end
 

--- a/app/policies/user_group_policy.rb
+++ b/app/policies/user_group_policy.rb
@@ -11,7 +11,7 @@ class UserGroupPolicy < ApplicationPolicy
     super || group_admin?
   end
 
-  def delete?
+  def destroy?
     super || group_admin?
   end
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -11,7 +11,7 @@ class UserPolicy < ApplicationPolicy
     super || user == record
   end
 
-  def delete?
+  def destroy?
     super || user == record
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -30,7 +30,7 @@ describe ApplicationPolicy do
     it_behaves_like "admins only"
   end
 
-  permissions :delete? do
+  permissions :destroy? do
     it_behaves_like "admins only"
   end
 end

--- a/spec/policies/owned_object_policy_spec.rb
+++ b/spec/policies/owned_object_policy_spec.rb
@@ -70,7 +70,7 @@ describe OwnedObjectPolicy do
     end
   end
 
-  permissions :delete? do
+  permissions :destroy? do
     let(:user) { build(:user) }
     let(:project) { build(:project, owner: user) }
 

--- a/spec/policies/user_group_policy_spec.rb
+++ b/spec/policies/user_group_policy_spec.rb
@@ -38,7 +38,7 @@ describe UserGroupPolicy do
     it_behaves_like "allows access for admins or group admins"
   end
 
-  permissions :delete? do
+  permissions :destroy? do
     it_behaves_like "allows access for admins or group admins"
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -35,7 +35,7 @@ describe UserPolicy do
     it_behaves_like "only self"
   end
 
-  permissions :delete? do
+  permissions :destroy? do
     it_behaves_like "only self"
   end
 end


### PR DESCRIPTION
Rails uses `destroy` instead of `delete`.
