### PR TITLE
Remove asset precompilation from start.sh.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,4 @@ cd /rails_app
 
 ln -sf /rails_conf/* ./config/
 
-bundle exec rake assets:precompile
-
 exec rails s $*


### PR DESCRIPTION
It takes too long to do on container start. This will now be done as
part of the deployment process instead.
