### PR TITLE
Return HTTP 200 unless no email param was supplied

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -30,26 +30,14 @@ class PasswordsController < Devise::PasswordsController
     end
 
     def create_from_json
-      status = false
-      if able_to_reset_password?
-        resource = resource_class.send_reset_password_instructions(resource_params)
-        yield resource if block_given?
-        status = successfully_sent?(resource)
-      end
+      resource = resource_class.send_reset_password_instructions(resource_params)
+      yield resource if block_given?
+      status = resource_params["email"].present? && successfully_sent?(resource)
       respond_to_request(status)
     end
 
     def respond_to_request(action_status)
       response_status = action_status ? :ok : :unprocessable_entity
       render status: response_status, json: {}
-    end
-
-    def able_to_reset_password?
-      if user = resource_class.find_for_authentication(resource_params)
-        disabled_or_omni_auth = user.disabled? || user.email.blank?
-        !disabled_or_omni_auth
-      else
-        false
-      end
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,6 +119,15 @@ class User < ActiveRecord::Base
     nil
   end
 
+  # Overrides Devise built-in to add disabled state
+  def self.send_reset_password_instructions(attributes = {})
+    recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
+    if recoverable.persisted? && !recoverable.disabled? && !recoverable.email.blank?
+      recoverable.send_reset_password_instructions
+    end
+    recoverable
+  end
+
   def memberships_for(action, klass)
     membership_roles = UserGroup.roles_allowed_to_access(action, klass)
     active_memberships.where.overlap(roles: membership_roles)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,7 @@ Devise.setup do |config|
   config.reconfirmable = true
   config.password_length = 4..128
   config.reset_password_within = 6.hours
-
+  config.paranoid = true
   config.sign_out_via = :delete
 
   # MAILER

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -42,8 +42,8 @@ describe PasswordsController, type: [ :controller, :mailer ] do
           post :create, user: { email: 'not_a_user@test.com' }
         end
 
-        it "should return 422" do
-          expect(response.status).to eq(422)
+        it "should return 200" do
+          expect(response.status).to eq(200)
         end
 
         it "should not send an email to the account email address" do
@@ -54,9 +54,9 @@ describe PasswordsController, type: [ :controller, :mailer ] do
       context "when the user is disabled" do
         let!(:disable_user) { user.disable! }
 
-        it "should respond with 422" do
+        it "should respond with 200" do
           post :create, user_email_attrs
-          expect(response.status).to eq(422)
+          expect(response.status).to eq(200)
         end
 
         it "should not send an email to the account email address" do
@@ -67,13 +67,13 @@ describe PasswordsController, type: [ :controller, :mailer ] do
       context "when the user was created using third party authentication" do
         #rework when third party authentication is added in (currently req a password)
         let!(:user) do
-          user = build(:omniauth_user, email: nil)
+          user = build(:omniauth_user)
           user
         end
 
-        it "should respond with 422" do
+        it "should respond with 200" do
           post :create, user_email_attrs
-          expect(response.status).to eq(422)
+          expect(response.status).to eq(200)
         end
 
         it "should not send an email to the account email address" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -87,6 +87,62 @@ describe User, type: :model do
     end
   end
 
+  describe '::send_reset_password_instructions' do
+    context 'when the user exists' do
+      let(:user) { create(:user) }
+
+      it 'sends a password reset' do
+        expect_any_instance_of(User).to receive(:send_reset_password_instructions).once
+        User.send_reset_password_instructions(email: user.email)
+      end
+
+      it 'returns the user' do
+        returned_user = User.send_reset_password_instructions(email: user.email)
+        expect(returned_user).to eq(user)
+      end
+    end
+
+    context 'when the user is disabled' do
+      let(:user) { create(:user).tap(&:disable!) }
+
+      it 'does not send a password reset' do
+        expect_any_instance_of(User).to receive(:send_reset_password_instructions).never
+        User.send_reset_password_instructions(email: user.email)
+      end
+
+      it 'returns the user' do
+        returned_user = User.send_reset_password_instructions(email: user.email)
+        expect(returned_user).to eq(user)
+      end
+    end
+
+    context 'when the user has no email' do
+      let(:user) { build(:user, email: nil) }
+
+      it 'does not send a password reset' do
+        expect_any_instance_of(User).to receive(:send_reset_password_instructions).never
+        User.send_reset_password_instructions(email: user.email)
+      end
+
+      it 'returns an unpersisted user' do
+        returned_user = User.send_reset_password_instructions(email: user.email)
+        expect(returned_user).not_to be_persisted
+      end
+    end
+
+    context 'when the user cannot be found' do
+      it 'does not send a password reset' do
+        expect_any_instance_of(User).to receive(:send_reset_password_instructions).never
+        User.send_reset_password_instructions(email: 'unknown@example.com')
+      end
+
+      it 'returns an unpersisted user' do
+        returned_user = User.send_reset_password_instructions(email: 'unknown@example.com')
+        expect(returned_user).not_to be_persisted
+      end
+    end
+  end
+
   describe "#signup_project" do
     let(:project) { create(:project) }
 


### PR DESCRIPTION
Fixes #1051.

Still returns an error if the user supplied no email param at all (form error vs leaking information about existence of users). Not sure if the way it's doing it currently works well with the frontend, possibly we need to return it like a validation error on `email` instead of just a blanket 422 status without body?