### PR TITLE
Set remember token in Zoo-Home authentication

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -29,16 +29,14 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def create_zoo_user(resource)
-    if resource.valid? && ZooHomeConfiguration.use_zoo_home?
+    return true unless ZooHomeConfiguration.use_zoo_home?
+    if resource.valid?
       zu = ZooniverseUser.create_from_user(resource)
-      if zu.persisted?
-        true
-      else
-        zu.errors.each do |attr, errors|
-          resource.errors.add(attr, errors)
-        end
-        false
+      return true if zu.persisted?
+      zu.errors.each do |attr, errors|
+        resource.errors.add(attr, errors)
       end
+      false
     end
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -24,8 +24,9 @@ Doorkeeper.configure do
   end
 
   resource_owner_from_credentials do
-    if params[:display_name] && u = User.find_for_database_authentication(display_name: params[:display_name])
-      valid_non_disabled_user = u.valid_password?(params[:password]) && !u.disabled?
+    if params[:display_name] && u = ZooniverseUser.authenticate(params[:display_name],
+                                                                params[:password]).try(:import)
+      valid_non_disabled_user = !u.disabled?
     else
       u = current_user
       valid_non_disabled_user = !u.blank? && !u.disabled?
@@ -36,7 +37,7 @@ Doorkeeper.configure do
   admin_authenticator do |routes|
     if u = current_user
       u.admin ? u :
-                (render file: "#{Rails.root}/public/403.html", status: 403, layout: false)
+        (render file: "#{Rails.root}/public/403.html", status: 403, layout: false)
     else
       redirect_to(new_user_session_path)
     end

--- a/lib/zoo_user_warden_strategy.rb
+++ b/lib/zoo_user_warden_strategy.rb
@@ -1,12 +1,22 @@
-Warden::Strategies.add(:zoo_user) do
-  def valid?
-   params['user'] && params['user']['display_name'] && params['user']['password']
-  end
+require 'devise/strategies/authenticatable'
 
+class ZooUserWardenStrategy < Devise::Strategies::Authenticatable
+  def valid?
+    params['user'] && params['user']['display_name'] && params['user']['password']
+  end
+  
   def authenticate!
     zoo_home_user = ZooniverseUser.authenticate(params['user']['display_name'],
                                                 params['user']['password'])
-    imported_user = zoo_home_user.import if zoo_home_user
-    imported_user ? success!(imported_user) : fail!(I18n.t("devise.failure.invalid"))
+    if zoo_home_user && imported_user = zoo_home_user.import 
+      remember_me(imported_user)
+      imported_user.after_database_authentication
+      success!(imported_user)
+    end
+    
+    fail!(I18n.t("devise.failure.invalid")) unless zoo_home_user
   end
 end
+
+
+Warden::Strategies.add(:zoo_user, ZooUserWardenStrategy)

--- a/lib/zooniverse_user.rb
+++ b/lib/zooniverse_user.rb
@@ -44,7 +44,7 @@ class ZooniverseUser < ActiveRecord::Base
   end
 
   def authenticate(plain_password)
-    crypted_password == Sha1Encryption.encrypt(plain_password, salt: password_salt) ? self : nil
+    (crypted_password == Sha1Encryption.encrypt(plain_password, salt: password_salt)) ? self : nil
   end
 
   def import

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -65,6 +65,11 @@ describe RegistrationsController, type: :controller do
             post :create, user: user_attributes
             expect(response).to have_http_status(:unprocessable_entity)
           end
+
+          it "should not sign the user in" do
+            expect(subject).to_not receive(:sign_in)
+            post :create, user: user_attributes
+          end
         end
       end
 

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -14,7 +14,7 @@ shared_context "a valid login" do
 end
 
 describe TokensController, type: :controller do
-  let(:owner) { create(:user)}
+  let(:owner) { create(:user, build_zoo_user: true)}
 
   describe "resource owner password credentials flow" do
     let(:params) { { "grant_type" => "password",


### PR DESCRIPTION
I think the issue with what was happening in the Front-End specs may have been related to failing to handle the rememberable token in the Warden strategy. I'm still figuring out how to test it but it may be worth hitting it with the front-end specs to see if anything happens. 