### PR TITLE
Fix kafka initialize when not defined for environment

### DIFF
--- a/config/initializers/kafka.rb
+++ b/config/initializers/kafka.rb
@@ -2,8 +2,7 @@ require 'multi_kafka_producer'
 
 adapter, kafka_config = begin
                           config = YAML.load(ERB.new(File.read(Rails.root.join('config/kafka.yml'))).result)
-                          config[Rails.env].symbolize_keys
-                          [ nil, config ]
+                          [ nil, config[Rails.env].symbolize_keys ]
                         rescue Errno::ENOENT, NoMethodError
                           [ :null, {  } ]
                         end


### PR DESCRIPTION
Catches no-method error when attempting to call symbolize keys.
