### PR TITLE
update identity user group validations

### DIFF
--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -7,7 +7,7 @@ class UserGroup < ActiveRecord::Base
 
   has_many :memberships
   has_many :active_memberships, -> { active.where(identity: false) },
-           class_name: "Membership" 
+           class_name: "Membership"
   has_many :users, through: :memberships
   has_many :classifications
   has_many :access_control_lists
@@ -20,7 +20,8 @@ class UserGroup < ActiveRecord::Base
   has_many :collections, through: :owned_resources, source: :resource,
            source_type: "Collection"
 
-  validates :display_name, presence: true, format: { without: /\$|@|\s+/ }
+  validates :display_name, presence: true
+  validates :display_name, format: { without: /\$|@|\s+/ }, unless: :identity?
   validates :name, presence: true, uniqueness: true
 
   before_validation :downcase_case_insensitive_fields

--- a/lib/identity_group_name_validator.rb
+++ b/lib/identity_group_name_validator.rb
@@ -16,8 +16,8 @@ class IdentityGroupNameValidator < ActiveModel::Validator
     [].tap do |error_list|
       %i( display_name name ).each do |attr|
         attr_errors = identity_group.errors[attr]
-        error_list.concat(attr_errors) unless attr_errors.empty?
+        error_list.concat(attr_errors)
       end
-    end
+    end.uniq
   end
 end

--- a/lib/identity_group_name_validator.rb
+++ b/lib/identity_group_name_validator.rb
@@ -2,10 +2,22 @@ class IdentityGroupNameValidator < ActiveModel::Validator
   def validate(user)
     if identity_group = user.try(:identity_membership).try(:user_group)
       unless identity_group.valid?
-        user.errors[:"identity_group.display_name"].concat(identity_group.errors[:name])
+        error_list = name_errors(identity_group)
+        user.errors[:"identity_group.display_name"].concat(error_list)
       end
     else
       user.errors.add(:identity_group, "can't be blank")
+    end
+  end
+
+  private
+
+  def name_errors(identity_group)
+    [].tap do |error_list|
+      %i( display_name name ).each do |attr|
+        attr_errors = identity_group.errors[attr]
+        error_list.concat(attr_errors) unless attr_errors.empty?
+      end
     end
   end
 end

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -8,7 +8,7 @@ describe UserGroup, :type => :model do
   let(:owned) { build(:project, owner: owner) }
   let(:locked_factory) { :user_group }
   let(:locked_update) { {display_name: "A-different_name"} }
-  
+
   it_behaves_like "optimistically locked"
 
   it_behaves_like "activatable"
@@ -35,7 +35,7 @@ describe UserGroup, :type => :model do
       let(:private_group) do
         create(:user_group, private: true)
       end
-      
+
       it "should return groups the user is an active member of" do
         expect(UserGroup.scope_for(:show, ApiUser.new(member))).to include(user_group)
       end
@@ -54,7 +54,7 @@ describe UserGroup, :type => :model do
     it 'should validate presence' do
       expect(build(:user_group, display_name: "")).to_not be_valid
     end
-    
+
     it 'should not have whitespace' do
       expect(build(:user_group, display_name: " asdf asdf")).to_not be_valid
     end
@@ -71,6 +71,30 @@ describe UserGroup, :type => :model do
       ug = build(:user_group, display_name: "")
       ug.valid?
       expect(ug.errors[:display_name]).to include("can't be blank")
+    end
+
+    context "when an identity group" do
+      let!(:stub_identity?) do
+        allow_any_instance_of(UserGroup).to receive(:identity?).and_return(true)
+      end
+
+      it 'should allow a whitespace' do
+        expect(build(:user_group, display_name: " asdf asdf")).to be_valid
+      end
+
+      it 'should allow a dollar sign' do
+        expect(build(:user_group, display_name: "$asdfasdf")).to be_valid
+      end
+
+      it 'should allow an at sign' do
+        expect(build(:user_group, display_name: "@asdfasdf")).to be_valid
+      end
+
+      it 'should have non-blank error' do
+        ug = build(:user_group, display_name: "")
+        ug.valid?
+        expect(ug.errors[:display_name]).to include("can't be blank")
+      end
     end
 
     it 'should validate uniqueness' do


### PR DESCRIPTION
closes #871 and #872 

So this will fix the missing identity groups for migrated users. We'll need to recreate them with this code to be able to successfully run the slug creation migration.
