### PR TITLE
copy subject_set to workflow via update_links

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -69,4 +69,25 @@ class Api::V1::WorkflowsController < Api::ApiController
     task_string_extractor.visit(tasks)
     [tasks, task_string_extractor.collector]
   end
+
+  def new_items(resource, relation, value)
+    items = construct_new_items(super(resource, relation, value), resource.project_id)
+    if items.any? { |item| item.is_a?(SubjectSet) }
+      items
+    else
+      items.first
+    end
+  end
+
+  def construct_new_items(item_scope, workflow_project_id)
+    Array.wrap(item_scope).map do |item|
+      if item.is_a?(SubjectSet) && !item.belongs_to_project?(workflow_project_id)
+        item.dup.tap do |subject_set|
+          subject_set.project_id = workflow_project_id
+        end
+      else
+        item
+      end
+    end
+  end
 end

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -18,10 +18,11 @@ class SubjectSet < ActiveRecord::Base
   can_through_parent :project, :update, :show, :destroy, :index, :update_links,
     :destroy_links
 
-  can_be_linked :workflow, :same_project?, :model
+  can_be_linked :project, :scope_for, :show, :user
+  can_be_linked :workflow, :scope_for, :show, :user
   can_be_linked :set_member_subject, :scope_for, :update, :user
 
-  def self.same_project?(workflow)
-    where(project: workflow.project)
+  def belongs_to_project?(other_project_id)
+    project_id == other_project_id
   end
 end

--- a/lib/json_api_controller/relation_manager.rb
+++ b/lib/json_api_controller/relation_manager.rb
@@ -40,8 +40,7 @@ module JsonApiController
 
     def new_items(resource, relation, value, *args)
       relation_find(value) do
-        assoc_class(relation)
-          .link_to_resource(resource, api_user, *args)
+        assoc_class(relation).link_to_resource(resource, api_user, *args)
       end
     end
 

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -146,7 +146,6 @@ describe Api::V1::GroupsController, type: :controller do
 
     context "created membership" do
       before(:each) do
-
         default_request scopes: scopes, user_id: authorized_user.id
         post :update_links, group_id: resource.id, users: [ new_user.id.to_s ], link_relation: "users"
       end

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -29,10 +29,11 @@ describe SubjectSet, :type => :model do
   describe "links" do
     let(:project) { create(:project) }
     let(:workflow) { create(:workflow, project: project) }
+    let(:user) { ApiUser.new(create(:user)) }
 
-    it 'should allow links to workflows in the same project' do
-      expect(SubjectSet).to link_to(workflow)
-        .with_scope(:where, { project: project })
+    it 'should allow links to workflows in other projects' do
+      expect(SubjectSet).to link_to(workflow).given_args(user)
+        .with_scope(:scope_for, :show, user)
     end
   end
 
@@ -63,7 +64,7 @@ describe SubjectSet, :type => :model do
   context "set with member subjects" do
     let(:subject_set) { create(:subject_set_with_subjects) }
 
-    describe "#set_member_subjects" do 
+    describe "#set_member_subjects" do
       it "should have many seted subjects" do
         expect(subject_set.set_member_subjects).to all( be_a(SetMemberSubject) )
       end
@@ -78,6 +79,21 @@ describe SubjectSet, :type => :model do
       it "should have a count of the number of set member subjects in the set" do
         expect(subject_set.set_member_subjects_count).to eq(subject_set.set_member_subjects.count)
       end
+    end
+  end
+
+  describe "#belongs_to_project?" do
+
+    it "should be false with nil" do
+      expect(subject_set.belongs_to_project?(nil)).to eq(false)
+    end
+
+    it "should be false with it's another project id" do
+      expect(subject_set.belongs_to_project?(subject_set.project_id+1)).to eq(false)
+    end
+
+    it "should be true with it's own project id" do
+      expect(subject_set.belongs_to_project?(subject_set.project_id)).to eq(true)
     end
   end
 end

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -60,7 +60,6 @@ shared_examples "is updatable" do
 end
 
 RSpec.shared_examples "has updatable links" do
-  let(:old_ids) { resource.send(test_relation).map(&:id) }
   let(:updated_resource) { resource.reload }
 
   before(:each) do
@@ -87,13 +86,12 @@ RSpec.shared_examples "supports update_links" do
       test_relation => test_relation_ids,
       resource_id => resource.id
     }
-
     post :update_links, params
   end
 
   it 'should update any included links' do
-    expect(updated_resource.send(test_relation)
-            .map(&:id).map(&:to_s)).to include(*test_relation_ids)
+    updated_relation_ids = updated_resource.send(test_relation).map(&:id).map(&:to_s)
+    expect(updated_relation_ids).to include(*test_relation_ids)
   end
 
   it 'should retain pre-existing links' do


### PR DESCRIPTION
closes #907 link the subject_set to a workflow and copy a subject set if it belongs to another project.

@edpaget can you make sure i'm doing this correctly and adding the SubjectSet `can_be_linked` scopes to show.

Also looks like we need to spec `Projects#update_links` as per the [docs](http://docs.panoptes.apiary.io/#reference/projects/project-create-links/add-a-link) as well as the `PUT` ones [here](https://github.com/zooniverse/Panoptes/blob/b90088a15a3d079072b795bfa9d5f1d0b253a6a4/spec/controllers/api/v1/projects_controller_spec.rb#L522). 

