### PR TITLE
Add ENTRYPOINT.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN gem install bundler
 WORKDIR /rails_app
 
 ENV RAILS_ENV docker_dev
+ENV JRUBY_OPTS --2.0
+
 ADD Gemfile /rails_app/Gemfile
 ADD Gemfile.lock /rails_app/Gemfile.lock
 RUN bundle install


### PR DESCRIPTION
As discussed in #102. You can simply `docker run -i -t panoptes`, or for example `docker run -i -t panoptes production`.

This does correctly attempt to start the rails server, but it currently fails with a syntax error which I assume is a separate issue.

```
SyntaxError: /usr/local/lib/ruby/gems/shared/gems/cellect-client-0.0.7/lib/cellect/client/connection.rb:17: syntax error, unexpected tLABEL
      def add_subject(id, workflow_id: workflow_id, group_id: nil, priority: nil)
```
