### PR TITLE
generate index action etags on the response objects

### DIFF
--- a/app/controllers/concerns/json_api_render.rb
+++ b/app/controllers/concerns/json_api_render.rb
@@ -3,8 +3,12 @@ module JSONApiRender
 
   included do
     ActionController.add_renderer :json_api do |obj, options|
+      response_body = JSONApiResponse.format_response_body(obj)
+      if options[:generate_response_obj_etag]
+        self.headers["ETag"] = JSONApiResponse.response_etag_header(response_body)
+      end
       self.content_type ||= Mime::Type.lookup("application/vnd.api+json; version=1")
-      self.response_body = JSONApiResponse.format_response_body(obj)
+      self.response_body = response_body
     end
   end
 
@@ -19,6 +23,10 @@ module JSONApiRender
     def self.format_response_body(obj)
       response = obj.is_a?(Exception) ? { errors: [ message: obj.message ] } : obj
       response.to_json
+    end
+
+    def self.response_etag_header(obj)
+      %("#{Digest::MD5.hexdigest(obj)}")
     end
   end
 end

--- a/lib/json_api_controller/indexable_resource.rb
+++ b/lib/json_api_controller/indexable_resource.rb
@@ -1,8 +1,8 @@
 module JsonApiController
   module IndexableResource
     def index
-      headers['ETag'] = gen_etag(controlled_resources)
-      render json_api: serializer.page(params, controlled_resources, context)
+      render json_api: serializer.page(params, controlled_resources, context),
+             generate_response_obj_etag: true
     end
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -44,6 +44,7 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       it_behaves_like "an api response"
+      it_behaves_like 'an indexable etag response'
     end
 
     context "an unauthenticated request" do

--- a/spec/support/indexable.rb
+++ b/spec/support/indexable.rb
@@ -22,6 +22,7 @@ shared_examples "is indexable" do
     end
 
     it_behaves_like 'an api response'
+    it_behaves_like 'an indexable etag response'
   end
 
   context 'when the authorized_user is an admin' do

--- a/spec/support/indexable_etag_response.rb
+++ b/spec/support/indexable_etag_response.rb
@@ -1,0 +1,7 @@
+shared_examples "an indexable etag response" do
+
+  it "should generate the etag from the response obj" do
+    expected_etag = %("#{Digest::MD5.hexdigest(response.body)}")
+    expect(response.headers["ETag"]).to eq(expected_etag)
+  end
+end


### PR DESCRIPTION
Do not enumerate the index action controlled resources to generate etags. Instead allow the serializer to apply the scope filtering and generate the etag from the response object. 

E.g. the users index action has the display_name filter using params[:display_name] but the etag generation used the User.active scope without applying the filter so would enumerate the whole collection of active users before hitting the serializer.

@edpaget so I thought about adding index action `scope_contexts` for the `Class.scope_for` methods but soon realized we'd have to understand which filters each model serializer allows and apply each controllers `scope_context`, that method totally works though. Anyway, instead i reverted back to adding the cache key on the serialised reponse object, except this time just the index actions. Show resources can still use the cache_key method.