### PR TITLE
add Location header to all JSON-API create actions

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -22,7 +22,9 @@ class Api::V1::CollectionsController < Api::ApiController
     collection.owner = current_resource_owner
     authorize collection, :create?
     collection.save!
-    json_api_render 201, CollectionSerializer.resource(collection)
+    json_api_render( 201,
+                     CollectionSerializer.resource(collection),
+                     api_collection_url(collection) )
   end
 
   def destroy
@@ -31,7 +33,7 @@ class Api::V1::CollectionsController < Api::ApiController
     collection.destroy!
     deleted_resource_response
   end
-  
+
   def creation_params
     params.require(:collection).permit :name, :display_name, :project_id
   end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -41,11 +41,9 @@ class Api::V1::ProjectsController < Api::ApiController
     authorize project, :create?
     project.save!
 
-    render json_api: ProjectSerializer.resource(project,
-                                                nil,
-                                                languages: [params[:primary_language]],
-                                                fields: ['title',
-                                                         'description'])
+    json_api_render( 201,
+                     create_project_response(project),
+                     api_project_url(project) )
   end
 
   def destroy
@@ -61,5 +59,12 @@ class Api::V1::ProjectsController < Api::ApiController
       owner_filter = params.delete(:owner)
       owner_ids = UriName.where(name: owner_filter).map(&:resource_id).join(",")
       params.merge!({ owner_ids: owner_ids }) unless owner_ids.blank?
+    end
+
+    def create_project_response(project)
+      ProjectSerializer.resource( project,
+                                  nil,
+                                  languages: [ params[:primary_language] ],
+                                  fields: ['title', 'description'] )
     end
 end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -17,7 +17,9 @@ class Api::V1::SubjectSetsController < Api::ApiController
     subject_set = SubjectSet.new creation_params
     authorize subject_set.project, :update?
     subject_set.save!
-    json_api_render 201, SubjectSetSerializer.resource(subject_set)
+    json_api_render( 201,
+                     SubjectSetSerializer.resource(subject_set),
+                     api_subject_set_url(subject_set) )
   end
 
   def destroy
@@ -26,9 +28,9 @@ class Api::V1::SubjectSetsController < Api::ApiController
     subject_set.destroy!
     deleted_resource_response
   end
-  
+
   private
-  
+
   def creation_params
     params.require(:subject_set).permit :name, :project_id
   end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::WorkflowsController < Api::ApiController
-  doorkeeper_for :update, :create, :delete, scopes: [:project] 
+  doorkeeper_for :update, :create, :delete, scopes: [:project]
   after_action :verify_authorized, except: :index
 
   def show
@@ -21,7 +21,9 @@ class Api::V1::WorkflowsController < Api::ApiController
     workflow = Workflow.new creation_params
     authorize workflow.project, :update?
     workflow.save!
-    json_api_render 201, WorkflowSerializer.resource(workflow)
+    json_api_render( 201,
+                     WorkflowSerializer.resource(workflow),
+                     api_workflow_url(workflow) )
   end
 
   def destroy
@@ -51,4 +53,4 @@ class Api::V1::WorkflowsController < Api::ApiController
       workflow_id: params[:id]
     }
   end
-end 
+end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -21,10 +21,6 @@ def create_classification
   setup_create_request(project.id, workflow.id, set_member_subject)
 end
 
-def created_classification_id
-  json_response["classifications"][0]["id"]
-end
-
 shared_context "a classification create" do
   it "should return 201" do
     create_classification
@@ -50,6 +46,7 @@ describe Api::V1::ClassificationsController, type: :controller do
   let!(:workflow) { project.workflows.first }
   let!(:set_member_subject) { workflow.subject_sets.first.set_member_subjects.first }
   let!(:user) { create(:user) }
+  let(:created_classification_id) { created_instance_id("classifications") }
 
   let(:api_resource_name) { "classifications" }
   let(:api_resource_attributes) do
@@ -115,6 +112,7 @@ describe Api::V1::ClassificationsController, type: :controller do
 
       it "should set the user" do
         create_classification
+        id = created_instance_id("classifications")
         expect(Classification.find(created_classification_id).user.id).to eq(user.id)
       end
 

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -1,9 +1,5 @@
 require 'spec_helper'
 
-def created_user_groups_id
-  json_response["user_groups"][0]["id"]
-end
-
 describe Api::V1::GroupsController, type: :controller do
   let!(:user_groups) do
     [ create(:user_group_with_users),
@@ -57,6 +53,7 @@ describe Api::V1::GroupsController, type: :controller do
   end
 
   describe "#create" do
+    let(:created_user_group_id) { created_instance_id("user_groups") }
 
     context "with valid params" do
       let!(:create_params) { { user_group: { display_name: "Zooniverse" } } }
@@ -75,12 +72,12 @@ describe Api::V1::GroupsController, type: :controller do
         end
 
         it "should set the Location header as per JSON-API specs" do
-          id = created_user_groups_id
+          id = created_user_group_id
           expect(response.headers["Location"]).to eq("http://test.host/api/groups/#{id}")
         end
 
         it "should create a the project with the correct name" do
-          created_id = created_user_groups_id
+          created_id = created_user_group_id
           expect(UserGroup.find(created_id).display_name).to eq("zooniverse")
         end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -131,6 +131,8 @@ describe Api::V1::ProjectsController, type: :controller do
   end
 
   describe "#create" do
+    let(:created_project_id) { created_instance_id("projects") }
+
     before(:each) do
       params = { display_name: "New Zoo",
                  description: "A new Zoo for you!",
@@ -140,8 +142,17 @@ describe Api::V1::ProjectsController, type: :controller do
       post :create, params, { 'CONTENT_TYPE' => 'application/json' }
     end
 
-    it "should create a new project" do
-      expect(Project.order(created_at: :desc).first.name).to eq("new_zoo")
+    it "should return 201" do
+      expect(response.status).to eq(201)
+    end
+
+    it "should create the new project" do
+      expect(Project.find(created_project_id).name).to eq("new_zoo")
+    end
+
+    it "should set the Location header as per JSON-API specs" do
+      id = created_project_id
+      expect(response.headers["Location"]).to eq("http://test.host/api/projects/#{id}")
     end
 
     it "should create an associated project_content model" do

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -43,12 +43,14 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
     it_behaves_like 'an api response'
   end
-  
+
   describe '#update' do
     it 'should be implemented'
   end
 
   describe '#create' do
+    let(:created_subject_set_id) { created_instance_id("subject_sets") }
+
     before(:each) do
       default_request scopes: %w(public subject_set), user_id: owner.id
       params = {
@@ -60,10 +62,18 @@ describe Api::V1::SubjectSetsController, type: :controller do
       post :create, params, { 'CONTENT_TYPE' => 'application/json' }
     end
 
-    it 'should create a new subject set' do
-      expect(response.status).to eq 201
-      created = json_response['subject_sets'].first
-      expect(created['name']).to eq 'Test subject set'
+    it "should return 201" do
+      expect(response.status).to eq(201)
+    end
+
+    it 'should create the new subject set' do
+      created = SubjectSet.find(created_subject_set_id)
+      expect(created.name).to eq 'Test subject set'
+    end
+
+    it "should set the Location header as per JSON-API specs" do
+      id = created_subject_set_id
+      expect(response.headers["Location"]).to eq("http://test.host/api/subject_sets/#{id}")
     end
 
     it_behaves_like 'an api response'

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -34,6 +34,8 @@ describe Api::V1::WorkflowsController, type: :controller do
   end
 
   describe '#create' do
+    let(:created_workflow_id) { created_instance_id("workflows") }
+
     before(:each) do
       default_request scopes: %w(public project), user_id: owner.id
       params = {
@@ -48,11 +50,19 @@ describe Api::V1::WorkflowsController, type: :controller do
       post :create, params
     end
 
-    it 'should create a new workflow' do
-      expect(response.status).to eq 201
-      created = json_response['workflows'].first
-      expect(created['name']).to eq 'Test workflow'
-      expect(created['tasks']).to eq [{ 'foo' => 'bar' }, { 'bar' => 'baz' }]
+    it "should return 201" do
+      expect(response.status).to eq(201)
+    end
+
+    it 'should create the new workflow' do
+      created = Workflow.find(created_workflow_id)
+      expect(created.name).to eq 'Test workflow'
+      expect(created.tasks).to eq [{ 'foo' => 'bar' }, { 'bar' => 'baz' }]
+    end
+
+    it "should set the Location header as per JSON-API specs" do
+      id = created_workflow_id
+      expect(response.headers["Location"]).to eq("http://test.host/api/workflows/#{id}")
     end
 
     it_behaves_like 'an api response'

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -6,6 +6,11 @@ module APIResponseHelpers
   def json_error_message(error_message)
     { errors: [ message: error_message ] }.to_json
   end
+
+  def created_instance_id(instance_type)
+    json_response[instance_type][0]["id"]
+  end
+
 end
 
 module APIRequestHelpers


### PR DESCRIPTION
Conform to the specs, "The response MUST include a Location header identifying the location of the primary resource created by the request."
http://jsonapi.org/format/#crud-creating-responses-201
