### PR TITLE
update code to use new retirement schema

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -25,10 +25,13 @@ class Subject < ActiveRecord::Base
   end
 
   def retired_for_workflow?(workflow)
+    retired = false
     if workflow && workflow.is_a?(Workflow) && workflow.persisted?
-      set_member_subjects.first.retired_workflow_ids.include?(workflow.id)
-    else
-      false
+      sms = workflow.set_member_subjects.where(subject_id: self.id).first
+      if sms && swc = SubjectWorkflowCount.find_by(workflow_id: workflow.id, set_member_subject_id: sms.id)
+        retired = swc.retired?
+      end
     end
+    retired
   end
 end

--- a/app/models/subject_workflow_count.rb
+++ b/app/models/subject_workflow_count.rb
@@ -3,6 +3,7 @@ class SubjectWorkflowCount < ActiveRecord::Base
   belongs_to :workflow
 
   validates_presence_of :set_member_subject, :workflow
+  validates_uniqueness_of :set_member_subject_id, scope: :workflow_id
 
   def retire?
     workflow.retirement_scheme.retire?(self)

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -19,7 +19,6 @@ class SubjectSerializer
 
   def retired
     @model.retired_for_workflow?(workflow)
-
   end
 
   def already_seen

--- a/db/migrate/20150717123631_add_uniq_subject_workflow_count_index.rb
+++ b/db/migrate/20150717123631_add_uniq_subject_workflow_count_index.rb
@@ -1,0 +1,6 @@
+class AddUniqSubjectWorkflowCountIndex < ActiveRecord::Migration
+  def change
+    add_index :subject_workflow_counts, [:set_member_subject_id, :workflow_id],
+    unique: true, name: 'index_subject_workflow_counts_on_sms_id_and_workflow_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150716161318) do
+ActiveRecord::Schema.define(version: 20150717123631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 20150716161318) do
     t.datetime "updated_at",            null: false
     t.datetime "retired_at"
   end
+  add_index "subject_workflow_counts", ["set_member_subject_id", "workflow_id"], name: "index_subject_workflow_counts_on_sms_id_and_workflow_id", unique: true
 
   create_table "subjects", force: :cascade do |t|
     t.string   "zooniverse_id",  index: {name: "index_subjects_on_zooniverse_id", unique: true}

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -37,7 +37,10 @@ module Formatter
       end
 
       def retired_in_workflow
-        sms.retired_workflow_ids.to_json
+        SubjectWorkflowCount.where(set_member_subject: sms)
+          .where.not(retired_at: nil)
+          .pluck(:workflow_id)
+          .to_json
       end
 
       def metadata

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -215,9 +215,8 @@ describe Api::V1::SubjectsController, type: :controller do
                    retired_set_member_subjects_count: 100)
           end
 
-          let!(:sms) do
+          let!(:smses) do
             create_list(:set_member_subject, 2,
-                        retired_workflows: [workflow],
                         subject_set: subject_set)
           end
 
@@ -229,6 +228,7 @@ describe Api::V1::SubjectsController, type: :controller do
           end
 
           before(:each) do
+            allow_any_instance_of(Subject).to receive(:retired_for_workflow?).and_return(true)
             get :index, request_params
           end
 
@@ -237,7 +237,7 @@ describe Api::V1::SubjectsController, type: :controller do
             expect(already_seen).to include(true)
           end
 
-          it 'should return retired as false' do
+          it 'should return all subjects as retired' do
             retired = json_response["subjects"].map{ |s| s['retired']}
             expect(retired).to all( be true )
           end

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Formatter::Csv::Subject do
   let(:sms) { create(:set_member_subject, subject_set: subject_set) }
   let!(:swc) do
     create :subject_workflow_count, classifications_count: 10, workflow: workflow,
-      set_member_subject: sms
+      set_member_subject: sms, retired_at: DateTime.now
   end
 
   let(:fields) do
@@ -17,7 +17,7 @@ RSpec.describe Formatter::Csv::Subject do
      subject_set.id,
      sms.subject.metadata.to_json,
      {workflow.id => 10}.to_json,
-     [].to_json]
+     [workflow.id].to_json]
   end
 
   let(:header) do

--- a/spec/models/subject_workflow_count_spec.rb
+++ b/spec/models/subject_workflow_count_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe SubjectWorkflowCount, type: :model do
   let(:count) { create(:subject_workflow_count) }
-  it 'should have a balid factory' do
+  it 'should have a valid factory' do
     expect(build(:subject_workflow_count)).to be_valid
   end
 
@@ -12,6 +12,18 @@ RSpec.describe SubjectWorkflowCount, type: :model do
 
   it 'should not be valid without a workflow' do
     expect(build(:subject_workflow_count, workflow: nil)).to_not be_valid
+  end
+
+  context "when there is a duplicate set_member_subject_id workflow_id entry" do
+    let(:duplicate) { count.dup }
+
+    it 'should not allow duplicates' do
+      expect(duplicate).to_not be_valid
+    end
+
+    it "should raise a uniq index db error" do
+      expect{duplicate.save(validate: false)}.to raise_error(ActiveRecord::RecordNotUnique)
+    end
   end
 
   describe "#retire!" do


### PR DESCRIPTION
Move away from the `SetMemberSubject#retired_workflow_ids` instead use the `SubjectWorkflowCount#retired_at` field in data dumps and the `Subject#retired_for_workflow?` method.