### PR TITLE
allow uniq user filtering on display_name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,8 @@ class User < ActiveRecord::Base
   has_many :collection_roles, through: :identity_group
 
   validates :login, presence: true, uniqueness: true
+  validates_presence_of :display_name
+  validates_uniqueness_of :display_name, case_sensitive: false
   validates_length_of :password, within: 8..128, allow_blank: true,
                       unless: :migrated_user?
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,7 +5,7 @@ class UserSerializer
               projects: { param: "owner", value: "login" },
               collections: { param: "owner", value: "login" }
 
-  can_filter_by :login
+  can_filter_by :login, :display_name
 
   def credited_name
     @model.credited_name if permitted_requester?

--- a/db/migrate/20150205121848_add_users_display_name_index.rb
+++ b/db/migrate/20150205121848_add_users_display_name_index.rb
@@ -1,0 +1,5 @@
+class AddUsersDisplayNameIndex < ActiveRecord::Migration
+  def change
+    add_index :users, :display_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150130202731) do
+ActiveRecord::Schema.define(version: 20150205121848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -298,6 +298,7 @@ ActiveRecord::Schema.define(version: 20150130202731) do
     t.boolean  "banned",                      default: false,    null: false
   end
 
+  add_index "users", ["display_name"], name: "index_users_on_display_name", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["login"], name: "index_users_on_login", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/lib/user_info_scrubber.rb
+++ b/lib/user_info_scrubber.rb
@@ -6,11 +6,29 @@ class UserInfoScrubber
   class ScrubDisabledUserError < StandardError; end
 
   def self.scrub_personal_info!(user)
-    if user.disabled?
-      raise ScrubDisabledUserError.new("Can't scrub personal details of a disabled user with id: #{user.id}")
+    @user = user
+    if @user.disabled?
+      message = "Can't scrub personal details of a disabled user with id: #{@user.id}"
+      raise ScrubDisabledUserError.new(message)
     else
-      user.update_columns( email: nil ,
-                           display_name: DELETED_USER_NAME )
+      scrub_details
     end
+  end
+
+  private
+
+  def self.scrub_details
+    begin
+      tries ||= 2
+      @user.update_columns(email: nil, display_name: scrubbed_display_name(tries))
+    rescue ActiveRecord::RecordNotUnique => e
+      retry if (tries -= 1) > 0
+      raise e
+    end
+  end
+
+  def self.scrubbed_display_name(tries)
+    suffix = tries > 0 ? tries : nil
+    "#{DELETED_USER_NAME}_#{SecureRandom.uuid}#{suffix}"
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -70,6 +70,18 @@ describe Api::V1::UsersController, type: :controller do
           expect(json_response[api_resource_name][0]['login']).to eq(user.login)
         end
       end
+
+      describe "filter by display_name" do
+        let(:index_options) { { display_name: user.display_name } }
+
+        it "should respond with 1 item" do
+          expect(json_response[api_resource_name].length).to eq(1)
+        end
+
+        it "should respond with the correct item" do
+          expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+        end
+      end
     end
 
     describe "overridden serialiser instance assocation links" do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -84,7 +84,8 @@ describe RegistrationsController, type: :controller do
 
         it "should provide an error message in the response body" do
           post :create, user: user_attributes
-          error_body = { "login" => ["can't be blank"], "identity_group.name" => ["can't be blank"] }
+          error_keys = %w(login display_name identity_group.name)
+          error_body = Hash[error_keys.zip(Array.new(3, ["can't be blank"]))]
           expect(response.body).to eq(json_error_message(error_body))
         end
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,12 +3,12 @@ FactoryGirl.define do
     transient do
       build_group true
     end
-    
+
     hash_func 'bcrypt'
     sequence(:email) {|n| "example#{n}@example.com"}
     password 'password'
     encrypted_password { User.new.send(:password_digest, 'password') }
-    display_name 'New User'
+    sequence(:display_name) { |n| "New User #{n}" }
     credited_name 'Dr User'
     activated_state :active
     sequence(:login) { |n| "new_user_#{n}" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe User, :type => :model do
+describe User, type: :model do
   let(:user) { create(:user) }
   let(:activatable) { user }
   let(:owner) { user }
@@ -100,7 +100,32 @@ describe User, :type => :model do
       dup_user.valid?
       expect(dup_user.errors[:login]).to include("has already been taken")
     end
+  end
 
+  describe '#display_name' do
+    it 'should validate presence' do
+      expect(build(:user, display_name: "").valid?).to be false
+    end
+
+    it 'should have non-blank error' do
+      user = build(:user, display_name: "")
+      user.valid?
+      expect(user.errors[:display_name]).to include("can't be blank")
+    end
+
+    it 'should validate uniqueness to enable filtering by the display name' do
+      display_name = 'Mista Bob Dobalina'
+      expect{ create(:user, display_name: display_name) }.to_not raise_error
+      expect{ create(:user, display_name: display_name.upcase, email: 'test2@example.com') }.to raise_error
+      expect{ create(:user, display_name: display_name.downcase, email: 'test3@example.com') }.to raise_error
+    end
+
+    it "should have the correct case-insensitive uniqueness error" do
+      user = create(:user)
+      dup_user = build(:user, display_name: user.display_name.upcase)
+      dup_user.valid?
+      expect(dup_user.errors[:display_name]).to include("has already been taken")
+    end
   end
 
   describe '#email' do
@@ -188,7 +213,7 @@ describe User, :type => :model do
     end
 
     it 'should not require a password when creating a user from an import' do
-      attrs = {login: "t", hash_func: 'sha1', email: "test@example.com"}
+      attrs = {login: "t", display_name: "Mr. T", hash_func: 'sha1', email: "test@example.com"}
       expect do
         User.create!(attrs) do |u|
           u.build_identity_group

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,24 +20,28 @@ RSpec.configure do |config|
 
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   Devise.mailer = Devise::Mailer
 
   config.before(:suite) do
-    begin
-      DatabaseCleaner.strategy = :transaction
-    ensure
-      DatabaseCleaner.clean_with(:truncation)
-    end
+    DatabaseCleaner.clean_with(:truncation)
   end
 
   config.before(:each) do
-    DatabaseCleaner.start
+    DatabaseCleaner.strategy = :transaction
   end
 
   config.before(:each, type: :controller) do
     stub_cellect_connection
+  end
+
+  config.before(:each, no_transaction: true) do
+    DatabaseCleaner.strategy = :deletion
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
   end
 
   config.after(:each) do


### PR DESCRIPTION
closes #501 

Commit history should explain what i was doing. The only funky stuff was retying possibly race conditions on scrubbing personal details with dup UUID values and getting rspec to reuse the transaction after PG error. I had to turn off transactional fixtures (tests) add use a deletion strategy for that specific spec (:no_transaction key).