### PR TITLE
track project live state in incoming classifications

### DIFF
--- a/spec/workers/classification_worker_spec.rb
+++ b/spec/workers/classification_worker_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe ClassificationWorker do
       it 'should call publish to kafka' do
         expect_any_instance_of(ClassificationLifecycle).to receive(:publish_to_kafka)
       end
-
     end
 
     context ":create" do
@@ -39,6 +38,10 @@ RSpec.describe ClassificationWorker do
 
       it 'should call classification count worker' do
         expect(ClassificationCountWorker).to receive(:perform_async).twice
+      end
+
+      it 'should call update_seen_subjects' do
+        expect_any_instance_of(ClassificationLifecycle).to receive(:update_seen_subjects)
       end
 
       context "when a user has seen the subjects before" do


### PR DESCRIPTION
Closes #1164 - Added live_project field to incoming classification metadata and refactored how classification lifecycle events work to ensure errors are raised before updating touching other models / firing new worker events and db calls are kept to a minimum.