### PR TITLE
proper etags for singular linked media resources

### DIFF
--- a/lib/json_api_controller/precondition_check.rb
+++ b/lib/json_api_controller/precondition_check.rb
@@ -10,6 +10,8 @@ module JsonApiController
       end
     end
 
+    private
+
     def precondition
       case action_name
       when "update", "destroy"


### PR DESCRIPTION
closes #1149 - generate an etag via the index route for linked media has_one relations and modify the precondition check for the media controller.