### PR TITLE
correct optional attributes in subject_serializer

### DIFF
--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -5,8 +5,8 @@ class SubjectSerializer
   attributes :id, :metadata, :locations, :zooniverse_id,
     :created_at, :updated_at
 
-  attribute :retired, if: :selected?
-  attribute :already_seen, if: :selected?
+  optional :retired, :already_seen
+
   can_include :project, :collections
 
   def locations
@@ -24,6 +24,16 @@ class SubjectSerializer
 
   def already_seen
     !!(user_seen && user_seen.subject_ids.include?(@model.id))
+  end
+
+  private
+
+  def include_retired?
+    selected?
+  end
+
+  def include_already_seen?
+    selected?
   end
 
   def selected?

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::SubjectsController, type: :controller do
 
   let(:api_resource_name) { "subjects" }
   let(:api_resource_attributes) do
-    [ "id", "metadata", "locations", "zooniverse_id", "created_at", "updated_at", "retired", "already_seen"]
+    [ "id", "metadata", "locations", "zooniverse_id", "created_at", "updated_at" ]
   end
   let(:api_resource_links) { [ "subjects.project" ] }
 
@@ -51,6 +51,20 @@ describe Api::V1::SubjectsController, type: :controller do
 
         it "should return a page of 2 objects" do
           expect(json_response[api_resource_name].length).to eq(2)
+        end
+
+        describe "optional context attributes" do
+          let(:attr_field_set) do
+            json_response[api_resource_name].map { |s| s.has_key?(optional_attr) }.uniq
+          end
+
+          %w( retired already_seen ).each do |attr|
+            let(:optional_attr) { attr }
+
+            it "should not serialize the #{attr} attribute" do
+              expect(attr_field_set).to match([false])
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #857 

RestpackSerializer doesn't allow optional conditions on the attribute definition. it uses the optional clause that adds a include_x? method definition that can be overridden.