### PR TITLE
track the id of the modifying user for paper trail versions

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -58,7 +58,9 @@ module Api
       ( param_langs | user_langs | header_langs ).compact
     end
 
-    alias_method :user_for_paper_trail, :current_resource_owner
+    def user_for_paper_trail
+      @whodunnit_id ||= current_resource_owner.try(:id) || "UnauthenticatedUser"
+    end
 
     def user_accept_languages
       api_user.try(:languages) || []

--- a/spec/support/versioned_resource.rb
+++ b/spec/support/versioned_resource.rb
@@ -30,6 +30,20 @@ RSpec.shared_examples "a versioned resource" do
     PaperTrail.enabled_for_controller = false
   end
 
+  describe "#user_for_paper_trail" do
+
+    it 'should respond with the current user id when logged in' do
+      expect(subject.send(:user_for_paper_trail)).to eq(authorized_user.id)
+    end
+
+    context "when not logged in" do
+      it 'should respond with the current user id' do
+        allow(subject).to receive(:current_resource_owner).and_return(nil)
+        expect(subject.send(:user_for_paper_trail)).to eq("UnauthenticatedUser")
+      end
+    end
+  end
+
   describe "#versions" do
     before(:each) do
       get :versions, { resource_param => resource.id }


### PR DESCRIPTION
whodunnit was storing the user object id and not the id of the database record.