### PR TITLE
use the workflow index number not the id

### DIFF
--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -44,7 +44,7 @@ class WorkflowSerializer
 
   def version_index_number(model)
     if model && last_version = model.versions.last
-      last_version.id
+      last_version.index + 1
     else
       DEFAULT_WORKFLOW_VERSION_NUM
     end

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -19,8 +19,9 @@ describe WorkflowSerializer do
   end
 
   describe "#version" do
-    it 'should be a string of the current workflow version id and the workflow content version id', :versioning do
-      expect(serializer.version).to eq("#{workflow.versions.last.id}.#{content.versions.last.id}")
+    it 'should be the current workflow and workflow content version number', :versioning do
+      expected = "#{workflow.versions.last.index+1}.#{content.versions.last.index+1}"
+      expect(serializer.version).to eq(expected)
     end
   end
 
@@ -44,7 +45,7 @@ describe WorkflowSerializer do
     describe "#version", versioning: true do
 
       it "should use a 1 suffix for missing content versions" do
-        version_num = workflow.versions.last.id
+        version_num = workflow.versions.last.index + 1
         expect(serializer.version).to eq("#{version_num}.1")
       end
     end


### PR DESCRIPTION
closes #883, track the workflow version by the index into the versions array not the id of the version model. 

@edpaget FYI - this will change the submitted workfow version ID of all live projects for aggregation.