### PR TITLE
Disable Deep Munging in Rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module Panoptes
     config.autoload_paths += Dir[Rails.root.join('app', 'models', '**/')]
     config.autoload_paths += Dir[Rails.root.join('app', 'serializers', '**/')]
 
+    config.action_dispatch.perform_deep_munge = false
     config.middleware.insert_before ActionDispatch::ParamsParser, "RejectPatchRequests"
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.middleware.insert_before ActionDispatch::ParamsParser, "CatchApiJsonParseErrors"

--- a/spec/requests/v1/api_empty_array_spec.rb
+++ b/spec/requests/v1/api_empty_array_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe 'when an empty array is in a param', type: :request do
+  include APIRequestHelpers
+
+  let(:user) { create(:user) }
+  let(:project) { create(:project, owner: user) }
+  let!(:workflow) { create(:workflow, project: project) }
+  let(:access_token) { create(:access_token, resource_owner_id: user.id, scopes: "public project") }
+  let(:url) { "/api/workflows/#{workflow.id}" }
+  let!(:etag) do
+    get url, nil,
+      { "HTTP_ACCEPT" => "application/vnd.api+json; version=1",
+       "HTTP_AUTHORIZATION" => "Bearer #{access_token.token}" }
+    response.headers['ETag']
+  end
+
+  context "for workflows" do
+    context "when a task has no answers" do
+      it 'should return an empty array' do
+        ups = {workflows: {
+                           tasks: {
+                                   interest: {
+                                              type: 'single',
+                                              question: "?PORQUE?",
+                                              answers: []
+                                             }
+                                  }
+                          }
+              }
+        put url, ups.to_json,
+          "HTTP_ACCEPT" => "application/vnd.api+json; version=1",
+          "CONTENT_TYPE" => "application/json",
+          "HTTP_AUTHORIZATION" => "Bearer #{access_token.token}",
+          "If-Match" => etag
+        expect(json_response["workflows"][0]["tasks"]["interest"]["answers"]).to eq([])
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Closes #743

Because most users of Rails are apparently unable or unwilling to check
params before passing arguments to AR#find, Rails converts empty arrays
in params to nil. This makes 0 sense to me, but whatever, it's easy to
turn off.