### PR TITLE
ignore subject limits for admin users

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::SubjectsController < Api::ApiController
   private
 
   def check_subject_limit
-    if Panoptes.max_subjects && api_user.uploaded_subjects_count >= Panoptes.max_subjects
+    if Panoptes.max_subjects && !api_user.is_admin? && api_user.uploaded_subjects_count >= Panoptes.max_subjects
       raise Api::LimitExceeded, "User has uploaded #{api_user.uploaded_subjects_count} subjects of #{Panoptes.max_subjects} maximum"
     end
   end


### PR DESCRIPTION
admin users will have to upload large data sets for projects.