### PR TITLE
do not violate uniq email index in database

### DIFF
--- a/lib/user_info_scrubber.rb
+++ b/lib/user_info_scrubber.rb
@@ -1,15 +1,20 @@
 class UserInfoScrubber
 
   DELETED_USER_NAME  = 'deleted_user'
-  DELETED_USER_EMAIL = 'deleted_user@zooniverse.org'
+  DELETED_USER_EMAIL_DOMAIN = '@zooniverse.org'
 
   class ScrubDisabledUserError < StandardError; end
+
+  def self.deleted_user_email(user)
+    "#{DELETED_USER_NAME}_#{user.id}#{DELETED_USER_EMAIL_DOMAIN}"
+  end
 
   def self.scrub_personal_info!(user)
     if user.disabled?
       raise ScrubDisabledUserError.new("Can't scrub personal details of a disabled user with id: #{user.id}")
     else
-      user.update_columns( email: DELETED_USER_EMAIL, display_name: DELETED_USER_NAME )
+      user.update_columns( email: deleted_user_email(user),
+                           display_name: DELETED_USER_NAME )
     end
   end
 end


### PR DESCRIPTION
closes #202 

when scrubbing user info the email must be unique in the database index. This index is used for signups / finding by email etc do I didn't want to remove the uniq key. Instead the deleted email address now contains the user primary key id, e.g. "deleted_user_1@zooniverse.org".
