### PR TITLE
Always include the language context

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -103,6 +103,15 @@ module Api
       end
     end
 
+    def context
+      case action_name
+      when "show", "index"
+        { languages: current_languages }
+      else
+        { }
+      end
+    end
+
     private
 
     # Turn on paper trail for all API controllers

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -167,13 +167,4 @@ class Api::V1::ProjectsController < Api::ApiController
     visitor.visit(urls)
     [urls, visitor.collector]
   end
-
-  def context
-    case action_name
-    when "show", "index"
-      { languages: current_languages, fields: CONTENT_FIELDS }
-    else
-      { fields: CONTENT_FIELDS }
-    end
-  end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -58,9 +58,13 @@ class ProjectSerializer
     @model.tags.map(&:name)
   end
 
+  def fields
+    %i(title description workflow_description introduction url_labels)
+  end
+
   def _content
     content = @model.content_for(@context[:languages])
-    content = @context[:fields].map{ |k| Hash[k, content.send(k)] }.reduce(&:merge)
+    content = fields.map{ |k| Hash[k, content.send(k)] }.reduce(&:merge)
     content.default_proc = proc { |hash, key| "" }
     content
   end

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
     let(:n_visible) { 2 }
 
     it_behaves_like "is indexable"
+
+    describe "include projects" do
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id
+        get :index, include: "project"
+      end
+
+      it 'should be able to include linked projects' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'should return the projects as links' do
+        expect(json_response['linked']['projects']).to_not be_empty
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
...allows projects to be included property wherever they're needed

Closes #1064