### PR TITLE
update partial indexes to allow our queries to hit them

### DIFF
--- a/db/migrate/20150706133624_fix_index_definitions.rb
+++ b/db/migrate/20150706133624_fix_index_definitions.rb
@@ -1,0 +1,17 @@
+class FixIndexDefinitions < ActiveRecord::Migration
+  def change
+    remove_index :projects, column: :beta_requested
+    remove_index :projects, column: :launch_requested
+
+    remove_index :users, column: :global_email_communication
+    remove_index :users, column: :beta_email_communication
+    remove_index :users, column: :ouroboros_created
+
+    add_index :projects, :beta_requested, where: "beta_requested = true"
+    add_index :projects, :launch_requested, where: "launch_requested = true"
+
+    add_index :users, :global_email_communication, where: "global_email_communication = true"
+    add_index :users, :beta_email_communication, where: "beta_email_communication = true"
+    add_index :users, :ouroboros_created, where: "ouroboros_created = false"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150706100343) do
+ActiveRecord::Schema.define(version: 20150706133624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,9 +176,9 @@ ActiveRecord::Schema.define(version: 20150706100343) do
     t.integer  "classifiers_count",     default: 0
     t.string   "slug",                  default: "", index: {name: "index_projects_on_slug"}
     t.text     "redirect",              default: ""
-    t.boolean  "launch_requested",      default: false, index: {name: "index_projects_on_launch_requested", where: "(launch_requested IS TRUE)"}
+    t.boolean  "launch_requested",      default: false, index: {name: "index_projects_on_launch_requested", where: "(launch_requested = true)"}
     t.boolean  "launch_approved",       default: false, index: {name: "index_projects_on_launch_approved"}
-    t.boolean  "beta_requested",        default: false, index: {name: "index_projects_on_beta_requested", where: "(beta_requested IS TRUE)"}
+    t.boolean  "beta_requested",        default: false, index: {name: "index_projects_on_beta_requested", where: "(beta_requested = true)"}
     t.boolean  "beta_approved",         default: false, index: {name: "index_projects_on_beta_approved"}
   end
 
@@ -305,7 +305,7 @@ ActiveRecord::Schema.define(version: 20150706100343) do
     t.integer  "classifications_count",       default: 0,        null: false
     t.integer  "activated_state",             default: 0,        null: false
     t.string   "languages",                   default: [],       null: false, array: true
-    t.boolean  "global_email_communication",  index: {name: "index_users_on_global_email_communication", where: "(global_email_communication IS TRUE)"}
+    t.boolean  "global_email_communication",  index: {name: "index_users_on_global_email_communication", where: "(global_email_communication = true)"}
     t.boolean  "project_email_communication"
     t.boolean  "admin",                       default: false,    null: false
     t.boolean  "banned",                      default: false,    null: false
@@ -313,11 +313,11 @@ ActiveRecord::Schema.define(version: 20150706100343) do
     t.boolean  "valid_email",                 default: true,     null: false
     t.integer  "uploaded_subjects_count",     default: 0
     t.integer  "project_id"
-    t.boolean  "beta_email_communication",    index: {name: "index_users_on_beta_email_communication", where: "(beta_email_communication IS TRUE)"}
+    t.boolean  "beta_email_communication",    index: {name: "index_users_on_beta_email_communication", where: "(beta_email_communication = true)"}
     t.string   "login",                       null: false, index: {name: "index_users_on_login", unique: true, case_sensitive: false}
     t.string   "unsubscribe_token",           index: {name: "index_users_on_unsubscribe_token", unique: true}
     t.string   "api_key"
-    t.boolean  "ouroboros_created",           default: false, index: {name: "index_users_on_ouroboros_created", where: "(ouroboros_created IS FALSE)"}
+    t.boolean  "ouroboros_created",           default: false, index: {name: "index_users_on_ouroboros_created", where: "(ouroboros_created = false)"}
   end
   add_index "users", ["display_name"], name: "users_display_name_trgm_index", using: :gist, operator_class: "gist_trgm_ops"
 


### PR DESCRIPTION
seems our partial indexes were not being used by queries, e.g.
```
######## BEFORE ##########
[1] pry(main)> Project.where(beta_requested: true).explain
  Project Load (0.7ms)  SELECT "projects".* FROM "projects" WHERE "projects"."beta_requested" = $1  [["beta_requested", "t"]]
=> EXPLAIN for: SELECT "projects".* FROM "projects" WHERE "projects"."beta_requested" = $1 [["beta_requested", "t"]]
                        QUERY PLAN
-----------------------------------------------------------
 Seq Scan on projects  (cost=0.00..18.47 rows=1 width=332)
   Filter: beta_requested
(2 rows)

######## AFTER ##########

[1] pry(main)> Project.where(beta_requested: true).explain
  Project Load (1.3ms)  SELECT "projects".* FROM "projects" WHERE "projects"."beta_requested" = $1  [["beta_requested", "t"]]
=> EXPLAIN for: SELECT "projects".* FROM "projects" WHERE "projects"."beta_requested" = $1 [["beta_requested", "t"]]
                                            QUERY PLAN
---------------------------------------------------------------------------------------------------
 Index Scan using index_projects_on_beta_requested on projects  (cost=0.12..4.14 rows=1 width=332)
   Index Cond: (beta_requested = true)
(2 rows)
```
