### PR TITLE
Remove subjects from queues

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -79,6 +79,10 @@ class SubjectQueue < ActiveRecord::Base
     query.update_all(["set_member_subject_ids = array_cat(set_member_subject_ids, array[?])", sms_ids])
   end
 
+  def self.below_minimum
+    where("cardinality(set_member_subject_ids) < ?", MINIMUM_LENGTH)
+  end
+
   def below_minimum?
     set_member_subject_ids.length < MINIMUM_LENGTH
   end

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -24,5 +24,4 @@ class SubjectSet < ActiveRecord::Base
   def self.same_project?(workflow)
     where(project: workflow.project)
   end
-
 end

--- a/app/models/subject_sets_workflow.rb
+++ b/app/models/subject_sets_workflow.rb
@@ -3,4 +3,11 @@ class SubjectSetsWorkflow < ActiveRecord::Base
   belongs_to :subject_set
 
   validates_uniqueness_of :workflow_id, scope: :subject_set_id
+
+  before_destroy :remove_from_queues
+
+  def remove_from_queues
+    QueueRemovalWorker.perform_async(subject_set.set_member_subjects.pluck(:id),
+                                    workflow_id)
+  end
 end

--- a/app/workers/queue_removal_worker.rb
+++ b/app/workers/queue_removal_worker.rb
@@ -3,5 +3,8 @@ class QueueRemovalWorker
 
   def perform(sms_ids, workflow_ids)
     SubjectQueue.dequeue_for_all(workflow_ids, sms_ids)
+    SubjectQueue.where(workflow: workflow_ids).below_minimum.find_each do |queue|
+      SubjectQueueWorker.perform_async(queue.workflow_id, queue.user_id)
+    end
   end
 end

--- a/app/workers/queue_removal_worker.rb
+++ b/app/workers/queue_removal_worker.rb
@@ -1,0 +1,7 @@
+class QueueRemovalWorker
+  include Sidekiq::Worker
+
+  def perform(sms_ids, workflow_ids)
+    SubjectQueue.dequeue_for_all(workflow_ids, sms_ids)
+  end
+end

--- a/app/workers/reload_queue_worker.rb
+++ b/app/workers/reload_queue_worker.rb
@@ -18,6 +18,7 @@ class ReloadQueueWorker
   def reload_subjects(set=nil)
     subjects = PostgresqlSelection.new(workflow, nil)
       .select(limit: SubjectQueue::DEFAULT_LENGTH, subject_set_id: set)
+      .compact
 
     SubjectQueue.reload(workflow, subjects, set: set)
   end

--- a/app/workers/reload_queue_worker.rb
+++ b/app/workers/reload_queue_worker.rb
@@ -13,6 +13,8 @@ class ReloadQueueWorker
     else
       reload_subjects
     end
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def reload_subjects(set=nil)

--- a/app/workers/subject_queue_worker.rb
+++ b/app/workers/subject_queue_worker.rb
@@ -15,6 +15,8 @@ class SubjectQueueWorker
     else
       load_subjects
     end
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   private

--- a/app/workers/subject_queue_worker.rb
+++ b/app/workers/subject_queue_worker.rb
@@ -22,6 +22,7 @@ class SubjectQueueWorker
   def load_subjects(set=nil)
     subject_ids = PostgresqlSelection.new(workflow, user)
       .select(limit: limit, subject_set_id: set)
+      .compact
     unless subject_ids.empty?
       SubjectQueue.enqueue(workflow, subject_ids, user: user, set: set)
     end

--- a/spec/factories/subject_sets_workflows.rb
+++ b/spec/factories/subject_sets_workflows.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :subject_sets_workflow do
+    workflow
+    association :subject_set, factory: :subject_set_with_subjects
+  end
+end

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -162,4 +162,13 @@ describe SetMemberSubject, :type => :model do
       expect(SetMemberSubject.by_subject_workflow(sid, wid)).to include(set_member_subject)
     end
   end
+
+  describe "#remove_from_queues" do
+    it 'should queue a removal worker' do
+      set_member_subject.save!
+      expect(QueueRemovalWorker).to receive(:perform_async)
+        .with(set_member_subject.id, set_member_subject.subject_set.workflows.pluck(:id))
+      set_member_subject.remove_from_queues
+    end
+  end
 end

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -24,6 +24,19 @@ RSpec.describe SubjectQueue, :type => :model do
     expect(build(:subject_queue, workflow: q.workflow, user: q.user)).to be_valid
   end
 
+  describe "::below_minimum" do
+    let(:subjects) { create_list(:set_member_subject, 21) }
+    let!(:above_minimum) { create(:subject_queue, set_member_subjects: subjects) }
+    let!(:below_minimum) { create(:subject_queue, set_member_subjects: subjects[0..5]) }
+    it 'should return all the queues with less than the minimum number of subjects' do
+      expect(SubjectQueue.below_minimum).to include(below_minimum)
+    end
+
+    it 'should not return queues with more than minimum' do
+      expect(SubjectQueue.below_minimum).to_not include(above_minimum)
+    end
+  end
+
   describe "::create_for_user" do
     let(:workflow) {create(:workflow)}
     let(:user) { create(:user) }

--- a/spec/models/subject_sets_workflow_spec.rb
+++ b/spec/models/subject_sets_workflow_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe SubjectSetsWorkflow do
+  let(:ss_w) { create(:subject_sets_workflow) }
+
+  describe "#remove_from_queues" do
+    it 'should queue a removal worker' do
+      expect(QueueRemovalWorker).to receive(:perform_async)
+        .with(ss_w.subject_set.set_member_subjects.pluck(:id), ss_w.workflow_id)
+      ss_w.remove_from_queues
+    end
+  end
+end

--- a/spec/support/destructable.rb
+++ b/spec/support/destructable.rb
@@ -22,7 +22,7 @@ shared_examples "is destructable" do
         set_preconditions
         delete :destroy, id: resource.id
       end
-      
+
       it "should return forbidden with a non-scoped token" do
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/workers/queue_removal_worker_spec.rb
+++ b/spec/workers/queue_removal_worker_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe QueueRemovalWorker do
       queues.each(&:reload)
       expect(queues[0..1].map(&:set_member_subject_ids)).to all( be_empty )
     end
+
+    it 'should queue rebuilds' do
+      expect(SubjectQueueWorker).to receive(:perform_async).exactly(2).times
+      subject.perform(first_set_sms_ids, workflows.first.id)
+    end
   end
 
   context "with multiple workflows" do
@@ -48,6 +53,11 @@ RSpec.describe QueueRemovalWorker do
       subject.perform(second_set_sms_ids, workflows[1..2].map(&:id))
       queues.each(&:reload)
       expect(queues[2..-1].map(&:set_member_subject_ids)).to all( be_empty )
+    end
+
+    it 'should queue rebuilds' do
+      expect(SubjectQueueWorker).to receive(:perform_async).exactly(4).times
+      subject.perform(second_set_sms_ids, workflows[1..2].map(&:id))
     end
   end
 end

--- a/spec/workers/queue_removal_worker_spec.rb
+++ b/spec/workers/queue_removal_worker_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe QueueRemovalWorker do
+  let(:workflows) { create_list(:workflow, 3) }
+  let(:subject_sets) do
+    [create(:subject_set_with_subjects, workflows: [workflows[0]]),
+     create(:subject_set_with_subjects, workflows: workflows[1..2])]
+  end
+
+  let(:first_set_sms_ids) { subject_sets[0].set_member_subjects.pluck(:id) }
+  let(:second_set_sms_ids) { subject_sets[1].set_member_subjects.pluck(:id) }
+
+  let!(:queues) do
+    [create(:subject_queue,
+            workflow: workflows[0],
+            user: nil,
+            set_member_subject_ids: first_set_sms_ids),
+     create(:subject_queue,
+            workflow: workflows[0],
+            set_member_subject_ids: first_set_sms_ids),
+     create(:subject_queue,
+            workflow: workflows[1],
+            user: nil,
+            set_member_subject_ids: second_set_sms_ids),
+     create(:subject_queue,
+            workflow: workflows[1],
+            set_member_subject_ids: second_set_sms_ids),
+          create(:subject_queue,
+            workflow: workflows[1],
+            user: nil,
+            set_member_subject_ids: second_set_sms_ids),
+     create(:subject_queue,
+            workflow: workflows[1],
+            set_member_subject_ids: second_set_sms_ids),
+    ]
+  end
+
+  context "with one workflow" do
+    it 'should dequeue all sms' do
+      subject.perform(first_set_sms_ids, workflows.first.id)
+      queues.each(&:reload)
+      expect(queues[0..1].map(&:set_member_subject_ids)).to all( be_empty )
+    end
+  end
+
+  context "with multiple workflows" do
+    it 'should dequeue all' do
+      subject.perform(second_set_sms_ids, workflows[1..2].map(&:id))
+      queues.each(&:reload)
+      expect(queues[2..-1].map(&:set_member_subject_ids)).to all( be_empty )
+    end
+  end
+end

--- a/spec/workers/reload_queue_worker_spec.rb
+++ b/spec/workers/reload_queue_worker_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe ReloadQueueWorker do
       end
     end
 
+    context "when the workflow does not exist" do
+      it 'should not raise an error' do
+        expect do
+          subject.perform(-1)
+        end.to_not raise_error
+      end
+    end
+
     context "with an existing queue" do
       let(:os) { create(:subject).id }
       let!(:queue) do

--- a/spec/workers/subject_queue_worker_spec.rb
+++ b/spec/workers/subject_queue_worker_spec.rb
@@ -25,10 +25,16 @@ RSpec.describe SubjectQueueWorker do
       end
     end
 
+    context "when the workflow does not exist" do
+      it 'should not raise an error' do
+        expect do
+          subject.perform(-1)
+        end.to_not raise_error
+      end
+    end
+
     describe "#load_subjects" do
-
       context "when there are selected subjects to queue" do
-
         it 'should attempt to queue an empty set' do
           allow_any_instance_of(PostgresqlSelection).to receive(:select).and_return([1])
           expect(SubjectQueue).to receive(:enqueue)


### PR DESCRIPTION
This _kind of_ handles updating queues to reflect changes in subject sets (being dissociated from workflows/having subjects added or removed). It should handle actually removing the items from queues just fine, but introduces a few problems. 

* When a SubjectSet is deleted. It will double queue subject removal through both the `subject_sets_workflows` and `set_member_subjects` callbacks. This shouldn't cause any errors, but may strain sidekiq for large queues. 
* It could empty a user's queue entirely. This was cause the user's initial request for subjects to fail, but will trigger a reload of their queue. This could be addressed by refreshing queues after deletion. 

Overall it may be worth thinking more about destroying related objects. Right now, destroying a project with two Subject Sets with 100k subjects in each them, where the subjects have all been classified at least once, will result in at least 600k Ruby objects being instantiated from the database during the request cycle. 