### PR TITLE
Track beta users

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::UsersController < Api::ApiController
 
   schema_type :strong_params
 
-  allowed_params :update, :display_name, :email, :credited_name, :global_email_communication
+  allowed_params :update, :display_name, :email, :credited_name,
+   :global_email_communication, :project_email_communication
 
   alias_method :user, :controlled_resource
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,7 +8,8 @@ class Api::V1::UsersController < Api::ApiController
   schema_type :strong_params
 
   allowed_params :update, :display_name, :email, :credited_name,
-   :global_email_communication, :project_email_communication
+   :global_email_communication, :project_email_communication,
+   :beta_email_communication
 
   alias_method :user, :controlled_resource
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,8 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.for(:sign_up) do |u|
       u.permit(:email, :password, :password_confirmation, :display_name,
                :credited_name, :global_email_communication,
-               :project_email_communication, :project_id)
+               :project_email_communication, :beta_email_communication,
+               :project_id)
     end
   end
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,7 +5,7 @@ class UserSerializer
 
   attributes :id, :display_name, :credited_name, :email, :created_at,
     :updated_at, :type, :firebase_auth_token, :global_email_communication,
-    :slug, :max_subjects, :uploaded_subjects_count
+    :project_email_communication, :slug, :max_subjects, :uploaded_subjects_count
   can_include :classifications, :project_preferences, :collection_preferences,
     projects: { param: "owner", value: "slug" },
     collections: { param: "owner", value: "slug" }
@@ -22,6 +22,10 @@ class UserSerializer
 
   def global_email_communication
     permitted_value(@model.global_email_communication)
+  end
+
+  def project_email_communication
+    permitted_value(@model.project_email_communication)
   end
 
   def firebase_auth_token

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,7 +5,9 @@ class UserSerializer
 
   attributes :id, :display_name, :credited_name, :email, :created_at,
     :updated_at, :type, :firebase_auth_token, :global_email_communication,
-    :project_email_communication, :slug, :max_subjects, :uploaded_subjects_count
+    :project_email_communication, :beta_email_communication,
+    :slug, :max_subjects, :uploaded_subjects_count
+
   can_include :classifications, :project_preferences, :collection_preferences,
     projects: { param: "owner", value: "slug" },
     collections: { param: "owner", value: "slug" }
@@ -26,6 +28,10 @@ class UserSerializer
 
   def project_email_communication
     permitted_value(@model.project_email_communication)
+  end
+
+  def beta_email_communication
+    permitted_value(@model.beta_email_communication)
   end
 
   def firebase_auth_token

--- a/db/migrate/20150605103339_add_beta_email_to_users.rb
+++ b/db/migrate/20150605103339_add_beta_email_to_users.rb
@@ -1,0 +1,8 @@
+class AddBetaEmailToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :beta_email_communication, :boolean
+
+    add_index :users, :global_email_communication, where: "global_email_communication IS TRUE"
+    add_index :users, :beta_email_communication, where: "beta_email_communication IS TRUE"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150602160633) do
+ActiveRecord::Schema.define(version: 20150605103339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -386,11 +386,14 @@ ActiveRecord::Schema.define(version: 20150602160633) do
     t.boolean  "valid_email",                 default: true,     null: false
     t.integer  "uploaded_subjects_count",     default: 0
     t.integer  "project_id"
+    t.boolean  "beta_email_communication"
   end
 
+  add_index "users", ["beta_email_communication"], name: "index_users_on_beta_email_communication", where: "(beta_email_communication IS TRUE)", using: :btree
   add_index "users", ["display_name"], name: "index_users_on_display_name", unique: true, using: :btree
   add_index "users", ["display_name"], name: "users_display_name_trgm_index", using: :gist, opclass: {"display_name"=>:gist_trgm_ops}
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["global_email_communication"], name: "index_users_on_global_email_communication", where: "(global_email_communication IS TRUE)", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "versions", force: :cascade do |t|

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -157,7 +157,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
         let(:collection) { create(:collection_with_subjects) }
         it "should create a new subject set with the collection's subjects" do
           set = SubjectSet.find(created_instance_id(api_resource_name))
-          expect(set.subjects).to match(collection.subjects)
+          expect(set.subjects).to match_array(collection.subjects)
         end
       end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::V1::UsersController, type: :controller do
   let(:api_resource_attributes) do
     [ "id", "display_name", "credited_name", "email",
       "created_at", "updated_at", "type",
-      "global_email_communication" ]
+      "global_email_communication", "project_email_communication" ]
   end
 
   let(:api_resource_links) do
@@ -59,6 +59,14 @@ describe Api::V1::UsersController, type: :controller do
 
       it 'should have an empty string credited name' do
         expect(json_response[api_resource_name]).to all( include("credited_name" => "") )
+      end
+
+      it 'should have an empty string global email communication' do
+        expect(json_response[api_resource_name]).to all( include("global_email_communication" => "") )
+      end
+
+      it 'should have an empty string project email communication' do
+        expect(json_response[api_resource_name]).to all( include("project_email_communication" => "") )
       end
 
       it "should have an empty string for the uploaded_subjects_count" do
@@ -233,6 +241,10 @@ describe Api::V1::UsersController, type: :controller do
       expect(created_instance(api_resource_name)["global_email_communication"]).to eq(true)
     end
 
+    it "should have a the project email communication for the user" do
+      expect(created_instance(api_resource_name)["project_email_communication"]).to eq(true)
+    end
+
     it_behaves_like "an api response"
   end
 
@@ -343,9 +355,12 @@ describe Api::V1::UsersController, type: :controller do
     context "with a valid replace put operation" do
       before(:each) { update_request }
       let(:new_display_name) { "Mr_Creosote" }
-      let(:new_gec) { true }
+      let(:new_gec) { false }
+      let(:new_pec) { false }
       let(:put_operations) do
-        { users: { display_name: new_display_name, global_email_communication: new_gec } }
+        { users: { display_name: new_display_name,
+                   global_email_communication: new_gec,
+                   project_email_communication: new_pec } }
       end
 
       it "should return 200 status" do
@@ -358,6 +373,10 @@ describe Api::V1::UsersController, type: :controller do
 
       it "should have updated the global email communication attribute" do
         expect(user.reload.global_email_communication).to eq(new_gec)
+      end
+
+      it "should have updated the project email communication attribute" do
+        expect(user.reload.project_email_communication).to eq(new_pec)
       end
 
       it "should have a single group" do

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -11,7 +11,8 @@ describe Api::V1::UsersController, type: :controller do
   let(:api_resource_attributes) do
     [ "id", "display_name", "credited_name", "email",
       "created_at", "updated_at", "type",
-      "global_email_communication", "project_email_communication" ]
+      "global_email_communication", "project_email_communication",
+      "beta_email_communication" ]
   end
 
   let(:api_resource_links) do
@@ -67,6 +68,10 @@ describe Api::V1::UsersController, type: :controller do
 
       it 'should have an empty string project email communication' do
         expect(json_response[api_resource_name]).to all( include("project_email_communication" => "") )
+      end
+
+      it 'should have an empty string beta email communication' do
+        expect(json_response[api_resource_name]).to all( include("beta_email_communication" => "") )
       end
 
       it "should have an empty string for the uploaded_subjects_count" do
@@ -245,6 +250,10 @@ describe Api::V1::UsersController, type: :controller do
       expect(created_instance(api_resource_name)["project_email_communication"]).to eq(true)
     end
 
+    it "should have a the beta email communication for the user" do
+      expect(created_instance(api_resource_name)["beta_email_communication"]).to eq(true)
+    end
+
     it_behaves_like "an api response"
   end
 
@@ -357,10 +366,12 @@ describe Api::V1::UsersController, type: :controller do
       let(:new_display_name) { "Mr_Creosote" }
       let(:new_gec) { false }
       let(:new_pec) { false }
+      let(:new_bec) { false }
       let(:put_operations) do
         { users: { display_name: new_display_name,
                    global_email_communication: new_gec,
-                   project_email_communication: new_pec } }
+                   project_email_communication: new_pec,
+                   beta_email_communication: new_bec } }
       end
 
       it "should return 200 status" do
@@ -377,6 +388,10 @@ describe Api::V1::UsersController, type: :controller do
 
       it "should have updated the project email communication attribute" do
         expect(user.reload.project_email_communication).to eq(new_pec)
+      end
+
+      it "should have updated the beta email communication attribute" do
+        expect(user.reload.beta_email_communication).to eq(new_bec)
       end
 
       it "should have a single group" do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -13,7 +13,7 @@ describe RegistrationsController, type: :controller do
     let(:user_params) do
       [ :email, :password, :password_confirmation, :display_name,
         :global_email_communication, :project_email_communication,
-        :project_id ]
+        :beta_email_communication, :project_id ]
     end
 
     before(:each) do
@@ -102,6 +102,14 @@ describe RegistrationsController, type: :controller do
           expect(User.find(created_instance_id("users"))).to_not be_nil
         end
 
+        it "should set the permitted params on the created user" do
+          post :create, user: user_attributes
+          user = User.find(created_instance_id("users"))
+          user_attributes.except(:password).each do |attr, expected_value|
+            expect(user.send(attr)).to eq(expected_value)
+          end
+        end
+
         it "should sign the user in" do
           expect(subject).to receive(:sign_in)
           post :create, user: user_attributes
@@ -142,7 +150,7 @@ describe RegistrationsController, type: :controller do
         end
       end
 
-      context "when email communications are true" do
+      context "when email communications are false" do
         let(:extra_attributes) { { display_name: 'asdfasdf', global_email_communication: false } }
         it 'should call subscribe worker' do
           expect(SubscribeWorker).to_not receive(:perform_async)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
     sequence(:display_name) { |n| "new_user_#{n}" }
     global_email_communication true
     project_email_communication true
+    beta_email_communication true
     admin false
     banned false
 


### PR DESCRIPTION
Resolves the back end part of https://github.com/zooniverse/Panoptes-Front-End/issues/415

Add a field to users to track which users want to receive beta emails. Also expose this and the project_email_communications attribute through the user serializer for the logged in user.

The beta list is planned to be managed like the zoo wide list using JiscMail so we may not need the indexes. I can see query use cases for them though.