### PR TITLE
queue updates for duplicate and deleted set_member_subjects

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -86,7 +86,7 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def self.enqueue_update(query, sms_ids)
-    query.update_all(["set_member_subject_ids = uniq(set_member_subject_ids + array[?])", sms_ids])
+    query.update_all(["set_member_subject_ids = set_member_subject_ids | array[?]", sms_ids])
   end
 
   def self.below_minimum

--- a/app/workers/queue_removal_worker.rb
+++ b/app/workers/queue_removal_worker.rb
@@ -3,8 +3,5 @@ class QueueRemovalWorker
 
   def perform(sms_ids, workflow_ids)
     SubjectQueue.dequeue_for_all(workflow_ids, sms_ids)
-    SubjectQueue.where(workflow: workflow_ids).below_minimum.find_each do |queue|
-      SubjectQueueWorker.perform_async(queue.workflow_id, queue.user_id)
-    end
   end
 end

--- a/spec/workers/queue_removal_worker_spec.rb
+++ b/spec/workers/queue_removal_worker_spec.rb
@@ -41,11 +41,6 @@ RSpec.describe QueueRemovalWorker do
       queues.each(&:reload)
       expect(queues[0..1].map(&:set_member_subject_ids)).to all( be_empty )
     end
-
-    it 'should queue rebuilds' do
-      expect(SubjectQueueWorker).to receive(:perform_async).exactly(2).times
-      subject.perform(first_set_sms_ids, workflows.first.id)
-    end
   end
 
   context "with multiple workflows" do
@@ -53,11 +48,6 @@ RSpec.describe QueueRemovalWorker do
       subject.perform(second_set_sms_ids, workflows[1..2].map(&:id))
       queues.each(&:reload)
       expect(queues[2..-1].map(&:set_member_subject_ids)).to all( be_empty )
-    end
-
-    it 'should queue rebuilds' do
-      expect(SubjectQueueWorker).to receive(:perform_async).exactly(4).times
-      subject.perform(second_set_sms_ids, workflows[1..2].map(&:id))
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/zooniverse/Panoptes-Front-End/issues/425

Use the union operator for set operations between lists of set_member_subjects to ensure no dups.

Also do not replenish a queue when deleting set_member_subjects, i.e. dequeuing. Dequeue works fine but replensihing all queues that fall below a minium straight after dequeue may add future non-existant data back into the queue. A new selection strategy that will return data and requeue if the queue is empty will avoid this need to replenish ahead of time.