### PR TITLE
Always return the newest exports if multiple exist

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,9 +21,9 @@ class Project < ActiveRecord::Base
   has_one :avatar, -> { where(type: "project_avatar") }, class_name: "Medium", as: :linked
   has_one :background, -> { where(type: "project_background") }, class_name: "Medium",
     as: :linked
-  has_one :classifications_export, -> { where(type: "project_classifications_export")},
+  has_one :classifications_export, -> { where(type: "project_classifications_export").order(created_at: :desc) },
     class_name: "Medium", as: :linked
-  has_one :subjects_export, -> { where(type: "project_subjects_export")},
+  has_one :subjects_export, -> { where(type: "project_subjects_export").order(created_at: :desc) },
     class_name: "Medium", as: :linked
   has_many :attached_images, -> { where(type: "project_attached_image") }, class_name: "Medium",
     as: :linked


### PR DESCRIPTION
Multiple export media shouldn't exist. However, my staging dump shows that they do. I wonder if that might be the issue causing #1006, since as far as I can see the medium being returned is always receiving some update call, so the updated_at should always be touched automatically.