### PR TITLE
do not welcome users without an email

### DIFF
--- a/app/workers/user_welcome_mailer_worker.rb
+++ b/app/workers/user_welcome_mailer_worker.rb
@@ -4,7 +4,8 @@ class UserWelcomeMailerWorker
   attr_reader :user, :project
 
   def perform(user_id, project_id=nil)
-    if @user = User.find(user_id)
+    @user = User.find(user_id)
+    if @user && !@user.email.blank?
       @project_name = if project_id
         Project.find(project_id).try(:display_name)
       end

--- a/spec/workers/user_welcome_mailer_worker_spec.rb
+++ b/spec/workers/user_welcome_mailer_worker_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe UserWelcomeMailerWorker do
       expect{ subject.perform(nil, project.id) }.to_not change{ ActionMailer::Base.deliveries.count }
     end
   end
+
+  context "when an the user has been scrubbed of email address" do
+
+    it 'should not deliver the mail' do
+      UserInfoScrubber.scrub_personal_info!(user)
+      expect{ subject.perform(user.id) }.to_not change{ ActionMailer::Base.deliveries.count }
+    end
+  end
 end


### PR DESCRIPTION
Users created via the API and then deactivated / deleted will not have an email. Staging tests this process and may try to fire emails with a to field.