### PR TITLE
Add limit on subjects uploaded from a user

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -20,6 +20,7 @@ module Api
     rescue_from JsonApiController::PreconditionNotPresent, with: :precondition_required
     rescue_from JsonApiController::PreconditionFailed,   with: :precondition_failed
     rescue_from ActiveRecord::StaleObjectError,          with: :conflict
+    rescue_from Api::LimitExceeded,                      with: :not_authorized
     rescue_from Api::PatchResourceError,
       Api::UserSeenSubjectIdError,
       ActionController::UnpermittedParameters,

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -12,6 +12,7 @@ module ApiErrors
       super("No #{media_type} exists for #{parent} ##{parent_id}")
     end
   end
+  class LimitExceeded < PanoptesApiError; end
   class RolesExist < StandardError
     def initialize
       super("Cannot create roles resource when one exists for the user and project")

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -4,8 +4,9 @@ class ApiUser
   attr_reader :user
 
   delegate :memberships_for, :owns?, :id, :languages, :user_groups,
-           :project_preferences, :collection_preferences, :classifications,
-           :user_groups, :has_finished?, :memberships, to: :user, allow_nil: true
+    :project_preferences, :collection_preferences, :classifications,
+    :user_groups, :has_finished?, :memberships, :uploaded_subjects_count,
+    to: :user, allow_nil: true
 
   def initialize(user, admin: false)
     @user, @admin_flag = user, admin

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -6,6 +6,8 @@ class Subject < ActiveRecord::Base
   has_paper_trail only: [:metadata, :locations]
 
   belongs_to :project
+  belongs_to :uploader, class_name: "User", foreign_key: "upload_user_id", touch: true,
+    counter_cache: :uploaded_subjects_count
   has_many :collections_subjects
   has_many :collections, through: :collections_subjects
   has_many :subject_sets, through: :set_member_subjects
@@ -13,7 +15,7 @@ class Subject < ActiveRecord::Base
   has_many :locations, -> { where(type: 'subject_location') }, class_name: "Medium", as: :linked
   has_many :recents, dependent: :destroy
 
-  validates_presence_of :project, :upload_user_id
+  validates_presence_of :project, :uploader
 
   can_through_parent :project, :update, :index, :show, :destroy, :update_links,
                      :destroy_links, :versions, :version

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ActiveRecord::Base
   has_many :project_roles, through: :identity_group
   has_many :collection_roles, through: :identity_group
   has_many :user_seen_subjects, dependent: :destroy
+  has_many :uploaded_subjects, class_name: "Subject", foreign_key: "upload_user_id"
 
   has_many :subject_queues, dependent: :destroy
 

--- a/config/initializers/user_limits.rb
+++ b/config/initializers/user_limits.rb
@@ -1,0 +1,17 @@
+module Panoptes
+  def self.user_limits
+    @user_limits ||= begin
+                       file = Rails.root.join('config/user_limits.yml')
+                       YAML.load(File.read(file))[Rails.env].symbolize_keys
+                     rescue Errno::ENOENT, NoMethodError
+                       {  }
+                     end
+  end
+
+  def self.max_subjects
+    user_limits[:subjects]
+  end
+end
+
+Panoptes.user_limits
+

--- a/config/user_limits.yml.hudson
+++ b/config/user_limits.yml.hudson
@@ -1,0 +1,5 @@
+development:
+
+test:
+  subjects: 100
+  projects: 100

--- a/config/user_limits.yml.hudson
+++ b/config/user_limits.yml.hudson
@@ -2,4 +2,3 @@ development:
 
 test:
   subjects: 100
-  projects: 100

--- a/db/migrate/20150512223346_add_uploaded_subjects_count_to_user.rb
+++ b/db/migrate/20150512223346_add_uploaded_subjects_count_to_user.rb
@@ -1,0 +1,5 @@
+class AddUploadedSubjectsCountToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :uploaded_subjects_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150512123559) do
+ActiveRecord::Schema.define(version: 20150512223346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -373,6 +373,7 @@ ActiveRecord::Schema.define(version: 20150512123559) do
     t.boolean  "banned",                      default: false,    null: false
     t.boolean  "migrated",                    default: false
     t.boolean  "valid_email",                 default: true,     null: false
+    t.integer  "uploaded_subjects_count",     default: 0
   end
 
   add_index "users", ["display_name"], name: "index_users_on_display_name", unique: true, using: :btree

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -274,6 +274,24 @@ describe Api::V1::SubjectsController, type: :controller do
       end
     end
 
+    context "when the user has exceeded the allowed number of subjects" do
+      let(:authorised_user) { create(:user, uploaded_subjects_count: 101) }
+
+      before(:each) do
+        default_request scopes: scopes, user_id: authorised_user.id
+        post :create, create_params
+      end
+
+      it 'should return 403' do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'should have an error message' do
+        msg = json_response["errors"][0]["message"]
+        expect(msg).to match(/User has uploaded [0-9]+ subjects of [0-9]+ maximum/)
+      end
+    end
+
     context "when the project is owned by the user" do
       it_behaves_like "is creatable"
     end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :subject do
     project
-    upload_user_id "1"
+    association :uploader, factory: :user
 
     sequence(:zooniverse_id) { |n| "TES#{n.to_s(26).rjust(8, '0')}" }
     metadata({distance_from_earth: "42 light years",

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -71,6 +71,13 @@ FactoryGirl.define do
     factory :admin_user do
       admin true
     end
+
+    factory :user_with_uploaded_subjects do
+      after(:create) do |u|
+        u.uploaded_subjects = create_list(:subject, 2, uploader: u)
+        u.save!
+      end
+    end
   end
 
   factory :omniauth_user, class: :user do

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -87,4 +87,11 @@ describe Subject, :type => :model do
       expect(subject.migrated_subject?).to be_truthy
     end
   end
+
+  describe "#uploader" do
+    it "should have a counter cache" do
+      subject.save!
+      expect(subject.uploader.uploaded_subjects_count).to eq(1)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -455,4 +455,18 @@ describe User, type: :model do
       expect(u.hash_func).to eq('bcrypt')
     end
   end
+
+  describe "#uploaded_subjects" do
+    it 'should list the subjects a user has uploaded' do
+      uploader = create(:user_with_uploaded_subjects)
+      expect(uploader.uploaded_subjects).to all( be_a(Subject) )
+    end
+  end
+
+  describe "#uploaded_subjects_count" do
+    it 'should have a count of the subjects a user has uploaded' do
+      uploader = create(:user_with_uploaded_subjects)
+      expect(uploader.uploaded_subjects_count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Adds a configuration file user_limits.yml with the form:
```
rails_env:
  subjects: 1000
```

Leaving it empty for an environment will cause it to not limit the
number of subjects.

Closes #774