### PR TITLE
use the serialized response object to generate the etags

### DIFF
--- a/lib/json_api_controller.rb
+++ b/lib/json_api_controller.rb
@@ -1,6 +1,6 @@
 module JsonApiController
   extend ActiveSupport::Concern
-  
+
   class BadLinkParams < StandardError; end
   class PreconditionNotPresent < StandardError; end
   class PreconditionFailed < StandardError; end
@@ -74,10 +74,8 @@ module JsonApiController
 
   private
 
-  def gen_etag(query)
-    etag = combine_etags(etag: query)
-    key = ActiveSupport::Cache.expand_cache_key(etag)
-    %("#{Digest::MD5.hexdigest(key)}")
+  def gen_etag(response_obj)
+    %(#{Digest::MD5.hexdigest(response_obj.to_json)})
   end
 
   def resource_scope(resources)

--- a/lib/json_api_controller/indexable_resource.rb
+++ b/lib/json_api_controller/indexable_resource.rb
@@ -1,8 +1,9 @@
 module JsonApiController
   module IndexableResource
     def index
-      headers['ETag'] = gen_etag(controlled_resources)
-      render json_api: serializer.page(params, controlled_resources, context)
+      response_obj = serializer.page(params, controlled_resources, context)
+      headers['ETag'] = gen_etag(response_obj)
+      render json_api: response_obj
     end
   end
 end

--- a/lib/json_api_controller/precondition_check.rb
+++ b/lib/json_api_controller/precondition_check.rb
@@ -19,7 +19,8 @@ module JsonApiController
 
     def precondition_fails?
       query = resource_class.where(id: resource_ids)
-      !(gen_etag(query) == precondition)
+      response_obj = serializer.resource(params, query, context)
+      !(gen_etag(response_obj) == precondition)
     end
 
     def precondition_error_msg

--- a/lib/json_api_controller/showable_resource.rb
+++ b/lib/json_api_controller/showable_resource.rb
@@ -1,8 +1,9 @@
 module JsonApiController
   module ShowableResource
     def show
-      headers['ETag'] = gen_etag(controlled_resources)
-      render json_api: serializer.resource(params, controlled_resources, context)
+      response_obj = serializer.resource(params, controlled_resources, context)
+      headers['ETag'] = gen_etag(response_obj)
+      render json_api: response_obj
     end
   end
 end


### PR DESCRIPTION
Etags dont' include object associations in the response object so they wouldn't change even though some association content had (i.e. project and project_contents).

From here https://github.com/zooniverse/Panoptes-Front-End/issues/283

Chrome sends an `If-None-Match` with the `ETag` value from the first cached request, Firefox doesn't. Our api is responding with 200 but chrome / safari are interpreting the etag : in-none-match header and deciding it was a 304 response even though the content actually may have changed depending on how we generate the etag. For what it's worth ETag's seems to be set by rails even when I had perform_caching turned off. I couldn't figure out why they were being set in the response objects but could be linked to the if-none-match header being set.

This is a simple attempt to use the fully serialized response obj to generate the etag. It should work for the PUT | DELETE on a resource if it hasn't changed but we have to pay the cost of duplicate serialization of the object. It's something like this or we figure out how to generate the etag based on all the serialized object associations so responses have a different ETag and thus are 200's and not 304's.

**UP FOR DISCUSSION - NO NEED TO MERGE JUST YET**