### PR TITLE
Fix Talk API client to set correct token

### DIFF
--- a/lib/tasks/talk.rake
+++ b/lib/tasks/talk.rake
@@ -3,7 +3,7 @@
 
 namespace :talk do
   desc "import owners and collaborators as admins of their talk instances"
-  task :create_admins do
+  task create_admins: :environment do
     client = TalkApiClient.new
     Project.find_each do |project|
       project.create_talk_admin client


### PR DESCRIPTION
Include scopes in token and make sure it using the token field instead
of the whole object