### PR TITLE
allow existing panotpes user accounts to be updated

### DIFF
--- a/lib/zoo_user_warden_strategy.rb
+++ b/lib/zoo_user_warden_strategy.rb
@@ -4,11 +4,9 @@ Warden::Strategies.add(:zoo_user) do
   end
 
   def authenticate!
-    u = ZooniverseUser.authenticate(params['user']['display_name'], params['user']['password'])
-    if u.nil?
-      fail!("Could not log in")
-    else
-      success!(u.import)
-    end
+    zoo_home_user = ZooniverseUser.authenticate(params['user']['display_name'],
+                                                params['user']['password'])
+    imported_user = zoo_home_user.import if zoo_home_user
+    imported_user ? success!(imported_user) : fail!("Could not log in")
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -53,7 +53,7 @@ describe RegistrationsController, type: :controller do
           post :create, user: user_attributes
           expect(ZooniverseUser.where(login: login).first).to_not be_nil
         end
-        
+
         context "when the user already exists in zooniverse_home" do
           let!(:existing_zoo_user) { create(:zooniverse_user, login: login) }
 
@@ -130,14 +130,14 @@ describe RegistrationsController, type: :controller do
     end
   end
 
-  context "as html" do
+  context "as html", disabled: true do
     let(:user_params) { [ :email, :password, :password_confirmation, :display_name ] }
 
     before(:each) do
       request.env["HTTP_ACCEPT"] = "text/html"
     end
 
-    describe "#create", disabled: true do
+    describe "#create" do
 
       context "with valid user attributes" do
         let(:login) { "zoonser" }

--- a/spec/lib/zooniverse_user_spec.rb
+++ b/spec/lib/zooniverse_user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe ZooniverseUser, type: :model do
   describe "::import_users" do
     let!(:zus) { create_list(:zooniverse_user, 2) }
-    
+
     context "with no arguments" do
       it 'should import all zooniverse users' do
         ZooniverseUser.import_users
@@ -22,22 +22,22 @@ RSpec.describe ZooniverseUser, type: :model do
       end
     end
   end
-  
+
   describe "::authenticate" do
     let!(:zu) { create(:zooniverse_user) }
-    
+
     it 'should return the user when supplied the password of a user with a matching login' do
       expect(ZooniverseUser.authenticate(zu.login, zu.password)).to eq(zu)
     end
 
     it 'should return nil when no user matches' do
-      expect(ZooniverseUser.authenticate("asdfasdf", zu.password)).to be_nil 
+      expect(ZooniverseUser.authenticate("asdfasdf", zu.password)).to be_nil
     end
   end
-  
+
   describe "::create_from_user" do
     let(:user) { create(:user) }
-    
+
     it 'should create a ZooniverseUser from a User' do
       expect(ZooniverseUser.create_from_user(user).login).to eq(user.display_name)
     end
@@ -49,7 +49,7 @@ RSpec.describe ZooniverseUser, type: :model do
       expect(user.zooniverse_id).to eq(zu.id.to_s)
     end
   end
-  
+
   describe "#password=" do
     subject do
       zu = build(:zooniverse_user, password: nil)
@@ -57,7 +57,7 @@ RSpec.describe ZooniverseUser, type: :model do
       zu.save!
       zu
     end
-    
+
     it 'should set the password_salt' do
       expect(subject.password_salt).to_not be_nil
     end
@@ -66,7 +66,7 @@ RSpec.describe ZooniverseUser, type: :model do
       expect(subject.crypted_password).to_not be_nil
     end
   end
-  
+
   describe "#import" do
     context 'when the User has not already be imported' do
       it 'should create a User from a Zooniverse User' do
@@ -79,15 +79,16 @@ RSpec.describe ZooniverseUser, type: :model do
       it 'should update the User' do
         user = create(:user, migrated: true, build_zoo_user: true)
         zu = ZooniverseUser.find(user.zooniverse_id.to_i)
-        zu.update!(login: "a new login")
-        expect(zu.import.display_name).to eq("a new login")
+        new_email = "new_test_email@test.com"
+        zu.update!(email: new_email)
+        expect(zu.import.email).to eq(new_email)
       end
     end
   end
-  
+
   describe "#authenticate" do
     let(:zu) { create(:zooniverse_user) }
-    
+
     context "when password matches" do
       it 'should return itself' do
         expect(zu.authenticate(zu.password)).to eq(zu)
@@ -96,11 +97,11 @@ RSpec.describe ZooniverseUser, type: :model do
 
     context "when password doesn't match" do
       it 'should return nil' do
-        expect(zu.authenticate("asdfasd")).to be_nil 
+        expect(zu.authenticate("asdfasd")).to be_nil
       end
     end
   end
-  
+
   describe "#set_tokens!" do
     subject do
       zu = build(:zooniverse_user, persistence_token: nil, single_access_token: nil, perishable_token: nil)
@@ -108,7 +109,7 @@ RSpec.describe ZooniverseUser, type: :model do
       zu.save!
       zu
     end
-    
+
     it 'should set the persistence token' do
       expect(subject.persistence_token).to_not be_nil
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,9 +22,9 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.use_transactional_fixtures = false
 
-  Devise.mailer = Devise::Mailer
-
   config.filter_run_excluding disabled: true
+
+  Devise.mailer = Devise::Mailer
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
@@ -56,6 +56,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :deletion
   end
 
+  config.before(:each, zoo_home_user: true) do
+    ZooniverseUser.delete_all
+  end
+
   config.after(:each) do
     ZooniverseUser.destroy_all
   end
@@ -72,7 +76,7 @@ RSpec.configure do |config|
     ActiveRecord::Migration.suppress_messages do
       ActiveRecord::Migration.run(CreateZooniverserUserDatabase, direction: :down)
     end
-    
+
     ActiveRecord::Base.establish_connection(:"#{Rails.env}")
   end
 


### PR DESCRIPTION
some real zoo_home_users have setup accounts on panoptes that share the login/display_name. Allow these accounts to be updated from zoo home so we don't have to remove dup account and orphpaning any existing linked instances e.g. projects, etc.