### PR TITLE
convert page size string values to ints

### DIFF
--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -58,7 +58,10 @@ class SubjectSelector
   end
 
   def default_page_size
-    params[:page_size] ||= 10
+    page_size = params[:page_size]
+    default = page_size ? page_size.to_i : 10
+    params.merge!(page_size: default)
+    params[:page_size]
   end
 
   def retrieve_subject_queue

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -17,7 +17,7 @@ class SubjectSelector
     queue, context = retrieve_subject_queue
 
     if queue
-      subjects = queue.next_subjects(default_page_size)
+      subjects = queue.next_subjects(subjects_page_size)
       if subjects.blank?
         selected_subjects(select_from_database, context)
       else
@@ -57,11 +57,10 @@ class SubjectSelector
     MissingSubjectSet.new("no subject set is associated with this workflow")
   end
 
-  def default_page_size
-    page_size = params[:page_size]
-    default = page_size ? page_size.to_i : 10
-    params.merge!(page_size: default)
-    params[:page_size]
+  def subjects_page_size
+    page_size = params[:page_size] ? params[:page_size].to_i : 10
+    params.merge!(page_size: page_size)
+    page_size
   end
 
   def retrieve_subject_queue

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe SubjectSelector do
       end
     end
 
+    context "when the params page size is set as a string" do
+      let(:size) { 2 }
+      subject do
+        described_class.new(user, workflow, {page_size: "#{size}"}, Subject.all)
+      end
+
+      it 'should return the page_size number of subjects' do
+        subjects, _ = subject.queued_subjects
+        expect(subjects.length).to eq(size)
+      end
+    end
+
     context "queue is empty" do
       let!(:non_logged_in_queue) do
         create(:subject_queue,
@@ -52,15 +64,6 @@ RSpec.describe SubjectSelector do
       it 'should return 5 subjects' do
         subjects, _ = subject.queued_subjects
         expect(subjects.length).to eq(5)
-      end
-
-      context "when the params page size is set as a string" do
-        subject { described_class.new(user, workflow, {page_size: "2"}, Subject.all)}
-
-        it 'should return the page_size number of subjects' do
-          subjects, _ = subject.queued_subjects
-          expect(subjects.length).to eq(5)
-        end
       end
     end
 

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe SubjectSelector do
       end
     end
 
-
     context "queue is empty" do
       let!(:non_logged_in_queue) do
         create(:subject_queue,
@@ -53,6 +52,16 @@ RSpec.describe SubjectSelector do
       it 'should return 5 subjects' do
         subjects, _ = subject.queued_subjects
         expect(subjects.length).to eq(5)
+      end
+
+      context "when the params page size is set as a string" do
+
+        subject { described_class.new(user, workflow, {page_size: "2"}, Subject.all)}
+
+        it 'should return the page_size number of subjects' do
+          subjects, _ = subject.queued_subjects
+          expect(subjects.length).to eq(5)
+        end
       end
     end
 

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe SubjectSelector do
       end
 
       context "when the params page size is set as a string" do
-
         subject { described_class.new(user, workflow, {page_size: "2"}, Subject.all)}
 
         it 'should return the page_size number of subjects' do


### PR DESCRIPTION
allow page size selection params to cascade into the subject selector.