### PR TITLE
optimize the subscription migration

### DIFF
--- a/lib/zooniverse_user_subscription.rb
+++ b/lib/zooniverse_user_subscription.rb
@@ -11,12 +11,18 @@ class ZooniverseUserSubscription < ActiveRecord::Base
   serialize :summary, Hash
 
   def self.import_zoo_user_subscriptions(user_logins=nil)
+    setup_caches
     zoo_user_scope = zoo_users_to_import(user_logins)
     total_batches = zoo_user_scope.count / ZOO_USER_BATCH_SIZE
     zoo_user_scope.find_in_batches.with_index do |zoo_users, batch|
       puts "Processing zoo user batch: #{ batch + 1} out of #{total_batches}"
       import_batch(zoo_users)
     end
+  end
+
+  def self.setup_caches
+    @cached_projects = {}
+    @cached_users = {}
   end
 
   def self.zoo_users_to_import(user_logins)
@@ -28,6 +34,8 @@ class ZooniverseUserSubscription < ActiveRecord::Base
   end
 
   def self.import_batch(zoo_users)
+    #reset the cache for each batch
+    @cached_users = {}
     import_user_scope = zoo_project_subscriptions(zoo_users.map(&:id))
     total = import_user_scope.count.keys.count
     import_user_scope.find_each.with_index do |user_project_sub, index|
@@ -36,6 +44,14 @@ class ZooniverseUserSubscription < ActiveRecord::Base
         user_project_sub.import
       end
     end
+  end
+
+  def self.cached_users
+    @cached_users
+  end
+
+  def self.cached_projects
+    @cached_projects
   end
 
   def self.zoo_project_subscriptions(user_ids)
@@ -55,7 +71,7 @@ class ZooniverseUserSubscription < ActiveRecord::Base
                                                                  user_id: panoptes_user.id)
       migrated_upp.activity_count = summate_activity_counts
       migrated_upp.email_communication = (notifications || true)
-      migrated_upp.save!
+      migrated_upp.save! if migrated_upp.changed?
     end
   end
 
@@ -66,24 +82,28 @@ class ZooniverseUserSubscription < ActiveRecord::Base
   private
 
   def find_legacy_migrated_project
-    zoo_project_id = project_id
+    return self.class.cached_projects[project_id] if self.class.cached_projects.has_key?(project_id)
     legacy_project = Project.where(migrated: true)
-      .where("configuration ->> 'zoo_home_project_id' = '#{zoo_project_id}'")
+      .where("configuration ->> 'zoo_home_project_id' = '#{project_id}'")
       .first
     unless legacy_project
       raise MissingLegacyProject.new("Legacy project missing make sure it has been migrated!")
     end
-    legacy_project
+    self.class.cached_projects[project_id] = legacy_project
   end
 
   def find_migrated_user
-    migrated_user = User.where(zooniverse_id: zooniverse_user.id)
-      .or(User.where(email: zooniverse_user.email))
-      .first
-    unless migrated_user
-      p "Skipping subscription for non-migrated user account: #{zooniverse_user.login}"
+    if self.class.cached_users.has_key?(zooniverse_user.id)
+      self.class.cached_users[zooniverse_user.id]
+    else
+      migrated_user = User.where(zooniverse_id: zooniverse_user.id)
+        .or(User.where(email: zooniverse_user.email))
+        .first
+      unless migrated_user
+        p "Skipping subscription for non-migrated user account: #{zooniverse_user.login}"
+      end
+      self.class.cached_users[zooniverse_user.id] = migrated_user
     end
-    migrated_user
   end
 
   # Summate all the activity counts for the user : project id combo


### PR DESCRIPTION
cache as much as possible to reduce the load on the target db. Not really happy with the coupling between the instance and class methods but i didn't want to refactor to extract the state to a migration driver.