### PR TITLE
Speed up destroy_links for subject sets

### DIFF
--- a/app/workers/count_reset_worker.rb
+++ b/app/workers/count_reset_worker.rb
@@ -1,0 +1,11 @@
+class CountResetWorker
+  include Sidekiq::Worker
+
+  def perform(subject_set_id)
+    SubjectSet.reset_counters(subject_set_id, :set_member_subjects)
+    Workflow.joins(:subject_sets).where(subject_sets: {id: subject_set_id}).find_each do |w|
+      w.retired_set_member_subjects_count = SetMemberSubject.where('? = ANY(retired_workflow_ids)', w.id).count
+      w.save!
+    end
+  end
+end

--- a/spec/workers/count_reset_worker_spec.rb
+++ b/spec/workers/count_reset_worker_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe CountResetWorker do
+  let(:workflows) { create_list(:workflow, 2, subject_sets: []) }
+  let(:subject_set) { create(:subject_set, workflows: workflows) }
+  let!(:sms) { create_list(:set_member_subject, 4, subject_set: subject_set, retired_workflows: [workflows.first]) }
+
+  subject { CountResetWorker.new }
+
+  describe "#perform" do
+    it 'should reset the set_member_subject_count' do
+      expect do
+        SetMemberSubject.where(id: sms[0..1].map(&:id)).delete_all
+        subject.perform(subject_set.id)
+      end.to change{SubjectSet.find(subject_set.id).set_member_subjects_count}.from(4).to(2)
+    end
+
+    it 'should reset the workflow retired count' do
+      workflow = workflows.first
+      workflow.retired_set_member_subjects_count = SetMemberSubject.where("? = ANY(retired_workflow_ids)", workflow.id).count
+      workflow.save!
+      expect do
+        SetMemberSubject.where(id: sms[0..1].map(&:id)).delete_all
+        subject.perform(subject_set.id)
+      end.to change{Workflow.find(workflow.id).retired_set_member_subjects_count}.from(4).to(2)
+    end
+  end
+
+end


### PR DESCRIPTION
Delete links without callbacks and manually queue workers. Closes #974