### PR TITLE
add metadata field to flag classifications for already seen subjects

### DIFF
--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -16,8 +16,6 @@ class UserSeenSubject < ActiveRecord::Base
   end
 
   def subjects_seen?(ids)
-    ids.find do |id|
-      subject_ids.include?(id)
-    end
+    Array.wrap(ids).any? { |id| subject_ids.include?(id) }
   end
 end

--- a/app/schemas/classification_create_schema.rb
+++ b/app/schemas/classification_create_schema.rb
@@ -16,7 +16,7 @@ class ClassificationCreateSchema < JsonSchema
     property "metadata" do
       type "object"
       required "started_at", "finished_at", "user_agent", "user_language", "workflow_version"
-      
+
       property "screen_resolution" do
         type "string"
       end
@@ -39,6 +39,10 @@ class ClassificationCreateSchema < JsonSchema
 
       property "user_agent" do
         type "string"
+      end
+
+      property "seen_before" do
+        type "boolean"
       end
     end
 

--- a/app/schemas/classification_update_schema.rb
+++ b/app/schemas/classification_update_schema.rb
@@ -31,6 +31,10 @@ class ClassificationUpdateSchema < JsonSchema
       property "user_agent" do
         type "string"
       end
+
+      property "seen_before" do
+        type "boolean"
+      end
     end
 
     property "annotations" do
@@ -41,7 +45,7 @@ class ClassificationUpdateSchema < JsonSchema
         property "task" do
           type "string"
         end
-        
+
         property "value" do
           type "string", "object", "array", "float", "integer"
         end

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -26,7 +26,6 @@ FactoryGirl.define do
       end
     end
 
-
     factory :classifaction_with_user_group do
       user_group
     end
@@ -38,6 +37,16 @@ FactoryGirl.define do
 
     factory :fake_gold_standard_classification do
       gold_standard false
+    end
+
+    factory :already_seen_classification do
+      after(:build) do |c|
+        c.metadata = c.metadata.merge(seen_before: "true")
+      end
+
+      factory :anonymous_already_seen_classification do
+        user nil
+      end
     end
   end
 end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -60,6 +60,21 @@ describe Classification, :type => :model do
       metadata.delete(:user_agent)
       expect(build(:classification, metadata: metadata)).to_not be_valid
     end
+
+    describe "seen_before attribute" do
+
+      it 'should be valid when set to true' do
+        expect(build(:already_seen_classification, metadata: metadata)).to be_valid
+      end
+
+      it 'should not be valid when set to nil' do
+        expect(build(:already_seen_classification, metadata: metadata)).to be_valid
+      end
+
+      it 'should not be valid when set to false' do
+        expect(build(:already_seen_classification, metadata: metadata)).to be_valid
+      end
+    end
   end
 
   describe "validate gold_standard" do
@@ -147,10 +162,10 @@ describe Classification, :type => :model do
 
     it 'should return all classifications for an admin user' do
       user = ApiUser.new(create(:user, admin: true), admin: true)
-      expect(Classification.scope_for(:show, user)).to match_array(classifications) 
+      expect(Classification.scope_for(:show, user)).to match_array(classifications)
     end
   end
-  
+
   describe "#creator?" do
     let(:user) { ApiUser.new(build(:user)) }
 
@@ -207,6 +222,16 @@ describe Classification, :type => :model do
         classification = build(:fake_gold_standard_classification)
         expect(classification.gold_standard?).to be_falsey
       end
+    end
+  end
+
+  describe "#seen_before?" do
+    it "should be truthy if seen_before metadata attribute is true" do
+      expect(build(:already_seen_classification).seen_before?).to be_truthy
+    end
+
+    it "should be falsey if missing the seen_before metadata attribute" do
+      expect(build(:classification).seen_before?).to be_falsey
     end
   end
 end

--- a/spec/models/user_seen_subject_spec.rb
+++ b/spec/models/user_seen_subject_spec.rb
@@ -84,12 +84,26 @@ RSpec.describe UserSeenSubject, :type => :model do
 
   describe "#add_subjects" do
     let(:uss) { user_seen_subject }
-    
+
     it "should add a subject's id to the subject_ids array" do
       s = create(:subject)
       uss.add_subjects([s.id])
       uss.reload
       expect(uss.subject_ids).to include(s.id)
+    end
+  end
+
+  describe "#subjects_seen?" do
+    let(:uss) { build(:user_seen_subject) }
+
+    it "should return true if any id param is in the list" do
+      seen_id = uss.subject_ids.sample(1)
+      expect(uss.subjects_seen?(seen_id)).to be_truthy
+    end
+
+    it "should return false if no id param is in the list" do
+      seen_id = uss.subject_ids.last + 1
+      expect(uss.subjects_seen?(seen_id)).to be_falsey
     end
   end
 end

--- a/spec/workers/classification_worker_spec.rb
+++ b/spec/workers/classification_worker_spec.rb
@@ -60,14 +60,28 @@ RSpec.describe ClassificationWorker do
       context "when a user has seen the subjects before" do
 
         it 'should not call the classification count worker' do
-          expect(ClassificationCountWorker).to_not receive(:perform_async).twice
+          create(:user_seen_subject,
+                 user: classification.user,
+                 workflow: classification.workflow,
+                 subject_ids: classification.subject_ids)
+          expect(ClassificationCountWorker).to_not receive(:perform_async)
         end
       end
 
       context "when a user is anonymous" do
 
+        let!(:classification) { create(:classification, user: nil) }
+
         it 'should call the classification count worker' do
           expect(ClassificationCountWorker).to receive(:perform_async).twice
+        end
+
+        context "when the classification has the already_seen metadata value" do
+          let!(:classification) { create(:anonymous_already_seen_classification) }
+
+          it 'should not call the classification count worker' do
+            expect(ClassificationCountWorker).to_not receive(:perform_async)
+          end
         end
       end
     end


### PR DESCRIPTION
Closes https://github.com/zooniverse/Panoptes-Front-End/issues/359 based of discussion in #843 

This adds an optional `metadata#seen_before` boolean attribute that can be submitted if a volunteer (logged in & anonymous) has classified this subject before. @brian-c you ok with this solution if the subject has been seen before?

Happy to make changes, thought I'd get this into code for discussion.