### PR TITLE
Rename groups_controller to user_groups_controller

### DIFF
--- a/app/controllers/api/v1/user_groups_controller.rb
+++ b/app/controllers/api/v1/user_groups_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::GroupsController < Api::ApiController
+class Api::V1::UserGroupsController < Api::ApiController
   include Recents
   include IndexSearch
 
@@ -24,18 +24,6 @@ class Api::V1::GroupsController < Api::ApiController
 
   private
 
-  def _resource_ids
-    ids = if params.has_key?("group_id")
-            params["group_id"]
-          elsif params.has_key?(:id)
-            params[:id]
-          else
-            ''
-          end.split(',')
-
-    ids.length < 2 ? ids.first : ids
-  end
-
   def build_resource_for_create(create_params)
     group = super(create_params)
     group.memberships.build(**initial_member)
@@ -47,14 +35,6 @@ class Api::V1::GroupsController < Api::ApiController
       user_group.projects |
       user_group.collections |
       user_group.memberships
-  end
-
-  def resource_name
-    "user_group"
-  end
-
-  def link_header(resource)
-    api_group_url(resource)
   end
 
   def initial_member

--- a/app/serializers/user_group_serializer.rb
+++ b/app/serializers/user_group_serializer.rb
@@ -11,8 +11,4 @@ class UserGroupSerializer
   def type
     "user_groups"
   end
-
-  def self.recents_base_url
-    "groups"
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,8 +65,8 @@ Rails.application.routes.draw do
         media_resources :avatar, :profile_header
       end
 
-      json_api_resources :groups, links: [:users] do
-        get "/recents", to: "groups#recents", format: false
+      json_api_resources :user_groups, links: [:users] do
+        get "/recents", to: "user_groups#recents", format: false
       end
 
       json_api_resources :projects, links: [:subject_sets, :workflows] do

--- a/spec/controllers/api/v1/user_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/user_groups_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::V1::GroupsController, type: :controller do
+describe Api::V1::UserGroupsController, type: :controller do
   let!(:user_groups) do
     [ create(:user_group_with_users),
       create(:user_group_with_projects),
@@ -91,7 +91,6 @@ describe Api::V1::GroupsController, type: :controller do
   describe "#create" do
     let(:test_attr) { :name }
     let(:test_attr_value) { "Zooniverse" }
-    let(:resource_name) { 'groups' }
     let(:create_params) { { user_groups: { name: "Zooniverse" } } }
 
     it_behaves_like "is creatable"
@@ -145,12 +144,12 @@ describe Api::V1::GroupsController, type: :controller do
     let(:new_membership) { Membership.where(user: new_user, user_group: resource).first }
     let(:test_relation) { :users }
     let(:test_relation_ids) { [ new_user.id.to_s ] }
-    let(:resource_id) { :group_id }
+    let(:resource_id) { :user_group_id }
 
     context "created membership" do
       before(:each) do
         default_request scopes: scopes, user_id: authorized_user.id
-        post :update_links, group_id: resource.id, users: [ new_user.id.to_s ], link_relation: "users"
+        post :update_links, user_group_id: resource.id, users: [ new_user.id.to_s ], link_relation: "users"
       end
 
       it 'should give the user a group_member role' do
@@ -164,13 +163,13 @@ describe Api::V1::GroupsController, type: :controller do
   describe "#destroy_links" do
     let(:resource) { user_groups.first }
     let(:test_relation) { :users }
-    let(:resource_id) { :group_id }
+    let(:resource_id) { :user_group_id }
     let(:test_relation_ids) { [ resource.users.first.id.to_s ] }
 
     context "setting membership to inactive" do
       before(:each) do
         default_request scopes: scopes, user_id: authorized_user.id
-        delete :destroy_links, group_id: resource.id, link_ids: test_relation_ids.join(','), link_relation: "users"
+        delete :destroy_links, user_group_id: resource.id, link_ids: test_relation_ids.join(','), link_relation: "users"
       end
 
       it 'should give the delete user membership to inactive' do
@@ -183,7 +182,7 @@ describe Api::V1::GroupsController, type: :controller do
   describe "#recents" do
     let(:resource) { user_groups.first }
     let(:resource_key) { :user_group }
-    let(:resource_key_id) { :group_id }
+    let(:resource_key_id) { :user_group_id }
 
     it_behaves_like "has recents"
   end


### PR DESCRIPTION
Tried to start writing something against the front-end and ran into 404s
looking for the 'user_groups' route and realized my inconsistent naming
was making this a lot more difficult than it needed to be.

Since nothing relies on these routes it should be safe to just change
/groups routes to /user_groups routes.