### PR TITLE
When talk isn't configured log api attempts

### DIFF
--- a/app/workers/talk_admin_create_worker.rb
+++ b/app/workers/talk_admin_create_worker.rb
@@ -3,6 +3,8 @@ class TalkAdminCreateWorker
 
   def perform(project_id)
     Project.find(project_id).create_talk_admin(client)
+  rescue TalkApiClient::NoTalkHostError => e
+    Rails.logger.info e # TODO: remove when production talk is deployed
   end
 
   def client

--- a/lib/talk_api_client.rb
+++ b/lib/talk_api_client.rb
@@ -1,4 +1,7 @@
 class TalkApiClient
+  class NoTalkHostError < StandardError
+  end
+
   class JSONAPIResource
     attr_reader :type, :href, :connection
     def initialize(connection, type, href)
@@ -10,7 +13,7 @@ class TalkApiClient
     end
 
     def create(attrs={})
-      response = connection.request('post', href) do |req|
+      connection.request('post', href) do |req|
         req.body = {@type => attrs}.to_json
       end
     end
@@ -48,6 +51,9 @@ class TalkApiClient
   attr_reader :connection, :token
 
   def initialize(adapter = Faraday.default_adapter)
+    unless host
+      raise NoTalkHostError, "A talk instance has not been configured for #{Rails.env} environment"
+    end
     @resources = {}.with_indifferent_access
     create_token
     create_connection(adapter)

--- a/spec/lib/talk_api_client_spec.rb
+++ b/spec/lib/talk_api_client_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe TalkApiClient do
     end
   end
 
+  it 'raise an error when no host is configured' do
+    described_class.host = nil
+    expect{described_class.new}.to raise_error(TalkApiClient::NoTalkHostError, "A talk instance has not been configured for test environment")
+  end
+
   context "instance methods" do
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|


### PR DESCRIPTION
There's no production talk at the moment, so just log that we tried to talk (heh) to it and do nothing. 