### PR TITLE
Use add_relation instead of update_relation

### DIFF
--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -15,7 +15,7 @@ module JsonApiController
     def update_links
       check_relation
       ActiveRecord::Base.transaction do
-        update_relation(relation, params[relation])
+        add_relation(relation, params[relation])
         controlled_resource.save!
       end
 

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -123,19 +123,22 @@ describe Api::V1::GroupsController, type: :controller do
     let(:new_user) { create(:user) }
     let(:resource) { user_groups.first }
     let(:new_membership) { Membership.where(user: new_user).first }
-    
-    before(:each) do
+    let(:test_relation) { :users }
+    let(:test_relation_ids) { [ new_user.id.to_s ] }
+    let(:resource_id) { :group_id }
+
+    context "created membership" do
+      before(:each) do
+        
+        default_request scopes: scopes, user_id: authorized_user.id
+        post :update_links, group_id: resource.id, users: [ new_user.id.to_s ], link_relation: "users"
+      end
       
-      default_request scopes: scopes, user_id: authorized_user.id
-      post :update_links, group_id: resource.id, users: [ new_user.id.to_s ], link_relation: "users"
-    end
-    
-    it 'should add a user to the group' do
-      expect(new_membership.user_group).to eq(resource)
+      it 'should give the user a group_member role' do
+        expect(new_membership.roles).to eq(%w(group_member))
+      end
     end
 
-    it 'should give the user a group_member role' do
-      expect(new_membership.roles).to eq(%w(group_member))
-    end
+    it_behaves_like "supports update_links"
   end
 end

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -48,6 +48,7 @@ shared_examples "is updatable" do
 end
 
 shared_examples "has updatable links" do
+  let(:old_ids) { resource.send(test_relation).map(&:id) }
   let(:updated_resource) { resource.reload }
   
   before(:each) do
@@ -58,6 +59,31 @@ shared_examples "has updatable links" do
   
   it 'should update any included links' do
     expect(updated_resource.send(test_relation)
-           .map(&:id)).to include(*test_relation_ids)
+            .map(&:id)).to include(*test_relation_ids)
+  end
+end
+
+RSpec.shared_examples "supports update_links" do
+  let!(:old_ids) { resource.send(test_relation).map(&:id) }
+  let(:updated_resource) { resource.reload }
+
+  before(:each) do
+    default_request scopes: scopes, user_id: authorized_user.id
+    params = {
+      link_relation: test_relation.to_s,
+      test_relation => test_relation_ids,
+      resource_id => resource.id
+    }
+    
+    post :update_links, params
+  end
+  
+  it 'should update any included links' do
+    expect(updated_resource.send(test_relation)
+            .map(&:id).map(&:to_s)).to include(*test_relation_ids)
+  end
+
+  it 'should retain pre-existing links' do
+    expect(updated_resource.send(test_relation).map(&:id)).to include(*old_ids)
   end
 end


### PR DESCRIPTION
the #update_links controller method previously calling the wrong method
to add links to a relation.

Closes #356
