### PR TITLE
Make SubjectSet to Workflow relationship 1 -> *

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1944,7 +1944,8 @@ All attributes except display_name are set by the API
                     "updated_at": "2014-02-13T10:11:34Z",
                     "set_member_subject_cound": 100,
                     "links": {
-                        "project": "1"
+                        "project": "1",
+                        "workflow": "10"
                     }
                 }]
             }
@@ -2008,8 +2009,8 @@ for the subject set's project.
 + Response 204
 
 ## Subject Set Links [/subject_sets/{id}/links/{link_type}]
-Allows the addition of links to workflows and subjects to a subject
-set object without needing to set a full representation of the linked
+Allows the addition of links to subjects to a subject
+set object without needing to send a full representation of the linked
 relationship.
 
 This is the recommended way to managed linked subjects.
@@ -2019,7 +2020,7 @@ This is the recommended way to managed linked subjects.
   + link_type (required, string) ... the relationship to modify must be the same as the supplied body key
 
 ### Add to link [POST]
-Only then Subjects and Workflows links may be edited.
+Only Subjects links may be edited.
 
 + Request
 
@@ -2110,18 +2111,20 @@ Subject Sets are returned as an array under *subject_sets*.
                     "display_name": "Weird Looking Galaxies",
                     "created_at": "2014-02-13T10:11:34Z",
                     "updated_at": "2014-02-13T10:11:34Z",
-                    "set_member_subject_cound": 100,
+                    "set_member_subject_count": 100,
                     "links": {
-                        "project": "1"
+                        "project": "1",
+                        "workflow": "10"
                     }
                 },{
                     "id": "20",
                     "display_name": "Boring Looking Galaxies",
                     "created_at": "2014-02-13T10:11:34Z",
                     "updated_at": "2014-02-13T10:11:34Z",
-                    "set_member_subject_cound": 100,
+                    "set_member_subject_count": 100,
                     "links": {
-                        "project": "1"
+                        "project": "1",
+                        "workflow": "11"
                     }
                 }]
             }
@@ -2148,7 +2151,7 @@ Subject Sets are returned as an array under *subject_sets*.
 
 ### Create a Subject Set [POST]
 A subject set must supply a display_name and a link to a project. Optionally,
-it may include links to subjects and workflows.
+it may include links to subjects and a workflow.
 
 + Request
 

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -3,9 +3,10 @@ class SubjectSet < ActiveRecord::Base
   include Linkable
   
   belongs_to :project
+  belongs_to :workflow
+  
   has_many :set_member_subjects
   has_many :subjects, through: :set_member_subjects
-  has_and_belongs_to_many :workflows
 
   validates_presence_of :project
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -7,7 +7,7 @@ class Workflow < ActiveRecord::Base
   has_paper_trail only: [:tasks, :grouped, :pairwise, :prioritized]
 
   belongs_to :project
-  has_and_belongs_to_many :subject_sets
+  has_many :subject_sets
   has_many :classifications
 
   validates_presence_of :project

--- a/db/migrate/20141204192248_add_workflow_id_to_subject_set.rb
+++ b/db/migrate/20141204192248_add_workflow_id_to_subject_set.rb
@@ -1,0 +1,5 @@
+class AddWorkflowIdToSubjectSet < ActiveRecord::Migration
+  def change
+    add_reference :subject_sets, :workflow, index: true
+  end
+end

--- a/db/migrate/20141204192317_drop_workflows_subject_sets.rb
+++ b/db/migrate/20141204192317_drop_workflows_subject_sets.rb
@@ -1,0 +1,5 @@
+class DropWorkflowsSubjectSets < ActiveRecord::Migration
+  def change
+    drop_table :subject_sets_workflows
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141201175902) do
+ActiveRecord::Schema.define(version: 20141204192317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -193,17 +193,11 @@ ActiveRecord::Schema.define(version: 20141201175902) do
     t.datetime "updated_at"
     t.integer  "set_member_subjects_count", default: 0, null: false
     t.json     "metadata"
+    t.integer  "workflow_id"
   end
 
   add_index "subject_sets", ["project_id"], name: "index_subject_sets_on_project_id", using: :btree
-
-  create_table "subject_sets_workflows", id: false, force: true do |t|
-    t.integer "subject_set_id", null: false
-    t.integer "workflow_id",    null: false
-  end
-
-  add_index "subject_sets_workflows", ["subject_set_id"], name: "index_subject_sets_workflows_on_subject_set_id", using: :btree
-  add_index "subject_sets_workflows", ["workflow_id"], name: "index_subject_sets_workflows_on_workflow_id", using: :btree
+  add_index "subject_sets", ["workflow_id"], name: "index_subject_sets_on_workflow_id", using: :btree
 
   create_table "subjects", force: true do |t|
     t.string   "zooniverse_id"

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
   let(:api_resource_name) { 'subject_sets' }
 
   let(:api_resource_attributes) { %w(id display_name set_member_subjects_count created_at updated_at) }
-  let(:api_resource_links) { %w(subject_sets.project subject_sets.workflows) }
+  let(:api_resource_links) { %w(subject_sets.project subject_sets.workflow) }
   
   let(:scopes) { %w(public project) }
   let(:resource_class) { SubjectSet }
@@ -45,7 +45,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
        subject_sets: {
                   display_name: "A Better Name",
                   links: {
-                          workflows: [workflow.id.to_s],
+                          workflow: workflow.id.to_s,
                           subjects: subjects.map(&:id).map(&:to_s)
                          }
                   

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
     factory :full_project do
       after(:create) do |p|
         workflow = create(:workflow, project: p)
-        subject_set = create_list(:subject_set_with_subjects, 2, project: p, workflows: [workflow])
+        subject_set = create_list(:subject_set_with_subjects, 2, project: p, workflow: workflow)
       end
     end
 

--- a/spec/factories/subject_sets.rb
+++ b/spec/factories/subject_sets.rb
@@ -3,18 +3,7 @@ FactoryGirl.define do
     display_name "A Subject set"
     metadata({ just_some: "stuff" })
     project
-
-    factory :subject_set_with_workflow do
-      after(:create) do |sg|
-        create_list(:workflow, 1, subject_sets: [sg])
-      end
-    end
-
-    factory :subject_set_with_workflows do
-      after(:create) do |sg|
-        create_list(:workflow, 2, subject_sets: [sg])
-      end
-    end
+    workflow
 
     factory :subject_set_with_subjects do
       after(:create) do |sg|

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -37,19 +37,19 @@ FactoryGirl.define do
 
     factory :workflow_with_subject_set do
       after(:create) do |w|
-        create_list(:subject_set, 1, workflows: [w])
+        create_list(:subject_set, 1, workflow: w)
       end
     end
 
     factory :workflow_with_subject_sets do
       after(:create) do |w|
-        create_list(:subject_set, 2, workflows: [w])
+        create_list(:subject_set, 2, workflow: w)
       end
     end
 
     factory :workflow_with_subjects do
       after(:create) do |w|
-        create_list(:subject_set_with_subjects, 2, workflows: [w])
+        create_list(:subject_set_with_subjects, 2, workflow: w)
       end
     end
 

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -27,11 +27,9 @@ describe SubjectSet, :type => :model do
     end
   end
 
-  describe "#workflows" do
-    let(:subject_set) { create(:subject_set_with_workflows) }
-
-    it "should have many workflows" do
-      expect(subject_set.workflows).to all( be_a(Workflow) )
+  describe "#workflow" do
+    it "should belong to a workflow" do
+      expect(subject_set.workflow).to be_a(Workflow)
     end
   end
 


### PR DESCRIPTION
Remove HABTM relationship between SubjectSet and Workflow so a workflow has
many subject sets and a subject set belongs to a single workflow. This will
support being able to set retirement rules on subject sets.

Closes #148. Closes #338
