### PR TITLE
Split CORS configuration by environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,16 +13,7 @@ module Panoptes
   class Application < Rails::Application
     config.autoload_paths += %W(#{config.root}/lib)
     config.autoload_paths += Dir[Rails.root.join('app', 'models', '**/')]
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins '*'
-        resource '/api/*', headers: :any,
-                           methods: [:delete, :get, :post, :options, :put],
-                           expose: ['ETag'] 
-        
-      end
-    end
-    
+   
     config.middleware.insert_before ActionDispatch::ParamsParser, "RejectPatchRequests"
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.middleware.insert_before ActionDispatch::ParamsParser, "CatchApiJsonParseErrors"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,4 +87,13 @@ Rails.application.configure do
 
   # Enable the logstasher logs for the current environment
   config.logstasher.enabled = true
+
+  config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins '*'
+      resource '/api/*', headers: :any,
+               methods: [:delete, :get, :post, :options, :put],
+               expose: ['ETag'] 
+    end
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -87,9 +87,10 @@ Rails.application.configure do
 
   config.middleware.insert_before 0, Rack::Cors do
     allow do
-      origins /^https?:\/\/(127\.0\.0\.1|localhost|10\.0\.2\.2|[a-z0-9-]+\.zooniverse\.org)(:\d+)?$/
+      origins(/^https?:\/\/(127\.0\.0\.1|localhost|10\.0\.2\.2|[a-z0-9-]+\.zooniverse\.org)(:\d+)?$/)
       resource '*', headers: :any,
-                    methods: [:get, :post, :put, :delete, :options, :patch]
+               methods: [:delete, :get, :post, :options, :put],
+               expose: ['ETag'] 
     end
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,4 +44,13 @@ Rails.application.configure do
   config.to_prepare do
     Doorkeeper::ApplicationsController.helper Doorkeeper::Helpers::Controller
   end
+  
+  config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins '*'
+      resource '/api/*', headers: :any,
+               methods: [:delete, :get, :post, :options, :put],
+               expose: ['ETag'] 
+    end
+  end
 end


### PR DESCRIPTION
#435 caused some problems by having multiple rack-cors instances. This makes sure only one is configured per environment. 