### PR TITLE
remove honey badger config init loader

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,8 +1,0 @@
-Honeybadger.configure do |config|
-  config_file = begin
-                  YAML.load(File.read(Rails.root.join("config/honeybadger.yml")))
-                rescue Errno::ENOENT => e
-                  {}
-                end
-  config.api_key = config_file.fetch(Rails.env, {}).symbolize_keys[:api_key]
-end


### PR DESCRIPTION
honeybadger now looks for a config/honeybadger.yml file by default.