### PR TITLE
Added comma to documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2168,7 +2168,7 @@ it may include links to subjects and a workflow.
 
             {
                 "subject_sets": {
-                    "display_name": "A Group of Interesting Subjects"
+                    "display_name": "A Group of Interesting Subjects",
                     "links": {
                         "project": "43",
                         "subjects": ["234", "1243", "8023"]


### PR DESCRIPTION
Resolves issue #400. Missing comma in example documentation for Create SubjectSet
