### PR TITLE
fix subject queues

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -9,7 +9,8 @@ module Api
                                   'application/vnd.api+json']
     API_ALLOWED_METHOD_OVERRIDES = { 'PATCH' => 'application/patch+json' }
 
-    rescue_from ActiveRecord::RecordNotFound,            with: :not_found
+    rescue_from ActiveRecord::RecordNotFound,
+                SubjectSelector::MissingSubjectQueue,     with: :not_found
     rescue_from ActiveRecord::RecordInvalid,             with: :invalid_record
     rescue_from Api::NotLoggedIn,                        with: :not_authenticated
     rescue_from Api::UnauthorizedTokenError,             with: :not_authenticated

--- a/app/workers/subject_queue_worker.rb
+++ b/app/workers/subject_queue_worker.rb
@@ -3,8 +3,8 @@ class SubjectQueueWorker
 
   attr_reader :workflow, :user, :limit
 
-  def perform(workflow, user=nil, limit=SubjectQueue::DEFAULT_LENGTH)
-    @workflow = Workflow.find(workflow)
+  def perform(workflow_id, user=nil, limit=SubjectQueue::DEFAULT_LENGTH)
+    @workflow = Workflow.find(workflow_id)
     @user = User.find(user) if user
     @limit = limit
 

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -1,5 +1,6 @@
 class SubjectSelector
   class MissingParameter < StandardError; end
+  class MissingSubjectQueue < StandardError; end
 
   attr_reader :user, :params, :workflow
 
@@ -11,12 +12,11 @@ class SubjectSelector
     raise workflow_id_error unless workflow
     raise group_id_error if needs_set_id?
 
-    queue = SubjectQueue.scoped_to_set(params[:subject_set_id])
-            .find_by!(user: user.user, workflow: workflow)
-
-    SubjectQueueWorker.perform_async(workflow.id, user.id) if queue.below_minimum?
-
-    selected_subjects(queue.next_subjects(default_page_size))
+    if queue = retrieve_subject_queue
+      selected_subjects(queue.next_subjects(default_page_size))
+    else
+      raise MissingSubjectQueue.new("No queue defined for user. Building one now, please try again.")
+    end
   end
 
   def selected_subjects(sms_ids, selector_context={})
@@ -41,5 +41,14 @@ class SubjectSelector
 
   def default_page_size
     params[:page_size] ||= 10
+  end
+
+  def retrieve_subject_queue
+    queue = SubjectQueue.scoped_to_set(params[:subject_set_id])
+              .find_by(user: user.user, workflow: workflow)
+    if queue.nil? || queue.below_minimum?
+      SubjectQueueWorker.perform_async(workflow.id, user.id)
+    end
+    queue
   end
 end

--- a/spec/workers/subject_queue_worker_spec.rb
+++ b/spec/workers/subject_queue_worker_spec.rb
@@ -10,9 +10,15 @@ RSpec.describe SubjectQueueWorker do
   describe "#perform" do
     context "with no user or set" do
       it 'should create a subject queue with the default number of items' do
-        subject.perform(workflow)
+        subject.perform(workflow.id)
         queue = SubjectQueue.find_by(workflow: workflow)
         expect(queue.set_member_subject_ids.length).to eq(100)
+      end
+    end
+
+    context "when a workflow id string is passed in", :inline do
+      it "should not raise an error" do
+        expect{subject.perform(workflow.id.to_s)}.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
Build a subject queue when a user requests one and it doesn't exist. Also provide a better error message on a 404 when one doesn't exist.

Finally fix the workflow string ID in sidekiq param scoping, https://app.honeybadger.io/projects/40595/faults/12434093