### PR TITLE
Catch JSON error raised in JRuby

### DIFF
--- a/app/middleware/catch_api_json_parse_errors.rb
+++ b/app/middleware/catch_api_json_parse_errors.rb
@@ -6,7 +6,7 @@ class CatchApiJsonParseErrors
   def call(env)
     begin
       @app.call(env)
-    rescue ActionDispatch::ParamsParser::ParseError => e
+    rescue ActionDispatch::ParamsParser::ParseError, JSON::ParserError => e
       if json_api_call?(env)
         return error.respond(e)
       else

--- a/spec/middleware/catch_api_json_parse_errors_spec.rb
+++ b/spec/middleware/catch_api_json_parse_errors_spec.rb
@@ -55,4 +55,18 @@ describe CatchApiJsonParseErrors do
       it_behaves_like 'a json error response'
     end
   end
+  
+  context "call errors with JSON::ParserError" do
+    let(:error) { JSON::ParserError.new('test') }
+    
+    before(:each) do
+      allow(app).to receive(:call).and_raise(error)
+    end
+
+    let(:request) {  middle.call(good_env) }
+    let(:status) { 400 }
+    let(:msg) { /There was a problem in the JSON you submitted/ }
+
+    it_behaves_like 'a json error response'
+  end
 end

--- a/spec/requests/v1/api_json_parser_errors_spec.rb
+++ b/spec/requests/v1/api_json_parser_errors_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe "handle malformed json", type: :request do
+  it 'should return 400 Bad Request' do
+    post "/api/classifications", 'this: "isn\'t json"', {
+           "HTTP_ACCEPT" => "application/vnd.api+json; version=1",
+           "CONTENT_TYPE" => "application/json"
+         }
+    expect(response).to have_http_status(:bad_request)
+  end
+end


### PR DESCRIPTION
JRuby seems to raise a JSON::ParserError instead of one raised by MRI,
this just expands our middleware to catch both