### PR TITLE
Make sure subject locations remain ordered

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -49,8 +49,8 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def add_locations(locations, subject)
-    (locations || []).each do |loc|
-      location_params = { content_type: loc }
+    (locations || []).each.with_index do |loc, i|
+      location_params = { content_type: loc, metadata: { index: i } }
       if api_user.is_admin?
         location_params.merge!(allow_any_content_type: true)
       end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -12,7 +12,8 @@ class Subject < ActiveRecord::Base
   has_many :collections, through: :collections_subjects
   has_many :subject_sets, through: :set_member_subjects
   has_many :set_member_subjects
-  has_many :locations, -> { where(type: 'subject_location') }, class_name: "Medium", as: :linked
+  has_many :locations, -> { where(type: 'subject_location') },
+    class_name: "Medium", as: :linked
   has_many :recents, dependent: :destroy
 
   validates_presence_of :project, :uploader

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -10,7 +10,8 @@ class SubjectSerializer
   can_include :project, :collections
 
   def locations
-    @model.locations.map do |loc|
+    
+    @model.locations.order("\"media\".\"metadata\"->>'index' ASC").map do |loc|
       {
        loc.content_type => loc.url_for_format(@context[:url_format] || :get)
       }

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -338,12 +338,19 @@ describe Api::V1::SubjectsController, type: :controller do
       {
        subjects: {
                   metadata: { cool_factor: "11" },
-                  locations: ["image/jpeg", "image/jpeg", "image/jpeg"],
+                  locations: ["image/jpeg", "image/jpeg", "image/png"],
                   links: {
                           project: project.id
                          }
                  }
       }
+    end
+
+    it "should return locations in the order they were submitted" do
+      default_request user_id: authorized_user.id, scopes: scopes
+      post :create, create_params
+      locations = json_response[api_resource_name][0]["locations"].flat_map(&:keys)
+      expect(locations).to eq(["image/jpeg", "image/jpeg", "image/png"])
     end
 
     context "when the user is not-the owner of the project" do


### PR DESCRIPTION
Record the index of the location (as it was sent by the client) in the
metadata field of the medium object and order by that field when its
serialized

Closes #1159