### PR TITLE
Specify bind address for puma

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:panoptes]
 user=root
-command=bundle exec rails s puma -p 80
+command=bundle exec rails s puma -p 80 -b 0.0.0.0
 directory=/rails_app
 autorestart=true
 


### PR DESCRIPTION
Looks like this now defaults to localhost as a result of updates in #739