### PR TITLE
Run sidekiq in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,6 @@ if [ "$RAILS_ENV" == "development" ]; then
     exec foreman start
   fi
 else
-  [ -z "$HOME" ] && export HOME=$(pwd)
   mkdir -p tmp/pids/
   rm -f tmp/pids/*.pid
   bundle exec sidekiq &


### PR DESCRIPTION
I've decided to just run sidekiq this way for now. I tried foreman, but it takes too long to start (because Java), and supervisor creates issues with environment variables.

It was necessary to set $HOME because of a bug in jbundler. That looks like it's fixed in later versions, though, so we could maybe upgrade (unless there's some reason not to).
