### PR TITLE
do not create user seens for anonymous classifications

### DIFF
--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -80,6 +80,22 @@ describe ClassificationLifecycle do
       subject.transact! { true }
     end
 
+    context "when an anonymour user classification" do
+      let!(:classification) { create(:classification, user: nil) }
+
+      it "should wrap the calls in a transaction" do
+        expect(Classification).to receive(:transaction)
+      end
+
+      it "should not attempt to update the seen subjects" do
+        expect_any_instance_of(UserSeenSubject).to_not receive(:subjects_seen?)
+      end
+
+      it "should still evaluate the block" do
+        expect(subject).to receive(:instance_eval)
+      end
+    end
+
     context "when the user has not already classified the subjects" do
       it "should wrap the calls in a transaction" do
         expect(Classification).to receive(:transaction)
@@ -130,8 +146,8 @@ describe ClassificationLifecycle do
         expect(subject).to_not receive(:dequeue_subject)
       end
 
-      it "should not call the instance_eval on the passed block" do
-        expect(subject).to_not receive(:instance_eval)
+      it "should call the instance_eval on the passed block" do
+        expect(subject).to receive(:instance_eval)
       end
 
       it "should call the #publish_to_kafka method" do

--- a/spec/workers/classification_worker_spec.rb
+++ b/spec/workers/classification_worker_spec.rb
@@ -56,6 +56,20 @@ RSpec.describe ClassificationWorker do
       it 'should call classification count worker' do
         expect(ClassificationCountWorker).to receive(:perform_async).twice
       end
+
+      context "when a user has seen the subjects before" do
+
+        it 'should not call the classification count worker' do
+          expect(ClassificationCountWorker).to_not receive(:perform_async).twice
+        end
+      end
+
+      context "when a user is anonymous" do
+
+        it 'should call the classification count worker' do
+          expect(ClassificationCountWorker).to receive(:perform_async).twice
+        end
+      end
     end
 
     context "anything else" do


### PR DESCRIPTION
Fixes: https://app.honeybadger.io/projects/40595/faults/12807870 which is backing up in sidekiq with retires.

Do not attempt to track seen for anonymous classifications. Also always count towards retirement for anonymous users but don’t count towards retirement if a known user has seen them before.

@edpaget this does raise the question of anonymous users seeing the same subject in a session as per [here](https://github.com/zooniverse/Panoptes/issues/830#issuecomment-101422062) and if we should count these towards retirement as the two classifications are now not independent of each other. @ggdhines does this matter do you think? If we need to ignore these for retirement counts / aggregation then we'll need another field on the classification to track it.