### PR TITLE
ensure only production gems make it into the docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ bin/**
 #ignore the api commit file
 public/commit_id.txt
 vendor/cache/
+vendor/bundle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD ./Gemfile.lock /rails_app/
 ADD ./Jarfile /rails_app/
 ADD ./Jarfile.lock /rails_app/
 
-RUN bundle install
+RUN bundle install --without development test
 
 ADD ./ /rails_app
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'jbundler', platform: :jruby
 gem 'rails', '4.1.9'
 gem 'postgres_ext', '~> 2.4.0'
 gem 'active_record_union', github: "edpaget/active_record_union", branch: "union-all"
-gem 'sdoc', '~> 0.4.0',          group: :doc
+gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'doorkeeper', '~> 1.4.1'
 gem 'devise'
 gem 'versionist'
@@ -14,7 +14,7 @@ gem 'paper_trail'
 gem 'omniauth'
 gem 'omniauth-facebook'
 gem 'omniauth-gplus'
-gem 'cellect-client', '0.1.2.pre.jruby'
+gem 'cellect-client'
 gem 'puma'
 gem 'logstasher'
 gem 'honeybadger'
@@ -22,7 +22,7 @@ gem 'jquery-rails'
 gem 'uglifier'
 gem 'sidekiq'
 gem 'sinatra', '>= 1.3.0', :require => nil
-gem 'aws-sdk'
+gem 'aws-sdk-v1'
 gem 'json-schema'
 gem 'p3p'
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.6)
     arel (5.0.1.20140414130214)
-    aws-sdk (1.61.0)
-      aws-sdk-v1 (= 1.61.0)
     aws-sdk-v1 (1.61.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -381,8 +379,8 @@ DEPENDENCIES
   activerecord-jdbcmysql-adapter
   activerecord-jdbcpostgresql-adapter
   activerecord-jdbcsqlite3-adapter
-  aws-sdk
-  cellect-client (= 0.1.2.pre.jruby)
+  aws-sdk-v1
+  cellect-client
   database_cleaner (~> 1.2.0)
   devise
   doorkeeper (~> 1.4.1)

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,6 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'fig_rake/rake'
+require 'fig_rake/rake' if ENV['FIG_RAKE']
 
 Rails.application.load_tasks

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,4 +2,8 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-require "fig_rake/rails"
+begin
+  require "fig_rake/rails"
+rescue LoadError => e
+  p e if ENV['RAILS_ENV'] == 'development'
+end

--- a/lib/sha1_encryption.rb
+++ b/lib/sha1_encryption.rb
@@ -1,5 +1,5 @@
 module Sha1Encryption
-  def self.encrypt(plain_password, salt: salt)
+  def self.encrypt(plain_password, salt: password_salt)
     bytes = plain_password.each_char.inject(''){ |bytes, c| bytes + c + "\x00" }
     concat = Base64.decode64(salt).force_encoding('utf-8') + bytes
     sha1 = Digest::SHA1.digest concat


### PR DESCRIPTION
closes #651 - ensure gems like spring and fig_rake are no where near production / staging.

this may break some fig envs, just change the docker file to use bundle install and then it should work again. we need to migrate fig to docker-compose and use and alternate dockerfile for production deploys and dev work.