### PR TITLE
Add ranking to projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'faraday-http-cache', '~> 1.0'
 gem 'activerecord-import', '~> 0.8'
 gem 'schema_plus_pg_indexes', '~> 0.1'
 gem 'pg_search'
+gem 'ranked-model', '~> 0.4.0'
 
 platforms :jruby do
   gem 'activerecord-jdbcpostgresql-adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,8 @@ GEM
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
     rake (10.4.2)
+    ranked-model (0.4.0)
+      activerecord (>= 3.1.12)
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -373,6 +375,7 @@ DEPENDENCIES
   puma (~> 2.0)
   rack-cors (~> 0.3)
   rails!
+  ranked-model (~> 0.4.0)
   restpack_serializer!
   rspec (~> 3.3.0)
   rspec-rails (~> 3.3.0)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,7 @@ class Project < ActiveRecord::Base
   include PreferencesLink
   include ExtendedCacheKey
   include PgSearch
+  include RankedModel
 
   EXPERT_ROLES = [:expert, :owner]
 
@@ -63,6 +64,9 @@ class Project < ActiveRecord::Base
     against: :display_name,
     using: :trigram,
     ranked_by: ":trigram"
+
+  ranks :launched_row_order
+  ranks :beta_row_order
 
   def expert_classifier_level(classifier)
     expert_role = project_roles.where(user_group: classifier.identity_group)

--- a/app/schemas/project_create_schema.rb
+++ b/app/schemas/project_create_schema.rb
@@ -38,6 +38,14 @@ class ProjectCreateSchema < JsonSchema
       type "boolean"
     end
 
+    property "launched_row_order_position" do
+      type "integer"
+    end
+
+    property "beta_row_order_position" do
+      type "integer"
+    end
+
     property "launch_approved" do
       type "boolean"
     end

--- a/app/schemas/project_update_schema.rb
+++ b/app/schemas/project_update_schema.rb
@@ -34,6 +34,14 @@ class ProjectUpdateSchema < JsonSchema
       end
     end
 
+    property "launched_row_order_position" do
+      type "integer"
+    end
+
+    property "beta_row_order_position" do
+      type "integer"
+    end
+
     property "redirect" do
       type "string"
     end

--- a/db/migrate/20150722180408_add_ranks_to_projects.rb
+++ b/db/migrate/20150722180408_add_ranks_to_projects.rb
@@ -1,0 +1,6 @@
+class AddRanksToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :launched_row_order, :integer, index: true
+    add_column :projects, :beta_row_order, :integer, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150721221349) do
+ActiveRecord::Schema.define(version: 20150722180408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,8 @@ ActiveRecord::Schema.define(version: 20150721221349) do
     t.boolean  "launch_approved",       default: false, index: {name: "index_projects_on_launch_approved"}
     t.boolean  "beta_requested",        default: false, index: {name: "index_projects_on_beta_requested", where: "(beta_requested = true)"}
     t.boolean  "beta_approved",         default: false, index: {name: "index_projects_on_beta_approved"}
+    t.integer  "launched_row_order",    index: {name: "index_projects_on_launched_row_order"}
+    t.integer  "beta_row_order",        index: {name: "index_projects_on_beta_row_order"}
   end
 
   create_table "recents", force: :cascade do |t|

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -13,6 +13,8 @@ FactoryGirl.define do
     primary_language "en"
     private false
     launch_approved true
+    launched_row_order_position { rand(0..100).to_i }
+    beta_row_order_position { rand(0..100).to_i }
     live false
     urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
 

--- a/spec/support/admin_only_option.rb
+++ b/spec/support/admin_only_option.rb
@@ -1,6 +1,7 @@
 RSpec.shared_examples 'admin only option' do |option, value|
   before(:each) do
     ps = create_params
+    ps[:format] = :json
     ps[:admin] = true
     ps[:projects][option] = value
     default_request scopes: scopes, user_id: authorized_user.id


### PR DESCRIPTION
When projects are requested with beta_approved or launch_approved they
will be sorted by default by their assigned ranking.

Closes #1161