### PR TITLE
ensure CORS requests cache for 5 minutes

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,7 +42,8 @@ Rails.application.configure do
       resource '*',
         headers: CorsConfig.request_headers,
         methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers
+        expose: CorsConfig.expose_headers,
+        max_age: CorsConfig.max_age
     end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,7 +94,8 @@ Rails.application.configure do
       resource '/api/*',
         headers: CorsConfig.request_headers,
         methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers
+        expose: CorsConfig.expose_headers,
+        max_age: CorsConfig.max_age
     end
   end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -91,7 +91,8 @@ Rails.application.configure do
       resource '*',
         headers: CorsConfig.request_headers,
         methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers
+        expose: CorsConfig.expose_headers,
+        max_age: CorsConfig.max_age
     end
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,7 +51,8 @@ Rails.application.configure do
       resource '/api/*',
         headers: CorsConfig.request_headers,
         methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers
+        expose: CorsConfig.expose_headers,
+        max_age: CorsConfig.max_age
     end
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -3,5 +3,6 @@ cors_config = ActiveSupport::HashWithIndifferentAccess.new.tap do |cors|
   cors[:request_headers] = :any
   cors[:request_methods] = %i(delete get post options put head)
   cors[:expose_headers] = %w(ETag)
+  cors[:max_age] = 300
 end
 CorsConfig = OpenStruct.new(cors_config)

--- a/spec/requests/v1/api_cors_headers_spec.rb
+++ b/spec/requests/v1/api_cors_headers_spec.rb
@@ -16,6 +16,10 @@ shared_examples 'cors headers' do
   it 'should have Access-Control-Allow-Methods header' do
     expect(response.headers).to include('Access-Control-Allow-Methods' => "DELETE, GET, POST, OPTIONS, PUT, HEAD")
   end
+
+  it 'should have the correct Access-Control-Max-Age header' do
+    expect(response.headers).to include('Access-Control-Max-Age' => "300")
+  end
 end
 
 RSpec.describe "api should return CORS headers on all requests", type: :request do


### PR DESCRIPTION
Close #648 

Access-Control-Max-Age is set by rack CORS via max_age. This header overrides normal Cache-Control settings.