### PR TITLE
add json events api for legacy projects

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,77 @@
+module Api
+
+  class EventsController < ApplicationController
+
+    KNOWN_EVENTS = %w( activity workflow_activity )
+
+    def self.resource_name
+      "event"
+    end
+
+    @actions = [:create]
+
+    include JsonApiController::JsonSchemaValidator
+
+    before_action :require_basic_authentication
+
+    def create
+      respond_to do |format|
+        format.json { process_incoming_event }
+      end
+    end
+
+    private
+
+    def require_basic_authentication
+      authenticate_or_request_with_http_basic do |username, password|
+        Panoptes::EventsApi.username == username &&
+          Panoptes::EventsApi.password == password
+      end
+    end
+
+    def process_incoming_event
+      response_status = :unprocessable_entity
+      if event_params_sanity_check
+        upp = user_project_preference
+        upp.activity_count = create_params[:count]
+        response_status = :ok if upp.save
+      end
+      render status: response_status, nothing: true
+    end
+
+    def event_params_sanity_check
+      required_params && known_event?
+    end
+
+    def required_params
+      params_to_check = [ create_params[:project_id], create_params[:zooniverse_user_id] ]
+      params_to_check.all? { |param| !param.blank? }
+    rescue JsonSchema::ValidationError
+      return false
+    end
+
+    def known_event?
+      unless known_event = create_params[:kind] && KNOWN_EVENTS.include?(create_params[:kind])
+        notify_honeybadger_of_unknown_event
+      end
+      known_event
+    end
+
+    def notify_honeybadger_of_unknown_event
+      Honeybadger.notify(
+        error_class:   "Legacy API Event",
+        error_message: "Unknown Legacy API Event Message Received",
+        parameters:    params
+      )
+    end
+
+    def user_project_preference
+      UserProjectPreference.find_or_initialize_by(project_id: create_params[:project_id],
+                                                  user_id: create_params[:zooniverse_user_id])
+    end
+
+    def resource_sym
+      self.class.resource_name.pluralize.to_sym
+    end
+  end
+end

--- a/app/schemas/event_create_schema.rb
+++ b/app/schemas/event_create_schema.rb
@@ -1,0 +1,43 @@
+class EventCreateSchema < JsonSchema
+  schema do
+    type "object"
+    description "An Event"
+    required "kind", "project_id", "zooniverse_user_id", "count"
+    additional_properties false
+
+    property "kind" do
+      type "string"
+    end
+
+    property "project_id" do
+      type "string", "integer"
+      pattern "^[0-9]*$"
+    end
+
+    property "zooniverse_user_id" do
+      type "string", "integer"
+      pattern "^[0-9]*$"
+    end
+
+    property "count" do
+      type "string", "integer"
+      pattern "^[0-9]*$"
+    end
+
+    property "project" do
+      type "string"
+    end
+
+    property "workflow" do
+      type "string"
+    end
+
+    property "message" do
+      type "string"
+    end
+
+    property "updated_at" do
+      type "string"
+    end
+  end
+end

--- a/config/events_api_auth.yml.hudson
+++ b/config/events_api_auth.yml.hudson
@@ -1,0 +1,7 @@
+development:
+  username: dev
+  password: dev_password
+
+test:
+  username: test
+  password: test_password

--- a/config/initializers/events_api_auth.rb
+++ b/config/initializers/events_api_auth.rb
@@ -1,0 +1,22 @@
+module Panoptes
+  module EventsApi
+    def self.auth
+      @events_api_auth ||= begin
+                         file = Rails.root.join('config/events_api_auth.yml')
+                         YAML.load(File.read(file))[Rails.env].symbolize_keys
+                       rescue Errno::ENOENT, NoMethodError
+                         {  }
+                       end
+    end
+
+    def self.username
+      auth[:username]
+    end
+
+    def self.password
+      auth[:password]
+    end
+  end
+end
+
+Panoptes::EventsApi.auth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,10 @@ Rails.application.routes.draw do
     post "/users" => "registrations#create", as: :user_registration
   end
 
+  namespace :api, constraints: { format: 'json' } do
+    post "/events" => "events#create"
+  end
+
   namespace :api do
     api_version(module: "V1", header: {name: "Accept", value: "application/vnd.api+json; version=1"}) do
       get "/me", to: 'users#me', format: false
@@ -65,7 +69,7 @@ Rails.application.routes.draw do
         media_resources :avatar, :background
       end
 
-      json_api_resources :workflows, links: [:subject_sets], versioned: true 
+      json_api_resources :workflows, links: [:subject_sets], versioned: true
 
       json_api_resources :subject_sets, links: [:subjects]
 

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -1,0 +1,175 @@
+require 'spec_helper'
+
+describe Api::EventsController, type: :controller do
+
+  def overridden_params(new_params)
+    event_params[:events].merge!(new_params)
+    event_params
+  end
+
+  context "using json" do
+    before(:each) do
+      request.env["HTTP_ACCEPT"] = "application/json"
+      request.env["CONTENT_TYPE"] = "application/json"
+    end
+
+    describe "#create" do
+      let(:workflow) { create(:workflow) }
+      let(:project) { workflow.project }
+      let(:user) { project.owner }
+      let(:event_count) { 10 }
+      let(:created_at) { project.created_at.to_s }
+      let(:event_kind) { "workflow_activity" }
+      let(:event_params) do
+        {
+          events: {
+            kind: event_kind, project_id: project.id, project: project.name,
+            zooniverse_user_id: user.id, workflow: workflow.display_name,
+            count: event_count, updated_at: created_at
+          }
+        }
+      end
+      let(:user_project_pref) do
+        UserProjectPreference.where(project_id: project.id, user_id: user.id).first
+      end
+      let(:basic_auth) do
+        creds = [ Panoptes::EventsApi.username,Panoptes::EventsApi.password ]
+        ActionController::HttpAuthentication::Basic.encode_credentials(*creds)
+      end
+
+      before(:each) do
+        request.env['HTTP_AUTHORIZATION'] = basic_auth
+      end
+
+      describe "basic auth method" do
+
+        context "with valid authentication credentials" do
+
+          it "should be successful" do
+            post :create, event_params
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context "with invalid authentication credentials" do
+          let!(:basic_auth) do
+            creds = [ user.display_name, user.password ]
+            ActionController::HttpAuthentication::Basic.encode_credentials(*creds)
+          end
+
+          it "should return unauthorized" do
+            post :create, event_params
+            expect(response.status).to eq(401)
+          end
+        end
+      end
+
+      context "with an unknown project id" do
+        let(:unexpected_event) do
+          overridden_params(project_id: "")
+        end
+
+        it "should return 422" do
+          post :create, unexpected_event
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "with an unknown user id" do
+        let(:unexpected_event) do
+          overridden_params(zooniverse_user_id: "")
+        end
+
+        it "should return 422" do
+          post :create, unexpected_event
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "when an unexpected event kind message is received" do
+        let(:unexpected_event) do
+          overridden_params(kind: "unkonwn")
+        end
+
+        it "should notify honeybadger" do
+          expect(Honeybadger).to receive(:notify)
+          post :create, unexpected_event
+        end
+
+        it "should return 422" do
+          post :create, unexpected_event
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "with a message with invalid params" do
+        let(:invalid_event_params) do
+          overridden_params(extra_param: "amazing")
+        end
+
+        it "should respond with a 422" do
+          post :create, invalid_event_params
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "with a first event message" do
+        let(:first_visit_event_params) do
+          overridden_params(message: "first_visit")
+        end
+
+        it "should respond with a 200" do
+          post :create, first_visit_event_params
+          expect(response.status).to eq(200)
+        end
+
+        it "should create the user project preference model (upp)" do
+          expect do
+            post :create, first_visit_event_params
+          end.to change { UserProjectPreference.count }.from(0).to(1)
+        end
+
+        it "should update the upp activity_count to the correct value" do
+          post :create, first_visit_event_params
+          expect(user_project_pref.activity_count).to eq(event_count)
+        end
+      end
+
+      context "with an activity event message" do
+
+        it "should respond with a 200" do
+          post :create, event_params
+          expect(response.status).to eq(200)
+        end
+
+        it "should create the user project preference model (upp)" do
+          expect do
+            post :create, event_params
+          end.to change { UserProjectPreference.count }.from(0).to(1)
+        end
+
+        it "should update the upp activity_count to the correct value" do
+          post :create, event_params
+          expect(user_project_pref.activity_count).to eq(event_count)
+        end
+
+        context "when the user project preference already exists" do
+          let!(:upp) do
+            create(:user_project_preference, project: project, user: user, activity_count: 100)
+          end
+
+          it "should update the model only" do
+            expect do
+              post :create, event_params
+            end.to_not change { UserProjectPreference.count }.from(1)
+          end
+
+          it "should overwrite the upp activity_count to the correct value" do
+            post :create, event_params
+            expect(upp.reload.activity_count).to eq(event_count)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -85,7 +85,7 @@ describe Api::V1::ClassificationsController, type: :controller do
         it_behaves_like "is indexable"
       end
 
-      context "a project owner retreiving classifications for the project" do 
+      context "a project owner retreiving classifications for the project" do
         let!(:classifications) { create_list(:classification, 2, project: project) }
         let(:authorized_user) { project.owner }
 

--- a/spec/factories/user_project_preferences.rb
+++ b/spec/factories/user_project_preferences.rb
@@ -4,6 +4,6 @@ FactoryGirl.define do
     project
     email_communication true
     preferences '{"tutorial": "done"}'
-    activity_count { { asteroid: { count: "19", updated_at: "2014-10-14 17:29:23 UTC" } } }
+    activity_count 19
   end
 end


### PR DESCRIPTION
closes #750 

I think this covers all the use cases for the events api in zoo home. I've set it to raise errors in honeybadger for unknown event kind types so we can add them in. I've added a config file to prod configs with almost the same creds as ouroboros prod has, staging is slightly different but i don't think we'll use this unless we test the staging version of ourobros (prob should now i type this).

I did find that some of the legacy projects are using different basic auth keys so will have to audit them to make sure they are working properly.