### PR TITLE
add digit regex for classification link ids

### DIFF
--- a/app/schemas/classification_create_schema.rb
+++ b/app/schemas/classification_create_schema.rb
@@ -27,7 +27,7 @@ class ClassificationCreateSchema < JsonSchema
       property "finished_at" do
         type "string"
       end
-      
+
       property "user_language" do
         type "string"
       end
@@ -45,11 +45,11 @@ class ClassificationCreateSchema < JsonSchema
       type "array"
       items do
         type "object"
-        
+
         property "task" do
           type "string"
         end
-        
+
         property "value" do
           type "string", "object", "array", "float", "integer"
         end
@@ -63,16 +63,19 @@ class ClassificationCreateSchema < JsonSchema
 
       property "project" do
         type "string", "integer"
+        pattern "^[0-9]*$"
       end
 
       property "workflow" do
         type "string", "integer"
+        pattern "^[0-9]*$"
       end
 
       property "subjects" do
         type "array"
         items do
           type "string", "integer"
+          pattern "^[0-9]*$"
         end
       end
     end

--- a/lib/json_schema.rb
+++ b/lib/json_schema.rb
@@ -1,6 +1,8 @@
 class JsonSchema
   class ValidationError < StandardError; end
 
+  ERROR_FORMAT_REGEX = /'#\/(.*)'\s(.+)\sin/
+
   class Builder
     attr_reader :schema
 
@@ -93,7 +95,8 @@ class JsonSchema
 
   def format_errors_to_hash(errors_array)
     errors_array.collect do |error|
-      error.scan(/'#\/(.+)'.+(did.+)\sin/).flatten
+      field, message = error.scan(ERROR_FORMAT_REGEX).flatten
+      [ field.blank? ? 'schema' : field, message ]
     end.to_h
   end
 end

--- a/lib/json_schema.rb
+++ b/lib/json_schema.rb
@@ -86,6 +86,14 @@ class JsonSchema
 
   def validate!(json)
     errors = JSON::Validator.fully_validate(@schema, json)
-    raise ValidationError, errors unless errors.empty?
+    unless errors.empty?
+      raise ValidationError, format_errors_to_hash(errors)
+    end
+  end
+
+  def format_errors_to_hash(errors_array)
+    errors_array.collect do |error|
+      error.scan(/'#\/(.+)'.+(did.+)\sin/).flatten
+    end.to_h
   end
 end

--- a/lib/json_schema.rb
+++ b/lib/json_schema.rb
@@ -94,9 +94,11 @@ class JsonSchema
   end
 
   def format_errors_to_hash(errors_array)
-    errors_array.collect do |error|
+    formatted_errors = errors_array.collect do |error|
       field, message = error.scan(ERROR_FORMAT_REGEX).flatten
       [ field.blank? ? 'schema' : field, message ]
-    end.to_h
+    end.flatten
+    # TODO: bump to array.to_h when jruby supports MRI 2.2
+    Hash[*formatted_errors]
   end
 end

--- a/lib/json_schema.rb
+++ b/lib/json_schema.rb
@@ -1,13 +1,13 @@
 class JsonSchema
   class ValidationError < StandardError; end
-  
+
   class Builder
     attr_reader :schema
-    
+
     def initialize(schema={})
       @schema = schema
     end
-    
+
     def build(&block)
       instance_exec(&block)
       schema
@@ -18,13 +18,17 @@ class JsonSchema
     def additional_properties(bool)
       schema[:additionalProperties] = bool
     end
-    
+
     def title(title)
       schema[:title] = title
     end
 
     def type(*type)
       schema[:type] = type.length == 1 ? type.first : type
+    end
+
+    def pattern(pattern)
+      schema[:pattern] = pattern
     end
 
     def description(desc)
@@ -66,7 +70,7 @@ class JsonSchema
       Builder.new.build(&block)
     end
   end
-  
+
   def self.build(&block)
     new(Builder.new.build(&block))
   end
@@ -75,7 +79,7 @@ class JsonSchema
     return @schema unless block_given?
     @schema = Builder.new.build(&block)
   end
-  
+
   def initialize(schema=self.class.schema)
     @schema = schema
   end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -94,7 +94,7 @@ describe Api::V1::ClassificationsController, type: :controller do
         it_behaves_like "a classification lifecycle event"
         it_behaves_like "a gold standard classfication"
 
-        context "when invalid link id strings are used", :focus do
+        context "when invalid link id strings are used" do
 
           it "should fail via the schema validator" do
             req_params = [ project.id,
@@ -102,8 +102,9 @@ describe Api::V1::ClassificationsController, type: :controller do
                            "MOCK_SUBJECT_FOR_CLASSIFIER" ]
             setup_create_request(*req_params)
             error = json_response["errors"].first["message"]
-            expected = /MOCK_SUBJECT_FOR_CLASSIFIER.*did not match the regex/
-            expect(error).to match(expected)
+            expected_error = { "links/workflow"   => "did not match the regex '^[0-9]*$'",
+                               "links/subjects/0" => "did not match the regex '^[0-9]*$'"}.to_s
+            expect(error).to match(expected_error)
           end
         end
       end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -36,7 +36,6 @@ def setup_create_request(project_id, workflow_id, subject_id)
     params[:classifications].merge!(gold_standard: gold_standard)
   end
 
-
   post :create, params
 end
 
@@ -94,6 +93,19 @@ describe Api::V1::ClassificationsController, type: :controller do
         it_behaves_like "a classification create"
         it_behaves_like "a classification lifecycle event"
         it_behaves_like "a gold standard classfication"
+
+        context "when invalid link id strings are used", :focus do
+
+          it "should fail via the schema validator" do
+            req_params = [ project.id,
+                           "MOCK_WORKFLOW_FOR_CLASSIFIER",
+                           "MOCK_SUBJECT_FOR_CLASSIFIER" ]
+            setup_create_request(*req_params)
+            error = json_response["errors"].first["message"]
+            expected = /MOCK_SUBJECT_FOR_CLASSIFIER.*did not match the regex/
+            expect(error).to match(expected)
+          end
+        end
       end
     end
   end

--- a/spec/lib/json_schema_spec.rb
+++ b/spec/lib/json_schema_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe JsonSchema do
+  let(:formated_error_messages) do
+    { "name" => "did not match the following type: string",
+      "metadata" => "did not contain a required property of 'start'" }.to_s
+  end
   shared_examples "validates json" do
     context "valid json" do
       let(:valid_json) do
@@ -34,9 +38,15 @@ RSpec.describe JsonSchema do
           subject.validate!(invalid_json)
         end.to raise_error(JsonSchema::ValidationError)
       end
+
+      it 'should format the error message for use in the API response' do
+        expect do
+          subject.validate!(invalid_json)
+        end.to raise_error(formated_error_messages)
+      end
     end
   end
-  
+
   describe "::schema" do
     subject do
       Class.new(JsonSchema) do
@@ -85,7 +95,7 @@ RSpec.describe JsonSchema do
         property "metadata" do
           type "object"
           required "start", "end"
-          
+
           property "start" do
             type "integer"
           end
@@ -96,7 +106,7 @@ RSpec.describe JsonSchema do
         end
       end
     end
-    
+
     it_behaves_like "validates json"
   end
 end

--- a/spec/lib/json_schema_spec.rb
+++ b/spec/lib/json_schema_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe JsonSchema do
-  let(:formated_error_messages) do
-    { "name" => "did not match the following type: string",
-      "metadata" => "did not contain a required property of 'start'" }.to_s
-  end
   shared_examples "validates json" do
     context "valid json" do
       let(:valid_json) do
@@ -18,6 +14,33 @@ RSpec.describe JsonSchema do
         expect do
           subject.validate!(valid_json)
         end.to_not raise_error
+      end
+
+      context "when allowing additional properties" do
+
+        it 'should not raise an error' do
+          expect do
+            subject.validate!(valid_json)
+          end.to_not raise_error
+        end
+      end
+
+      context "when not allowing additional properties on the schema" do
+        let(:non_aprops_schema) do
+          Class.new(JsonSchema) do
+            schema do
+              type "object"
+              additional_properties false
+            end
+          end.new
+        end
+
+        it "should format the error message with the schema root field name" do
+          field_msg = "contains additional properties [\"invalid_property\"] outside of the schema when none are allowed"
+          expect do
+            non_aprops_schema.validate!({ "invalid_property" => "value" })
+          end.to raise_error({ "schema" => field_msg }.to_s)
+        end
       end
     end
 
@@ -40,9 +63,11 @@ RSpec.describe JsonSchema do
       end
 
       it 'should format the error message for use in the API response' do
+        message = { "name" => "of type Fixnum did not match the following type: string",
+                    "metadata" => "did not contain a required property of 'start'" }.to_s
         expect do
           subject.validate!(invalid_json)
-        end.to raise_error(formated_error_messages)
+        end.to raise_error(message)
       end
     end
   end
@@ -53,6 +78,7 @@ RSpec.describe JsonSchema do
         schema do
           type "object"
           required "id", "name"
+
           property "id" do
             type "integer"
           end
@@ -84,6 +110,7 @@ RSpec.describe JsonSchema do
       JsonSchema.build do
         type "object"
         required "id", "name"
+
         property "id" do
           type "integer"
         end


### PR DESCRIPTION
closes #520, closes #456 

Ad digit regex for classification id links (probably need to expand these to other links).
Add consistent error formatting for failed json schema validations (there may be more errors that i haven't seen todo).