### PR TITLE
Optimize the fig dev env/build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN apt-get update && apt-get -y upgrade && \
     bundle install --without test development && \
     jbundle install --without test development
 
-RUN touch /firstrun
-
 ADD ./ /rails_app
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -48,20 +48,17 @@ An easy way to get the full Panoptes stack running (see `fig.yml` to dig into th
 
 3. Copy all the `config/*.yml.hudson` files to `config/*.yml`. The default values should work out of the box.
 
-4. Run `./scripts/fig/up_panoptes.sh`.
-    * On the first run it will build the docker containers, setup the database and install the development and test environment gems.
-    * **Note:** It will not start the rails server(s), and will exit after db migration.
+4. Run `fig up`
+    * On the first run it will build the docker containers, setup the database.
+    * **NOTE: Use the `./scripts/fig/up_panoptes.sh` after the first `fig up` to avoid reinstalling the gems.**
 
-5. Run `./scripts/fig/up_panoptes.sh` again.
-  * On second run the script will start Panoptes and all the dependent services.
-  * **Note:** this script does not recreate containers to avoid installing gems and migrating the database.
-   * If you've added new gems, or you otherwise need to recreate the build image, run `fig up`.
-
-6. Run `scripts/fig/run_cmd_panoptes.sh "bundle install && rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb"`
+6. Run `scripts/fig/run_cmd_panoptes.sh "rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb"`
     * This will seed the fig development database in the docker container.
     * **Note:** Run this only after step 4 has completed successfully.
 
-7. Finally, if you want to apply schema migrations, run `scripts/fig/migrate_db_panoptes.sh`
+8. If you've added new gems run `scripts/fig/gem_install_panoptes.sh`.
+
+9. Finally, if you want to apply schema migrations, run `scripts/fig/migrate_db_panoptes.sh`
 
 
 This will get you a working copy of the checked out code base. Keep your code up to date and rebuild the image if needed!
@@ -133,12 +130,12 @@ Thanks a bunch for wanting to help Zooniverse. Here are few quick guidelines to 
 2. Clone the code and follow one of the above guides to setup a dev environment.
 3. Create a new git branch and make your changes.
 4. Make sure the tests still pass by running `bundle exec rspec`.
-5. Add tests if you introduced new functionality. 
+5. Add tests if you introduced new functionality.
 6. Commit your changes. Try to make your commit message [informative](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), but we're not sticklers about it. Do try to to add `Closes #issue` or `Fixes #issue` somewhere in your message if it's addressing a specific open issue.
 7. Submit a Pull Request
 8. Wait for feedback or a merge!
 
-Your Pull Request will run on [travis-ci](https://travis-ci.org/zooniverse/Panoptes), and we'll probably wait for it to pass on MRI Ruby 2.1.2 and JRuby 1.7.16 before we take a look at it. 
+Your Pull Request will run on [travis-ci](https://travis-ci.org/zooniverse/Panoptes), and we'll probably wait for it to pass on MRI Ruby 2.1.2 and JRuby 1.7.16 before we take a look at it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,18 @@ An easy way to get the full Panoptes stack running (see `fig.yml` to dig into th
 
 3. Copy all the `config/*.yml.hudson` files to `config/*.yml`. The default values should work out of the box.
 
-4. Run `fig up`
-    * On the first run it will build the docker containers, setup the database.
-    * **NOTE: Use the `./scripts/fig/up_panoptes.sh` after the first `fig up` to avoid reinstalling the gems.**
+4. Run `scripts/fig/build_panoptes.sh` to build the docker containers
+
+5. Run `fig up ` OR `scripts/fig/up_panoptes.sh` to start all Panoptes services.
 
 6. Run `scripts/fig/run_cmd_panoptes.sh "rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb"`
     * This will seed the fig development database in the docker container.
     * **Note:** Run this only after step 4 has completed successfully.
 
-8. If you've added new gems run `scripts/fig/gem_install_panoptes.sh`.
+7. If you've added new gems you'll need to rebuild the docker image via the command in step 4.
+  ** NOTE --> ADD A NOTE ABOUT --NO-CACHE here and look into voiding the cache on the gem install commmand**
 
-9. Finally, if you want to apply schema migrations, run `scripts/fig/migrate_db_panoptes.sh`
+8. Finally, if you want to apply schema migrations, run `scripts/fig/migrate_db_panoptes.sh`
 
 
 This will get you a working copy of the checked out code base. Keep your code up to date and rebuild the image if needed!

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ An easy way to get the full Panoptes stack running (see `fig.yml` to dig into th
 
 3. Run `scripts/fig/build_panoptes.sh` to build the docker containers
 
-4. Run `fig up ` OR `scripts/fig/up_panoptes.sh` to start all Panoptes services.
+4. Run, `scripts/fig/migrate_db_panoptes.sh` to setup the database.
+  * Use this command to apply any schema migrations during development. **Note:** This script runs in a separately built container and can be applied when the server is running.
 
 5. Once step 4 is finished, run `scripts/fig/run_cmd_panoptes.sh "rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb"`
-  * This will seed the development database with an Admin user and a Doorkeeper client applications.
+  * This will seed the development database with an Admin user and a Doorkeeper client application for API access.
 
-6. If you've added new gems you'll need to rebuild the docker image via the command in step 4.
-  * ** Note:** This will only be rebuild the changes made to the filesystem that are used in the Dockerfile, see [Docker RUN instructions cache](https://docs.docker.com/reference/builder/).
-
-7. Finally, if you want to apply schema migrations, run `scripts/fig/migrate_db_panoptes.sh`
+6. Run `fig up ` OR `scripts/fig/up_panoptes.sh` to start all Panoptes services.
 
 This will get you a working copy of the checked out code base. Keep your code up to date and rebuild the image if needed!
+
+If you've added new gems you'll need to rebuild the docker image via the command in step 4.
 
 Finally there are some helper scripts to get access to a console, bash shell etc. **Note:** these commands build a new container on each run, see [Fig CLI](http://www.fig.sh/cli.html).
   * To get a rails console `scripts/fig/rails_console_panoptes.sh`

--- a/README.md
+++ b/README.md
@@ -44,34 +44,29 @@ An easy way to get the full Panoptes stack running (see `fig.yml` to dig into th
 
 1. Ensure your repo directory starts with a lowercase letter - you may need to move `/Panoptes` to `/panoptes`.
 
-2. Prepare your fig development environment config files. You should only have to do this before the first boot. **Note:** The fig docker environment uses linked docker containers, so your Postgres and Zookeeper hosts urls need to refer to these containers.
+2. Prepare your development environment config files, you should only have to do this before the first boot. **Note:** The fig docker environment uses linked docker containers, so your Postgres and Zookeeper hosts urls need to refer to these containers.
+  * Copy all the `config/*.yml.hudson` files to `config/*.yml`. The default values should work out of the box.
 
-3. Copy all the `config/*.yml.hudson` files to `config/*.yml`. The default values should work out of the box.
+3. Run `scripts/fig/build_panoptes.sh` to build the docker containers
 
-4. Run `scripts/fig/build_panoptes.sh` to build the docker containers
+4. Run `fig up ` OR `scripts/fig/up_panoptes.sh` to start all Panoptes services.
 
-5. Run `fig up ` OR `scripts/fig/up_panoptes.sh` to start all Panoptes services.
+5. Once step 4 is finished, run `scripts/fig/run_cmd_panoptes.sh "rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb"`
+  * This will seed the development database with an Admin user and a Doorkeeper client applications.
 
-6. Run `scripts/fig/run_cmd_panoptes.sh "rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb"`
-    * This will seed the fig development database in the docker container.
-    * **Note:** Run this only after step 4 has completed successfully.
+6. If you've added new gems you'll need to rebuild the docker image via the command in step 4.
+  * ** Note:** This will only be rebuild the changes made to the filesystem that are used in the Dockerfile, see [Docker RUN instructions cache](https://docs.docker.com/reference/builder/).
 
-7. If you've added new gems you'll need to rebuild the docker image via the command in step 4.
-  ** NOTE --> ADD A NOTE ABOUT --NO-CACHE here and look into voiding the cache on the gem install commmand**
-
-8. Finally, if you want to apply schema migrations, run `scripts/fig/migrate_db_panoptes.sh`
-
+7. Finally, if you want to apply schema migrations, run `scripts/fig/migrate_db_panoptes.sh`
 
 This will get you a working copy of the checked out code base. Keep your code up to date and rebuild the image if needed!
 
-Finally there are some helper scripts to get access to a console, bash shell etc. **Note:** these commands build a new run container
-* To get a rails console `scripts/fig/rails_console_panoptes.sh`
-  + **Note:** you can override the RAILS_ENV by passing a valid argument, just make sure you've setup the DB for it!
-* To get a bash console `scripts/fig/run_cmd_panoptes.sh bash`
-* You can also attach a bash process to the running container, e.g. `docker exec -it panoptes_panoptes_1 bash`
-  + Assuming the 'panoptes_panoptes_1' container is running, use `fig ps` or `docker ps` to check.
-
-**Note:** if you've ever built a Panoptes docker container before you should just run `fig up` instead of the `./scripts/fig/up_panoptes.sh` to ensure the previously built container is not re-used. After rebuilding you should be good to use `./scripts/fig/up_panoptes.sh` script to use the re-created containers.
+Finally there are some helper scripts to get access to a console, bash shell etc. **Note:** these commands build a new container on each run, see [Fig CLI](http://www.fig.sh/cli.html).
+  * To get a rails console `scripts/fig/rails_console_panoptes.sh`
+    + **Note:** you can override the RAILS_ENV by passing a valid argument, just make sure you've set the DB for the env!
+  * To get a bash console `scripts/fig/run_cmd_panoptes.sh bash`
+  * You can also attach a bash process to the running container, e.g. `docker exec -it panoptes_panoptes_1 bash`
+    + Assuming the 'panoptes_panoptes_1' container is running, use `fig ps` or `docker ps` to check.
 
 ### 2. Run manually with self installed and run dependencies
 

--- a/db/fig_dev_seed_data/fig_dev_seed_data.rb
+++ b/db/fig_dev_seed_data/fig_dev_seed_data.rb
@@ -28,6 +28,11 @@ password = STDIN.noecho(&:gets).chomp
 if password.length < 8
   abort(red("Failed: Password must be at least 8 characters long\n"))
 end
+puts yellow("Please re-enter your password")
+second_password = STDIN.noecho(&:gets).chomp
+unless password == second_password
+  abort(red("Failed: passwords do not match!\n"))
+end
 
 #setup an admin user
 attrs = { display_name: 'Zooniverse Admin',

--- a/fig.yml
+++ b/fig.yml
@@ -25,13 +25,10 @@ kafka:
     - zookeeper:zk
   command: -i 1 -H kafka -p 9092 -z zk:2181
 
-panoptesdata:
-  build: scripts/fig/
-
 panoptes:
   build: .
-  volumes_from:
-    - panoptesdata
+  volumes:
+    - ./:/rails_app
   ports:
     - "3000:80"
   environment:

--- a/fig.yml
+++ b/fig.yml
@@ -25,10 +25,13 @@ kafka:
     - zookeeper:zk
   command: -i 1 -H kafka -p 9092 -z zk:2181
 
+panoptesdata:
+  build: scripts/fig/
+
 panoptes:
   build: .
-  volumes:
-    - ./:/rails_app
+  volumes_from:
+    - panoptesdata
   ports:
     - "3000:80"
   environment:

--- a/scripts/fig/Dockerfile
+++ b/scripts/fig/Dockerfile
@@ -1,0 +1,3 @@
+FROM zooniverse/ruby:jruby-1.7.16.1
+
+VOLUME ./:/rails_app

--- a/scripts/fig/Dockerfile
+++ b/scripts/fig/Dockerfile
@@ -16,8 +16,6 @@ ADD ./Jarfile.lock /rails_app/
 
 RUN bundle install && jbundle install
 
-RUN touch /firstrun
-
 ADD ./ /rails_app
 
 EXPOSE 80

--- a/scripts/fig/Dockerfile
+++ b/scripts/fig/Dockerfile
@@ -4,15 +4,15 @@ VOLUME ./:/rails_app
 
 WORKDIR /rails_app
 
-ADD ./Gemfile /rails_app/
-ADD ./Gemfile.lock /rails_app/
-ADD ./Jarfile /rails_app/
-ADD ./Jarfile.lock /rails_app/
-
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y git && apt-get clean
+
+ADD ./Gemfile /rails_app/
+ADD ./Gemfile.lock /rails_app/
+ADD ./Jarfile /rails_app/
+ADD ./Jarfile.lock /rails_app/
 
 RUN bundle install && jbundle install
 

--- a/scripts/fig/Dockerfile
+++ b/scripts/fig/Dockerfile
@@ -1,3 +1,25 @@
 FROM zooniverse/ruby:jruby-1.7.16.1
 
 VOLUME ./:/rails_app
+
+WORKDIR /rails_app
+
+ADD ./Gemfile /rails_app/
+ADD ./Gemfile.lock /rails_app/
+ADD ./Jarfile /rails_app/
+ADD ./Jarfile.lock /rails_app/
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install -y git && apt-get clean
+
+RUN bundle install && jbundle install
+
+RUN touch /firstrun
+
+ADD ./ /rails_app
+
+EXPOSE 80
+
+ENTRYPOINT /rails_app/start.sh

--- a/scripts/fig/build_panoptes.sh
+++ b/scripts/fig/build_panoptes.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+SCRIPT_DIR="`dirname \"$0\"`"
+cp -f Dockerfile Dockerfile.orig
+cp -f $SCRIPT_DIR/Dockerfile .
+fig build
+mv -f Dockerfile.orig Dockerfile

--- a/scripts/fig/build_panoptes.sh
+++ b/scripts/fig/build_panoptes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 SCRIPT_DIR="`dirname \"$0\"`"
 cp -f Dockerfile Dockerfile.orig
 cp -f $SCRIPT_DIR/Dockerfile .

--- a/scripts/fig/migrate_db_panoptes.sh
+++ b/scripts/fig/migrate_db_panoptes.sh
@@ -5,4 +5,4 @@ echo $rails_env
 if [ $# -eq 1 ]; then
   rails_env=$1
 fi
-$SCRIPT_DIR/run_cmd_panoptes.sh "bundle install && rake db:migrate RAILS_ENV=$rails_env"
+$SCRIPT_DIR/run_cmd_panoptes.sh "rake db:migrate RAILS_ENV=$rails_env"

--- a/scripts/fig/rails_console_panoptes.sh
+++ b/scripts/fig/rails_console_panoptes.sh
@@ -4,4 +4,4 @@ rails_env="development"
 if [ $# -eq 1 ]; then
  rails_env="$1"
 fi
-$SCRIPT_DIR/run_cmd_panoptes.sh "bundle install && rails c $rails_env"
+$SCRIPT_DIR/run_cmd_panoptes.sh "rails c $rails_env"

--- a/scripts/fig/up_panoptes.sh
+++ b/scripts/fig/up_panoptes.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -ex
-fig up --no-recreate
+fig up

--- a/start.sh
+++ b/start.sh
@@ -8,16 +8,7 @@ then
 fi
 
 if [ "$RAILS_ENV" == "development" ]; then
-  if [ -e /firstrun ]
-  then
-    if [ -d "/rails_app/.jbundler" ]
-    then
-        rm -rf /rails_app/.jbundler
-    fi
-    # ensure the dev and test gems are installed
-    # https://github.com/bundler/bundler/issues/2862
-    bundle install --without nothing
-    jbundle install --without nothing
+  if [ -e /firstrun ]; then
     rake db:migrate
     rm /firstrun
   fi

--- a/start.sh
+++ b/start.sh
@@ -8,10 +8,6 @@ then
 fi
 
 if [ "$RAILS_ENV" == "development" ]; then
-  if [ -e /firstrun ]; then
-    rake db:migrate
-    rm /firstrun
-  fi
   exec foreman start
 else
   mkdir -p tmp/pids/

--- a/start.sh
+++ b/start.sh
@@ -14,13 +14,14 @@ if [ "$RAILS_ENV" == "development" ]; then
     then
         rm -rf /rails_app/.jbundler
     fi
-    bundle install
-    jbundle install
+    # ensure the dev and test gems are installed
+    # https://github.com/bundler/bundler/issues/2862
+    bundle install --without nothing
+    jbundle install --without nothing
     rake db:migrate
     rm /firstrun
-  else
-    exec foreman start
   fi
+  exec foreman start
 else
   mkdir -p tmp/pids/
   rm -f tmp/pids/*.pid


### PR DESCRIPTION
Closes #344 - not ready to merge just yet, can someone check the README instructions make sense and work before merging?

So i tried using a persistent data volume beneath panoptes but `fig up` would recreate the containers on each launch, whic was no better than the existing setup with `fig up --no-recreate`. The solution I've settled on is to switch in a development dockerfile (with dev/test gems) before `fig build` to ensure all gems are installed. Then just manually migrate and seed the db before using `fig up`. This alleviates the need to install gems / migrate the DB on each run and we can recreate containers each time with minimal work to get started.