### PR TITLE
Always return randomly selected subjects from the queue

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -101,10 +101,6 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def next_subjects(limit=10)
-    if user_id
-      set_member_subject_ids[0..limit-1]
-    else
-      set_member_subject_ids.sample(limit)
-    end
+    set_member_subject_ids.sample(limit)
   end
 end

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe SubjectQueue, :type => :model do
       end
 
       it 'should return the first subjects in the queue' do
-        expect(ues.next_subjects).to match_array(ues.set_member_subject_ids[0..9])
+        expect(ues.next_subjects).to_not match_array(ues.set_member_subject_ids[0..9])
       end
     end
 


### PR DESCRIPTION
PostgreSQL will always sort the integers when performing some array operations, including union and difference. That meant that `set_member_subject_ids` would become sorted upon both enqueue and dequeue of any subject (but the initial creation of the queue would be with a shuffled array).

By simply always returning a random selection from the list of enqueued ids, we ensure that we always return a random selection. This also allows for more complicated ordering on a per-workflow basis later on by doing something other than `array.sample()`.

It also means you can use F5 to get a different subject (which @aliburchard wanted I believe).

Fixes #1033 