### PR TITLE
Actually test scopes

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -14,6 +14,7 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def create
+    p current_resource_owner
     update_cellect if current_resource_owner
     render json_api: {}, status: 204
   end

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -100,7 +100,8 @@ describe Api::ApiController, type: :controller do
     end
 
     before(:each) do
-      default_request(user_id: create(:user_with_languages))
+      user = create(:user_with_languages)
+      default_request(user_id: user.id)
       get :index, language: 'es'
     end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -79,7 +79,7 @@ describe Api::V1::UsersController, type: :controller do
     end
 
     context "when updating a non-existant user" do
-      let!(:user_id) { 100 }
+      let!(:user_id) { -1 }
       let(:patch_operations) { nil }
 
       it "should return a 404 status" do
@@ -87,7 +87,7 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       it "should return a specific error message in the response body" do
-        error_message = json_error_message("Couldn't find User with 'id'=100")
+        error_message = json_error_message("Couldn't find User with 'id'=#{user_id}")
         expect(response.body).to eq(error_message)
       end
     end
@@ -153,9 +153,9 @@ describe Api::V1::UsersController, type: :controller do
   describe "#destroy" do
     let(:user) { users.first}
     let(:user_id) { user.id }
-    let(:token) { create(:access_token) }
+    let(:access_token) { create(:access_token) }
     let!(:stub_token_auth) do
-      allow(Doorkeeper).to receive(:authenticate).and_return(token)
+      allow(Doorkeeper).to receive(:authenticate).and_return(access_token)
     end
 
     it "should call the UserInfoScrubber with the user" do
@@ -181,7 +181,7 @@ describe Api::V1::UsersController, type: :controller do
 
     it "should revoke the request doorkeeper token" do
       delete :destroy, id: user_id
-      expect(token.reload.revoked?).to eq(true)
+      expect(access_token.reload.revoked?).to eq(true)
     end
 
     context "an unauthorized user" do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -77,7 +77,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
     context "with a logged in user" do
       before(:each) do
-        default_request user_id: user, scopes: %(project, public)
+        default_request user_id: user.id, scopes: %(project public)
         get :show, id: workflows.first.id
       end
 

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -22,10 +22,14 @@ module APIRequestHelpers
   end
 
   def stub_token(scopes: [], user_id: nil)
-    allow(controller).to receive(:doorkeeper_token) { double( accessible?: true,
-                                                              scopes: scopes,
-                                                              acceptable?: true,
-                                                              resource_owner_id: user_id ) }
+    allow(controller).to receive(:doorkeeper_token).and_return(token(scopes, user_id))
+  end
+
+  def token(scopes, user_id)
+    token = create(:access_token, resource_owner_id: user_id)
+    allow(token).to receive(:accessible?).and_return(true)
+    allow(token).to receive(:scopes).and_return(Doorkeeper::OAuth::Scopes.from_array(scopes))
+    token
   end
 
   def stub_token_with_scopes(*scopes)


### PR DESCRIPTION
Because of some recent changes I made to doorkeeper. tokens weren't
actually testing to see if they had required oauth scopes.

I think it's debate-able about whether these changes and tests belong in
the controller specs or in request specs
