### PR TITLE
update subscribe worker params

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -31,13 +31,13 @@ class Api::V1::UsersController < Api::ApiController
       case
       when user.global_email_communication_changed?
         if user.global_email_communication
-          SubscribeWorker.perform_async(user.email, user.display_name)
+          SubscribeWorker.perform_async(user.email)
         else
           UnsubscribeWorker.perform_async(user.email)
         end
       when user.email_changed?
         if user.global_email_communication
-          SubscribeWorker.perform_async(user.email, user.display_name)
+          SubscribeWorker.perform_async(user.email)
           UnsubscribeWorker.perform_async(user.changes[:email].first)
         end
       end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -41,7 +41,7 @@ class RegistrationsController < Devise::RegistrationsController
     super(sign_up_params)
     resource.build_identity_group
     if resource.global_email_communication
-      SubscribeWorker.perform_async(resource.email, resource.display_name)
+      SubscribeWorker.perform_async(resource.email)
     end
   end
 

--- a/app/workers/subscribe_worker.rb
+++ b/app/workers/subscribe_worker.rb
@@ -1,7 +1,7 @@
 class SubscribeWorker
   include Sidekiq::Worker
 
-  def perform(email)
+  def perform(email, name=nil)
     if Rails.env == 'production' || Rails.env == 'test'
       JiscMailer.subscribe(email).deliver
     end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -365,8 +365,7 @@ describe Api::V1::UsersController, type: :controller do
 
       context 'when email preferences are true' do
         it 'should subscribe the new email' do
-          expect(SubscribeWorker).to receive(:perform_async).with("test@example.com",
-                                                                  user.display_name)
+          expect(SubscribeWorker).to receive(:perform_async).with("test@example.com")
         end
 
         it 'should remove the old email' do
@@ -396,8 +395,7 @@ describe Api::V1::UsersController, type: :controller do
         let(:put_operations) { {users: {global_email_communication: true}} }
 
         it 'should queue a subscribe worker' do
-          expect(SubscribeWorker).to receive(:perform_async).with(user.email,
-                                                                  user.display_name)
+          expect(SubscribeWorker).to receive(:perform_async).with(user.email)
         end
       end
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -149,8 +149,7 @@ describe RegistrationsController, type: :controller do
       context "when email communications are true" do
         let(:extra_attributes) { { login: 'asdfasdfasdf', global_email_communication: true } }
         it 'should call subscribe worker' do
-          expect(SubscribeWorker).to receive(:perform_async)
-            .with(user_attributes[:email], user_attributes[:display_name])
+          expect(SubscribeWorker).to receive(:perform_async).with(user_attributes[:email])
           post :create, user: user_attributes
         end
       end
@@ -276,8 +275,7 @@ describe RegistrationsController, type: :controller do
       context "when email communications are true" do
         let(:extra_attributes) { { login: 'asdfasdf', global_email_communication: true } }
         it 'should call subscribe worker' do
-          expect(SubscribeWorker).to receive(:perform_async)
-            .with(user_attributes[:email], 'asdfasdf')
+          expect(SubscribeWorker).to receive(:perform_async).with(user_attributes[:email])
           post :create, user: user_attributes
         end
       end


### PR DESCRIPTION
allow subscribe worker to accept email and name params but only forward the email onto the mailer.