### PR TITLE
track which user uploads a subject

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::SubjectsController < Api::ApiController
                  scopes: [:subject]
   resource_actions :show, :create, :update, :destroy
   schema_type :json_schema
-  
+
   alias_method :subject, :controlled_resource
 
   def index
@@ -29,6 +29,7 @@ class Api::V1::SubjectsController < Api::ApiController
   def build_resource_for_create(create_params)
     create_params[:locations] = add_subject_path(create_params[:locations],
                                                  create_params[:links][:project])
+    create_params[:upload_user_id] = api_user.id
     subject = super(create_params)
     subject
   end
@@ -47,7 +48,7 @@ class Api::V1::SubjectsController < Api::ApiController
                                       controlled_resources,
                                       cellect_host(params[:workflow_id]))
   end
-  
+
   def add_subject_path(locations, project_id)
     locations.map.with_index do |mime, idx|
       mime.split(',').reduce({}) do |location, mime|

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -8,8 +8,8 @@ class Subject < ActiveRecord::Base
   has_and_belongs_to_many :collections
   has_many :subject_sets, through: :set_member_subjects
   has_many :set_member_subjects
-  
-  validates_presence_of :project
+
+  validates_presence_of :project, :upload_user_id
 
   can_through_parent :project, :update, :index, :show, :destroy, :update_links,
                      :destroy_links, :versions, :version

--- a/db/migrate/20150129122349_add_uploading_user_id_to_subject.rb
+++ b/db/migrate/20150129122349_add_uploading_user_id_to_subject.rb
@@ -1,0 +1,6 @@
+class AddUploadingUserIdToSubject < ActiveRecord::Migration
+  def change
+    add_column :subjects, :upload_user_id, :string
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150128191540) do
+ActiveRecord::Schema.define(version: 20150129122349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -205,7 +205,8 @@ ActiveRecord::Schema.define(version: 20150128191540) do
     t.datetime "updated_at"
     t.integer  "project_id"
     t.boolean  "migrated"
-    t.integer  "lock_version",  default: 0
+    t.integer  "lock_version",   default: 0
+    t.string   "upload_user_id"
   end
 
   add_index "subjects", ["project_id"], name: "index_subjects_on_project_id", using: :btree

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :subject do
     project
+    upload_user_id "1"
+
     sequence(:zooniverse_id) { |n| "TES#{n.to_s(26).rjust(8, '0')}" }
     metadata({distance_from_earth: "42 light years",
               brightness: -20,

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -5,7 +5,7 @@ describe Subject, :type => :model do
   let(:subject) { build(:subject) }
   let(:locked_factory) { :subject }
   let(:locked_update) { {metadata: { "Test" => "data" } } }
-  
+
   it_behaves_like "optimistically locked"
 
   it "should have a valid factory" do
@@ -45,6 +45,11 @@ describe Subject, :type => :model do
 
   it "should be invalid without a project_id" do
     subject.project = nil
+    expect(subject).to_not be_valid
+  end
+
+  it "should be invalid without an upload_user_id" do
+    subject.upload_user_id = nil
     expect(subject).to_not be_valid
   end
 


### PR DESCRIPTION
Store the specific user id without a relation as subjects may outlive their users. Useful if we need to audit which user uploaded a subject. 

Not using an AR relation here just storing the user id as a subject may well outlive a user account.