### PR TITLE
allow the resource cache_key to include associations and methods

### DIFF
--- a/app/models/concerns/association_cache_key.rb
+++ b/app/models/concerns/association_cache_key.rb
@@ -1,0 +1,53 @@
+module AssociationCacheKey
+  extend ActiveSupport::Concern
+
+  included do
+    @included_associations = []
+    @included_resource_methods = []
+  end
+
+  module ClassMethods
+    def cache_by_association(*associations)
+      associations.each do |association|
+        if self.reflect_on_association(association)
+          @included_associations << association
+        end
+      end
+    end
+
+    def cache_by_resource_method(*resource_methods)
+      resource_methods.each do |method|
+        @included_resource_methods << method if self.method_defined?(method)
+      end
+    end
+
+    def included_associations
+      @included_associations
+    end
+
+    def included_resource_methods
+      @included_resource_methods
+    end
+  end
+
+  def cache_key
+    cache_key = super
+    associations_cache_key = compound_association_cache_keys.join("+")
+    methods_cache_key = compound_method_cache_keys.join("+")
+    "#{cache_key}+#{associations_cache_key}+#{methods_cache_key}"
+  end
+
+  private
+
+  def compound_association_cache_keys
+    self.class.included_associations.map do |association|
+      self.send(association).map(&:cache_key).join("+")
+    end
+  end
+
+  def compound_method_cache_keys
+    self.class.included_resource_methods.map do |method|
+      "#{method}/#{self.send(method)}"
+    end
+  end
+end

--- a/app/models/concerns/extended_cache_key.rb
+++ b/app/models/concerns/extended_cache_key.rb
@@ -1,4 +1,4 @@
-module AssociationCacheKey
+module ExtendedCacheKey
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,7 +6,7 @@ class Project < ActiveRecord::Base
   include Linkable
   include Translatable
   include PreferencesLink
-  include AssociationCacheKey
+  include ExtendedCacheKey
 
   EXPERT_ROLES = [:expert, :owner]
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,7 @@ class Project < ActiveRecord::Base
   include Linkable
   include Translatable
   include PreferencesLink
+  include AssociationCacheKey
 
   EXPERT_ROLES = [:expert, :owner]
 
@@ -20,6 +21,9 @@ class Project < ActiveRecord::Base
     as: :linked
   has_many :classification_exports, -> { where(type: "classifications_export")},
     class_name: "Medium", as: :linked
+
+  cache_by_association :project_contents
+  cache_by_resource_method :subjects_count, :retired_subjects_count, :finished?
 
   accepts_nested_attributes_for :project_contents
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -3,6 +3,7 @@ class Workflow < ActiveRecord::Base
   include Translatable
   include RoleControl::ParentalControlled
   include SubjectCounts
+  include ExtendedCacheKey
 
   has_paper_trail only: [:tasks, :grouped, :pairwise, :prioritized]
 
@@ -16,6 +17,9 @@ class Workflow < ActiveRecord::Base
   has_many :subject_queues, dependent: :destroy
   has_and_belongs_to_many :expert_subject_sets, -> { expert_sets }, class_name: "SubjectSet"
   belongs_to :tutorial_subject, class_name: "Subject"
+
+  cache_by_association :workflow_contents
+  cache_by_resource_method :subjects_count, :finished?
 
   DEFAULT_CRITERIA = 'classification_count'
   DEFAULT_OPTS = { 'count' => 15 }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,12 +11,15 @@ describe Project, :type => :model do
   let(:primary_language_factory) { :project }
   let(:locked_factory) { :project }
   let(:locked_update) { {display_name: "A Different Name"} }
-  it_behaves_like "optimistically locked"
+  let(:cached_resource) { project }
 
+  it_behaves_like "optimistically locked"
   it_behaves_like "is ownable"
   it_behaves_like "has subject_count"
   it_behaves_like "activatable"
   it_behaves_like "is translatable"
+  it_behaves_like "has an extended cache key", [:project_contents],
+    [:subjects_count, :retired_subjects_count, :finished?]
 
   it "should have a valid factory" do
     expect(project).to be_valid

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -8,10 +8,13 @@ describe Workflow, :type => :model do
   let(:primary_language_factory) { :workflow }
   let(:locked_factory) { :workflow }
   let(:locked_update) { {display_name: "A Different Name"} }
+  let(:cached_resource) { workflow }
 
   it_behaves_like "optimistically locked"
   it_behaves_like "has subject_count"
   it_behaves_like "is translatable"
+  it_behaves_like "has an extended cache key", [:workflow_contents],
+    [:subjects_count, :finished?]
 
   it "should have a valid factory" do
     expect(workflow).to be_valid

--- a/spec/support/extended_cache_key.rb
+++ b/spec/support/extended_cache_key.rb
@@ -1,0 +1,79 @@
+shared_examples "has an extended cache key" do |associations, resource_methods|
+
+  let(:stubbed_timestamp) { "20150511125031990014934" }
+  let(:stubbed_resource_id) { 2 }
+
+  def resource_cache_key(resource)
+    "#{resource.model_name.cache_key}/#{stubbed_resource_id}-#{stubbed_timestamp}"
+  end
+
+  def resource_association_instances
+    cached_resource.class.included_associations.map do |assoc|
+      cached_resource.send(assoc)
+    end.flatten
+  end
+
+  let(:resource_class) { cached_resource.class }
+
+  describe "::cache_by_association" do
+
+    it "should store the association key" do
+      resource_class.cache_by_association(*associations)
+      expect(resource_class.included_associations).to match_array(associations)
+    end
+  end
+
+  describe "::cache_by_resource_method" do
+
+    it "should store the resource methods" do
+      resource_class.cache_by_resource_method(*resource_methods)
+      expect(resource_class.included_resource_methods).to match_array(resource_methods)
+    end
+  end
+
+  describe "#cache_key" do
+    let(:cache_key_result) { cached_resource.cache_key }
+
+    context "when no extra cache key directives are set" do
+
+      before(:each) do
+        %i(included_associations included_resource_methods).each do |cache_key|
+          allow(cached_resource.class).to receive(cache_key).and_return([])
+        end
+      end
+
+      it "should only include the resource cache key" do
+        resource_cache_key = /#{cached_resource.model_name.cache_key}\/\w+$/
+        expect(cache_key_result).to match(resource_cache_key)
+      end
+    end
+
+    # by default or else the model spec won't need the shared helpers
+    context "when extra cache key directives are set" do
+
+      before(:each) do
+        resource_association_instances.each do |instance|
+          stubbed_cache_key = resource_cache_key(instance)
+          allow_any_instance_of(instance.class).to receive(:cache_key).and_return(stubbed_cache_key)
+        end
+      end
+
+      it "should include the resource key" do
+        expect(cache_key_result).to match(/#{cached_resource.model_name.cache_key}\/\w+/)
+      end
+
+      it "should include the resource method key" do
+        method_key = resource_methods.map do |method|
+          Regexp.escape("#{method}:#{cached_resource.send(method)}")
+        end.join
+        expect(cache_key_result).to match(/#{method_key}/)
+      end
+
+      it "should include all the association keys" do
+        assoc_regex = cached_resource.send(*associations).map do |relation|
+          expect(cache_key_result).to match(/#{relation.model_name.cache_key}\/\w+/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Supersedes #815 

allow the resource's cache key to be created from association cache keys and selected method keys e.g. summary counters.

@edpaget I haven't specc'd this yet but wanted to run the idea by you. No need to merge just yet.
