### PR TITLE
Convert to new Locations Format

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -598,9 +598,9 @@ the API.
                     "zooniverse_id": "AGFS0001231",
                     "created_at": "2014-03-24T10:42:21Z",
                     "updated_at": "2014-03-24T10:42:21Z",
-                    "locations": {
-                        "standard": "http://s3.amazonaws.com/subjects/1.png"
-                    },
+                    "locations": [
+                        {"image/jpeg": "http://s3.amazonaws.com/subjects/1.png"}
+                    ],
                     "metadata": {
                         "lens_type": "50mm"
                     },
@@ -632,10 +632,10 @@ Users are permitted to edit subjects they own or subjects
 belonging to projects a user has edit permissions for. A user may
 not change the project or owner of a subject.
 
-A request changing the *locations* hash should be full list of keys and
-mime-types for the assoicated media (see sample below). The response
-will contain signed s3 urls the client may make a PUT request
-containing the media to. The signed urls will be valid for 20 minutes.
+The *locations* array should have the mime-types of the subject's
+associated media. The response will contain signed s3 urls the client
+may make a PUT request containing the media to. The signed urls will
+be valid for 20 minutes.
 
 A request chagning the *metadata* hash must contain a full
 representation of the attribute.
@@ -651,9 +651,9 @@ representation of the attribute.
 
             {
                 "subjects": {
-                    "locations": {
-                        "standard": "image/png"
-                    }
+                    "locations": [
+                        "image/png"
+                    ]
                 }
             }
 
@@ -860,9 +860,9 @@ Subjects are returned as an array under the _subject_ key.
                     "zooniverse_id": "AGFS0001231",
                     "created_at": "2014-03-24T10:42:21Z",
                     "updated_at": "2014-03-24T10:42:21Z",
-                    "locations": {
-                        "standard": "http://s3.amazonaws.com/subjects/1.png"
-                    },
+                    "locations": [
+                        {"image/jpeg": "http://s3.amazonaws.com/subjects/1.png"}
+                    ],
                     "metadata": {
                         "lens_type": "50mm"
                     },
@@ -879,9 +879,9 @@ Subjects are returned as an array under the _subject_ key.
                     "zooniverse_id": "AGFS0001232",
                     "created_at": "2014-03-24T10:44:21Z",
                     "updated_at": "2014-03-24T10:44:21Z",
-                    "locations": {
-                        "standard": "http://s3.amazonaws.com/subjects/2.png"
-                    },
+                    "locations": [
+                        {"image/jpeg": "http://s3.amazonaws.com/subjects/2.png"}
+                    ],
                     "metadata": {
                         "lens_type": "50mm"
                     },
@@ -924,11 +924,12 @@ classify, usually for expert classifiers.
     [Subject Collection][]
 
 ### Create a Subject [POST]
-A *locations* attributes and a project link are required. The
-*locations* hash should include keys and the mime-type of their
+A *locations* attributes and a project link are required.
+
+The *locations* array should have the mime-types of the subject's
 associated media. The response will contain signed s3 urls the client
-may make a PUT request containing the media to. The signed urls
-will be valid for 20 minutes.
+may make a PUT request containing the media to. The signed urls will
+be valid for 20 minutes.
 
 The *metadata* attribute and a link to an owner besides
 the active user are optional.
@@ -944,9 +945,9 @@ the active user are optional.
 
             {
                 "subjects": {
-                    "locations": {
-                        "standard": "image/png",
-                    },
+                    "locations": [
+                        "image/png"
+                    ],
                     "metadata": {
                         "lens_type": "50mm"
                     },

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -45,28 +45,30 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def selector
-    @selector ||= SubjectSelector.new(api_user, params)
+    @selector ||= SubjectSelector.new(api_user,
+                                      params)
   end
 
   def create_params
     params.require(:subjects)
       .permit(metadata: params[:subjects][:metadata].try(:keys),
-              locations: params[:subjects][:locations].try(:keys),
+              locations: [],
               links: [:project, :subject_sets, owner: [:id, :type]])
   end
 
   def update_params
     params.require(:subjects)
       .permit(metadata: params[:subjects][:metadata].try(:keys),
-              locations: params[:subjects][:locations].try(:keys),
+              locations: [],
               links: [:subject_sets])
   end
 
   def add_subject_path(locations, project_id)
-    locations.reduce({}) do |locs, (location, mime)|
-      locs[location] = {mime_type: mime,
-                        s3_path: subject_path(location, mime, project_id)}
-      locs
+    locations.map.with_index do |mime, idx|
+      mime.split(',').reduce({}) do |location, mime|
+        location[mime] = subject_path(idx, mime, project_id)
+        location
+      end
     end
   end
 

--- a/app/models/concerns/subject_locations_extractor.rb
+++ b/app/models/concerns/subject_locations_extractor.rb
@@ -9,7 +9,7 @@ class SubjectLocationsExtractor
 
   def locations
     duplicate_locations
-    return {} unless @locations
+    return [] unless @locations
     if migrated_subject?
       migrated_locations
     else
@@ -32,11 +32,12 @@ class SubjectLocationsExtractor
   end
 
   def panoptes_locations
-    @locations.reduce({}) do |locs, (key, data)|
-      path, mime_type = data.values_at("s3_path", "mime_type")
-      obj = ::Panoptes.subjects_bucket.objects[path]
-      locs[key] = s3_url(obj, mime_type)
-      locs
+    @locations.map do |media|
+      media.reduce({}) do |m, (mime_type, path)|
+        obj = ::Panoptes.subjects_bucket.objects[path]
+        m[mime_type] = s3_url(obj, mime_type)
+        m
+      end
     end
   end
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -22,7 +22,7 @@ class Subject < ActiveRecord::Base
   end
 
   def self.can_create?(actor)
-    true
+    !!actor
   end
 
   def migrated_subject?

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -131,10 +131,6 @@ describe Api::V1::SubjectsController, type: :controller do
         let(:request_params) { { sort: 'cellect', workflow_id: workflow.id.to_s } }
         let(:cellect_results) { subjects.take(2).map(&:id) }
 
-        let!(:session) do
-          request.session = { cellect_hosts: { workflow.id.to_s => 'example.com' } }
-        end
-
         describe "testing the response" do
 
           before(:each) do
@@ -191,9 +187,7 @@ describe Api::V1::SubjectsController, type: :controller do
           metadata: {
             interesting_data: "Tested Collection"
           },
-          locations: {
-            standard: "image/jpeg"
-          }
+          locations: [ "image/jpeg" ]
         }
       }
     end
@@ -211,11 +205,7 @@ describe Api::V1::SubjectsController, type: :controller do
       {
         subjects: {
           metadata: { cool_factor: "11" },
-          locations: {
-            standard:  "image/jpeg",
-            thumbnail: "image/jpeg",
-            inverted:  "image/jpeg",
-          },
+          locations: ["image/jpeg", "image/jpeg", "image/jpeg"],
           links: {
             project: project.id
           }
@@ -230,7 +220,7 @@ describe Api::V1::SubjectsController, type: :controller do
       end
 
       let(:standard_url) do
-        json_response['subjects'][0]['locations']['standard']
+        json_response['subjects'][0]['locations'][0]['image/jpeg']
       end
 
       it 'should return locations as a hash of signed s3 urls' do

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -6,8 +6,7 @@ FactoryGirl.define do
     metadata({distance_from_earth: "42 light years",
               brightness: -20,
               loudness: 11})
-    locations({main_image: {mime_type: "image/jpeg",
-                            s3_path: "1/main_image/#{SecureRandom.uuid}.jpeg"}})
+    locations([ {"image/jpeg" => "1/1/#{SecureRandom.uuid}.jpeg"} ])
 
     factory :subject_with_collections do
       after(:create) do |s|


### PR DESCRIPTION
Locations becomes an array of available media. Create and Update
methods accept an array of mime types. If a particular peice of media
has multiple representations they should be sent as a comma-seperated
string of mime types.

Examples:

two jpeg images

```
"locations": ["image/jpeg", "image/jpeg"]
```

A single video encoded multiple ways

```
"locations": ["video/webm,video/mp4"]
```

Closes #369 Closes #341
