### PR TITLE
handle an invalid email address on welcome

### DIFF
--- a/app/workers/user_welcome_mailer_worker.rb
+++ b/app/workers/user_welcome_mailer_worker.rb
@@ -13,5 +13,7 @@ class UserWelcomeMailerWorker
     end
   rescue ActiveRecord::RecordNotFound
     nil
+  rescue Net::SMTPSyntaxError => e
+    @user.update_attribute(:valid_email, false)
   end
 end


### PR DESCRIPTION
closes https://github.com/zooniverse/Panoptes-Front-End/issues/1155

catch the errors don’t try and send again and mark the user as invalid email.

Not sure if the `rescue Net::SMTPSyntaxError => e` is too broad or will catch the errors we need with invalid params here. I think it's ok but i couldn't quickly find any decent docs on it.