### PR TITLE
change default ordering for home controller response format

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,9 +2,9 @@ class HomeController < Api::ApiController
 
   def index
     respond_to do |format|
+      format.html { render }
       format.json { render json: {} }
       format.json_api { render json_api: {} }
-      format.html { render }
     end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -4,21 +4,38 @@ describe HomeController, type: :controller do
 
   describe "GET 'index'" do
 
-    before(:each) do
-      get 'index', format: :json
+    context "with all media types" do
+
+      before(:each) do
+        request.env["HTTP_ACCEPT"] = "*/*"
+        get 'index'
+      end
+
+      it "should be successful" do
+        expect(response).to be_success
+      end
+
+      it "should default to html" do
+        expect(response.content_type).to eq("text/html")
+      end
     end
 
-    it "returns success" do
-      expect(response).to be_success
-    end
+    context "as json" do
+      before(:each) do
+        get 'index', format: :json
+      end
 
-    it "returns the expected json header" do
-      expect(response.content_type).to eq("application/json")
-    end
+      it "returns success" do
+        expect(response).to be_success
+      end
 
-    it "should respond with a json response for the root" do
-      json_response = JSON.parse(response.body)
-      expect(json_response).to eq({})
+      it "returns the expected json header" do
+        expect(response.content_type).to eq("application/json")
+      end
+
+      it "should respond with a json response for the root" do
+        expect(json_response).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
Home Controller with all media types accept header would return JSON instead of HTML.
