### PR TITLE
ensure passwords match for the sha1 hash algorithm

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,7 +89,7 @@ class User < ActiveRecord::Base
     if hash_func == 'bcrypt'
       super(password)
     elsif hash_func == 'sha1'
-      if encrypted_password = sha1_encrypt(password)
+      if encrypted_password == sha1_encrypt(password)
         logger.info "User #{id} is using sha1 password. Updating..."
         self.password = password
         self.hash_func = 'bcrypt'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,7 +27,7 @@ FactoryGirl.define do
     factory :insecure_user do
       hash_func 'sha1'
       password 'tajikistan'
-      encrypted_password 'gFlanK5bXjD2YS7LSYndVJNGGdY='
+      encrypted_password 'zKUhbXyjCsgmcv6Fh5rQiHTzJWI='
       password_salt 'nK5bXjD2YS7LSYndVJNGGdY='
     end
 


### PR DESCRIPTION
possible security issue where we don't compare hashed values == for older sha1 haah users (we don't have any)