### PR TITLE
Visit by class name instead of key

### DIFF
--- a/lib/tasks_visitor.rb
+++ b/lib/tasks_visitor.rb
@@ -1,13 +1,13 @@
 class TasksVisitor
   def visit(node, path=[], key=nil)
     method = :"visit_#{key}"
-    method = respond_to?(method, true) ? method : :visit_hash
+    method = respond_to?(method, true) ? method : :"visit_#{node.class.to_s.gsub('::', '_')}"
     send(method, node, path)
   end
 
   private
 
-  def array_node(n, path)
+  def visit_Array(n, path)
     n.each_with_index.map { |sub_node, i| visit(sub_node, path + [i]) }
   end
 
@@ -15,17 +15,19 @@ class TasksVisitor
     n
   end
 
-  def visit_hash(n, path)
+  def visit_Hash(n, path)
     n.each do |k, v|
       n[k] = visit(v, path + [k], k)
     end
   end
+  
+  alias :visit_ActiveSupport_HashWithIndifferentAccess :visit_Hash
+  alias :visit_ActionController_Parameters :visit_Hash
 
-  %w(tools answers).each do |key|
-    alias :"visit_#{key}" :array_node
-  end
-
-  %w(type value type color required next).each do |key|
-    alias :"visit_#{key}" :noop
-  end
+  alias :visit_String :noop
+  alias :visit_TrueClass :noop
+  alias :visit_FalseClass :noop
+  alias :visit_NilClass :noop
+  alias :visit_Fixnum :noop
+  alias :visit_Float :noop
 end

--- a/lib/tasks_visitors/extract_strings.rb
+++ b/lib/tasks_visitors/extract_strings.rb
@@ -16,6 +16,7 @@ module TasksVisitors
       path
     end
 
+    alias :visit_instruction :substitute_string
     alias :visit_label :substitute_string
     alias :visit_question :substitute_string
   end

--- a/lib/tasks_visitors/inject_strings.rb
+++ b/lib/tasks_visitors/inject_strings.rb
@@ -10,6 +10,7 @@ module TasksVisitors
       @strings[n]
     end
 
+    alias :visit_instruction :inject_string
     alias :visit_question :inject_string
     alias :visit_label :inject_string
   end

--- a/spec/lib/tasks_visitors/extract_strings_spec.rb
+++ b/spec/lib/tasks_visitors/extract_strings_spec.rb
@@ -32,7 +32,27 @@ RSpec.describe TasksVisitors::ExtractStrings do
           {value: 'sorta', label: 'In between'},
           {value: 'not', label: 'Cigar shaped'}
         ],
-        next: nil}
+        next: nil
+      },
+      "location" => {
+        "type" => "marking",
+        "instruction" => "Mark any stray ghost particles or slime bubbles you can see.",
+        "features" => [
+          {
+            "shape" => "point",
+            "value" => "particle",
+            "label" => "Ghost particle",
+            "color" => "pink"
+          },
+          {
+            "shape" => "ellipse",
+            "value" => "bubble",
+            "label" => "Slime bubble",
+            "color" => "lime"
+          }
+        ],
+        "next" => nil
+      }
     }
   end
 
@@ -73,9 +93,9 @@ RSpec.describe TasksVisitors::ExtractStrings do
 
       it 'should populate the collector with strings' do
         expect(collector).to include("interest.question" => "Color some points",
-                                             "interest.tools.0.label" => 'Red',
-                                             "roundness.question" => 'How round is it?',
-                                             "roundness.answers.2.label" => "Cigar shaped")
+                                     "interest.tools.0.label" => 'Red',
+                                     "roundness.question" => 'How round is it?',
+                                     "roundness.answers.2.label" => "Cigar shaped")
       end
     end
 


### PR DESCRIPTION
Visit by class so we can be more flexible in defining workflows
Maybe revisit (heh) when the format is more locked down

This should fix the 500 errors @brian-c was seeing.