### PR TITLE
ensure the specialized serializers loaded on include by restpack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: git://github.com/edpaget/restpack_serializer.git
-  revision: 13f5d936c689a00f220cc78e73c3f8eb14d3d516
+  revision: 9a7cdb2777006c7cd05c512859f5c9451248ca8d
   branch: dev
   specs:
-    restpack_serializer (0.5.7.pre1)
+    restpack_serializer (0.5.9)
       activerecord (>= 4.0.3, < 5.0)
       activesupport (>= 4.0.3, < 5.0)
       kaminari (~> 0.16.1)
@@ -157,7 +157,7 @@ GEM
     json-schema (2.5.0)
       addressable (~> 2.3)
     jwt (1.2.1)
-    kaminari (0.16.2)
+    kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     libv8 (3.16.14.7)

--- a/app/serializers/access_control_list_serializer.rb
+++ b/app/serializers/access_control_list_serializer.rb
@@ -1,32 +1,3 @@
 class AccessControlListSerializer
-  include RestPack::Serializer
-
-  def self.key
-    @key
-  end
-
-  def self.model_class
-    AccessControlList
-  end
-
-  def add_links(model, data)
-    data = super(model, data)
-    data[:links][self.class.resource_type] = data[:links][:resource][:id]
-    data[:links].delete(:resource)
-    group = model.user_group
-    group = group.users.first if group.identity?
-    data[:links][:owner] = { id: group.id.to_s,
-                             to_s: group.class.model_name.plural,
-                             href: group.class.model_name.route_key}
-    data
-  end
-
-  def self.links
-    links = super
-    links.delete("#{key}.user_group")
-    link_type = resource_type.pluralize
-    links["#{key}.#{resource_type}"] = { type: link_type,
-                                         href: "/#{link_type}/{#{key}.#{resource_type}}" }
-    links
-  end
+  include ACLSerializer
 end

--- a/app/serializers/acl_serializer.rb
+++ b/app/serializers/acl_serializer.rb
@@ -1,0 +1,36 @@
+module ACLSerializer
+  extend ActiveSupport::Concern
+
+  include RestPack::Serializer
+
+  module ClassMethods
+    def key
+      @key
+    end
+
+    def model_class
+      AccessControlList
+    end
+
+    def links
+      links = super
+      links.delete("#{key}.user_group")
+      link_type = resource_type.pluralize
+      links["#{key}.#{resource_type}"] = { type: link_type,
+                                           href: "/#{link_type}/{#{key}.#{resource_type}}" }
+      links
+    end
+  end
+
+  def add_links(model, data)
+    data = super(model, data)
+    data[:links][self.class.resource_type] = data[:links][:resource][:id]
+    data[:links].delete(:resource)
+    group = model.user_group
+    group = group.users.first if group.identity?
+    data[:links][:owner] = { id: group.id.to_s,
+                             to_s: group.class.model_name.plural,
+                             href: group.class.model_name.route_key}
+    data
+  end
+end

--- a/app/serializers/collection_role_serializer.rb
+++ b/app/serializers/collection_role_serializer.rb
@@ -1,7 +1,9 @@
-class CollectionRoleSerializer < AccessControlListSerializer
+class CollectionRoleSerializer
+  include ACLSerializer
+
   attributes :id, :roles
   can_include :user_group, :resource
-  
+
   def self.key
     "collection_roles"
   end

--- a/app/serializers/project_role_serializer.rb
+++ b/app/serializers/project_role_serializer.rb
@@ -1,7 +1,9 @@
-class ProjectRoleSerializer < AccessControlListSerializer
+class ProjectRoleSerializer
+  include ACLSerializer
+
   attributes :id, :roles
   can_include :user_group, :resource
-  
+
   def self.key
     "project_roles"
   end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -122,10 +122,13 @@ describe Api::V1::ProjectsController, type: :controller do
         end
 
         context "when the serializer models are known" do
-          let(:includes) { "workflows,subject_sets" }
+          let(:included_models) do
+            %w(workflows subject_sets project_contents project_roles)
+          end
+          let(:includes) { included_models.join(',') }
 
           it "should include the relations in the response as linked" do
-            expect(json_response['linked'].keys).to match_array(%w(workflows subject_sets))
+            expect(json_response['linked'].keys).to match_array(included_models)
           end
         end
 
@@ -348,7 +351,7 @@ describe Api::V1::ProjectsController, type: :controller do
         params = params.merge(id: resource.id)
         put :update, params
       end
-      
+
       it 'should update the default contents when the display_name is updated' do
         contents_title = resource.primary_content.title
         expect(contents_title).to eq(test_attr_value)


### PR DESCRIPTION
Fixes #527, closes #526, closes #523 

#530 will depend on this work. Also this relies on an updated version of restpack serializer, https://github.com/edpaget/restpack_serializer/pull/3 so it'll fail till that become available via the dev branch.