### PR TITLE
don't attempt to update empty queues

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -49,7 +49,7 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def self.enqueue_for_all(workflow, sms_ids)
-    return if sms_id.blank?
+    return if sms_ids.blank?
     sms_ids = Array.wrap(sms_ids)
     enqueue_update(where(workflow: workflow), sms_ids)
   end

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -37,6 +37,7 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def self.enqueue(workflow, sms_ids, user: nil, set: nil)
+    return if sms_ids.blank?
     ues = scoped_to_set(set).find_or_create_by!(user: user, workflow: workflow)
     enqueue_update(where(id: ues.id), sms_ids)
   end
@@ -68,7 +69,8 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def self.dequeue_update(query, sms_ids)
-    query.update_all(["set_member_subject_ids = ARRAY(SELECT unnest(set_member_subject_ids) except SELECT unnest(array[?]))", sms_ids])
+    dequeue_sql = "set_member_subject_ids = ARRAY(SELECT unnest(set_member_subject_ids) except SELECT unnest(array[?]))"
+    query.update_all([dequeue_sql, sms_ids])
   end
 
   def self.enqueue_update(query, sms_ids)

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -43,18 +43,19 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def self.dequeue(workflow, sms_ids, user: nil, set: nil)
-    return if sms_ids.nil?
+    return if sms_ids.blank?
     ues = scoped_to_set(set).where(user: user, workflow: workflow)
     dequeue_update(ues, sms_ids)
   end
 
   def self.enqueue_for_all(workflow, sms_ids)
+    return if sms_id.blank?
     sms_ids = Array.wrap(sms_ids)
     enqueue_update(where(workflow: workflow), sms_ids)
   end
 
   def self.dequeue_for_all(workflow, sms_id)
-    return if sms_id.nil?
+    return if sms_id.blank?
     dequeue_update(where(workflow: workflow), sms_id)
   end
 

--- a/app/workers/subject_queue_worker.rb
+++ b/app/workers/subject_queue_worker.rb
@@ -17,10 +17,13 @@ class SubjectQueueWorker
     end
   end
 
+  private
+
   def load_subjects(set=nil)
     subject_ids = PostgresqlSelection.new(workflow, user)
       .select(limit: limit, subject_set_id: set)
-
-    SubjectQueue.enqueue(workflow, subject_ids, user: user, set: set)
+    unless subject_ids.empty?
+      SubjectQueue.enqueue(workflow, subject_ids, user: user, set: set)
+    end
   end
 end

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe SubjectQueue, :type => :model do
           expect(queue.set_member_subject_ids).to include(subject.id)
         end
 
-        context "passing an empty set of sms_ids", :focus do
+        context "passing an empty set of sms_ids" do
 
           it 'should not raise an error' do
             expect {
@@ -224,6 +224,29 @@ RSpec.describe SubjectQueue, :type => :model do
                              [subjects.first.id],
                              user: user)
         expect(ues.reload.set_member_subject_ids).to_not include(subjects.first.id)
+      end
+
+      context "passing an empty set of sms_ids" do
+
+        it 'should not raise an error' do
+          expect {
+            SubjectQueue.dequeue(workflow, [], user: user)
+          }.to_not raise_error
+        end
+
+        it 'not attempt find the queue' do
+          expect(SubjectQueue).to_not receive(:where)
+          SubjectQueue.dequeue(workflow, [], user: user)
+        end
+
+        it 'should not call #dequeue_update' do
+          expect_any_instance_of(SubjectQueue).to_not receive(:dequeue_update)
+          SubjectQueue.dequeue(workflow, [], user: user)
+        end
+
+        it 'should return nil' do
+          expect(SubjectQueue.dequeue(workflow, [], user: user)).to be_nil
+        end
       end
     end
   end

--- a/spec/workers/subject_queue_worker_spec.rb
+++ b/spec/workers/subject_queue_worker_spec.rb
@@ -3,11 +3,14 @@ require "spec_helper"
 RSpec.describe SubjectQueueWorker do
   subject { described_class.new }
   let(:workflow) { create(:workflow_with_subject_set) }
-  let!(:subjects) do
-    create_list(:set_member_subject, 100, subject_set: workflow.subject_sets.first)
-  end
 
   describe "#perform" do
+
+    before(:each) do
+      available_smss = (1..100).to_a
+      allow_any_instance_of(PostgresqlSelection).to receive(:select).and_return(available_smss)
+    end
+
     context "with no user or set" do
       it 'should create a subject queue with the default number of items' do
         subject.perform(workflow.id)

--- a/spec/workers/subject_queue_worker_spec.rb
+++ b/spec/workers/subject_queue_worker_spec.rb
@@ -21,5 +21,26 @@ RSpec.describe SubjectQueueWorker do
         expect{subject.perform(workflow.id.to_s)}.to_not raise_error
       end
     end
+
+    describe "#load_subjects" do
+
+      context "when there are selected subjects to queue" do
+
+        it 'should attempt to queue an empty set' do
+          allow_any_instance_of(PostgresqlSelection).to receive(:select).and_return([1])
+          expect(SubjectQueue).to receive(:enqueue)
+          subject.perform(workflow.id)
+        end
+      end
+
+      context "when there are no selected subjects to queue" do
+
+        it 'should not attempt to queue an empty set' do
+          allow_any_instance_of(PostgresqlSelection).to receive(:select).and_return([])
+          expect(SubjectQueue).to_not receive(:enqueue)
+          subject.perform(workflow.id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #804 - Avoid calling en/de_queue methods with an empty args.