### PR TITLE
reject creation of a workflow for a live project

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -15,8 +15,9 @@ module Api
       SubjectSelector::MissingSubjectQueue,
       SubjectSelector::MissingSubjectSet,                  with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
-    rescue_from Api::NotLoggedIn,                          with: :not_authenticated
-    rescue_from Api::UnauthorizedTokenError,               with: :not_authenticated
+    rescue_from Api::LiveProjectChanges,                   with: :forbidden
+    rescue_from Api::NotLoggedIn,
+      Api::UnauthorizedTokenError,                         with: :not_authenticated
     rescue_from Api::UnsupportedMediaType,                 with: :unsupported_media_type
     rescue_from JsonApiController::PreconditionNotPresent, with: :precondition_required
     rescue_from JsonApiController::PreconditionFailed,     with: :precondition_failed

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -7,6 +7,7 @@ module ApiErrors
   class NotLoggedIn < PanoptesApiError; end
   class NoUserError < PanoptesApiError; end
   class UnpermittedParameter < PanoptesApiError; end
+  class LiveProjectChanges < PanoptesApiError; end
   class NoMediaError < PanoptesApiError
     def initialize(media_type, parent, parent_id, media_id=nil)
       super("No #{media_type}#{ media_string(media_id) }exists for #{parent} ##{parent_id}")

--- a/app/controllers/concerns/json_api_responses.rb
+++ b/app/controllers/concerns/json_api_responses.rb
@@ -63,4 +63,8 @@ module JSONApiResponses
   def service_unavailable(exception)
     json_api_render(:service_unavailable, exception)
   end
+
+  def forbidden(exception)
+    json_api_render(:forbidden, exception)
+  end
 end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -232,6 +232,22 @@ describe Api::V1::WorkflowsController, type: :controller do
         expect(json_response['links']['workflows.tutorial_subject']['href']).to eq("/subjects/{workflows.tutorial_subject}")
       end
     end
+
+    context "when the project is live" do
+      before(:each) do
+        allow_any_instance_of(Project).to receive(:live).and_return(true)
+        default_request scopes: scopes, user_id: authorized_user.id
+        post :create, create_params
+      end
+
+      it 'returns forbidden with a useful error' do
+        aggregate_failures "status and error" do
+          expect(response).to be_forbidden
+          msg = "Can't create a workflow for a live project."
+          expect(response.body).to eq(json_error_message(msg))
+        end
+      end
+    end
   end
 
   describe '#destroy' do

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
     primary_language "en"
     private false
     launch_approved true
-    live true
+    live false
     urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
 
     association :owner, factory: :user


### PR DESCRIPTION
Closes #894 - live projects should not have workflows added to them without consultation / approval. A project should downgrade use the front end to development and re-apply for launch / beta approval status.