### PR TITLE
ensure migrated users have a valid unsubscribe token

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -188,6 +188,7 @@ class User < ActiveRecord::Base
         logger.info "User #{id} is using sha1 password. Updating..."
         self.password = plain_password
         self.hash_func = 'bcrypt'
+        setup_unsubscribe_token
         self.save!
         break
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -364,10 +364,10 @@ describe User, type: :model do
 
     context "with the old sha1 hashing alg" do
       let(:user) do
-        u = create(:insecure_user)
-        u.hash_func = 'sha1'
-        u.save
-        u
+        create(:insecure_user) do |u|
+          u.hash_func = 'sha1'
+          u.unsubscribe_token = nil
+        end
       end
 
       it 'should validate imported user with sha1+salt password' do
@@ -381,6 +381,11 @@ describe User, type: :model do
       it 'should update an imported user to use bcrypt hashing' do
         user.valid_password?('tajikistan')
         expect(user.hash_func).to eq("bcrypt")
+      end
+
+      it 'should add the unsubscribe token' do
+        user.valid_password?('tajikistan')
+        expect(user.unsubscribe_token).to_not be_nil
       end
     end
   end


### PR DESCRIPTION
hijacked the valid password method to ensure users are valid to login, this will allow migrated staging users to login. I can alternatively run the data migration on staging if this is too hacky.