### PR TITLE
scrub sql error messages from json_responses

### DIFF
--- a/lib/json_api_controller/relation_manager.rb
+++ b/lib/json_api_controller/relation_manager.rb
@@ -60,7 +60,7 @@ module JsonApiController
       relation = yield
       relation.find(find_arg)
     rescue ActiveRecord::RecordNotFound
-      raise ActiveRecord::RecordNotFound.new("Couldn't find record")
+      raise ActiveRecord::RecordNotFound.new("Couldn't find resource")
     end
   end
 end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -240,7 +240,7 @@ describe Api::V1::SubjectsController, type: :controller do
       end
 
       it 'should scrub any schema sql from the error message' do
-        expect(response.body).to eq(json_error_message("Couldn't find record"))
+        expect(response.body).to eq(json_error_message("Couldn't find resource"))
       end
     end
   end


### PR DESCRIPTION
Do not expose any internal schema / access control messages in the response object. Also i couldn't differentiate between 403 errors and plain 404's with non-existant ids. Open to ideas here but i thought straight up 404's are actually a succint response (unless you believe you do have access rights).

@brian-c not sure if you raised an issue for this but this may completely close the issue with SQL debug statements in the json response object.
