### PR TITLE
classification csv export to s3 for a project

### DIFF
--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -1,0 +1,51 @@
+require 'csv'
+require 'formatter_csv_classification'
+
+class ClassificationsDumpWorker
+  include Sidekiq::Worker
+  include Formatter::CSV
+
+  attr_reader :project
+
+  def perform(project_id)
+    if @project = Project.find(project_id)
+      begin
+        CSV.open(temp_file_path, 'wb') do |csv|
+          csv << Formatter::CSV::Classification.project_headers
+          completed_project_classifications.find_each do |classification|
+            csv << Formatter::CSV::Classification.new(classification, project).to_array
+          end
+        end
+        write_to_s3
+      ensure
+        FileUtils.rm(temp_file_path)
+      end
+    end
+  end
+
+  private
+
+  def temp_file_path
+    "#{Rails.root}/tmp/#{project_file_path}"
+  end
+
+  def completed_project_classifications
+    project.classifications.where(completed:true)
+  end
+
+  def project_file_path
+    "#{project.name.downcase.gsub(/\s/, "_")}.csv"
+  end
+
+  def upload_file_path
+    "#{::Panoptes.export_bucket_path}/#{project.id}/#{project_file_path}"
+  end
+
+  def s3_object
+    ::Panoptes.subjects_bucket.objects[upload_file_path]
+  end
+
+  def write_to_s3
+    s3_object.write(file: temp_file_path, content_type: "text/csv")
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 
 module Panoptes
   class Application < Rails::Application
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += Dir[Rails.root.join('lib', '**/')]
     config.autoload_paths += Dir[Rails.root.join('app', 'models', '**/')]
     config.autoload_paths += Dir[Rails.root.join('app', 'serializers', '**/')]
 

--- a/config/aws.yml.hudson
+++ b/config/aws.yml.hudson
@@ -3,9 +3,11 @@ development:
   secret_access_key:
   subjects_bucket:
   bucket_path:
+  export_bucket_path:
 
 test:
   access_key_id: 'test_key_id'
   secret_access_key: 'secret_access_key'
   subjects_bucket: 's3_subject_bucket'
   bucket_path: 'test_bucket_path'
+  export_bucket_path: 'test_export_path'

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -17,6 +17,10 @@ module Panoptes
   def self.bucket_path
     @bucket_path ||= aws_config[:bucket_path]
   end
+
+  def self.export_bucket_path
+    @bucket_path ||= aws_config[:export_bucket_path]
+  end
 end
 
 keys = Panoptes.aws_config.slice(:access_key_id, :secret_access_key)

--- a/lib/presenter/formatter_csv_classification.rb
+++ b/lib/presenter/formatter_csv_classification.rb
@@ -1,0 +1,58 @@
+module Formatter
+  module CSV
+    class Classification
+      attr_reader :classification, :project
+
+      delegate :workflow_id, :created_at, :gold_standard, to: :classification
+
+      def self.project_headers
+        %w( project_name user_id user_ip workflow_id created_at
+            gold_standard expert subject_ids metadata
+            annotations )
+      end
+
+      def initialize(classification, project)
+        @classification = classification
+        @project = project
+      end
+
+      def to_array
+        self.class.project_headers.map do |attribute|
+          send(attribute)
+        end
+      end
+
+      private
+
+      def project_name
+        project.name
+      end
+
+      def user_id
+        if user_id = classification.user_id
+          "#{user_id}".hash
+        end
+      end
+
+      def user_ip
+        classification.user_ip.to_s
+      end
+
+      def subject_ids
+        classification.subject_ids.join(", ")
+      end
+
+      def metadata
+        classification.metadata.to_s
+      end
+
+      def annotations
+        classification.annotations.to_s
+      end
+
+      def expert
+        classification.expert_classifier
+      end
+    end
+  end
+end

--- a/lib/presenter/formatter_csv_classification.rb
+++ b/lib/presenter/formatter_csv_classification.rb
@@ -43,11 +43,11 @@ module Formatter
       end
 
       def metadata
-        classification.metadata.to_s
+        classification.metadata.to_json
       end
 
       def annotations
-        classification.annotations.to_s
+        classification.annotations.to_json
       end
 
       def expert

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe ClassificationsDumpWorker do
+  let(:worker) { described_class.new }
+  let(:project) { create(:project) }
+  let!(:classifications) { create_list(:classification, 5, project: project) }
+  let(:another_project) { create(:project) }
+  let!(:other_project_classifications) { create(:classification, project: another_project) }
+
+  describe "#perform" do
+
+    before(:each) do
+      AWS.stub!
+    end
+
+    context "when the project id doesn't correspond to a project" do
+
+      it "should not do anything" do
+        allow(Project).to receive(:find).and_return(nil)
+        expect(Tempfile).to_not receive(:open)
+        worker.perform(another_project.id)
+      end
+    end
+
+    context "when the project exists" do
+
+      let(:project_file_name) { "#{project.name.downcase.gsub(/\s/, "_")}.csv" }
+      let(:temp_file_path) { "#{Rails.root}/tmp/#{project_file_name}" }
+
+      it "should create a csv file with the correct number of entries" do
+        expect_any_instance_of(CSV).to receive(:<<).exactly(6).times
+        worker.perform(project.id)
+      end
+
+      it "push the file to s3" do
+        expect(worker).to receive(:write_to_s3).once
+        worker.perform(project.id)
+      end
+
+      it "should clean up the file after sending to s3" do
+        expect(FileUtils).to receive(:rm).with(temp_file_path)
+        worker.perform(project.id)
+      end
+    end
+  end
+end

--- a/spec/workers/subject_queue_worker_spec.rb
+++ b/spec/workers/subject_queue_worker_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SubjectQueueWorker do
       end
     end
 
-    context "when a workflow id string is passed in", :inline do
+    context "when a workflow id string is passed in" do
       it "should not raise an error" do
         expect{subject.perform(workflow.id.to_s)}.to_not raise_error
       end


### PR DESCRIPTION
This should upload a csv dump of a project's completed classifications. I had to battle the specs for too long on this one. 

**Requires** the addtion of `export_bucket_path` to the aws.yml files