### PR TITLE
dequeue set_member_subject ids after selection

### DIFF
--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -17,11 +17,12 @@ class SubjectSelector
     queue, context = retrieve_subject_queue
 
     if queue
-      subjects = queue.next_subjects(subjects_page_size)
-      if subjects.blank?
+      set_member_subject_ids = queue.next_subjects(subjects_page_size)
+      if set_member_subject_ids.blank?
         selected_subjects(select_from_database, context)
       else
-        selected_subjects(subjects, context)
+        dequeue_subject(set_member_subject_ids)
+        selected_subjects(set_member_subject_ids, context)
       end
     else
       raise MissingSubjectQueue.new("No queue defined for user. Building one now, please try again.")
@@ -82,4 +83,10 @@ class SubjectSelector
     end
     [queue, context]
   end
+
+  def dequeue_subject(set_member_subject_ids)
+    sms_ids = SetMemberSubject.by_subject_workflow(set_member_subject_ids, workflow).pluck(:id)
+    SubjectQueue.dequeue(workflow, sms_ids, user: user.user)
+  end
+
 end

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -85,8 +85,6 @@ class SubjectSelector
   end
 
   def dequeue_subject(set_member_subject_ids)
-    sms_ids = SetMemberSubject.by_subject_workflow(set_member_subject_ids, workflow).pluck(:id)
-    SubjectQueue.dequeue(workflow, sms_ids, user: user.user)
+    SubjectQueue.dequeue(workflow, set_member_subject_ids, user: user.user)
   end
-
 end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -43,12 +43,6 @@ describe ClassificationLifecycle do
       end
     end
 
-    it "should call the #dequeue_subject method" do
-      classification.save!
-      expect(subject).to receive(:dequeue_subject).once
-      subject.queue(:update)
-    end
-
     context "with update action" do
       let(:test_method) { :update }
 
@@ -210,29 +204,6 @@ describe ClassificationLifecycle do
 
       it 'should do nothing' do
         expect(MultiKafkaProducer).to_not receive(:publish)
-      end
-    end
-  end
-
-  describe "#dequeue_subject" do
-    after(:each) { subject.dequeue_subject }
-
-    context "complete classification" do
-      let(:classification) { create(:classification, completed: true) }
-
-      it 'should call dequeue_subject_for_user' do
-        expect(SubjectQueue).to receive(:dequeue)
-          .with(classification.workflow,
-                array_including(sms_ids),
-                user: classification.user)
-      end
-    end
-
-    context "incomplete classification" do
-      let(:classification) { create(:classification, completed: false) }
-
-      it 'should call dequeue when incomplete' do
-        expect(SubjectQueue).to receive(:dequeue)
       end
     end
   end

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SubjectSelector do
   let(:workflow) { create(:workflow_with_subjects) }
   let(:user) { ApiUser.new(create(:user)) }
 
-  let!(:non_logged_in_queue) do
+  let(:subject_queue) do
     create(:subject_queue,
            workflow: workflow,
            user: nil,
@@ -15,8 +15,16 @@ RSpec.describe SubjectSelector do
   subject { described_class.new(user, workflow, {}, Subject.all)}
 
   describe "#queued_subjects" do
+
+    it 'should return url_format: :get in the context object' do
+      subject_queue
+      _, ctx = subject.queued_subjects
+      expect(ctx).to include(url_format: :get)
+    end
+
     context "when the user doesn't have a queue" do
       before(:each) do
+        subject_queue.set_member_subjects
         subject.queued_subjects
       end
 
@@ -25,8 +33,9 @@ RSpec.describe SubjectSelector do
       end
 
       it 'should add the logged out subjects to the new queue' do
+        smses = subject_queue.set_member_subjects
         new_queue = SubjectQueue.find_by(workflow: workflow, user: user.user)
-        expect(new_queue.set_member_subjects).to match_array(non_logged_in_queue.set_member_subjects)
+        expect(new_queue.set_member_subjects).to match_array(smses)
       end
     end
 
@@ -45,13 +54,14 @@ RSpec.describe SubjectSelector do
       end
 
       it 'should return the page_size number of subjects' do
+        subject_queue
         subjects, _ = subject.queued_subjects
         expect(subjects.length).to eq(size)
       end
     end
 
     context "queue is empty" do
-      let!(:non_logged_in_queue) do
+      let(:subject_queue) do
         create(:subject_queue,
                workflow: workflow,
                user: user.user,
@@ -62,14 +72,45 @@ RSpec.describe SubjectSelector do
       let!(:subjects) { create_list(:set_member_subject, 10, subject_set: workflow.subject_sets.first) }
 
       it 'should return 5 subjects' do
+        subject_queue
         subjects, _ = subject.queued_subjects
         expect(subjects.length).to eq(5)
       end
     end
 
-    it 'should return url_format: :get in the context object' do
-      _, ctx = subject.queued_subjects
-      expect(ctx).to include(url_format: :get)
+    describe "#dequeue for user after selection" do
+      let(:smses) { workflow.set_member_subjects }
+      let(:sms_ids) { smses.map(&:id) }
+      let(:subject_queue) do
+        create(:subject_queue,
+               workflow: workflow,
+               user: queue_owner,
+               subject_set: nil,
+               set_member_subjects: smses)
+      end
+
+      before(:each) { subject_queue }
+
+      context "when the user has a queue" do
+        let(:queue_owner) { user.user }
+
+        it 'should call dequeue_subject for the user' do
+          expect(SubjectQueue).to receive(:dequeue)
+            .with(workflow, array_including(sms_ids), user: user.user)
+          subject.queued_subjects
+        end
+      end
+
+      context "when the queue has no user" do
+        let(:queue_owner) { nil }
+        let(:user) { ApiUser.new(nil) }
+
+        it 'should call dequeue_subject for the user' do
+          expect(SubjectQueue).to receive(:dequeue)
+            .with(workflow, array_including(sms_ids), user: nil)
+          subject.queued_subjects
+        end
+      end
     end
   end
 end

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -23,27 +23,21 @@ RSpec.describe SubjectSelector do
     end
 
     context "when the user doesn't have a queue" do
-      before(:each) do
-        subject_queue.set_member_subjects
+
+      it 'should create a new queue from the logged out queue' do
+        subject_queue
+        expect(SubjectQueue).to receive(:create_for_user)
+          .with(workflow, user.user, set: nil).and_call_original
         subject.queued_subjects
       end
 
-      it 'should create a new queue from the logged out queue' do
-        expect(SubjectQueue.find_by(workflow: workflow, user: user.user)).to_not be_nil
-      end
+      context "when the workflow doesn't have any subject sets" do
 
-      it 'should add the logged out subjects to the new queue' do
-        smses = subject_queue.set_member_subjects
-        new_queue = SubjectQueue.find_by(workflow: workflow, user: user.user)
-        expect(new_queue.set_member_subjects).to match_array(smses)
-      end
-    end
-
-    context "when the user doesn't have a queue" do
-      it 'should raise an informative error' do
-        allow_any_instance_of(Workflow).to receive(:subject_sets).and_return([])
-        expect{subject.queued_subjects}.to raise_error(SubjectSelector::MissingSubjectSet,
-          "no subject set is associated with this workflow")
+        it 'should raise an informative error' do
+          allow_any_instance_of(Workflow).to receive(:subject_sets).and_return([])
+          expect{subject.queued_subjects}.to raise_error(SubjectSelector::MissingSubjectSet,
+            "no subject set is associated with this workflow")
+        end
       end
     end
 

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -54,9 +54,20 @@ RSpec.describe SubjectQueue, :type => :model do
     end
 
     context "queue saves" do
-      it 'should return the new queue' do
+      let!(:logged_out_queue) do
         create(:subject_queue, workflow: workflow, user: nil, subject_set: nil)
-        expect(SubjectQueue.create_for_user(workflow, user)).to be_a(SubjectQueue)
+      end
+      let(:new_queue) { SubjectQueue.create_for_user(workflow, user)}
+
+      it 'should return the new queue' do
+        aggregate_failures "copied queue" do
+          expect(new_queue).to be_a(SubjectQueue)
+          expect(new_queue.id).to_not eq(logged_out_queue.id)
+        end
+      end
+
+      it 'should add the logged out subjects to the new queue' do
+        expect(new_queue.set_member_subject_ids).to match_array(logged_out_queue.set_member_subject_ids)
       end
     end
   end


### PR DESCRIPTION
closes #1176 - get set member subject ids out of the queue asap and let them replenish if they are needed when the queue's replenish.

This should hopefully avoid any race condition between classification processing and next subjects calls by increasing the time window between. 