### PR TITLE
add client utc_offset to classification metadata

### DIFF
--- a/app/schemas/classification_create_schema.rb
+++ b/app/schemas/classification_create_schema.rb
@@ -44,6 +44,10 @@ class ClassificationCreateSchema < JsonSchema
       property "seen_before" do
         type "boolean"
       end
+
+      property "utc_offset" do
+        type "string"
+      end
     end
 
     property "annotations" do

--- a/app/schemas/classification_update_schema.rb
+++ b/app/schemas/classification_update_schema.rb
@@ -35,6 +35,10 @@ class ClassificationUpdateSchema < JsonSchema
       property "seen_before" do
         type "boolean"
       end
+
+      property "utc_offset" do
+        type "string"
+      end
     end
 
     property "annotations" do

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -6,7 +6,8 @@ def metadata_values
     finished_at: DateTime.now,
     workflow_version: "1.1",
     user_language: 'en',
-    user_agent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0"
+    user_agent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0",
+    utc_offset: Time.now.utc_offset
   }
 end
 
@@ -115,7 +116,7 @@ describe Api::V1::ClassificationsController, type: :controller do
         it_behaves_like "a classification lifecycle event"
         it_behaves_like "a gold standard classfication"
 
-        context "when extra invalid classifcation properties are added" do
+        context "when extra invalid classification properties are added" do
           let!(:invalid_property) { :custom_field }
 
           it "should fail via the schema validator with the correct message" do


### PR DESCRIPTION
May be useful information to determine when a user classified. This came up the other day when we were assessing Penguin Watch competition annotations. The annotation time stamps are in UTC so it'd be nice to add another field to capture the UTC offset of the client computer to have more insight into when a user classifies.