### PR TITLE
Make sure user group is loaded to update links

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -29,19 +29,13 @@ class Api::V1::GroupsController < Api::ApiController
       user_group.memberships
   end
 
-  def new_items(relation, value)
-    items = super(relation, value)
-    
-    if relation == :users
-      items.map do |user|
-        Membership.new(user: user,
-                       group: user_group,
-                       state: :invited,
-                       roles: ["group_member"])
+  def controlled_resource
+    @controlled_resource ||=
+      if params.has_key? :group_id
+        resource_class.find(params[:group_id])
+      else
+        super
       end
-    else
-      items
-    end
   end
 
   def resource_name

--- a/lib/role_control/roled_controller.rb
+++ b/lib/role_control/roled_controller.rb
@@ -4,7 +4,7 @@ module RoleControl
 
     module ClassMethods
       def access_control_action(controller_action, test_action, actor_method: :api_user, &block)
-        method_name = :"access_control_for_#{ controller_action}"
+        method_name = :"access_control_for_#{ controller_action }"
 
         define_method method_name do
           resource = send(:controlled_resource)

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Api::V1::GroupsController, type: :controller do
   let!(:user_groups) do
     [ create(:user_group_with_users),
-     create(:user_group_with_projects),
-     create(:user_group_with_collections) ]
+      create(:user_group_with_projects),
+      create(:user_group_with_collections) ]
   end
 
   let(:user) { user_groups[0].users.first }
@@ -38,9 +38,9 @@ describe Api::V1::GroupsController, type: :controller do
     let(:test_attr_value) { "A Different Name" }
     let(:update_params) do
       {
-       user_groups: {
-                     display_name: "A Different Name",
-                    }
+        user_groups: {
+          display_name: "A Different Name",
+        }
       }
     end
 
@@ -101,5 +101,25 @@ describe Api::V1::GroupsController, type: :controller do
     end
 
     it_behaves_like "is deactivatable"
+  end
+
+  describe "#update_links" do
+    let(:new_user) { create(:user) }
+    let(:resource) { user_groups.first }
+    let(:new_membership) { Membership.where(user: new_user).first }
+    
+    before(:each) do
+      
+      default_request scopes: scopes, user_id: authorized_user.id
+      post :update_links, group_id: resource.id, users: [ new_user.id.to_s ], link_relation: "users"
+    end
+    
+    it 'should add a user to the group' do
+      expect(new_membership.user_group).to eq(resource)
+    end
+
+    it 'should give the user a group_member role' do
+      expect(new_membership.roles).to eq(%w(group_member))
+    end
   end
 end


### PR DESCRIPTION
The resource_name of the groups controller was user_groups, causing
problems automatically loading the resource through RoledContoller.
This makes the resource loading explict and adds a test to make sure
the the update_links routes behaves correctly.

Closes #323
