### PR TITLE
ensure zoo home auth strategy only runs when it should

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -95,5 +95,12 @@ module Api
         end
       end
     end
+
+    private
+
+    # Turn on paper trail for all API controllers
+    def paper_trail_enabled_for_controller
+      true
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include JSONApiRender
   include JSONApiResponses
-  
+
   protect_from_forgery with: :exception
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
@@ -23,5 +23,14 @@ class ApplicationController < ActionController::Base
       u.permit(:email, :password, :password_confirmation, :display_name,
                :credited_name, :global_email_communication, :project_email_communication)
     end
+  end
+
+  private
+
+  # Turn off paper trail globally and enable it specifically in the required controllers
+  # paper trail calls current_user in a before action which inteferes with
+  # custom devise authentication strategies
+  def paper_trail_enabled_for_controller
+    false
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -14,7 +14,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   def create_from_json
     build_resource(sign_up_params)
-    if created_in_zoo_home = create_zoo_user(resource)
+    if create_zoo_user(resource)
       resource_saved = resource.save
     end
     yield resource if block_given?

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -14,7 +14,9 @@ class RegistrationsController < Devise::RegistrationsController
 
   def create_from_json
     build_resource(sign_up_params)
-    resource_saved = create_zoo_user(resource) && resource.save
+    if created_in_zoo_home = create_zoo_user(resource)
+      resource_saved = resource.save
+    end
     yield resource if block_given?
     status, content = registrations_response(resource_saved)
     clean_up_passwords resource

--- a/lib/zoo_user_warden_strategy.rb
+++ b/lib/zoo_user_warden_strategy.rb
@@ -7,6 +7,6 @@ Warden::Strategies.add(:zoo_user) do
     zoo_home_user = ZooniverseUser.authenticate(params['user']['display_name'],
                                                 params['user']['password'])
     imported_user = zoo_home_user.import if zoo_home_user
-    imported_user ? success!(imported_user) : fail!("Could not log in")
+    imported_user ? success!(imported_user) : fail!(I18n.t("devise.failure.invalid"))
   end
 end

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -7,7 +7,7 @@ describe Api::ApiController, type: :controller do
   before(:each) do
     allow_any_instance_of(described_class).to receive(:resource_class).and_return(Collection)
   end
-  
+
   context "without doorkeeper" do
     controller do
 
@@ -24,6 +24,18 @@ describe Api::ApiController, type: :controller do
         expect(response.status).to eq(200)
       end
     end
+
+    describe "calling paper trail whodunnit before filter" do
+
+      it "should enable current user lookup" do
+        expect(subject.send(:paper_trail_enabled_for_controller)).to be_truthy
+      end
+
+      it "should call the current_user method" do
+        expect(subject).to receive(:user_for_paper_trail).once
+        get :index
+      end
+    end
   end
 
   context "with doorkeeper" do
@@ -34,7 +46,7 @@ describe Api::ApiController, type: :controller do
                                    { at: "least" },
                                    { thats: "what I pretend" } ] }
       end
-      
+
     end
 
     it "should return 401 without a logged in user" do
@@ -114,10 +126,10 @@ describe Api::ApiController, type: :controller do
       expect(json_response[-3..-1]).to include('zh', 'zh-tw', 'fr-fr')
     end
   end
-  
+
   describe "when a banned user attempts to take an action" do
     let(:user) { create(:user, banned: true) }
-    
+
     controller do
       def update
         render nothing: true
@@ -133,14 +145,14 @@ describe Api::ApiController, type: :controller do
     end
 
     let(:api_user) { ApiUser.new(user) }
-    
+
     before(:each) do
-      routes.draw do 
+      routes.draw do
         put "update" => "api/api#update"
         post "create" => "api/api#create"
         delete "destroy" => "api/api#destroy"
       end
-      
+
       allow(controller).to receive(:api_user).and_return(api_user)
       @request.env["CONTENT_TYPE"] = "application/json"
     end
@@ -151,14 +163,14 @@ describe Api::ApiController, type: :controller do
         expect(response.status).to eq(201)
       end
     end
-    
+
     context "update action" do
       it 'should return an empty okay response' do
         put :update
         expect(response.status).to eq(200)
       end
     end
-    
+
     context "destroy action" do
       it 'should return an empty no content response' do
         delete :destroy

--- a/spec/controllers/non_paper_trail_controller_spec.rb
+++ b/spec/controllers/non_paper_trail_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+class NonPaperTrailEnabled < ApplicationController; end
+
+RSpec.describe ApplicationController, type: :controller do
+  controller NonPaperTrailEnabled do
+    def paper_trail_test
+      render text: "testing paper trail before filters"
+    end
+  end
+
+  describe "calling paper trail whodunnit before filter" do
+    before(:each) do
+      routes.draw { get "paper_trail_test" => "non_paper_trail_enabled#paper_trail_test" }
+    end
+
+    it "should not enable current user lookup" do
+      expect(subject.send(:paper_trail_enabled_for_controller)).to be_falsey
+    end
+
+    it "should not call the current_user method" do
+      expect(subject).not_to receive(:user_for_paper_trail)
+      get :paper_trail_test
+    end
+  end
+end


### PR DESCRIPTION
This fixes the panoptes-front-end failing api tests.

Paper trail adds before filters to rails's application controller that will call current_user to determine the whodunnit field. Devise controllers implement this method and were triggering the zoo_home warden authentication strategy when they shouldn't have. I've disabled paper trails in the application_controller base class and enabled it for the api end points. I could be more specific here and just enable it for the end points that are using versioning but it might add some surprises when people add new models and expect versioning to work. 