### PR TITLE
use wildcard for real name in jiscmail list

### DIFF
--- a/app/mailers/jisc_mailer.rb
+++ b/app/mailers/jisc_mailer.rb
@@ -3,10 +3,9 @@ class JiscMailer < ApplicationMailer
 
   JISC_MAIL_ADDRESS = "listserv@jiscmail.ac.uk"
 
-  def subscribe(email, name)
+  def subscribe(email)
     check_config
     @email = email
-    @name = name
     mail(to: JISC_MAIL_ADDRESS)
   end
 

--- a/app/views/jisc_mailer/subscribe.text.erb
+++ b/app/views/jisc_mailer/subscribe.text.erb
@@ -1,1 +1,1 @@
-quiet add zooniverse <%= @email %> <%= @name %> PW=<%= ::Panoptes.jisc_mail_config[:password] %>
+quiet add zooniverse <%= @email %> * PW=<%= ::Panoptes.jisc_mail_config[:password] %>

--- a/app/workers/subscribe_worker.rb
+++ b/app/workers/subscribe_worker.rb
@@ -1,9 +1,9 @@
 class SubscribeWorker
   include Sidekiq::Worker
 
-  def perform(email, display_name)
+  def perform(email)
     if Rails.env == 'production' || Rails.env == 'test'
-      JiscMailer.subscribe(email, display_name).deliver
+      JiscMailer.subscribe(email).deliver
     end
   end
 end

--- a/spec/mailers/jisc_mailer_spec.rb
+++ b/spec/mailers/jisc_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe JiscMailer, :type => :mailer do
 
   describe "::subscribe" do
     context "with a configured password" do
-      let(:mail) { JiscMailer.subscribe(user.email, user.display_name) }
+      let(:mail) { JiscMailer.subscribe(user.email) }
 
       it 'should mail the listserv' do
         expect(mail.to).to include("listserv@jiscmail.ac.uk")
@@ -16,7 +16,7 @@ RSpec.describe JiscMailer, :type => :mailer do
       end
 
       it 'should have the subscribe command' do
-        expect(mail.body.encoded).to eq("quiet add zooniverse #{ user.email } #{ user.display_name } PW=test_password\r\n\r\n")
+        expect(mail.body.encoded).to eq("quiet add zooniverse #{ user.email } * PW=test_password\r\n\r\n")
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe JiscMailer, :type => :mailer do
       it 'should raise an error' do
         allow(Panoptes).to receive(:jisc_mail_config).and_return({})
         expect do
-          JiscMailer.subscribe(user.email, user.display_name).deliver
+          JiscMailer.subscribe(user.email).deliver
         end.to raise_error("JISC Mail password required")
       end
     end

--- a/spec/workers/subscribe_worker_spec.rb
+++ b/spec/workers/subscribe_worker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SubscribeWorker do
 
   it 'should send mail' do
     expect do
-      subject.perform(user.email, user.display_name)
+      subject.perform(user.email)
     end.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
 end


### PR DESCRIPTION
add commands were bouncing due to invalid real names, using no names now via spec http://www.lsoft.com/manuals/16.0/htmlhelp/list%20subscribers/LSCommands.html