### PR TITLE
Switch to mri ruby for the API nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zooniverse/ruby:jruby-1.7.18
+FROM zooniverse/ruby:2.2.1
 
 WORKDIR /rails_app
 


### PR DESCRIPTION
This will run the API nodes on MRI. based on benchmarking on my dev machine MRI is ~3 times faster, I'm not 100% sure why but my first guess would be the jruby gems.

Dont merge untill the ruby:2.2.1 docker image is built, https://registry.hub.docker.com/u/zooniverse/ruby/builds_history/67460/