### PR TITLE
Move rack-cors to the top of the middleware stack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ module Panoptes
   class Application < Rails::Application
     config.autoload_paths += %W(#{config.root}/lib)
     config.autoload_paths += Dir[Rails.root.join('app', 'models', '**/')]
-    config.middleware.insert_before Warden::Manager, Rack::Cors do
+    config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
         resource '/api/*', headers: :any,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.middleware.insert_before Warden::Manager, Rack::Cors do
+  config.middleware.insert_before 0, Rack::Cors do
     allow do
       origins '*'
       resource '*', headers: :any,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.middleware.insert_before Warden::Manager, Rack::Cors do
+  config.middleware.insert_before 0, Rack::Cors do
     allow do
       origins /^https?:\/\/(127\.0\.0\.1|localhost|10\.0\.2\.2|[a-z0-9-]+\.zooniverse\.org)(:\d+)?$/
       resource '*', headers: :any,


### PR DESCRIPTION
According to cyu/rack-cors#33 it needs to at the top of the
middleware stack for recent versions of Rails 4

Closes #432 I believe. 