### PR TITLE
Stringex's unique validation for urls uses SQL LIKE

### DIFF
--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -3,7 +3,8 @@ class UserGroup < ActiveRecord::Base
   include Activatable
   include Linkable
 
-  acts_as_url :display_name, sync_url: true, url_attribute: :slug
+  # Acts as url uses a LIKE query which can't be indexed we'll ensure uniqueness on our own
+  acts_as_url :display_name, sync_url: true, url_attribute: :slug, allow_duplicates: true
 
   has_many :memberships
   has_many :active_memberships, -> { active.where(identity: false) },
@@ -23,6 +24,7 @@ class UserGroup < ActiveRecord::Base
   validates :display_name, presence: true
   validates :display_name, format: { without: /\$|@|\s+/ }, unless: :identity?
   validates :name, presence: true, uniqueness: true
+  validates :slug, uniqueness: true
 
   before_validation :downcase_case_insensitive_fields
 

--- a/db/migrate/20150527223732_add_unique_index_to_slug.rb
+++ b/db/migrate/20150527223732_add_unique_index_to_slug.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToSlug < ActiveRecord::Migration
+  def change
+    remove_index :user_groups, :slug
+    add_index :user_groups, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150526180444) do
+ActiveRecord::Schema.define(version: 20150527223732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -329,7 +329,7 @@ ActiveRecord::Schema.define(version: 20150526180444) do
 
   add_index "user_groups", ["display_name"], name: "index_user_groups_on_display_name", unique: true, using: :btree
   add_index "user_groups", ["name"], name: "index_user_groups_on_name", unique: true, using: :btree
-  add_index "user_groups", ["slug"], name: "index_user_groups_on_slug", using: :btree
+  add_index "user_groups", ["slug"], name: "index_user_groups_on_slug", unique: true, using: :btree
 
   create_table "user_project_preferences", force: :cascade do |t|
     t.integer  "user_id"


### PR DESCRIPTION
Which is slow and not indexable without using postgresql extensions, and
is also pointless for this task. This adds custom validation of the slug
column and a unique index

Closes #897