### PR TITLE
copy set_member_subjects with subject_set

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -96,8 +96,10 @@ class Api::V1::WorkflowsController < Api::ApiController
     orig_subject_set.dup.tap do |subject_set|
       subject_set.project_id = workflow_project_id
       subject_set.set_member_subjects_count = 0
-      subject_set.set_member_subjects = orig_subject_set.set_member_subjects.map do |sms|
-        SetMemberSubject.new(subject_set: subject_set, subject_id: sms.subject_id)
+      subject_set.set_member_subjects = [].tap do |new_smss|
+        orig_subject_set.set_member_subjects.find_each do |sms|
+          new_smss << SetMemberSubject.new(subject_set: subject_set, subject_id: sms.subject_id)
+        end
       end
     end
   end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::WorkflowsController < Api::ApiController
   resource_actions :default
   schema_type :json_schema
 
+  attr_accessor :workflow_project_id
+
   def show
     load_queue
     super
@@ -71,7 +73,8 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def new_items(resource, relation, value)
-    items = construct_new_items(super(resource, relation, value), resource.project_id)
+    @workflow_project_id = resource.project_id
+    items = construct_new_items(super(resource, relation, value))
     if items.any? { |item| item.is_a?(SubjectSet) }
       items
     else
@@ -79,14 +82,22 @@ class Api::V1::WorkflowsController < Api::ApiController
     end
   end
 
-  def construct_new_items(item_scope, workflow_project_id)
+  def construct_new_items(item_scope)
     Array.wrap(item_scope).map do |item|
       if item.is_a?(SubjectSet) && !item.belongs_to_project?(workflow_project_id)
-        item.dup.tap do |subject_set|
-          subject_set.project_id = workflow_project_id
-        end
+        duplicate_subject_set_and_subjects(item)
       else
         item
+      end
+    end
+  end
+
+  def duplicate_subject_set_and_subjects(orig_subject_set)
+    orig_subject_set.dup.tap do |subject_set|
+      subject_set.project_id = workflow_project_id
+      subject_set.set_member_subjects_count = 0
+      subject_set.set_member_subjects = orig_subject_set.set_member_subjects.map do |sms|
+        SetMemberSubject.new(subject_set: subject_set, subject_id: sms.subject_id)
       end
     end
   end


### PR DESCRIPTION
Related to #942 copying a subject set didn't copy any subjects. This PR ensures that when copying a subject set from another project that the subjects are also copied.