### PR TITLE
Dequeue and update user seen subjects in sync

### DIFF
--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -5,14 +5,16 @@ class UserSeenSubject < ActiveRecord::Base
   validates_presence_of :user, :workflow
 
   def self.add_seen_subjects_for_user(user: nil, workflow: nil, subject_ids: nil)
-    uss = find_or_create_by!(user: user, workflow: workflow)
-    uss.add_subjects(subject_ids)
+    uss = where(user: user, workflow: workflow)
+    if uss.exists?
+      uss.add_subjects(subject_ids)
+    else
+      uss.create!(subject_ids: subject_ids)
+    end
   end
 
-  def add_subjects(subjects)
-    subject_ids_will_change!
-    subject_ids.concat(subjects)
-    save!
+  def self.add_subjects(subjects)
+    update_all(["subject_ids = uniq(subject_ids + array[?])", subjects])
   end
 
   def subjects_seen?(ids)

--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -7,14 +7,10 @@ class UserSeenSubject < ActiveRecord::Base
   def self.add_seen_subjects_for_user(user: nil, workflow: nil, subject_ids: nil)
     uss = where(user: user, workflow: workflow)
     if uss.exists?
-      uss.add_subjects(subject_ids)
+      uss.update_all(["subject_ids = uniq(subject_ids + array[?])", subject_ids])
     else
       uss.create!(subject_ids: subject_ids)
     end
-  end
-
-  def self.add_subjects(subjects)
-    update_all(["subject_ids = uniq(subject_ids + array[?])", subjects])
   end
 
   def subjects_seen?(ids)

--- a/db/migrate/20150527200052_enable_int_array.rb
+++ b/db/migrate/20150527200052_enable_int_array.rb
@@ -1,0 +1,5 @@
+class EnableIntArray < ActiveRecord::Migration
+  def change
+    enable_extension "intarray"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150526180444) do
+ActiveRecord::Schema.define(version: 20150527200052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "intarray"
 
   create_table "access_control_lists", force: :cascade do |t|
     t.integer  "user_group_id"

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -53,7 +53,7 @@ class SubjectSelector
                             [user.user, {}]
                           end
 
-    queue = SubjectQueue.scoped_to_set(params[:subject_set_id])
+    queue = SubjectQueue.by_set(params[:subject_set_id])
       .find_by(user: queue_user, workflow: workflow)
 
     case

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -43,6 +43,18 @@ describe ClassificationLifecycle do
       end
     end
 
+    it "should call the #update_seen_subjects method" do
+      classification.save!
+      expect(subject).to receive(:update_seen_subjects).once
+      subject.queue(:create)
+    end
+
+    it "should call the #dequeue_subject method" do
+      classification.save!
+      expect(subject).to receive(:dequeue_subject).once
+      subject.queue(:update)
+    end
+
     context "with update action" do
       let(:test_method) { :update }
 
@@ -113,14 +125,6 @@ describe ClassificationLifecycle do
         expect(subject).to receive(:mark_expert_classifier).once
       end
 
-      it "should call the #update_seen_subjects method" do
-        expect(subject).to receive(:update_seen_subjects).once
-      end
-
-      it "should call the #dequeue_subject method" do
-        expect(subject).to receive(:dequeue_subject).once
-      end
-
       it "should call the instance_eval on the passed block" do
         expect(subject).to receive(:instance_eval).once
       end
@@ -146,14 +150,6 @@ describe ClassificationLifecycle do
         expect(subject).to_not receive(:mark_expert_classifier)
       end
 
-      it "should not call the #update_seen_subjects method" do
-        expect(subject).to_not receive(:update_seen_subjects)
-      end
-
-      it "should not call the #dequeue_subject method" do
-        expect(subject).to_not receive(:dequeue_subject)
-      end
-
       it "should call the instance_eval on the passed block" do
         expect(subject).to receive(:instance_eval)
       end
@@ -171,7 +167,6 @@ describe ClassificationLifecycle do
       end
     end
   end
-
 
   describe "#publish_to_kafka" do
     after(:each) { subject.publish_to_kafka }

--- a/spec/models/user_seen_subject_spec.rb
+++ b/spec/models/user_seen_subject_spec.rb
@@ -82,14 +82,22 @@ RSpec.describe UserSeenSubject, :type => :model do
     end
   end
 
-  describe "#add_subjects" do
-    let(:uss) { user_seen_subject }
+  describe "::add_subjects" do
+    let(:uss) { user_seen_subject.save!; user_seen_subject }
 
     it "should add a subject's id to the subject_ids array" do
       s = create(:subject)
-      uss.add_subjects([s.id])
+      UserSeenSubject.where(id: uss.id).add_subjects([s.id])
       uss.reload
       expect(uss.subject_ids).to include(s.id)
+    end
+
+    it 'should be scoped to query passed to it' do
+      s = create(:subject)
+      uss2 = create(:user_seen_subject)
+      UserSeenSubject.where(id: uss.id).add_subjects([s.id])
+      uss.reload
+      expect(uss2.subject_ids).to_not include(s.id)
     end
   end
 

--- a/spec/models/user_seen_subject_spec.rb
+++ b/spec/models/user_seen_subject_spec.rb
@@ -82,25 +82,6 @@ RSpec.describe UserSeenSubject, :type => :model do
     end
   end
 
-  describe "::add_subjects" do
-    let(:uss) { user_seen_subject.save!; user_seen_subject }
-
-    it "should add a subject's id to the subject_ids array" do
-      s = create(:subject)
-      UserSeenSubject.where(id: uss.id).add_subjects([s.id])
-      uss.reload
-      expect(uss.subject_ids).to include(s.id)
-    end
-
-    it 'should be scoped to query passed to it' do
-      s = create(:subject)
-      uss2 = create(:user_seen_subject)
-      UserSeenSubject.where(id: uss.id).add_subjects([s.id])
-      uss.reload
-      expect(uss2.subject_ids).to_not include(s.id)
-    end
-  end
-
   describe "#subjects_seen?" do
     let(:uss) { build(:user_seen_subject) }
 

--- a/spec/workers/classification_worker_spec.rb
+++ b/spec/workers/classification_worker_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe ClassificationWorker do
         classification_worker.perform(classification.id, "update")
       end
 
-      it 'should call update_seen_subject' do
-        expect_any_instance_of(ClassificationLifecycle).to receive(:update_seen_subjects)
-      end
-
-      it 'should call dequeue_subject' do
-        expect_any_instance_of(ClassificationLifecycle).to receive(:dequeue_subject)
-      end
-
       it 'should call publish to kafka' do
         expect_any_instance_of(ClassificationLifecycle).to receive(:publish_to_kafka)
       end
@@ -39,14 +31,6 @@ RSpec.describe ClassificationWorker do
 
       it 'should call create_project_preferences' do
         expect_any_instance_of(ClassificationLifecycle).to receive(:create_project_preference)
-      end
-
-      it 'should call update_seen_subject' do
-        expect_any_instance_of(ClassificationLifecycle).to receive(:update_seen_subjects)
-      end
-
-      it 'should call dequeue_subject' do
-        expect_any_instance_of(ClassificationLifecycle).to receive(:dequeue_subject)
       end
 
       it 'should call publish to kafka' do


### PR DESCRIPTION
Handle this bit of bookkeeping during the request/response cycle to make
sure seen subjects are never shown to users. Also apply the "uniq"
function in PostgreSQL to queues and seen lists to make sure they don't
contain duplicate data.

Enable the "intarray" extension in PostgreSQL, which is installed in
RDS, in order to make sure these array operations and faster and easier to understand.

This should Close zooniverse/Panoptes-Front-End#426 and zooniverse/Panoptes-Front-End#425