### PR TITLE
Subjects in classifications

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -294,8 +294,8 @@ A classifications has the following attributes:
 - gold_standard
 - annotations
 
-Annotations is an array of maps of the form `{ "question_key":
-"question answer" }`. Metadata contains additional information about a
+Annotations is an array of maps of the form `{ "task": "task_key",
+"value": "question answer" }`. Metadata contains additional information about a
 classification including:
 
 - started_at
@@ -323,7 +323,7 @@ classification including:
                         "type": "workflows"
                     },
                     "classifications.subject": {
-                        "href": "/set_member_subjects/{classifications.set_member_subject}",
+                        "href": "/subjects/{classifications.subjects}",
                         "type": "subjects"
                     }
                 },
@@ -347,7 +347,7 @@ classification including:
                     ],
                     "links": {
                         "user": "1",
-                        "set_member_subject": "10",
+                        "subjects": ["10"],
                         "workflow": "81",
                         "project": "2"
                     }
@@ -449,7 +449,7 @@ key.
                         "type": "workflows"
                     },
                     "classifications.subject": {
-                        "href": "/set_member_subjects/{classifications.set_member_subject}",
+                        "href": "/subjects/{classifications.subjects}",
                         "type": "subjects"
                     }
                 },
@@ -488,7 +488,7 @@ key.
                         ],
                     "links": {
                         "user": "1",
-                        "set_member_subject": "10",
+                        "subjects": ["10"],
                         "workflow": "81",
                         "project": "2"
                     }
@@ -517,7 +517,7 @@ key.
                     ],
                     "links": {
                         "user": "1",
-                        "set_member_subject": "11",
+                        "subjects": ["11"],
                         "workflow": "81",
                         "project": "2"
                     }
@@ -3136,7 +3136,7 @@ subjects with a new queue of subjects.
             {
                 "subject_queues: {
                     "links"; {
-                        "set_member_subjects": ["10", "22"]
+                        "subjects": ["10", "22"]
                     }
                 }
             }
@@ -3157,7 +3157,7 @@ Removes the queue entirely
 
 + Response 204
 
-## Add set_member_subject links [/subject_queues/{id}/links/set_member_subjects]
+## Add subject links [/subject_queues/{id}/links/subjects]
 Add subjects to a queue.
 
 ### Add links [POST]
@@ -3174,14 +3174,14 @@ have edit permissions.
     + Body
 
             {
-                "set_member_subjects": ["1", "2"]
+                "subjects": ["1", "2"]
             }
 
 + Response 200
 
     [SubjectQueue][]
 
-## Remove subject links [/subject_queues/{id}/links/set_member_subjects/{link_ids}]
+## Remove subject links [/subject_queues/{id}/links/subjects/{link_ids}]
 Remove subjects from a queue.
 
 ### Remove links [DELETE]
@@ -3223,9 +3223,9 @@ SubjectQueues are returned as an array under *subject_queues*.
                         "href": "/workflows/{subject_queues.workflow}",
                         "type": "workflows"
                     },
-                    "subject_queues.set_member_subjects": {
-                        "href": "/subjects?set_member_subject_ids={subject_queues.set_member_subjects}",
-                        "type": "set_member_subjects"
+                    "subject_queues.subjects": {
+                        "href": "/subjects?subject_ids={subject_queues.subjects}",
+                        "type": "subjects"
                     }
                 },
                 "meta": {
@@ -3283,7 +3283,7 @@ SubjectQueues are returned as an array under *subject_queues*.
 
 ### Create SubjectQueue [POST]
 Creating a subject queue only requires a user and a workflow link. You
-may optionally include a list of set_member_subjects to populate the queue.
+may optionally include a list of subjects to populate the queue.
 
 + Request
 
@@ -3299,7 +3299,7 @@ may optionally include a list of set_member_subjects to populate the queue.
                     "links": {
                         "user": "10",
                         "workflow": "42",
-                        "set_member_subjects": ["3", "12321", "8004"]
+                        "subjects": ["3", "12321", "8004"]
                     }
                 }
             }

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -32,24 +32,11 @@ class Api::V1::ClassificationsController < Api::ApiController
       .exists?(id: resource_ids)
   end
 
-
-  def sms_ids_from_links(link_params)
-    sms = if ids = link_params.delete(:set_member_subjects)
-      SetMemberSubject.select(:id).find(ids)
-    elsif ids = link_params.delete(:subjects)
-      SetMemberSubject.joins(:subject_set)
-        .where(subject_sets: {workflow_id: link_params[:workflow]})
-        .select(:id)
-        .find_by(subject_id: ids)
-    end
-    sms.try(:map, &:id) || [sms.id]
-  end
-
   def build_resource_for_create(create_params)
     classification = super(create_params) do |create_params, link_params|
       link_params[:user] = api_user.user
       create_params[:user_ip] = request_ip
-      create_params[:set_member_subject_ids] = sms_ids_from_links(link_params)
+      create_params[:subject_ids] = link_params.delete(:subjects)
     end
     classification
   end

--- a/app/controllers/api/v1/subject_queues_controller.rb
+++ b/app/controllers/api/v1/subject_queues_controller.rb
@@ -3,8 +3,8 @@ class Api::V1::SubjectQueuesController < Api::ApiController
   resource_actions :default
   schema_type :strong_params
 
-  allowed_params :create, links: [:user, :workflow, set_member_subjects: []]
-  allowed_params :update, links: [set_member_subjects: []]
+  allowed_params :create, links: [:user, :workflow, subjects: []]
+  allowed_params :update, links: [subjects: []]
 
   protected
 
@@ -17,8 +17,8 @@ class Api::V1::SubjectQueuesController < Api::ApiController
   end
 
   def assoc_class(relation)
-    if relation.to_sym == :set_member_subjects
-      SetMemberSubject
+    if relation.to_sym == :subjects
+      Subject
     else
       super
     end

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -6,7 +6,7 @@ class Classification < ActiveRecord::Base
 
   enum expert_classifier: [:expert, :owner]
 
-  validates_presence_of :set_member_subject_ids, :project,
+  validates_presence_of :subject_ids, :project,
                         :workflow, :annotations, :user_ip
 
   validates :user, presence: true, if: :incomplete?

--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -4,14 +4,14 @@ class UserSeenSubject < ActiveRecord::Base
 
   validates_presence_of :user, :workflow
 
-  def self.add_seen_subjects_for_user(user: nil, workflow: nil, set_member_subject_ids: nil)
+  def self.add_seen_subjects_for_user(user: nil, workflow: nil, subject_ids: nil)
     uss = self.find_or_create_by!(user: user, workflow: workflow)
-    uss.add_set_member_subjects(set_member_subject_ids)
+    uss.add_subjects(subject_ids)
   end
 
-  def add_set_member_subjects(subjects)
-    set_member_subject_ids_will_change!
-    set_member_subject_ids.concat(subjects)
+  def add_subjects(subjects)
+    subject_ids_will_change!
+    subject_ids.concat(subjects)
     save!
   end
 end

--- a/app/models/user_subject_queue.rb
+++ b/app/models/user_subject_queue.rb
@@ -8,8 +8,8 @@ class UserSubjectQueue < ActiveRecord::Base
 
   can_through_parent :workflow, :update, :destroy, :update_links, :destroy_links
 
-  delegate :add_subjects, to: :set_member_subjects
-  delegate :remove_subjects, to: :set_member_subjects
+  delegate :add_subjects, to: :subjects
+  delegate :remove_subjects, to: :subjects
 
   def self.scope_for(action, groups, opts={})
     case action
@@ -20,40 +20,40 @@ class UserSubjectQueue < ActiveRecord::Base
     end
   end
 
-  def self.enqueue_subject_for_user(user: nil, workflow: nil, set_member_subject: nil)
+  def self.enqueue_subject_for_user(user: nil, workflow: nil, subject: nil)
     ues = find_or_create_by!(user: user, workflow: workflow)
-    ues.add_subjects(set_member_subject)
+    ues.add_subjects(subject)
   end
 
-  def self.dequeue_subjects_for_user(user: nil, workflow: nil, set_member_subject_ids: nil)
+  def self.dequeue_subjects_for_user(user: nil, workflow: nil, subject_ids: nil)
     ues = find_by!(user: user, workflow: workflow)
-    ues.remove_subjects(set_member_subject_ids)
-    ues.destroy if ues.set_member_subject_ids.empty?
+    ues.remove_subjects(subject_ids)
+    ues.destroy if ues.subject_ids.empty?
   end
 
-  def self.are_subjects_queued?(user: nil, workflow: nil, set_member_subject_ids: nil)
-    where.overlap(set_member_subject_ids: set_member_subject_ids)
+  def self.are_subjects_queued?(user: nil, workflow: nil, subject_ids: nil)
+    where.overlap(subject_ids: subject_ids)
       .exists?(user: user, workflow: workflow)
   end
   
   def next_subjects(limit=10)
-    set_member_subject_ids[0,limit]
+    subject_ids[0,limit]
   end
   
-  def set_member_subjects=(subjects)
-    set_member_subject_ids_will_change!
-    self.set_member_subject_ids = subjects.map(&:id)
+  def subjects=(subjects)
+    subject_ids_will_change!
+    self.subject_ids = subjects.map(&:id)
     save! && reload if persisted?
     subjects
   end
 
   def reload
     super
-    @set_member_subject_relation ||= SetMemberSubjectRelation.new(self)
+    @subject_relation ||= SubjectRelation.new(self)
     self
   end
 
-  def set_member_subjects
-    @set_member_subject_relation ||= SetMemberSubjectRelation.new(self)
+  def subjects
+    @subject_relation ||= SubjectRelation.new(self)
   end
 end

--- a/app/schemas/classification_create_schema.rb
+++ b/app/schemas/classification_create_schema.rb
@@ -21,22 +21,23 @@ class ClassificationCreateSchema < JsonSchema
       end
 
       property "started_at" do
-        type ""
+        type "string"
       end
 
       property "finished_at" do
-        type ""
+        type "string"
       end
-
+      
       property "user_language" do
+        type "string"
       end
 
       property "workflow_version" do
-        type ""
+        type "string"
       end
 
       property "user_agent" do
-        type ""
+        type "string"
       end
     end
 
@@ -68,13 +69,6 @@ class ClassificationCreateSchema < JsonSchema
         type "string", "integer"
       end
 
-      property "set_member_subjects" do
-        type "array"
-        items do
-          type "string", "integer"
-        end
-      end
-      
       property "subjects" do
         type "array"
         items do

--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -1,19 +1,19 @@
 class ClassificationSerializer
   include RestPack::Serializer
   attributes :id, :annotations, :created_at
-  can_include :project, :user, :user_group
+  can_include :project, :user, :user_group, :workflow
 
   def add_links(model, data)
     data = super(model, data)
-    data[:links][:set_member_subjects] = model.set_member_subject_ids.map(&:to_s)
+    data[:links][:subjects] = model.subject_ids.map(&:to_s)
     data
   end
 
   def self.links
     links = super
-    links["#{key}.set_member_subjects"] = {
-      type: "set_member_subjects",
-      href: "/set_member_subjects/{#{key}.set_member_subjects}"
+    links["#{key}.subjects"] = {
+      type: "subjects",
+      href: "/subjects/{#{key}.subjects}"
     }
     links
   end

--- a/app/serializers/user_subject_queue_serializer.rb
+++ b/app/serializers/user_subject_queue_serializer.rb
@@ -13,17 +13,17 @@ class UserSubjectQueueSerializer
   end
 
   def links
-    {set_member_subjects: @model.set_member_subject_ids,
+    {subjects: @model.subject_ids,
      user: @model.user.id,
      workflow: @model.workflow.id}
   end
 
   def self.links
     links = super
-    links["subject_queues.set_member_subjects"] = {
-                                                   href: "/subjects?set_member_subject_ids={subject_queues.set_member_subjects}",
-                                                   type: "set_member_subjects",
-                                                  }
+    links["subject_queues.subjects"] = {
+      href: "/subjects?subject_ids={subject_queues.subjects}",
+      type: "subjects",
+    }
     links
   end
 end

--- a/db/migrate/20150210025312_create_database.rb
+++ b/db/migrate/20150210025312_create_database.rb
@@ -1,5 +1,6 @@
 class CreateDatabase < ActiveRecord::Migration
   def change
+    # These are extensions that must be enabled in order to support this database
     enable_extension "plpgsql"
 
     create_table "access_control_lists", force: true do |t|
@@ -35,11 +36,11 @@ class CreateDatabase < ActiveRecord::Migration
       t.datetime "updated_at"
       t.integer  "user_group_id"
       t.inet     "user_ip"
-      t.boolean  "completed",              default: true, null: false
+      t.boolean  "completed",         default: true, null: false
       t.boolean  "gold_standard"
       t.integer  "expert_classifier"
-      t.json     "metadata",               default: {},   null: false
-      t.integer  "set_member_subject_ids", default: [],                array: true
+      t.json     "metadata",          default: {},   null: false
+      t.integer  "subject_ids",       default: [],                array: true
     end
 
     add_index "classifications", ["project_id"], name: "index_classifications_on_project_id", using: :btree
@@ -239,7 +240,7 @@ class CreateDatabase < ActiveRecord::Migration
       t.integer  "workflow_id"
       t.datetime "created_at"
       t.datetime "updated_at"
-      t.integer  "set_member_subject_ids", default: [], null: false, array: true
+      t.integer  "subject_ids", default: [], null: false, array: true
     end
 
     add_index "user_seen_subjects", ["user_id", "workflow_id"], name: "index_user_seen_subjects_on_user_id_and_workflow_id", using: :btree
@@ -248,10 +249,10 @@ class CreateDatabase < ActiveRecord::Migration
     create_table "user_subject_queues", force: true do |t|
       t.integer  "user_id"
       t.integer  "workflow_id"
-      t.integer  "set_member_subject_ids", default: [], null: false, array: true
+      t.integer  "subject_ids",  default: [], null: false, array: true
       t.datetime "created_at"
       t.datetime "updated_at"
-      t.integer  "lock_version",           default: 0
+      t.integer  "lock_version", default: 0
     end
 
     add_index "user_subject_queues", ["user_id", "workflow_id"], name: "index_user_subject_queues_on_user_id_and_workflow_id", unique: true, using: :btree
@@ -329,5 +330,6 @@ class CreateDatabase < ActiveRecord::Migration
 
     add_index "workflows", ["project_id"], name: "index_workflows_on_project_id", using: :btree
     add_index "workflows", ["tutorial_subject_id"], name: "index_workflows_on_tutorial_subject_id", using: :btree
+
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150210025312) do
+ActiveRecord::Schema.define(version: 20150210055339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,11 +49,11 @@ ActiveRecord::Schema.define(version: 20150210025312) do
     t.datetime "updated_at"
     t.integer  "user_group_id"
     t.inet     "user_ip"
-    t.boolean  "completed",              default: true, null: false
+    t.boolean  "completed",         default: true, null: false
     t.boolean  "gold_standard"
     t.integer  "expert_classifier"
-    t.json     "metadata",               default: {},   null: false
-    t.integer  "set_member_subject_ids", default: [],                array: true
+    t.json     "metadata",          default: {},   null: false
+    t.integer  "subject_ids",       default: [],                array: true
   end
 
   add_index "classifications", ["project_id"], name: "index_classifications_on_project_id", using: :btree
@@ -253,7 +253,7 @@ ActiveRecord::Schema.define(version: 20150210025312) do
     t.integer  "workflow_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "set_member_subject_ids", default: [], null: false, array: true
+    t.integer  "subject_ids", default: [], null: false, array: true
   end
 
   add_index "user_seen_subjects", ["user_id", "workflow_id"], name: "index_user_seen_subjects_on_user_id_and_workflow_id", using: :btree
@@ -262,10 +262,10 @@ ActiveRecord::Schema.define(version: 20150210025312) do
   create_table "user_subject_queues", force: true do |t|
     t.integer  "user_id"
     t.integer  "workflow_id"
-    t.integer  "set_member_subject_ids", default: [], null: false, array: true
+    t.integer  "subject_ids",  default: [], null: false, array: true
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "lock_version",           default: 0
+    t.integer  "lock_version", default: 0
   end
 
   add_index "user_subject_queues", ["user_id", "workflow_id"], name: "index_user_subject_queues_on_user_id_and_workflow_id", unique: true, using: :btree

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -28,7 +28,7 @@ class ClassificationLifecycle
 
   def update_cellect(cellect_host)
     return unless should_update_seen?
-    set_member_subject_ids.each do |id|
+    subject_ids.each do |id|
       Cellect::Client.connection
         .add_seen(user_id: user.try(:id),
                   workflow_id: workflow.id,
@@ -96,15 +96,15 @@ class ClassificationLifecycle
     @project ||= classification.project
   end
 
-  def set_member_subject_ids
-    @set_member_subject_ids ||= classification.set_member_subject_ids
+  def subject_ids
+    @subject_ids ||= classification.subject_ids
   end
 
   def user_workflow_subject
     @user_workflow_subject ||= {
       user: user,
       workflow: workflow,
-      set_member_subject_ids: set_member_subject_ids
+      subject_ids: subject_ids
     }
   end
 end

--- a/lib/subject_relation.rb
+++ b/lib/subject_relation.rb
@@ -7,7 +7,7 @@
 ## This doesn't replicate all of AR:A just enough to fool RestPack and
 ## JsonApiController into thinking its one. 
 
-class SetMemberSubjectRelation
+class SubjectRelation
   include Enumerable
   
   attr_reader :owner
@@ -16,22 +16,22 @@ class SetMemberSubjectRelation
   
   def initialize(owner)
     @owner = owner
-    @relation = SetMemberSubject.where(id: owner.set_member_subject_ids)
+    @relation = Subject.where(id: owner.subject_ids)
   end
 
   def concat(*models)
     models = models.flatten
-    owner.set_member_subject_ids_will_change!
+    owner.subject_ids_will_change!
     ids = models.map { |m| m.try(:id) || m }
-    owner.set_member_subject_ids.concat(ids)
+    owner.subject_ids.concat(ids)
     owner.save!
   end
 
   def destroy(*models)
     models = models.flatten
-    owner.set_member_subject_ids_will_change!
+    owner.subject_ids_will_change!
     ids = models.map { |m| m.try(:id) || m }
-    owner.set_member_subject_ids.delete(*ids)
+    owner.subject_ids.delete(*ids)
     owner.save!
   end
   

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -31,8 +31,7 @@ class SubjectSelector
   end
 
   def selected_subjects(subject_ids)
-    set_member_subjects = SetMemberSubject.where(id: subject_ids).select(:subject_id)
-    subjects = @scope.where(id: set_member_subjects)
+    subjects = @scope.where(id: subject_ids) 
     subjects
   end
 

--- a/spec/controllers/api/v1/subject_queues_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_queues_controller_spec.rb
@@ -4,12 +4,12 @@ describe Api::V1::SubjectQueuesController, type: :controller do
   let(:authorized_user) { create(:user) }
   let(:api_resource_name) { 'subject_queues' }
   let(:api_resource_attributes) { %w(id) }
-  let(:api_resource_links) { %w(subject_queues.user subject_queues.workflow subject_queues.set_member_subjects) }
+  let(:api_resource_links) { %w(subject_queues.user subject_queues.workflow subject_queues.subjects) }
 
   let(:project) { create(:project, owner: authorized_user) }
   let(:workflow) { create(:workflow, project: project) }
   let(:resource) { create(:user_subject_queue, workflow: workflow) }
-  let(:subjects) { create_list(:set_member_subject, 3) }
+  let(:subjects) { create_list(:subject, 3) }
   let(:subject_ids) { subjects.map(&:id).map(&:to_s) }
 
   let(:scopes) { %w(public project) }
@@ -30,13 +30,13 @@ describe Api::V1::SubjectQueuesController, type: :controller do
   end
 
   describe "#update" do
-    let(:test_attr) { :set_member_subject_ids }
+    let(:test_attr) { :subject_ids }
     let(:test_attr_value) { subject_ids.map(&:to_i) }
     let(:update_params) do
       {
        user_subject_queues: {
                              links: {
-                                     set_member_subjects: subject_ids
+                                     subjects: subject_ids
                                     }
                             }
       }
@@ -46,7 +46,7 @@ describe Api::V1::SubjectQueuesController, type: :controller do
   end
 
   describe "#create" do
-    let(:test_attr) { :set_member_subject_ids }
+    let(:test_attr) { :subject_ids }
     let(:test_attr_value) { subject_ids.map(&:to_i) }
     let(:create_params) do
       {
@@ -54,7 +54,7 @@ describe Api::V1::SubjectQueuesController, type: :controller do
                              links: {
                                      workflow: workflow,
                                      user: create(:user),
-                                     set_member_subjects: subject_ids
+                                     subjects: subject_ids
                                     }
                             }
       }

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -5,7 +5,7 @@ UUIDv4Regex = /[a-f0-9]{8}\-[a-f0-9]{4}\-4[a-f0-9]{3}\-(8|9|a|b)[a-f0-9]{3}\-[a-
 describe Api::V1::SubjectsController, type: :controller do
   let!(:workflow) { create(:workflow_with_subject_sets) }
   let!(:subject_set) { workflow.subject_sets.first }
-  let!(:subjects) { create_list(:set_member_subject, 2, subject_set: subject_set) }
+  let!(:subjects) { create_list(:set_member_subject, 2, subject_set: subject_set).map(&:subject) }
   let!(:user) { create(:user) }
 
   let(:scopes) { %w(subject) }
@@ -70,7 +70,7 @@ describe Api::V1::SubjectsController, type: :controller do
             create(:user_subject_queue,
                    user: user,
                    workflow: workflow,
-                   set_member_subject_ids: subjects.map(&:id))
+                   subject_ids: subjects.map(&:id))
             get :index, request_params
           end
 

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
     user
     project
     workflow
-    set_member_subject_ids { create_list(:set_member_subject, 2).map(&:id) }
+    subject_ids { create_list(:set_member_subject, 2).map(&:subject).map(&:id) }
 
     factory :classifaction_with_user_group do
       user_group

--- a/spec/factories/user_seen_subjects.rb
+++ b/spec/factories/user_seen_subjects.rb
@@ -4,6 +4,6 @@ FactoryGirl.define do
   factory :user_seen_subject do
     user
     workflow
-    set_member_subject_ids [1,2,3]
+    subject_ids { create_list(:set_member_subject, 2).map(&:subject).map(&:id) }
   end
 end

--- a/spec/factories/user_subject_queues.rb
+++ b/spec/factories/user_subject_queues.rb
@@ -4,6 +4,6 @@ FactoryGirl.define do
   factory :user_subject_queue do
     user
     workflow
-    set_member_subject_ids []
+    subject_ids []
   end
 end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -120,14 +120,14 @@ describe ClassificationLifecycle do
           create(:user_subject_queue,
                  user: classification.user,
                  workflow: classification.workflow,
-                 set_member_subject_ids: classification.set_member_subject_ids)
+                 subject_ids: classification.subject_ids)
         end
 
         it 'should call dequeue_subject_for_user' do
           expect(UserSubjectQueue).to receive(:dequeue_subjects_for_user)
                                        .with(user: classification.user,
                                              workflow: classification.workflow,
-                                             set_member_subject_ids: classification.set_member_subject_ids)
+                                             subject_ids: classification.subject_ids)
         end
       end
 
@@ -201,11 +201,11 @@ describe ClassificationLifecycle do
 
     context "with a user" do
       let(:classification) { build(:classification) }
-      it 'should add the set_member_subject_id to the seen subjects' do
+      it 'should add the subject_id to the seen subjects' do
         expect(UserSeenSubject).to receive(:add_seen_subjects_for_user)
                                     .with(user: classification.user,
                                           workflow: classification.workflow,
-                                          set_member_subject_ids: classification.set_member_subject_ids)
+                                          subject_ids: classification.subject_ids)
       end
     end
 
@@ -223,7 +223,7 @@ describe ClassificationLifecycle do
     it "should setup the add seen command to cellect" do
       expect(stubbed_cellect_connection).to receive(:add_seen)
                                              .with(
-                                               subject_id: classification.set_member_subject_ids.first,
+                                               subject_id: classification.subject_ids.first,
                                                workflow_id: classification.workflow.id,
                                                user_id: classification.user.id,
                                                host: 'http://test.host/'

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -9,8 +9,8 @@ describe Classification, :type => :model do
     expect(build(:classification, project: nil)).to_not be_valid
   end
 
-  it "must have an array of set_member_subjects" do
-    expect(build(:classification, set_member_subject_ids: nil)).to_not be_valid
+  it "must have an subjects" do
+    expect(build(:classification, subject_ids: nil)).to_not be_valid
   end
 
   it "must have a workflow" do

--- a/spec/models/user_seen_subject_spec.rb
+++ b/spec/models/user_seen_subject_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 def created_uss
-  UserSeenSubject.where(params.except(:set_member_subject)).first
+  UserSeenSubject.where(params.except(:subject)).first
 end
 
 RSpec.describe UserSeenSubject, :type => :model do
-  let(:user_seen_subject) { build(:user_seen_subject, set_member_subject_ids: []) }
+  let(:user_seen_subject) { build(:user_seen_subject, subject_ids: []) }
 
   it "should have a valid factory" do
     expect(user_seen_subject).to be_valid
@@ -13,7 +13,7 @@ RSpec.describe UserSeenSubject, :type => :model do
 
   describe "::add_seen_subjects_for_user" do
     let(:subject) { create(:subject) }
-    let(:params) { { user: user, workflow: workflow, set_member_subject_ids: [subject.id] } }
+    let(:params) { { user: user, workflow: workflow, subject_ids: [subject.id] } }
 
     context "when no user or workflow exists" do
       let(:workflow) { nil }
@@ -38,9 +38,9 @@ RSpec.describe UserSeenSubject, :type => :model do
           end.to change{ UserSeenSubject.count }.by(1)
         end
 
-        it "should add the subject id to the set_member_subject_ids array" do
+        it "should add the subject id to the subject_ids array" do
           UserSeenSubject.add_seen_subjects_for_user(params)
-          expect(created_uss.set_member_subject_ids).to eq([ subject.id ])
+          expect(created_uss.subject_ids).to eq([ subject.id ])
         end
       end
 
@@ -53,10 +53,10 @@ RSpec.describe UserSeenSubject, :type => :model do
           end.not_to change{ UserSeenSubject.count }
         end
 
-        it "should add the subject id to the set_member_subject_ids array" do
+        it "should add the subject id to the subject_ids array" do
           UserSeenSubject.add_seen_subjects_for_user(params)
           user_seen_subject.reload
-          expect(user_seen_subject.set_member_subject_ids).to include(subject.id)
+          expect(user_seen_subject.subject_ids).to include(subject.id)
         end
       end
     end
@@ -82,14 +82,14 @@ RSpec.describe UserSeenSubject, :type => :model do
     end
   end
 
-  describe "#add_set_member_subjects" do
+  describe "#add_subjects" do
     let(:uss) { user_seen_subject }
     
-    it "should add a subject's id to the set_member_subject_ids array" do
+    it "should add a subject's id to the subject_ids array" do
       s = create(:subject)
-      uss.add_set_member_subjects([s])
+      uss.add_subjects([s])
       uss.reload
-      expect(uss.set_member_subject_ids).to include(s.id)
+      expect(uss.subject_ids).to include(s.id)
     end
   end
 end


### PR DESCRIPTION
Address Brian's concerns from #512. Hide set_memebr_subjects entirely.
I'll need to update the cellect_panotpes driver to use only subjects