### PR TITLE
Always return some data to classify

### DIFF
--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -18,9 +18,9 @@ class SetMemberSubject < ActiveRecord::Base
   before_create :set_random
   before_destroy :remove_from_queues
 
-  can_be_linked :subject_queue, :in_workflow, :model
+  can_be_linked :subject_queue, :in_queue_workflow, :model
 
-  def self.in_workflow(queue)
+  def self.in_queue_workflow(queue)
     query = joins(subject_set: :workflows)
       .where(workflows: { id: queue.workflow.id })
     query = query.where(subject_set_id: queue.subject_set.id) if queue.subject_set

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -36,18 +36,20 @@ class SetMemberSubject < ActiveRecord::Base
     SetMemberSubjectSelector.new(workflow, user).set_member_subjects
   end
 
+  def self.by_workflow(workflow)
+    joins(:workflows).where(workflows: {id: workflow.id})
+  end
+
   def self.non_retired_for_workflow(workflow)
-      joins(:workflows)
-      .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.set_member_subject_id = set_member_subjects.id")
-      .where(workflows: {id: workflow.id})
-      .where('subject_workflow_counts.id IS NULL OR subject_workflow_counts.retired_at IS NULL')
+    by_workflow(workflow)
+    .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.set_member_subject_id = set_member_subjects.id")
+    .where('subject_workflow_counts.id IS NULL OR subject_workflow_counts.retired_at IS NULL')
   end
 
   def self.unseen_for_user_by_workflow(user, workflow)
-      joins(:workflows)
-      .joins("LEFT OUTER JOIN user_seen_subjects ON user_seen_subjects.user_id = #{user.id} AND user_seen_subjects.workflow_id = #{workflow.id}")
-      .where(workflows: {id: workflow.id})
-      .where('user_seen_subjects.id IS NULL OR (NOT "set_member_subjects"."subject_id" = ANY("user_seen_subjects"."subject_ids"))')
+    by_workflow(workflow)
+    .joins("LEFT OUTER JOIN user_seen_subjects ON user_seen_subjects.user_id = #{user.id} AND user_seen_subjects.workflow_id = #{workflow.id}")
+    .where('user_seen_subjects.id IS NULL OR (NOT "set_member_subjects"."subject_id" = ANY("user_seen_subjects"."subject_ids"))')
   end
 
   def retire_workflow(workflow)

--- a/lib/set_member_subject_selector.rb
+++ b/lib/set_member_subject_selector.rb
@@ -42,20 +42,8 @@ class SetMemberSubjectSelector
   end
 
   def select_non_retired_unseen_for_user
-    unseen_for_user.merge(non_retired_for_workflow).select(SELECT_FIELDS)
-  end
-
-  def non_retired_for_workflow
-    SetMemberSubject
-      .joins(:workflows)
-      .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.set_member_subject_id = set_member_subjects.id")
-      .where(workflows: {id: workflow.id})
-      .where('subject_workflow_counts.id IS NULL OR subject_workflow_counts.retired_at IS NULL')
-  end
-
-  def unseen_for_user
-    SetMemberSubject
-      .joins("LEFT OUTER JOIN user_seen_subjects ON user_seen_subjects.user_id = #{user.id} AND user_seen_subjects.workflow_id = #{workflow.id}")
-      .where('user_seen_subjects.id IS NULL OR (NOT "set_member_subjects"."subject_id" = ANY("user_seen_subjects"."subject_ids"))')
+    SetMemberSubject.unseen_for_user_by_workflow(user, workflow)
+      .merge(SetMemberSubject.non_retired_for_workflow(workflow))
+      .select(SELECT_FIELDS)
   end
 end

--- a/lib/set_member_subject_selector.rb
+++ b/lib/set_member_subject_selector.rb
@@ -8,16 +8,11 @@ class SetMemberSubjectSelector
   end
 
   def set_member_subjects
-    if select_from_all?
-      workflow.set_member_subjects.select(SELECT_FIELDS)
+    to_classify = select_set_member_subjects_to_classify
+    if to_classify.empty?
+      select_all_workflow_set_member_subjects
     else
-      SetMemberSubject.select(SELECT_FIELDS)
-        .joins(subject_set: {workflows: :user_seen_subjects})
-        .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.set_member_subject_id = set_member_subjects.id")
-        .where(user_seen_subjects: {user_id: user.id},
-               workflows: {id: workflow.id})
-        .where(never_seen_before_or_not_retired)
-        .where.not('"set_member_subjects"."subject_id" = ANY("user_seen_subjects"."subject_ids")')
+      to_classify
     end
   end
 
@@ -34,12 +29,25 @@ class SetMemberSubjectSelector
     !user.user_seen_subjects.where(workflow: workflow).exists?
   end
 
-  def never_seen_before_or_not_retired
-    table = SubjectWorkflowCount.arel_table
-
-    never_seen_before = table[:workflow_id].eq(nil)
-    not_retired = table[:workflow_id].eq(workflow.id).and(table[:retired_at].eq(nil))
-
-    never_seen_before.or(not_retired)
+  def select_set_member_subjects_to_classify
+    if select_from_all?
+      select_all_workflow_set_member_subjects
+    else
+      select_non_retired_unseen_for_user
+    end
   end
+
+  def select_all_workflow_set_member_subjects
+    workflow.set_member_subjects.select(SELECT_FIELDS)
+  end
+
+  def select_non_retired_unseen_for_user
+    SetMemberSubject.select(SELECT_FIELDS)
+      .joins(subject_set: {workflows: :user_seen_subjects})
+      .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.set_member_subject_id = set_member_subjects.id")
+      .where(user_seen_subjects: {user_id: user.id},
+             workflows: {id: workflow.id},
+             subject_workflow_counts: {workflow_id: workflow.id, retired_at: nil})
+      .where.not('"set_member_subjects"."subject_id" = ANY("user_seen_subjects"."subject_ids")')
+    end
 end

--- a/spec/factories/subject_workflow_counts.rb
+++ b/spec/factories/subject_workflow_counts.rb
@@ -5,7 +5,9 @@ FactoryGirl.define do
     classifications_count 1
 
     after(:build) do |swc|
-      swc.workflow.subject_sets << swc.set_member_subject.subject_set
+      if swc.workflow.subject_sets.empty?
+        swc.workflow.subject_sets << swc.set_member_subject.subject_set
+      end
     end
   end
 end

--- a/spec/factories/subject_workflow_counts.rb
+++ b/spec/factories/subject_workflow_counts.rb
@@ -1,11 +1,14 @@
 FactoryGirl.define do
   factory :subject_workflow_count do
+    transient do
+      link_subject_sets true
+    end
     set_member_subject
     workflow
     classifications_count 1
 
-    after(:build) do |swc|
-      if swc.workflow.subject_sets.empty?
+    after(:build) do |swc, env|
+      if env.link_subject_sets && swc.workflow && swc.workflow.subject_sets.empty?
         swc.workflow.subject_sets << swc.set_member_subject.subject_set
       end
     end

--- a/spec/factories/subject_workflow_counts.rb
+++ b/spec/factories/subject_workflow_counts.rb
@@ -3,5 +3,9 @@ FactoryGirl.define do
     set_member_subject
     workflow
     classifications_count 1
+
+    after(:build) do |swc|
+      swc.workflow.subject_sets << swc.set_member_subject.subject_set
+    end
   end
 end

--- a/spec/lib/set_member_subject_selector_spec.rb
+++ b/spec/lib/set_member_subject_selector_spec.rb
@@ -45,5 +45,14 @@ describe SetMemberSubjectSelector do
         sms_to_classify
       end
     end
+
+    context "when there are set_member_subjects from other workfow" do
+
+      it "should only return set_member_subjects from the set workflow" do
+        sms = create(:set_member_subject)
+        all_sms = [count.set_member_subject, sms]
+        expect(sms_to_classify).to eq([count.set_member_subject])
+      end
+    end
   end
 end

--- a/spec/lib/set_member_subject_selector_spec.rb
+++ b/spec/lib/set_member_subject_selector_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe SetMemberSubjectSelector do
   let(:count) { create(:subject_workflow_count) }
   let(:user) { create(:user) }
+  let(:seen_subject) { create(:subject, subject_sets: [count.set_member_subject.subject_set]) }
 
   before do
     count.workflow.subject_sets = [count.set_member_subject.subject_set]
@@ -12,18 +13,35 @@ describe SetMemberSubjectSelector do
   context 'when there is a user and they have participated before' do
     before { allow_any_instance_of(SetMemberSubjectSelector).to receive(:select_from_all?).and_return(false) }
 
+    let(:sms_to_classify) { SetMemberSubjectSelector.new(count.workflow, user).set_member_subjects }
+
     it 'does not include subjects that have been seen' do
       seen_subject = create(:subject, subject_sets: [count.set_member_subject.subject_set])
       create(:user_seen_subject, user: user, workflow: count.workflow, subject_ids: [seen_subject.id])
-
-      sms = SetMemberSubjectSelector.new(count.workflow, user).set_member_subjects
-      expect(sms).to eq([count.set_member_subject])
+      expect(sms_to_classify).to eq([count.set_member_subject])
     end
 
     it 'does not include subjects that are retired' do
       count.retire!
-      sms = SetMemberSubjectSelector.new(count.workflow, user).set_member_subjects
-      expect(sms).to be_empty
+      expect(sms_to_classify).to be_empty
+    end
+
+    context "when all the user has seen all non-retired" do
+
+      before(:each) do
+        create(:user_seen_subject, user: user, workflow: count.workflow, subject_ids: [seen_subject.id])
+        create(:subject_workflow_count, set_member_subject: seen_subject.set_member_subjects.first, workflow: count.workflow)
+        count.retire!
+      end
+
+      it "should return something to classify" do
+        expect(sms_to_classify).to_not be_empty
+      end
+
+      it "should select from the whole set of set_member_subjects" do
+        expect_any_instance_of(SetMemberSubjectSelector).to receive(:select_all_workflow_set_member_subjects)
+        sms_to_classify
+      end
     end
   end
 end

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -98,6 +98,31 @@ describe SetMemberSubject, :type => :model do
     end
   end
 
+  describe ":by_workflow" do
+
+    it "should retun an empty set" do
+      workflow = create(:workflow)
+      expect(SetMemberSubject.by_workflow(workflow)).to be_empty
+    end
+
+    context "when a workflow sms exist" do
+      let(:workflow_sms) { create(:set_member_subject) }
+      let(:workflow) { workflow_sms.workflows.first }
+
+      it "should return the workflow sms" do
+        expect(SetMemberSubject.by_workflow(workflow)).to eq([workflow_sms])
+      end
+
+      context "when another workflow sms exists" do
+
+        it "should only return the workflow sms" do
+          create(:set_member_subject)
+          expect(SetMemberSubject.by_workflow(workflow)).to eq([workflow_sms])
+        end
+      end
+    end
+  end
+
   describe ":non_retired_for_workflow" do
     let(:count) { create(:subject_workflow_count) }
     let(:workflow) { count.workflow }

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -21,28 +21,6 @@ describe SetMemberSubject, :type => :model do
     expect(create(:set_member_subject).random).to_not be_nil
   end
 
-  describe "#subject_set" do
-    it "must have a subject set" do
-      set_member_subject.subject_set = nil
-      expect(set_member_subject).to_not be_valid
-    end
-
-    it "should belong to a subject set" do
-      expect(set_member_subject.subject_set).to be_a(SubjectSet)
-    end
-  end
-
-  describe "#subject" do
-    it "must have a subject" do
-      set_member_subject.subject = nil
-      expect(set_member_subject).to_not be_valid
-    end
-
-    it "should belong to a subject" do
-      expect(set_member_subject.subject).to be_a(Subject)
-    end
-  end
-
   describe "::available" do
     let(:workflow) { create(:workflow) }
     let(:subject_set) { create(:subject_set, workflows: [workflow]) }
@@ -111,6 +89,102 @@ describe SetMemberSubject, :type => :model do
     end
   end
 
+  describe "::by_subject_workflow" do
+    it "should retrieve and object by subject and workflow id" do
+      set_member_subject.save!
+      sid = set_member_subject.subject_id
+      wid = set_member_subject.subject_set.workflows.first.id
+      expect(SetMemberSubject.by_subject_workflow(sid, wid)).to include(set_member_subject)
+    end
+  end
+
+  describe ":non_retired_for_workflow", :focus do
+    let(:count) { create(:subject_workflow_count) }
+    let(:workflow) { count.workflow }
+    let!(:another_workflow_sms) { create(:set_member_subject) }
+
+    context "when none are retired" do
+
+      it "should return the workflow's non retired sms" do
+        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to include(count.set_member_subject)
+      end
+    end
+
+    context "when the workflow sms is retired" do
+
+      it "should return an empty set" do
+        count.retire!
+        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to be_empty
+      end
+    end
+  end
+
+  describe ":non_retired_for_workflow", :focus do
+    let(:count) { create(:subject_workflow_count) }
+    let(:workflow) { count.workflow }
+    let!(:another_workflow_sms) { create(:set_member_subject) }
+
+    context "when none are retired" do
+
+      it "should return the workflow's non retired sms" do
+        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to include(count.set_member_subject)
+      end
+    end
+
+    context "when the workflow sms is retired" do
+
+      it "should return an empty set" do
+        count.retire!
+        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to be_empty
+      end
+    end
+  end
+
+  describe ":unseen_for_user_by_workflow" do
+    let(:user) { create(:user) }
+    let(:workflow) { create(:workflow_with_subjects) }
+    let(:smses){ workflow.set_member_subjects }
+    let!(:another_workflow_sms) { create(:set_member_subject) }
+
+    context "when the user has not seen any workflow subjects" do
+
+      it "should return the all the worflow set_member_subjects " do
+        create(:user_seen_subject, workflow: workflow, user: user, subject_ids: [])
+        expect(SetMemberSubject.unseen_for_user_by_workflow(user, workflow)).to eq(smses)
+      end
+    end
+
+    context "when the user has seen all the workflow subjects" do
+
+      it "should return an empty set" do
+        create(:user_seen_subject, workflow: workflow, user: user, subject_ids: smses.map(&:subject_id))
+        expect(SetMemberSubject.unseen_for_user_by_workflow(user, workflow)).to be_empty
+      end
+    end
+  end
+
+  describe "#subject_set" do
+    it "must have a subject set" do
+      set_member_subject.subject_set = nil
+      expect(set_member_subject).to_not be_valid
+    end
+
+    it "should belong to a subject set" do
+      expect(set_member_subject.subject_set).to be_a(SubjectSet)
+    end
+  end
+
+  describe "#subject" do
+    it "must have a subject" do
+      set_member_subject.subject = nil
+      expect(set_member_subject).to_not be_valid
+    end
+
+    it "should belong to a subject" do
+      expect(set_member_subject.subject).to be_a(Subject)
+    end
+  end
+
   describe "#retire_workflow" do
     it 'should add the workflow the retired_workflows relationship' do
       sms = set_member_subject
@@ -122,15 +196,6 @@ describe SetMemberSubject, :type => :model do
       sms.retire_workflow(workflow1)
       sms.reload
       expect(sms.retired_workflows).to eq([workflow1])
-    end
-  end
-
-  describe "::by_subject_workflow" do
-    it "should retrieve and object by subject and workflow id" do
-      set_member_subject.save!
-      sid = set_member_subject.subject_id
-      wid = set_member_subject.subject_set.workflows.first.id
-      expect(SetMemberSubject.by_subject_workflow(sid, wid)).to include(set_member_subject)
     end
   end
 

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -98,7 +98,7 @@ describe SetMemberSubject, :type => :model do
     end
   end
 
-  describe ":non_retired_for_workflow", :focus do
+  describe ":non_retired_for_workflow" do
     let(:count) { create(:subject_workflow_count) }
     let(:workflow) { count.workflow }
     let!(:another_workflow_sms) { create(:set_member_subject) }
@@ -119,7 +119,7 @@ describe SetMemberSubject, :type => :model do
     end
   end
 
-  describe ":non_retired_for_workflow", :focus do
+  describe ":non_retired_for_workflow" do
     let(:count) { create(:subject_workflow_count) }
     let(:workflow) { count.workflow }
     let!(:another_workflow_sms) { create(:set_member_subject) }

--- a/spec/models/subject_workflow_count_spec.rb
+++ b/spec/models/subject_workflow_count_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe SubjectWorkflowCount, type: :model do
   end
 
   it 'should not be valid without a set_member_subject' do
-    expect(build(:subject_workflow_count, set_member_subject: nil)).to_not be_valid
+    swc = build(:subject_workflow_count, set_member_subject: nil, link_subject_sets: false)
+    expect(swc).to_not be_valid
   end
 
   it 'should not be valid without a workflow' do
-    expect(build(:subject_workflow_count, workflow: nil)).to_not be_valid
+    swc = build(:subject_workflow_count, workflow: nil, link_subject_sets: false)
+    expect(swc).to_not be_valid
   end
 
   context "when there is a duplicate set_member_subject_id workflow_id entry" do

--- a/spec/workers/count_reset_worker_spec.rb
+++ b/spec/workers/count_reset_worker_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe CountResetWorker do
     it 'should reset the workflow retired count' do
       workflow = workflows.first
       workflow.update! retired_set_member_subjects_count: 100
-
-      create(:subject_workflow_count, set_member_subject: sms[0], workflow: workflow, retired_at: Time.now)
-      create(:subject_workflow_count, set_member_subject: sms[1], workflow: workflow, retired_at: Time.now)
+      
+      sms.take(2).each do |s|
+        opts = { set_member_subject: s, workflow: workflow, retired_at: Time.now, link_subject_sets: false}
+        create(:subject_workflow_count, opts)
+      end
 
       expect do
         worker.perform(subject_set.id)


### PR DESCRIPTION
I was classifying on a project that was returning no subjects when i was logged in, turns out I'd seen all the non-retired images. This PR will return data as if the user has seen all data / workflow is finished by a merge of the two clauses `non_retired_for_workflow` and `unseen_for_user`. 

Also when i was breaking up the queries, I'm pretty sure we were being too restrictive with the join on user_seen_subjects (inner join) which wouldn't have returned subjects we hadn't seen. 

@edpaget @marten I'd like a few sets of eyes on this to make sure the resulting sql is correct, also happy to spec out more examples if needed.