### PR TITLE
build a logged out queue if none exists

### DIFF
--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -41,7 +41,13 @@ RSpec.describe SubjectQueue, :type => :model do
     let(:workflow) {create(:workflow)}
     let(:user) { create(:user) }
 
-    context "no logged out queue" do
+    context "when no logged out queue" do
+
+      it 'should attempt to build a logged out queue' do
+        expect(SubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
+        SubjectQueue.create_for_user(workflow, user)
+      end
+
       it 'should return nil' do
         expect(SubjectQueue.create_for_user(workflow, user)).to be_nil
       end


### PR DESCRIPTION
Change behaviour to ensure a logged out queue will eventually exist when attempting to build a queue for a logged in user.

Ran into this when testing out the project builder as the front end doesn't call workflow show routes now so the logged out queue doesn't get prebuilt under some combination of setup. 