### PR TITLE
do not allow filtering params to subejct serializer

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -13,7 +13,8 @@ class Api::V1::SubjectsController < Api::ApiController
   def index
     case params[:sort]
     when 'queued', 'cellect' #temporary to not break compatibility with front-end
-      render json_api: SubjectSerializer.page(params, *selector.queued_subjects)
+      non_filterable_params = params.except(:project_id, :collection_id)
+      render json_api: SubjectSerializer.page(non_filterable_params, *selector.queued_subjects)
     else
       super
     end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -87,6 +87,20 @@ describe Api::V1::SubjectsController, type: :controller do
             end
 
             it_behaves_like "an api response"
+
+            context "with extraneous filtering params" do
+              let!(:request_params) do
+                { sort: 'queued', workflow_id: workflow.id.to_s, project_id: "1", collection_id: "1" }
+              end
+
+              it "should return 200" do
+                expect(response.status).to eq(200)
+              end
+
+              it 'should return a page of 2 objects' do
+                expect(json_response[api_resource_name].length).to eq(2)
+              end
+            end
           end
 
           context 'when the queue is below minimum' do


### PR DESCRIPTION
Linked to https://github.com/zooniverse/Panoptes-Front-End/issues/512 

Passing filtering params will exclude valid values from the serialized response. E.g. filtering subjects based on project_id for copied subjects (default subject set) will exclude these values from the response.