### PR TITLE
Include login_prompt parameter on serializer

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -54,6 +54,10 @@ class UserSerializer
     "users"
   end
 
+  def login_prompt
+    @model.migrated && @model.sign_in_count <= 1
+  end
+
   private
 
   def permitted_requester?
@@ -61,7 +65,8 @@ class UserSerializer
   end
 
   %w(credited_name email global_email_communication project_email_communication
-     beta_email_communication uploaded_subjects_count max_subjects admin).each do |me_only_attribute|
+     beta_email_communication uploaded_subjects_count max_subjects admin
+     login_prompt).each do |me_only_attribute|
     alias_method :"include_#{me_only_attribute}?", :permitted_requester?
   end
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -54,5 +54,13 @@ namespace :migrate do
       beta_users.update_all(beta_email_communication: true)
       puts "Updated #{ beta_users_count } users to receive emails for beta tests."
     end
+
+    desc "Reset user sign_in_count"
+    task reset_sign_in_count: :environment do
+      user_logins = ENV['USERS'].try(:split, ",")
+      query = User.where(migrated: true).where("sign_in_count > 1")
+      query = query.where(login: user_logins) if user_logins
+      query.update_all(sign_in_count: 0)
+    end
   end
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe UserSerializer do
+  let(:user) { create(:user, migrated: migrated, sign_in_count: sign_in) }
+
+  describe "#login_prompt" do
+    subject do
+      s =described_class.new
+      s.instance_variable_set(:@model, user)
+      s.instance_variable_set(:@context, {requesting_user: user})
+      s.login_prompt
+    end
+
+    context "a migrated user" do
+      let(:migrated) { true }
+      context "with a previous sign on" do
+        let(:sign_in) { 2 }
+
+        it { is_expected.to be false }
+      end
+
+      context "without a previous sign on" do
+        let(:sign_in) { 1 }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "a non-migrated-user" do
+      let(:migrated) { false }
+      let(:sign_in) { 10 }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
Let's the front-end know to ask them if they want to change their login
name on the first visit for returning users.