### PR TITLE
Retire via api

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   doorkeeper_for :update, :create, :destroy, :retire_subject, scopes: [:project]
   before_action  :reject_live_project_changes, only: [ :create ]
 
-  resource_actions :default
+  resource_actions :default, :retire_subject
   schema_type :json_schema
 
   def show

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,7 +43,7 @@ class Project < ActiveRecord::Base
   validates_with UniqueForOwnerValidator
 
   can_by_role :destroy, :update, :update_links, :destroy_links, :create_classifications_export,
-    :create_subjects_export, roles: [ :owner, :collaborator ]
+    :create_subjects_export, :retire_subject, roles: [ :owner, :collaborator ]
 
   can_by_role :show, :index, :versions, :version, public: true,
     roles: [ :owner, :collaborator, :tester, :translator, :scientist, :moderator ]

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -34,7 +34,7 @@ class Workflow < ActiveRecord::Base
   end
 
   can_through_parent :project, :update, :index, :show, :destroy, :update_links,
-    :destroy_links, :translate, :versions, :version
+    :destroy_links, :translate, :versions, :version, :retire_subject
 
   can_be_linked :subject_set, :same_project?, :model
   can_be_linked :subject_queue, :scope_for, :update, :user

--- a/lib/json_api_controller.rb
+++ b/lib/json_api_controller.rb
@@ -10,7 +10,12 @@ module JsonApiController
     def resource_actions(*actions)
       @actions = actions
       if actions.first == :default
-        @actions = [:show, :index, :create, :update, :destroy]
+        default_actions = [:show, :index, :create, :update, :destroy]
+        if actions.length > 1
+          actions.shift
+          default_actions = default_actions | actions
+        end
+        @actions = default_actions
       end
 
       @actions.each do |action|

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -279,21 +279,26 @@ describe Api::V1::WorkflowsController, type: :controller do
 
   describe '#retire_subject' do
     let(:subject_id) { "1" }
-    let(:workflow_id) { "2" }
+    let(:workflow_id) { "#{workflow.id}" }
+
+    after(:each) do
+      default_request scopes: scopes, user_id: requesting_user.id
+      post :retire_subject, subject_id: subject_id, id: workflow_id
+    end
 
     context "with authorized user" do
+      let(:requesting_user) { owner }
+
       it 'should call the subject retirement worker' do
         expect(SubjectRetirementWorker).to receive(:perform_async).with(subject_id, workflow_id)
-        default_request scopes: scopes, user_id: authorized_user.id
-        post :retire_subject, subject_id: subject_id, id: workflow_id
       end
     end
 
     context "without authorized user" do
+      let(:requesting_user) { user }
+
       it 'should not call the subject retirement worker' do
-        expect(SubjectRetirementWorker).to_not receive(:perform_async).with(subject_id, workflow_id)
-        default_request scopes: scopes, user_id: create(:user).id
-        post :retire_subject, subject_id: subject_id, id: workflow_id
+        expect(SubjectRetirementWorker).to_not receive(:perform_async)
       end
     end
   end


### PR DESCRIPTION
@marten - ok so this was a little more complex but related to the check a resource exists before_action. Our system uses custom authorisation which is defined on the models via roles and is then checked in `controlled_resource(s)` controller actions / filters. Since you were adding a non-standard controller action it wasn't obvious that this is what needed to happen. 

Have a look around and fire any questions via this PR so we've got some context to talk about it.