### PR TITLE
expose public project roles 

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -4,7 +4,7 @@ module Api
   class ApiController < ApplicationController
     include JsonApiController
     include RoleControl::RoledController
-    
+
     API_ACCEPTED_CONTENT_TYPES = ['application/json',
                                   'application/vnd.api+json']
     API_ALLOWED_METHOD_OVERRIDES = { 'PATCH' => 'application/patch+json' }
@@ -79,7 +79,9 @@ module Api
     end
 
     def require_login
-      raise Api::NotLoggedIn unless api_user.logged_in?
+      unless api_user.logged_in?
+        raise Api::NotLoggedIn.new("You must be logged in to access this resource.")
+      end
     end
 
     def ban_user

--- a/app/controllers/api/v1/project_roles_controller.rb
+++ b/app/controllers/api/v1/project_roles_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::ProjectRolesController < Api::ApiController
   include RolesController
-
-  doorkeeper_for :all, scopes: [:project]
+  skip_before_filter :require_login, only: :index
+  doorkeeper_for :show, :create, :update, scopes: [:project]
   schema_type :strong_params
-  
+
   allowed_params :create, roles: [], links: [:user, :project]
 
   allowed_params :update, roles: []

--- a/app/controllers/api/v1/project_roles_controller.rb
+++ b/app/controllers/api/v1/project_roles_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::ProjectRolesController < Api::ApiController
   include RolesController
+
+  before_filter :format_filter_params, only: :index
   skip_before_filter :require_login, only: :index
+
   doorkeeper_for :show, :create, :update, scopes: [:project]
   schema_type :strong_params
 
@@ -10,5 +13,13 @@ class Api::V1::ProjectRolesController < Api::ApiController
 
   def resource_name
     "project_role"
+  end
+
+  private
+
+  def format_filter_params
+    if project_id_filter = params.delete(:project_id)
+      params[:resource_id] = project_id_filter
+    end
   end
 end

--- a/app/serializers/access_control_list_serializer.rb
+++ b/app/serializers/access_control_list_serializer.rb
@@ -26,7 +26,7 @@ class AccessControlListSerializer
     links.delete("#{key}.user_group")
     link_type = resource_type.pluralize
     links["#{key}.#{resource_type}"] = { type: link_type,
-                                         href: "/#{link_type}/{#{key}.#{resource_type}" }
+                                         href: "/#{link_type}/{#{key}.#{resource_type}}" }
     links
   end
 end

--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
         end
 
         describe "filter by project_id" do
-          let(:index_options) { { resource_id: new_project.id } }
+          let(:index_options) { { project_id: new_project.id } }
 
           it "should respond with 1 item" do
             expect(json_response[api_resource_name].length).to eq(1)

--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -31,6 +31,27 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
     describe "a logged in user" do
 
       it_behaves_like "is indexable"
+
+      describe "filter params" do
+        let!(:new_project) { create(:project) }
+
+        before(:each) do
+          get :index, index_options
+        end
+
+        describe "filter by project_id" do
+          let(:index_options) { { resource_id: new_project.id } }
+
+          it "should respond with 1 item" do
+            expect(json_response[api_resource_name].length).to eq(1)
+          end
+
+          it "should respond with the correct item" do
+            project_id = json_response[api_resource_name][0]['links']['project']
+            expect(project_id).to eq(new_project.id.to_s)
+          end
+        end
+      end
     end
   end
 

--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 RSpec.describe Api::V1::ProjectRolesController, type: :controller do
-  let(:authorized_user) { create(:user) }
-  let(:project) { create(:project, owner: authorized_user) }
-  
+  let(:user) { create(:user) }
+  let(:authorized_user) { user }
+  let(:project) { create(:project, owner: user) }
+
   let!(:acls) do
     create_list :access_control_list, 2, resource: project,
                 roles: ["tester"]
   end
-  
+
   let(:api_resource_name) { 'project_roles' }
   let(:api_resource_attributes) { %w(id roles) }
   let(:api_resource_links) { %w(project_roles.project) }
@@ -21,7 +22,16 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
     let!(:private_resource) { create(:access_control_list, resource: create(:project, private: true)) }
     let(:n_visible) { 3 }
 
-    it_behaves_like "is indexable"
+    context "when not logged in" do
+      let(:authorized_user) { nil }
+
+      it_behaves_like "is indexable"
+    end
+
+    describe "a logged in user" do
+
+      it_behaves_like "is indexable"
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
partly solves #526 @edpaget can you have a look?

Filtering on the polymorphic access control list resource assocation requires the use of `resource_id` instead of the preferred `project_id`. 