### PR TITLE
ignore user model association link ids

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -29,4 +29,8 @@ class UserSerializer
     @context[:requester] && @context[:requester].logged_in? &&
       (@context[:requester].is_admin? || @model.id == @context[:requester].id)
   end
+
+  def add_links(model, data)
+    data[:links] = {}
+  end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -71,6 +71,23 @@ describe Api::V1::UsersController, type: :controller do
         end
       end
     end
+
+    describe "overridden serialiser instance assocation links" do
+
+      before(:each) do
+        user = users.first
+        create(:classification, user: user)
+        get :index, { login: user.login }
+      end
+
+      it "should respond with 1 item" do
+        expect(json_response[api_resource_name].length).to eq(1)
+      end
+
+      it "should respond with the no model links" do
+        expect(json_response[api_resource_name][0]['links']).to eq({})
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
Closes #471 

Avoid costly queries to possibly large table / index scans. I don't think we need the actual instance ID links on the user instances to traverse the API. Instead we can use the non-instance links element for URL traversing to related models.