### PR TITLE
Use array_includes so order doesn't matter

### DIFF
--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -152,7 +152,7 @@ describe ClassificationLifecycle do
         end.map(&:id)
         expect(SubjectQueue).to receive(:dequeue)
           .with(classification.workflow,
-                sms_ids,
+                array_including(sms_ids),
                 user: classification.user)
       end
     end


### PR DESCRIPTION
This should fix the failing spec.