### PR TITLE
do not orphan user identity groups

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -11,10 +11,8 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def create_from_json
-    resource_saved = ActiveRecord::Base.transaction(requires_new: true) do
-      build_resource(sign_up_params)
-      raise ActiveRecord::Rollback unless resource.save
-    end
+    build_resource(sign_up_params)
+    resource_saved = resource.save
     yield resource if block_given?
     status, content = registrations_response(resource_saved)
     clean_up_passwords resource

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -11,8 +11,10 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def create_from_json
-    build_resource(sign_up_params)
-    resource_saved = resource.save
+    resource_saved = ActiveRecord::Base.transaction(requires_new: true) do
+      build_resource(sign_up_params)
+      raise ActiveRecord::Rollback unless resource.save
+    end
     yield resource if block_given?
     status, content = registrations_response(resource_saved)
     clean_up_passwords resource

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,9 +15,11 @@ class User < ActiveRecord::Base
   has_many :memberships
   has_many :active_memberships, -> { active }, class_name: 'Membership'
   has_one :identity_membership, -> { identity }, class_name: 'Membership'
-  
+
   has_many :user_groups, through: :active_memberships
-  has_one :identity_group, through: :identity_membership, source: :user_group, class_name: "UserGroup"
+  has_one :identity_group, through: :identity_membership,
+                          source: :user_group,
+                          class_name: "UserGroup"
 
   has_many :project_roles, through: :identity_group
   has_many :collection_roles, through: :identity_group
@@ -82,7 +84,7 @@ class User < ActiveRecord::Base
   def password_required?
     super && hash_func != 'sha1'
   end
-  
+
   def valid_password?(password)
     if hash_func == 'bcrypt'
       super(password)
@@ -117,13 +119,13 @@ class User < ActiveRecord::Base
     raise StandardError, "Identity Group Exists" if identity_group
     build_identity_membership
     name = StringConverter.downcase_and_replace_spaces(login)
-    self.identity_group = identity_membership.build_user_group(name: name)
+    identity_membership.build_user_group(name: name)
   end
 
   def is_admin?
     !!admin
   end
-  
+
   protected
 
   def migrated_user?

--- a/lib/identity_group_name_validator.rb
+++ b/lib/identity_group_name_validator.rb
@@ -1,11 +1,11 @@
 class IdentityGroupNameValidator < ActiveModel::Validator
   def validate(user)
-    if user.identity_group
-      unless user.identity_group.valid?
-        user.errors[:"identity_group.name"].concat(user.identity_group.errors[:name])
+    if identity_group = user.try(:identity_membership).try(:user_group)
+      unless identity_group.valid?
+        user.errors[:"identity_group.name"].concat(identity_group.errors[:name])
       end
     else
-      user.errors[:"identity_group"] = "must have identity_group"
+      user.errors.add(:identity_group, "can't be blank")
     end
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -88,6 +88,39 @@ describe RegistrationsController, type: :controller do
           expect(response.body).to eq(json_error_message(error_body))
         end
       end
+
+      context "when the password is too short" do
+
+        let(:extra_attributes) { { password: "123456" } }
+
+        it "should return 422" do
+          post :create, user: user_attributes
+          expect(response.status).to eq(422)
+        end
+
+        it "should not increase the count of users" do
+          expect{ post :create, user: user_attributes }.not_to change{ User.count }
+        end
+
+        it "should provide an error message in the response body" do
+          post :create, user: user_attributes
+          error_body = { "password" => ["is too short (minimum is 8 characters)"] }
+          expect(response.body).to eq(json_error_message(error_body))
+        end
+
+        it "should not orphan an identity User Group", :focus do
+          attrs = user_attributes.merge(login: "test_user", password: '123456')
+          expect{ post :create, user: attrs }.not_to change{ UserGroup.count }
+        end
+
+        context "HTML form signups", :focus do
+
+          it "should not orphan an identity User Group" do
+            attrs = user_attributes.merge(login: "test_user", password: '123456')
+            expect{ post :create, user: attrs }.not_to change{ UserGroup.count }
+          end
+        end
+      end
     end
   end
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -108,17 +108,9 @@ describe RegistrationsController, type: :controller do
           expect(response.body).to eq(json_error_message(error_body))
         end
 
-        it "should not orphan an identity User Group", :focus do
+        it "should not orphan an identity User Group" do
           attrs = user_attributes.merge(login: "test_user", password: '123456')
           expect{ post :create, user: attrs }.not_to change{ UserGroup.count }
-        end
-
-        context "HTML form signups", :focus do
-
-          it "should not orphan an identity User Group" do
-            attrs = user_attributes.merge(login: "test_user", password: '123456')
-            expect{ post :create, user: attrs }.not_to change{ UserGroup.count }
-          end
         end
       end
     end
@@ -188,6 +180,25 @@ describe RegistrationsController, type: :controller do
         it "should not persist the user account" do
           post :create, user: user_attributes
           expect(User.where(login: user_attributes[:login])).to_not exist
+        end
+      end
+
+      context "when the password is too short" do
+
+        let(:extra_attributes) { { password: "123456" } }
+
+        it "should return 200 with the new html view via respond_with behaviour" do
+          post :create, user: user_attributes
+          expect(response.status).to eq(200)
+        end
+
+        it "should not increase the count of users" do
+          expect{ post :create, user: user_attributes }.not_to change{ User.count }
+        end
+
+        it "should not orphan an identity User Group" do
+          attrs = user_attributes.merge(login: "test_user", password: '123456')
+          expect{ post :create, user: attrs }.not_to change{ UserGroup.count }
         end
       end
     end


### PR DESCRIPTION
closes #494 

Don't use assignment on the `User#identity_group` has_one relation as this autosaves the relation regardless of the `User` model validity. Instead validate via the :through `identity_membership`relation.

I really with rails had builders for the `has_one :through` relations, we live and learn.