### PR TITLE
Add dependent relationships to models

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,9 +10,10 @@ class Project < ActiveRecord::Base
   EXPERT_ROLES = [:expert, :owner]
 
   has_many :workflows
-  has_many :subject_sets
+  has_many :subject_sets, dependent: :destroy
   has_many :classifications
   has_many :subjects
+  has_many :acls, class_name: "AccessControlList", as: :resource, dependent: :destroy
   has_many :project_roles, -> { where.not(roles: []) }, class_name: "AccessControlList", as: :resource
 
   accepts_nested_attributes_for :project_contents

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -6,7 +6,7 @@ class SubjectSet < ActiveRecord::Base
   has_many :subject_sets_workflows, dependent: :destroy
   has_many :workflows, through: :subject_sets_workflows
 
-  has_many :set_member_subjects
+  has_many :set_member_subjects, dependent: :destroy
   has_many :subjects, through: :set_member_subjects
 
   validates_presence_of :project

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
   has_many :collection_roles, through: :identity_group
   has_many :user_seen_subjects
 
-  has_many :subject_queues, dependent: :destroy
+  has_many :subject_queues
 
   validates :display_name, presence: true, uniqueness: { case_sensitive: false },
             format: { without: /\$|@|\s+/ }, unless: :migrated

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,25 +7,26 @@ class User < ActiveRecord::Base
          :omniauthable, omniauth_providers: [:facebook, :gplus]
 
   has_many :classifications
-  has_many :authorizations
-  has_many :collection_preferences, class_name: "UserCollectionPreference"
-  has_many :project_preferences, class_name: "UserProjectPreference"
-  has_many :oauth_applications, class_name: "Doorkeeper::Application", as: :owner
+  has_many :authorizations, dependent: :destroy
+  has_many :collection_preferences, class_name: "UserCollectionPreference", dependent: :destroy
+  has_many :project_preferences, class_name: "UserProjectPreference", dependent: :destroy
+  has_many :oauth_applications, class_name: "Doorkeeper::Application", as: :owner, dependent: :destroy
 
-  has_many :memberships
+  has_many :memberships, dependent: :destroy
   has_many :active_memberships, -> { active }, class_name: 'Membership'
   has_one :identity_membership, -> { identity }, class_name: 'Membership'
 
   has_many :user_groups, through: :active_memberships
   has_one :identity_group, through: :identity_membership,
                           source: :user_group,
-                          class_name: "UserGroup"
+                          class_name: "UserGroup",
+                          dependent: :destroy
 
   has_many :project_roles, through: :identity_group
   has_many :collection_roles, through: :identity_group
-  has_many :user_seen_subjects
+  has_many :user_seen_subjects, dependent: :destroy
 
-  has_many :subject_queues
+  has_many :subject_queues, dependent: :destroy
 
   validates :display_name, presence: true, uniqueness: { case_sensitive: false },
             format: { without: /\$|@|\s+/ }, unless: :migrated


### PR DESCRIPTION
When a project is destroyed its subject sets and associated models
should also be destroyed, but we should keep subjects around in case
they are being used by other projects. Classifications and workflows
should also remain so we can still redo the since if necessary.

Subjects and Workflows can still be explicitly destroyed on their own.

Closes #652