### PR TITLE
case insensitive owner filter on the idenity group

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,3 +377,6 @@ DEPENDENCIES
   therubyrhino
   uglifier (~> 2.0)
   versionist (~> 1.0)
+
+BUNDLED WITH
+   1.10.4

--- a/app/controllers/concerns/filter_by_owner.rb
+++ b/app/controllers/concerns/filter_by_owner.rb
@@ -8,7 +8,7 @@ module FilterByOwner
   def add_owner_ids_to_filter_param!
     owner_filter = params.delete(:owner).try(:split, ',')
     unless owner_filter.blank?
-      groups = UserGroup.where('lower(name) = ?', owner_filter.map(&:downcase))
+      groups = UserGroup.where(UserGroup.arel_table[:name].lower.in(owner_filter.map(&:downcase)))
       @controlled_resources = controlled_resources
         .joins(:access_control_lists)
         .where(access_control_lists: {user_group: groups})

--- a/app/controllers/concerns/filter_by_owner.rb
+++ b/app/controllers/concerns/filter_by_owner.rb
@@ -8,7 +8,7 @@ module FilterByOwner
   def add_owner_ids_to_filter_param!
     owner_filter = params.delete(:owner).try(:split, ',')
     unless owner_filter.blank?
-      groups = UserGroup.where(name: owner_filter)
+      groups = UserGroup.where('lower(name) = ?', owner_filter.map(&:downcase))
       @controlled_resources = controlled_resources
         .joins(:access_control_lists)
         .where(access_control_lists: {user_group: groups})

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -138,7 +138,7 @@ describe Api::V1::ProjectsController, type: :controller do
           end
 
           context "when the project owner name has a differnt case to the identity group" do
-            let!(:index_options) { { owner: project_owner.login.upcase } }
+            let!(:index_options) { { owner: [project_owner.login.upcase, 'SOMETHING'].join(',') } }
 
             it "should respond with 1 item" do
               expect(json_response[api_resource_name].length).to eq(1)

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -136,6 +136,19 @@ describe Api::V1::ProjectsController, type: :controller do
             owner_id = json_response[api_resource_name][0]['links']['owner']['id']
             expect(owner_id).to eq(new_project.owner.id.to_s)
           end
+
+          context "when the project owner name has a differnt case to the identity group" do
+            let!(:index_options) { { owner: project_owner.login.upcase } }
+
+            it "should respond with 1 item" do
+              expect(json_response[api_resource_name].length).to eq(1)
+            end
+
+            it "should respond with the correct item" do
+              owner_id = json_response[api_resource_name][0]['links']['owner']['id']
+              expect(owner_id).to eq(new_project.owner.id.to_s)
+            end
+          end
         end
 
         describe "filter by current_user_roles" do


### PR DESCRIPTION
older identity groups may have a different case to the login field so we need to use a case insensitive query path here.

http://preview.zooniverse.org/panoptes/#/projects/VVH/prettiest-pugs
http://preview.zooniverse.org/panoptes/#/projects/OxfordGreg/star-trek-aliens