### PR TITLE
Select users to notify about classification dumps

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -96,7 +96,7 @@ class Api::V1::MediaController < Api::ApiController
 
   def controlled_scope
     case media_name
-    when "classifications_exports"
+    when "classifications_export"
       :update
     else
       action_name.to_sym

--- a/app/mailers/classification_data_mailer.rb
+++ b/app/mailers/classification_data_mailer.rb
@@ -1,13 +1,9 @@
 class ClassificationDataMailer < ApplicationMailer
 
-  def classification_data(project, data_url)
+  def classification_data(project, data_url, emails)
     @project = project
-    @email_to = User.joins(user_groups: :access_control_lists)
-      .where(access_control_lists: { resource_type: "Project", resource_id: project.id })
-      .where.overlap(access_control_lists: { roles: ["owner", "collaborator"]})
-      .pluck(:email)
     @url = data_url
-    mail(to: @email_to, subject: "Classification Data is Ready")
+    mail(to: emails, subject: "Classification Data is Ready")
   end
 
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -32,10 +32,10 @@ class Medium < ActiveRecord::Base
   # TODO: This method is a good argument for converting this into a STI model
   def location
     case type
-    when "project_avatar", "user_avatar", "project_background"
-      resource, media_type = type.split("_")
-      "/#{resource.pluralize}/#{linked_id}/#{media_type}"
-    when "project_classifications_export", "project_attached_image"
+    when "project_avatar", "user_avatar", "project_background", "project_classifications_export"
+      resource, *media_type = type.split("_")
+      "/#{resource.pluralize}/#{linked_id}/#{media_type.join("_")}"
+    when "project_attached_image"
       resource, *media_type = type.split("_")
       "/#{resource.pluralize}/#{linked_id}/#{media_type.join("_").pluralize}/#{id}"
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,7 +21,7 @@ class Project < ActiveRecord::Base
   has_one :avatar, -> { where(type: "project_avatar") }, class_name: "Medium", as: :linked
   has_one :background, -> { where(type: "project_background") }, class_name: "Medium",
     as: :linked
-  has_many :classifications_exports, -> { where(type: "project_classifications_export")},
+  has_one :classifications_export, -> { where(type: "project_classifications_export")},
     class_name: "Medium", as: :linked
   has_many :attached_images, -> { where(type: "project_attached_image") }, class_name: "Medium",
     as: :linked

--- a/app/serializers/concerns/media_links_serializer.rb
+++ b/app/serializers/concerns/media_links_serializer.rb
@@ -4,8 +4,24 @@ module MediaLinksSerializer
   module ClassMethods
     def media_include(*links)
       @can_includes ||= []
-      @can_includes += links
-      @media_links = links
+      links.each do |link|
+        case link
+        when Symbol
+          @can_includes << link
+        when Hash
+          opts, _ = link.values
+          link_name, _ = link.keys
+          @can_includes << link_name if opts.fetch(:include, true)
+        end
+      end
+      @media_links = links.map do |link|
+        case link
+        when Hash
+          link.keys.first
+        else
+          link
+        end
+      end
     end
 
     def media_links

--- a/app/serializers/medium_serializer.rb
+++ b/app/serializers/medium_serializer.rb
@@ -2,7 +2,7 @@ class MediumSerializer
   include RestPack::Serializer
 
   attributes :id, :href, :src, :content_type, :media_type, :external_link,
-    :created_at, :metadata
+    :created_at, :metadata, :updated_at
 
   can_include :linked
 

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -13,7 +13,7 @@ class ProjectSerializer
   can_include :workflows, :subject_sets, :owners, :project_contents,
     :project_roles
   can_filter_by :display_name, :slug, :beta, :approved
-  media_include :avatar, :background, :attached_images
+  media_include :avatar, :background, :attached_images, :classifications_export
 
   def title
     content[:title]

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -13,7 +13,7 @@ class ProjectSerializer
   can_include :workflows, :subject_sets, :owners, :project_contents,
     :project_roles
   can_filter_by :display_name, :slug, :beta, :approved
-  media_include :avatar, :background, :attached_images, :classifications_export
+  media_include :avatar, :background, :attached_images, classifications_export: { include: false}
 
   def title
     content[:title]

--- a/app/workers/classification_data_mailer_worker.rb
+++ b/app/workers/classification_data_mailer_worker.rb
@@ -1,7 +1,7 @@
 class ClassificationDataMailerWorker
   include Sidekiq::Worker
 
-  def perform(project_id, s3_url)
-    ClassificationDataMailer.classification_data(Project.find(project_id), s3_url.to_s).deliver
+  def perform(project_id, s3_url, emails)
+    ClassificationDataMailer.classification_data(Project.find(project_id), s3_url.to_s, emails).deliver
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,8 +67,8 @@ Rails.application.routes.draw do
       end
 
       json_api_resources :projects, links: [:subject_sets, :workflows] do
-        media_resources :avatar, :background, :attached_images, classifications_exports: { except: [:update, :create] }
-        post "/classifications_exports", to: "projects#create_export", format: false
+        media_resources :avatar, :background, :attached_images, classifications_export: { except: [:create] }
+        post "/classifications_export", to: "projects#create_export", format: false
       end
 
       json_api_resources :workflows, links: [:subject_sets], versioned: true

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -79,6 +79,13 @@ describe Api::V1::ProjectsController, type: :controller do
           end
         end
 
+        describe "include classifications_export" do
+          let(:index_options) { {include: 'classifications_export'} }
+          it 'should not allow classifications_export to be included' do
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
         describe "filter by beta" do
           context "for beta projects" do
             let(:index_options) { { beta: "true" } }

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -20,6 +20,7 @@ describe Api::V1::ProjectsController, type: :controller do
       "projects.project_roles",
       "projects.avatar",
       "projects.background",
+      "projects.classifications_export",
       "projects.attached_images" ]
   end
 
@@ -57,7 +58,7 @@ describe Api::V1::ProjectsController, type: :controller do
       describe "params" do
         let!(:project_owner) { create(:user) }
         let!(:new_project) do
-          create(:project, display_name: "Non-test project", owner: project_owner)
+          create(:full_project, display_name: "Non-test project", owner: project_owner)
         end
 
         before(:each) do
@@ -69,12 +70,12 @@ describe Api::V1::ProjectsController, type: :controller do
 
           it 'should include avatar' do
             expect(json_response["linked"]["avatars"].map{ |r| r['id'] })
-              .to include(*projects.map(&:avatar).map(&:id).map(&:to_s))
+              .to include(new_project.avatar.id.to_s)
           end
 
           it 'should include background' do
             expect(json_response["linked"]["backgrounds"].map{ |r| r['id'] })
-              .to include(*projects.map(&:background).map(&:id).map(&:to_s))
+              .to include(new_project.background.id.to_s)
           end
         end
 
@@ -538,7 +539,7 @@ describe Api::V1::ProjectsController, type: :controller do
 
   describe "#create_export" do
     let(:resource) { create(:full_project, owner: user) }
-    let(:resource_url) { /http:\/\/test.host\/api\/projects\/#{resource.id}\/classifications_exports\/[0-9]+/ }
+    let(:resource_url) { /http:\/\/test.host\/api\/projects\/#{resource.id}\/classifications_export/ }
     let(:test_attr) { :type }
     let(:test_attr_value) { "project_classifications_export" }
     let(:new_resource) { Medium.find(created_instance_id(api_resource_name)) }
@@ -551,7 +552,10 @@ describe Api::V1::ProjectsController, type: :controller do
 
     let(:create_params) do
       params = {
-                media: { content_type: "text/csv" }
+                media: {
+                        content_type: "text/csv",
+                        metadata: { recipients: create_list(:user, 1).map(&:id) }
+                       }
                }
       params.merge(project_id: resource.id, media_name: "classifications_exports")
     end
@@ -562,6 +566,24 @@ describe Api::V1::ProjectsController, type: :controller do
       expect(ClassificationsDumpWorker).to receive(:perform_async).with(resource.id, an_instance_of(Fixnum))
       default_request scopes: scopes, user_id: user.id
       post :create_export, create_params
+    end
+
+    it 'should add the current user to the recipients list if none are specified' do
+      params = create_params
+      params[:media].delete(:metadata)
+      default_request scopes: scopes, user_id: user.id
+      post :create_export, params
+      expect(resource.classifications_export.metadata).to include("recipients" => [authorized_user.id])
+    end
+
+    it 'should update an existing export if one exists' do
+      params = create_params
+      params[:media].delete(:metadata)
+      export = create(:medium, linked: resource, type: "project_classifications_export", content_type: "text/csv", metadata: {})
+      default_request scopes: scopes, user_id: user.id
+      post :create_export, params
+      export.reload
+      expect(export.metadata).to include("recipients" => [authorized_user.id])
     end
   end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Api::V1::UsersController, type: :controller do
   let!(:users) {
-    create_list(:user, 22)
+    create_list(:user_with_avatar, 22)
   }
 
   let(:scopes) { %w(public user) }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -20,8 +20,6 @@ FactoryGirl.define do
     association :owner, factory: :user
 
     after(:build) do |p, env|
-      p.avatar = build(:medium, type: "project_avatar", linked: p)
-      p.background = build(:medium, type: "project_background", linked: p)
       if env.build_contents
         p.project_contents << build_list(:project_content, 1, project: p, language: p.primary_language)
         if env.build_extra_contents
@@ -37,6 +35,8 @@ FactoryGirl.define do
 
     factory :full_project do
       after(:create) do |p|
+        p.avatar = create(:medium, type: "project_avatar", linked: p)
+        p.background = create(:medium, type: "project_background", linked: p)
         workflow = create(:workflow, project: p)
         create_list(:subject_set_with_subjects, 2, project: p, workflows: [workflow])
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,8 +18,6 @@ FactoryGirl.define do
     banned false
 
     after(:build) do |u, env|
-      u.avatar = build(:medium, type: "user_avatar", linked: u)
-
       if env.build_group
         u.identity_group = build(:user_group, display_name: u.display_name)
         u.identity_membership = build(:membership, user: u, user_group: u.identity_group, state: 0, identity: true, roles: ["group_admin"])
@@ -28,6 +26,12 @@ FactoryGirl.define do
       if env.build_zoo_user
         zu = create(:zooniverse_user, login: u.display_name, password: u.password, email: u.email)
         u.zooniverse_id = zu.id.to_s
+      end
+    end
+
+    factory :user_with_avatar do
+      after(:build) do |u|
+        u.avatar = build(:medium, type: "user_avatar", linked: u)
       end
     end
 

--- a/spec/lib/accept_language_extractor_spec.rb
+++ b/spec/lib/accept_language_extractor_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe AcceptLanguageExtractor do
   describe "#parse_languages" do
     subject { AcceptLanguageExtractor.new("en-US,en;q=0.5,*") }
-    
+
     it 'should ignore non-alpha languages' do
       expect(subject.parse_languages).to_not include("*")
     end

--- a/spec/lib/export/export_json_project_spec.rb
+++ b/spec/lib/export/export_json_project_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Export::JSON::Project do
     JSON.parse(exporter.to_json)[object_key]
   end
 
-  let(:project) { create(:project_with_workflows) }
+  let(:project) { create(:full_project) }
   let(:avatar) { project.avatar }
   let(:background) { project.background }
   let(:project_content) { project.primary_content }
@@ -119,7 +119,6 @@ RSpec.describe Export::JSON::Project do
     end
 
     describe "workflows" do
-
       it "should be able to rebuild each workflow from the export" do
         export_values("workflows").each do |workflow_attrs|
           new_workflow = Workflow.new(workflow_attrs)
@@ -173,7 +172,7 @@ RSpec.describe Export::JSON::Project do
         end
 
         it "should build 8 instances" do
-          expect(instances.size).to eq(8)
+          expect(instances.size).to eq(6)
         end
 
         it "should be able to recreate the set of valid project instances" do

--- a/spec/mailers/classification_data_mailer_spec.rb
+++ b/spec/mailers/classification_data_mailer_spec.rb
@@ -3,22 +3,13 @@ require "spec_helper"
 RSpec.describe ClassificationDataMailer, :type => :mailer do
   let(:project) { create(:project) }
   let(:owner) { project.owner }
-  let(:mail) { ClassificationDataMailer.classification_data(project, "https://fake.s3.url.example.com")}
-
-  let!(:collaborators) do
-    users = create_list(:user, 2)
-    users.map(&:identity_group).each do |u|
-      create(:access_control_list, roles: ["collaborator"], resource: project, user_group: u)
-    end
-    users
+  let(:mail) do
+    ClassificationDataMailer.classification_data(project, "https://fake.s3.url.example.com", emails)
   end
+  let(:emails) { %w(test@examples.com admin@example.com) }
 
-  it 'should mail the project owner' do
-    expect(mail.to).to include(owner.email)
-  end
-
-  it 'should mail any project collaborators' do
-    expect(mail.to).to include(*collaborators.map(&:email))
+  it 'should mail the project the included emails' do
+    expect(mail.to).to include(*emails)
   end
 
   it 'should come from no-reply@zooniverse.org' do

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -33,7 +33,6 @@ describe ProjectSerializer do
     let(:links) { [:attached_images, :avatar, :background] }
     let(:serialized) { ProjectSerializer.resource({}, Project.where(id: project.id), context) }
 
-
     it 'should include top level links for media' do
       expect(serialized[:links]).to include(*links.map{ |l| "projects.#{l}" })
     end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ProjectSerializer do
-  let(:project) { create(:project_with_contents) }
+  let(:project) { create(:full_project) }
   let(:context) { {languages: ['en'], fields: [:title, :url_labels]} }
 
   let(:serializer) do
@@ -32,6 +32,7 @@ describe ProjectSerializer do
   describe "media links" do
     let(:links) { [:attached_images, :avatar, :background] }
     let(:serialized) { ProjectSerializer.resource({}, Project.where(id: project.id), context) }
+
 
     it 'should include top level links for media' do
       expect(serialized[:links]).to include(*links.map{ |l| "projects.#{l}" })

--- a/spec/workers/classification_data_mailer_worker_spec.rb
+++ b/spec/workers/classification_data_mailer_worker_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe ClassificationDataMailerWorker do
   let(:s3_url) { "https://fake.s3.url.example.com" }
 
   it 'should deliver the mail' do
-    expect{ subject.perform(project.id, s3_url) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    expect{ subject.perform(project.id, s3_url, ["ed.paget@gmail.com"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
 end


### PR DESCRIPTION
Pass a metadata key "recipients" when a classification export is created
with user ids and only those users will receive email notifications when
the dump is ready.

If no key is passed the project owner will be notified.

Closes zooniverse/Panoptes-Front-End#446
Closes zooniverse/Panoptes-Front-End#399
Closes #914