### PR TITLE
handle deleted subject sets in the count workers

### DIFF
--- a/app/workers/count_reset_worker.rb
+++ b/app/workers/count_reset_worker.rb
@@ -7,5 +7,6 @@ class CountResetWorker
       w.retired_set_member_subjects_count = SetMemberSubject.where('? = ANY(retired_workflow_ids)', w.id).count
       w.save!
     end
+  rescue ActiveRecord::RecordNotFound
   end
 end

--- a/spec/workers/count_reset_worker_spec.rb
+++ b/spec/workers/count_reset_worker_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe CountResetWorker do
         subject.perform(subject_set.id)
       end.to change{Workflow.find(workflow.id).retired_set_member_subjects_count}.from(4).to(2)
     end
-  end
 
+    context "when the subject_set by id can't be found" do
+
+      it "should stop and not update the workflow retired sms counts" do
+        subject_set_id = subject_set.id
+        subject_set.destroy
+        expect_any_instance_of(Workflow).to_not receive(:save!)
+        subject.perform(subject_set_id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Seems some subject set are deleted before classifications came back from clients and the .reset_counters calls .find internally so will raise the not found error. 