### PR TITLE
Do not export classifications for workflows that have been deleted

### DIFF
--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -26,6 +26,9 @@ class ClassificationsDumpWorker
   end
 
   def completed_project_classifications
-    project.classifications.complete.includes(:user, workflow: [:workflow_contents])
+    project.classifications
+    .complete
+    .joins(:workflow)
+    .includes(:user, workflow: [:workflow_contents])
   end
 end

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -1,5 +1,9 @@
 FactoryGirl.define do
   factory :classification do
+    transient do
+      build_real_subjects true
+    end
+
     metadata({
               user_agent: "cURL",
               started_at: 2.minutes.ago.to_s,
@@ -16,7 +20,15 @@ FactoryGirl.define do
     user
     project
     workflow
-    subject_ids { create_list(:set_member_subject, 2).map(&:subject).map(&:id) }
+    subject_ids do
+      if build_real_subjects
+        #TODO: clean this up -> this cascading create_list always builds:
+        # 7 Projects, 3 Workflows, 2 SubjectSets, 2 Subjects
+        create_list(:set_member_subject, 2).map(&:subject).map(&:id)
+      else
+        (1..10).to_a.sample(2)
+      end
+    end
 
     factory(:classification_with_recents) do
       after(:build) do |c|

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -2,10 +2,32 @@ require 'spec_helper'
 
 RSpec.describe ClassificationsDumpWorker do
   let(:worker) { described_class.new }
-  let(:project) { create(:project) }
-  let!(:classifications) { create_list(:classification, 5, project: project) }
+  let(:workflow) { create(:workflow) }
+  let(:project) { workflow.project }
+  let!(:classifications) do
+    create_list(:classification, 5, project: project, workflow: workflow, build_real_subjects: false)
+  end
 
   describe "#perform" do
     it_behaves_like "dump worker", ClassificationDataMailerWorker, "project_classifications_export"
+  end
+
+  describe "#completed_project_classifications" do
+    before(:each) do
+      allow(worker).to receive(:project).and_return(project)
+    end
+
+    it "should find all the classifications" do
+      expect(worker.send(:completed_project_classifications)).to match_array(classifications)
+    end
+
+    context "when the classification has a workflow that doesn't exist" do
+
+      it "should find only the the classifications with existing workflows" do
+        classifications.last.update_column(:workflow_id, Workflow.last.id+1)
+        expected_ids = worker.send(:completed_project_classifications).map(&:id)
+        expect(expected_ids).to match_array(classifications[0..-2].map(&:id))
+      end
+    end
   end
 end


### PR DESCRIPTION
Classifications for deleted workflows should not be included in the export ad most of the classification knowledge is embedded in the workflow.

FYI - i found a chain of factory girl create associations that creates an unexpected number of records. We can seriously reduce our test setup limes by finding these and eliminating them.