### PR TITLE
Specify worker queue for sidekiq

### DIFF
--- a/app/workers/classification_worker.rb
+++ b/app/workers/classification_worker.rb
@@ -1,6 +1,8 @@
 class ClassificationWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :high
+
   def self.perform(id, action)
     classification = ClassificationLifecycle.new(Classification.find(id))
     case action

--- a/config/sidekiq.yml.hudson
+++ b/config/sidekiq.yml.hudson
@@ -15,4 +15,5 @@ production:
 :queues:
   - high
   - medium
+  - default
   - low


### PR DESCRIPTION
Panoptes wasn't processing any background jobs since they were all dumping to the default queue.