### PR TITLE
ensure user login field cannot be null

### DIFF
--- a/db/migrate/20150622085848_add_not_null_login_users.rb
+++ b/db/migrate/20150622085848_add_not_null_login_users.rb
@@ -1,0 +1,5 @@
+class AddNotNullLoginUsers < ActiveRecord::Migration
+  def change
+    change_column_null :users, :login, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150616113559) do
+ActiveRecord::Schema.define(version: 20150622085848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Seems the prod & staging db’s are slightly inconsistent due to manual migrations last week. Ensure the prod system has a not null constraint on the user’s login column.