### PR TITLE
allow classification annotations data types to persist via transport

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -5,9 +5,11 @@ module Api
 
     class PatchResourceError < PanoptesControllerError; end
     class UnauthorizedTokenError < PanoptesControllerError; end
+    class InvalidJsonAnnotationsError < PanoptesControllerError; end
 
     rescue_from ActiveRecord::RecordNotFound, with: :not_found
     rescue_from ActiveRecord::RecordInvalid, with: :invalid_record
+    rescue_from InvalidJsonAnnotationsError, with: :invalid_record
     rescue_from Pundit::NotAuthorizedError, with: :not_authorized
     rescue_from UnauthorizedTokenError, with: :not_authenticated
 

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -41,11 +41,23 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def creation_params
+    ensure_json_annotations
     permitted_attrs = [ :project_id,
                         :workflow_id,
                         :set_member_subject_id ]
     classification_params.permit(*permitted_attrs).tap do |while_listed|
       while_listed[:annotations] = params[:classification][:annotations]
+    end
+  end
+
+  def ensure_json_annotations
+    if annotations = classification_params["annotations"]
+      begin
+        JSON.parse(annotations)
+      rescue TypeError
+        error_message = "Validation failed: Annotations must be valid serialized JSON"
+        raise InvalidJsonAnnotationsError.new(error_message)
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -1,24 +1,31 @@
 require 'spec_helper'
 
 def annotation_values
-  [ { value: "adult" },
-    { started_at: DateTime.now },
-    { finished_at: DateTime.now },
-    { user_agent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0" } ]
+  [ { key: "marking",
+      value: [ { x: 734.16, y: 527.203, value: "adult", frame: 0 },
+               { x: 431.18, y: 236.907, value: "chick", frame:0 } ]
+     },
+    { started_at: "Tue, 22 Jul 2014 13:28:51 GMT" },
+    { finished_at: "Tue, 22 Jul 2014 13:30:31 GMT" },
+    { user_agent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0" }
+  ].to_json
 end
 
-def setup_create_request(project_id, workflow_id, set_member_subject)
-  request.session = { cellect_hosts: { workflow_id.to_s => "example.com" } }
-  params = { classification: { project_id: project_id,
-                               workflow_id: workflow_id,
-                               set_member_subject_id: set_member_subject.id,
-                               subject_id: set_member_subject.subject_id,
-                               annotations: annotation_values } }
-  post :create, params
+def create_params
+  { classification: { project_id: project.id,
+                      workflow_id: workflow.id,
+                      set_member_subject_id: set_member_subject.id,
+                      subject_id: set_member_subject.subject_id,
+                      annotations: annotation_values } }
+end
+
+def setup_create_request
+  request.session = { cellect_hosts: { workflow.id.to_s => "example.com" } }
+  post :create, create_params
 end
 
 def create_classification
-  setup_create_request(project.id, workflow.id, set_member_subject)
+  setup_create_request
 end
 
 def created_classification_id
@@ -37,10 +44,16 @@ shared_context "a classification create" do
     expect(response.headers["Location"]).to eq("http://test.host/api/classifications/#{id}")
   end
 
-  it "should create the classification" do
+  it "should create a classification" do
     expect do
       create_classification
     end.to change{Classification.count}.from(0).to(1)
+  end
+
+  it "should maintain the annotations internal data types" do
+    create_classification
+    classification = Classification.find(created_classification_id)
+    expect(classification.annotations.to_json).to eq(annotation_values)
   end
 end
 
@@ -119,6 +132,45 @@ describe Api::V1::ClassificationsController, type: :controller do
       end
 
       it_behaves_like "a classification create"
+
+      context "with invalid params" do
+
+        before(:each) do
+          invalid_params = create_params
+          invalid_params[:classification].delete(:project_id)
+          post :create, invalid_params
+        end
+
+        it "should respond with bad_request" do
+          expect(response.status).to eq(400)
+        end
+
+        it "should have the validation errors in the response body" do
+          message = "Validation failed: Project can't be blank"
+          error_response = { errors: [ { message: message } ] }.to_json
+          expect(response.body).to eq(error_response)
+        end
+      end
+
+      context "with non-json serialized annotations" do
+        let!(:non_serialised_json) { [ { key: "marking" }, { value: "adult"} ] }
+
+        before(:each) do
+          invalid_params = create_params
+          invalid_params[:classification][:annotations] = non_serialised_json
+          post :create, invalid_params
+        end
+
+        it "should respond with bad_request" do
+          expect(response.status).to eq(400)
+        end
+
+        it "should have the validation errors in the response body" do
+          message = "Validation failed: Annotations must be valid serialized JSON"
+          error_response = { errors: [ { message: message } ] }.to_json
+          expect(response.body).to eq(error_response)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Ensure the submitted classification annotations are serialised JSON. The DB adapters will persiste the annotation JSON data with their serialised types and they won't be converted to strings.
