### PR TITLE
avoid optimistic lock errors when deactivating workflows

### DIFF
--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -15,8 +15,15 @@ class RetirementWorker
 
   def deactivate_workflow!(workflow)
     if workflow.finished?
-      workflow.active = false
-      workflow.save!
+      ignore_optimistic_lock { workflow.update_attribute(:active, false) }
     end
+  end
+
+  private
+
+  def ignore_optimistic_lock
+    ActiveRecord::Base.lock_optimistically = false
+    yield
+    ActiveRecord::Base.lock_optimistically = true
   end
 end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -15,15 +15,7 @@ class RetirementWorker
 
   def deactivate_workflow!(workflow)
     if workflow.finished?
-      ignore_optimistic_lock { workflow.update_attribute(:active, false) }
+      Workflow.where(id: workflow.id).update_all(active: false)
     end
-  end
-
-  private
-
-  def ignore_optimistic_lock
-    ActiveRecord::Base.lock_optimistically = false
-    yield
-    ActiveRecord::Base.lock_optimistically = true
   end
 end

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe RetirementWorker do
           worker.deactivate_workflow!(workflow)
         end.to change{Workflow.find(workflow.id).active}.from(true).to(false)
       end
+
+      context "when the workflow optimistic lock is updated" do
+
+        it 'should save the changes and not raise an error' do
+          allow(workflow).to receive(:finished?).and_return(true)
+          Workflow.find(workflow.id).touch
+          expect { worker.deactivate_workflow!(workflow) }.to_not raise_error
+        end
+      end
     end
 
     context "workflow is not finished" do


### PR DESCRIPTION
HBadger is reporting these errors from our retirement worker. It's most likely a counter being updated behind the scenes so just avoiding the error as we just want to deactivate the workflow when it’s finished.

Maybe not the best way to avoid these errors so happy to change if there are better ideas.