### PR TITLE
add live mode field to project 

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1037,6 +1037,10 @@ It has the following attributes:
 
 + Parameters
   + id (required, integer) ... integer id of the resource to retrieve
+  + display_name (string) ... project name filter
+  + approved (boolean) ... approved state filter
+  + beta (boolean) ... beta state filter
+  + live (boolean) ... live state filter
 
 + Model
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -26,7 +26,7 @@ All requests should set `Accept: application/vnd.api+json; version=1`. You will 
 
 All PUT and POST requests should set `Content-Type: application/vnd.api+json; version=1` or `Content-Type: application/json`. You will receive a `415 Unsupported Media Type` without one of those two headers.
 
-All PUT and DELETE requests should set the `If-Match` header to the value of the `ETag` header of the request where the resource was originally retrieved. You will receive a `428 Precondition Required` without the header and a `412 Precondition Failed` if the etags do not match. 
+All PUT and DELETE requests should set the `If-Match` header to the value of the `ETag` header of the request where the resource was originally retrieved. You will receive a `428 Precondition Required` without the header and a `412 Precondition Failed` if the etags do not match.
 
 # Group Panoptes API Root [/]
 Panoptes API entry point.
@@ -541,7 +541,7 @@ and *user_group_id* parameters.
     + project_id (optional, integer) ... only retrieve classifications for a specific project
     + user_group_id (optional, integer) ... only retrieve classifications for a specific user group
     + include (optional, string) ... comma separated list of linked resources to return with the collection
-    + for (optional, string) ... one of 'projects', 'user', 'user_groups', 'user' by default (see explanation above).
+    + for (optional, string) ... one of 'projects', 'user', 'user_groups', 'user' by default (see explanation above)
 
 + Request
 
@@ -1008,20 +1008,29 @@ text describing the tasks volunteers perform.
 It has the following attributes:
 
 - id
+- display_name
+- classification_count
+- subject_counts
 - created_at
 - updated_at
-- name
-- display_name
-- user_count
-- classification_count
-- activated_state
-- primary_language
+- available_languages
 - title
 - description
-- introduction
-- science_case
-- team_members
 - guide
+- team_members
+- science_case
+- introduction
+- avatar
+- background_image
+- private
+- faq
+- result
+- education_content
+- retired_subjects_count
+- configuration
+- beta
+- approved
+- live
 
 *id*, *created_at*, *updated_at*, *user_count*, and
 *classification_count* are set by the API.
@@ -1058,28 +1067,37 @@ It has the following attributes:
                 },
                 "projects": [{
                     "id": "1",
+                    "display_name": "Galaxy Zoo",
+                    "classification_count": "1000000",
+                    "subjects_count": "10000",
                     "created_at": "2014-03-24T10:42:21Z",
                     "updated_at": "2014-03-24T10:42:21Z",
-                    "name": "galaxy_zoo",
-                    "display_name": "Galaxy Zoo",
-                    "primary_language": "en",
-                    "user_count": "10000",
-                    "classification_count": "1000000",
-                    "activated_state": 0,
+                    "available_languages": ["en"],
                     "title": "Galaxy Zoo",
                     "description": "A Project ...",
-                    "introduction": "asdfasdf",
-                    "science_case": "88mph + 1.21 GW = 1955",
+                    "guide": [{
+                        "image": "http://something.example.com/delorean.jpg",
+                        "explanation": "our ride"
+                    }],
                     "team_members": [{
                         "name": "Doc Brown",
                         "bio": "",
                         "twitter": "thatsmydelorean",
                         "insitution": nil
                     }],
-                    "guide": [{
-                        "image": "http://something.example.com/delorean.jpg",
-                        "explanation": "our ride"
-                    }],
+                    "science_case": "88mph + 1.21 GW = 1955",
+                    "introduction": "asdfasdf",
+                    "avatar": "http://test.host/x02234.png",
+                    "background_image": "http://test.host/12312asd.jp2",
+                    "private": false,
+                    "faq": "This project uses..",
+                    "result": "We found amazing things",
+                    "education_content": "Educator content goes here",
+                    "retired_subjects_count": "5000",
+                    "configuration": { "option_1": "value" },
+                    "beta": "false",
+                    "approved": "true",
+                    "live": "true",
                     "links": {
                         "owner": {
                             "id": "2",

--- a/apiary.apib
+++ b/apiary.apib
@@ -1000,7 +1000,7 @@ The *metadata* attribute is optional.
 # Group Projects
 Resources related to _Panoptes Projects_.
 
-## Project [/projects/{id}{?include}]
+## Project [/projects/{id}{?include,display_name,approved,beta,live}]
 A Project is a collection of subjects and task workflows that a
 volunteer performs on subjects. The project also holds supplementary
 text describing the tasks volunteers perform.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,7 +17,7 @@ class Project < ActiveRecord::Base
 
   accepts_nested_attributes_for :project_contents
 
-  validates_inclusion_of :private, :live, in: [true, false]
+  validates_inclusion_of :private, :live, in: [true, false], message: "must be true or false"
 
   ## TODO: This potential has locking issues
   validates_with UniqueForOwnerValidator

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,7 +17,7 @@ class Project < ActiveRecord::Base
 
   accepts_nested_attributes_for :project_contents
 
-  validates_inclusion_of :private, in: [true, false]
+  validates_inclusion_of :private, :live, in: [true, false]
 
   ## TODO: This potential has locking issues
   validates_with UniqueForOwnerValidator

--- a/app/schemas/project_update_schema.rb
+++ b/app/schemas/project_update_schema.rb
@@ -23,6 +23,10 @@ class ProjectUpdateSchema < JsonSchema
       type "boolean"
     end
 
+    property "live" do
+      type "boolean"
+    end
+
     property "approved" do
       type "boolean"
     end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -7,11 +7,11 @@ class ProjectSerializer
              :title, :description, :guide, :team_members, :science_case,
              :introduction, :avatar, :background_image, :private, :faq, :result,
              :education_content, :retired_subjects_count, :avatar, :background_image,
-             :configuration, :beta, :approved
+             :configuration, :beta, :approved, :live
 
   can_include :workflows, :subject_sets, :owners, :project_contents,
               :project_roles
-  can_filter_by :display_name, :beta, :approved
+  can_filter_by :display_name, :beta, :approved, :live
 
   def title
     content[:title]

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -11,7 +11,7 @@ class ProjectSerializer
 
   can_include :workflows, :subject_sets, :owners, :project_contents,
               :project_roles
-  can_filter_by :display_name, :beta, :approved, :live
+  can_filter_by :display_name, :beta, :approved
 
   def title
     content[:title]

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -6,8 +6,8 @@ class ProjectSerializer
              :subjects_count, :created_at, :updated_at, :available_languages,
              :title, :description, :guide, :team_members, :science_case,
              :introduction, :avatar, :background_image, :private, :faq, :result,
-             :education_content, :retired_subjects_count, :avatar, :background_image,
-             :configuration, :beta, :approved, :live
+             :education_content, :retired_subjects_count, :configuration,
+             :beta, :approved, :live
 
   can_include :workflows, :subject_sets, :owners, :project_contents,
               :project_roles

--- a/db/migrate/20150430084746_add_live_field_to_projects.rb
+++ b/db/migrate/20150430084746_add_live_field_to_projects.rb
@@ -1,5 +1,15 @@
 class AddLiveFieldToProjects < ActiveRecord::Migration
-  def change
-    add_column :projects, :live, :boolean, index: true, default: false
+
+  #ensure the project AR model always exits outside the /model definition
+  class Project < ActiveRecord::Base
+  end
+
+  def up
+    add_column :projects, :live, :boolean, index: true, default: false, null: false
+    Project.update_all(live: false)
+  end
+
+  def down
+    remove_column :projects, :live
   end
 end

--- a/db/migrate/20150430084746_add_live_field_to_projects.rb
+++ b/db/migrate/20150430084746_add_live_field_to_projects.rb
@@ -1,0 +1,5 @@
+class AddLiveFieldToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :live, :boolean, index: true, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 20150430132128) do
     t.jsonb    "configuration"
     t.boolean  "approved",              default: false
     t.boolean  "beta",                  default: false
-    t.boolean  "live",                  default: false
+    t.boolean  "live",                  default: false, null: false
   end
 
   add_index "projects", ["approved"], name: "index_projects_on_approved", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,8 +174,8 @@ ActiveRecord::Schema.define(version: 20150430132128) do
     t.integer  "user_count"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "classifications_count", default: 0,     null: false
-    t.integer  "activated_state",       default: 0,     null: false
+    t.integer  "classifications_count", default: 0, null: false
+    t.integer  "activated_state",       default: 0, null: false
     t.string   "primary_language"
     t.text     "avatar"
     t.text     "background_image"

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::V1::ProjectsController, type: :controller do
      "updated_at", "created_at", "available_languages", "title", "avatar",
      "description", "team_members", "guide", "science_case", "introduction",
      "faq", "result", "education_content", "background_image", "private",
-     "retired_subjects_count", "avatar", "background_image"]
+     "live", "retired_subjects_count", "avatar", "background_image"]
   end
   let(:api_resource_links) do
     [ "projects.workflows",
@@ -54,6 +54,18 @@ describe Api::V1::ProjectsController, type: :controller do
       describe "with no filtering" do
         let(:n_visible) { 4 }
         it_behaves_like "is indexable"
+
+        it "should not have beta projects" do
+          get :index
+          ids = json_response["projects"].map{ |p| p["id"] }
+          expect(Project.find(ids)).to_not include(beta_resource)
+        end
+
+        it "should not have unapproved projects" do
+          get :index
+          ids = json_response["projects"].map{ |p| p["id"] }
+          expect(Project.find(ids)).to_not include(unapproved_resource)
+        end
       end
 
       describe "filter params" do
@@ -217,18 +229,18 @@ describe Api::V1::ProjectsController, type: :controller do
 
       let(:default_create_params) do
         { projects: { display_name: display_name,
-                     description: "A new Zoo for you!",
-                     primary_language: 'en',
-                     education_content: "asdfasdf",
-                     faq: "some other stuff",
-                     result: "another string",
-                     avatar: "an avatar",
-                     background_image: "and image",
-                     configuration: {
-                                     an_option: "a setting"
-                                    },
-                     beta: true,
-                     private: true } }
+                      description: "A new Zoo for you!",
+                      primary_language: 'en',
+                      education_content: "asdfasdf",
+                      faq: "some other stuff",
+                      result: "another string",
+                      avatar: "an avatar",
+                      background_image: "and image",
+                      configuration: {
+                                      an_option: "a setting"
+                                     },
+                      beta: true,
+                      private: true } }
       end
 
       let (:create_params) do
@@ -295,22 +307,22 @@ describe Api::V1::ProjectsController, type: :controller do
 
           it "should create an associated project_content model" do
             expect(Project.find(created_project_id)
-                   .project_contents.first).to_not be_nil
+                    .project_contents.first).to_not be_nil
           end
 
           it 'should set the contents title do' do
             expect(Project.find(created_project_id)
-                   .project_contents.first.title).to eq('New Zoo')
+                    .project_contents.first.title).to eq('New Zoo')
           end
 
           it 'should set the description' do
             expect(Project.find(created_project_id)
-                   .project_contents.first.description).to eq('A new Zoo for you!')
+                    .project_contents.first.description).to eq('A new Zoo for you!')
           end
 
           it 'should set the language' do
             expect(Project.find(created_project_id)
-                   .project_contents.first.language).to eq('en')
+                    .project_contents.first.language).to eq('en')
           end
         end
       end
@@ -332,8 +344,8 @@ describe Api::V1::ProjectsController, type: :controller do
         context "user is the current user" do
           let(:owner_params) do
             {
-             id: authorized_user.id.to_s,
-             type: "users"
+              id: authorized_user.id.to_s,
+              type: "users"
             }
           end
 
@@ -351,7 +363,7 @@ describe Api::V1::ProjectsController, type: :controller do
             user = create(:user)
             {
               id: user.id.to_s,
-                type: "users"
+              type: "users"
             }
           end
 
@@ -376,8 +388,8 @@ describe Api::V1::ProjectsController, type: :controller do
 
         let(:owner_params) do
           {
-           id: owner.id.to_s,
-           type: "user_groups"
+            id: owner.id.to_s,
+            type: "user_groups"
           }
         end
 
@@ -401,24 +413,24 @@ describe Api::V1::ProjectsController, type: :controller do
     let(:test_attr_value) { "A Better Name" }
     let(:update_params) do
       {
-       projects: {
-                  display_name: "A Better Name",
-                  beta: true,
-                  name: "something_new",
-                  education_content: "asdfasdf",
-                  faq: "some other stuff",
-                  result: "another string",
-                  avatar: "an avatar",
-                  background_image: "and image",
-                  configuration: {
-                                  an_option: "a setting"
-                                 },
-                  links: {
-                          workflows: [workflow.id.to_s],
-                          subject_sets: [subject_set.id.to_s]
-                         }
+        projects: {
+          display_name: "A Better Name",
+          beta: true,
+          name: "something_new",
+          education_content: "asdfasdf",
+          faq: "some other stuff",
+          result: "another string",
+          avatar: "an avatar",
+          background_image: "and image",
+          configuration: {
+                          an_option: "a setting"
+                         },
+          links: {
+            workflows: [workflow.id.to_s],
+            subject_sets: [subject_set.id.to_s]
+          }
 
-                 }
+        }
       }
     end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -415,7 +415,6 @@ describe Api::V1::ProjectsController, type: :controller do
       {
         projects: {
           display_name: "A Better Name",
-          beta: true,
           name: "something_new",
           education_content: "asdfasdf",
           faq: "some other stuff",
@@ -425,6 +424,8 @@ describe Api::V1::ProjectsController, type: :controller do
           configuration: {
                           an_option: "a setting"
                          },
+          beta: true,
+          live: true,
           links: {
             workflows: [workflow.id.to_s],
             subject_sets: [subject_set.id.to_s]

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -15,9 +15,9 @@ describe Api::V1::ProjectsController, type: :controller do
   end
   let(:api_resource_links) do
     [ "projects.workflows",
-     "projects.subject_sets",
-     "projects.project_contents",
-     "projects.project_roles" ]
+      "projects.subject_sets",
+      "projects.project_contents",
+      "projects.project_roles" ]
   end
 
   let(:scopes) { %w(public project) }

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -51,23 +51,6 @@ describe Api::V1::ProjectsController, type: :controller do
         it_behaves_like "it has custom owner links"
       end
 
-      describe "with no filtering" do
-        let(:n_visible) { 4 }
-        it_behaves_like "is indexable"
-
-        it "should not have beta projects" do
-          get :index
-          ids = json_response["projects"].map{ |p| p["id"] }
-          expect(Project.find(ids)).to_not include(beta_resource)
-        end
-
-        it "should not have unapproved projects" do
-          get :index
-          ids = json_response["projects"].map{ |p| p["id"] }
-          expect(Project.find(ids)).to_not include(unapproved_resource)
-        end
-      end
-
       describe "filter params" do
         let!(:project_owner) { create(:user) }
         let!(:new_project) do

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -9,13 +9,14 @@ FactoryGirl.define do
     sequence(:display_name) { |n| "Test Project #{ n }" }
     user_count { 10 + rand(1000) }
     activated_state Project.activated_states[:active]
+    configuration { { x: "y", z: "q" } }
     primary_language "en"
     avatar "http://test.host/x02234.jpg.gif.png.webp"
     background_image "http://test.host/12312asd.jp2"
     private false
     approved true
     beta false
-    live false
+    live true
 
     association :owner, factory: :user
 
@@ -31,6 +32,10 @@ FactoryGirl.define do
 
     factory :private_project do
       private(true)
+    end
+
+    factory :approved_project do
+      approved(true)
     end
 
     factory :live_project do

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     private false
     approved true
     beta false
+    live false
 
     association :owner, factory: :user
 
@@ -30,6 +31,10 @@ FactoryGirl.define do
 
     factory :private_project do
       private(true)
+    end
+
+    factory :live_project do
+      live(true)
     end
 
     factory :full_project do

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -34,14 +34,6 @@ FactoryGirl.define do
       private(true)
     end
 
-    factory :approved_project do
-      approved(true)
-    end
-
-    factory :live_project do
-      live(true)
-    end
-
     factory :full_project do
       after(:create) do |p|
         workflow = create(:workflow, project: p)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -21,7 +21,7 @@ describe Project, :type => :model do
   it "should have a valid factory" do
     expect(project).to be_valid
   end
-  
+
   it 'should require unique displays name for an owner' do
     owner = create(:user)
     expect(create(:project, display_name: "hi fives", owner: owner)).to be_valid
@@ -62,6 +62,21 @@ describe Project, :type => :model do
     it "should allow collections to link user has show permissions" do
       expect(Project).to link_to(Collection).given_args(user)
                           .with_scope(:scope_for, :show, user)
+    end
+  end
+
+  describe "#live" do
+    before(:each) do
+      project.update_attributes(live: nil)
+    end
+
+    it "should not accept nil values" do
+      expect(project.valid?).to eq(false)
+    end
+
+    it "should have a useful error message" do
+      project.valid?
+      expect(project.errors[:live]).to include("must be true or false")
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -37,6 +37,10 @@ describe Project, :type => :model do
     expect(build(:project, private: nil)).to_not be_valid
   end
 
+  it 'should require a live field to be set' do
+    expect(build(:project, live: nil)).to_not be_valid
+  end
+
   describe "links" do
     let(:user) { ApiUser.new(create(:user)) }
 


### PR DESCRIPTION
addresses @aliburchard comments about live project https://github.com/zooniverse/Panoptes-Front-End/issues/240. Added a field to determine the status science mode status of a project that can be used to drive the UI and provide warnings to users about changing workflow configs, etc.