### PR TITLE
Fix bad omniauth spec handle error conditions better

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -2,20 +2,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def callback
     @user = User.from_omniauth(request.env['omniauth.auth'])
-
-    unless @user.valid?
-      # TODO Redirect to a page to edit user options
-    else
-      @user.save!
-      sign_in @user, event: :authentication
-      redirect_to sign_in_redirect
-    end
+    sign_in @user, event: :authentication
+    redirect_to sign_in_redirect
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+    # TODO Redirect to a page to edit user options
   end
 
   alias_method :facebook, :callback 
   alias_method :gplus, :callback
   
   private
+  
   def sign_in_redirect
     request.env['omniauth.origin'] || 'https://zooniverse.org/'
   end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -32,6 +32,7 @@ shared_examples "an omniauth callback" do
   end
 
   it 'should redirect to a user editor if the created user is not valid'
+  it 'should redirect to a user editor if the created user is not unique'
 end
 
 describe OmniauthCallbacksController, type: :controller do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,10 +48,6 @@ describe User, :type => :model do
       it 'should create a user with a authorization' do
         expect(user_from_auth_hash.authorizations).to all( be_an(Authorization) )
       end
-
-      it 'should not persist the user' do
-        expect(user.persisted?).to be false
-      end
     end
 
     context 'a new user with email' do
@@ -73,6 +69,14 @@ describe User, :type => :model do
 
       it 'should return the existing user' do
         expect(User.from_omniauth(auth_hash)).to eq(omniauth_user)
+      end
+    end
+
+    context 'an invalid user' do
+      it 'should raise an exception' do
+        create(:user, email: 'examplar@example.com')
+        auth_hash = OmniAuth.config.mock_auth[:gplus]
+        expect{ User.from_omniauth(auth_hash) }.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end
   end


### PR DESCRIPTION
Cam noticed a bad spec that was covering up some incorrect error handling for OAuth logins.
