### PR TITLE
Only create slugs for active projects

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,7 +5,7 @@ class Collection < ActiveRecord::Base
   include Linkable
   include PreferencesLink
 
-  acts_as_url :display_name, sync_url: true, url_attribute: :slug
+  acts_as_url :display_name, sync_url: true, url_attribute: :slug, allow_duplicates: true
 
   belongs_to :project
   has_many :collections_subjects, dependent: :destroy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,7 +10,7 @@ class Project < ActiveRecord::Base
 
   EXPERT_ROLES = [:expert, :owner]
 
-  acts_as_url :display_name, sync_url: true, url_attribute: :slug
+  acts_as_url :display_name, sync_url: true, url_attribute: :slug, allow_duplicates: true
 
   has_many :workflows
   has_many :subject_sets, dependent: :destroy

--- a/db/migrate/20150521160726_add_slug_to_projects_collections_and_users.rb
+++ b/db/migrate/20150521160726_add_slug_to_projects_collections_and_users.rb
@@ -5,7 +5,7 @@ class AddSlugToProjectsCollectionsAndUsers < ActiveRecord::Migration
     end
 
     project_count = Project.count
-    Project.find_each.with_index do |project, i|
+    Project.active.find_each.with_index do |project, i|
       p "#{i+1} of #{project_count}"
       project.slug = project.display_name.to_url
       project.save!
@@ -19,7 +19,7 @@ class AddSlugToProjectsCollectionsAndUsers < ActiveRecord::Migration
     end
 
     collection_count = Collection.count
-    Collection.find_each.with_index do |col, i|
+    Collection.active.find_each.with_index do |col, i|
       p "#{i+1} of #{collection_count}"
       col.slug = col.display_name.to_url
       col.save!


### PR DESCRIPTION
Inactive projects fail a validation since they user is also inactive