### PR TITLE
ensure user display name is always present

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,8 +31,9 @@ class User < ActiveRecord::Base
 
   belongs_to :signup_project, class_name: 'Project', foreign_key: "project_id"
 
-  validates :display_name, presence: true, uniqueness: { case_sensitive: false },
-    format: { without: /\$|@|\s+/ }, unless: :migrated
+  validates :display_name, presence: true, uniqueness: { case_sensitive: false }
+  validates :display_name, format: { without: /\$|@|\s+/ }, unless: :migrated
+
   validates_length_of :password, within: 8..128, allow_blank: true, unless: :migrated
   validates_inclusion_of :valid_email, in: [true, false], message: "must be true or false"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,8 +104,32 @@ describe User, type: :model do
       expect(build(:user, display_name: "$asdfasdf")).to_not be_valid
     end
 
-    it 'should not ahve an at sign' do
+    it 'should not have an at sign' do
       expect(build(:user, display_name: "@asdfasdf")).to_not be_valid
+    end
+
+    context "migrated users" do
+      let(:user) { build(:user, migrated: true) }
+
+      it 'should validate presence' do
+        user.display_name = ""
+        expect(user).to_not be_valid
+      end
+
+      it 'should not have whitespace' do
+        user.display_name = " asdf asdf"
+        expect(user).to be_valid
+      end
+
+      it 'should not have a dollar sign' do
+        user.display_name = "$asdfasdf"
+        expect(user).to be_valid
+      end
+
+      it 'should not have an at sign' do
+        user.display_name = "@asdfasdf"
+        expect(user).to be_valid
+      end
     end
 
     it 'should have non-blank error' do


### PR DESCRIPTION
split the validations between presence and format for migrated / normal users