### PR TITLE
consistent redirect behaviour

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -27,9 +27,9 @@ class EmailsController < ActionController::Base
          User.user_from_unsubscribe_token(token)
       end
       revoke_email_subscriptions(user) if user
-      redirect_to "#{Panoptes.unsubscribe_redirect}?token=#{token}"
+      redirect_to "#{Panoptes.unsubscribe_redirect}?processed=true"
     else
-      head :unprocessable_entity
+      redirect_to "#{Panoptes.unsubscribe_redirect}"
     end
   end
 

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -47,9 +47,9 @@ describe EmailsController, type: :controller do
 
       context "when not supplying a token" do
 
-        it "should return 422" do
+        it "should redirect to the unsubscribe page" do
           get :unsubscribe_via_token
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.location).to eq(base_url)
         end
       end
 
@@ -58,12 +58,12 @@ describe EmailsController, type: :controller do
 
         it "should redirect" do
           get :unsubscribe_via_token, token: token
-          expect(response.location).to eq("#{base_url}?token=#{token}")
+          expect(response.location).to eq("#{base_url}?processed=true")
         end
 
-        it "should redirect to the unsubscribed success page" do
+        it "should redirect to the front end unsubscribed page" do
           get :unsubscribe_via_token, token: token
-          expect(response.location).to eq("#{base_url}?token=#{token}")
+          expect(response.location).to eq("#{base_url}?processed=true")
         end
       end
 
@@ -77,7 +77,7 @@ describe EmailsController, type: :controller do
 
         it "should redirect to the unsubscribed success page" do
           unsubscribe_user
-          expect(response.location).to eq("#{base_url}?token=#{token}")
+          expect(response.location).to eq("#{base_url}?processed=true")
         end
       end
     end


### PR DESCRIPTION
Keep existing behaviour of pre email links allow /unsubscribe url to redirect to front end no token is supplied.