### PR TITLE
Allow tokens retrieval with client credentials

### DIFF
--- a/lib/gem_ext.rb
+++ b/lib/gem_ext.rb
@@ -1,5 +1,6 @@
 require_relative './gem_ext/doorkeeper/application'
 require_relative './gem_ext/doorkeeper/server'
+require_relative './gem_ext/doorkeeper/client_credentials_creator'
 require_relative './gem_ext/rails/query_methods.rb'
 require_relative './gem_ext/rails/reflection.rb'
 require_relative './gem_ext/rails/join_association.rb'

--- a/lib/gem_ext/doorkeeper/application.rb
+++ b/lib/gem_ext/doorkeeper/application.rb
@@ -14,7 +14,7 @@ Doorkeeper::Application.class_eval do
     elsif insecure?
       %w(refresh_token)
     else
-      %w(client_credentails authorization_code password refresh_token)
+      %w(client_credentials authorization_code password refresh_token)
     end
   end
 

--- a/lib/gem_ext/doorkeeper/client_credentials_creator.rb
+++ b/lib/gem_ext/doorkeeper/client_credentials_creator.rb
@@ -1,0 +1,11 @@
+require 'doorkeeper/oauth/client_credentials/creator'
+
+Doorkeeper::OAuth::ClientCredentialsRequest::Creator.class_eval do
+  def call(client, scopes, attributes = {})
+    Doorkeeper::AccessToken.create(attributes.merge(
+      resource_owner_id: client.application.owner_id,
+      application_id: client.id,
+      scopes: scopes.to_s
+    ))
+  end
+end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -7,7 +7,6 @@ shared_context "a valid login" do
   end
 
   it "it should return the expected response format" do
-    token_response_keys = [ "access_token", "token_type", "expires_in", "refresh_token", "scope" ]
     req
     expect(json_response).to include(*token_response_keys)
   end
@@ -17,6 +16,7 @@ describe TokensController, type: :controller do
   let(:owner) { create(:user)}
 
   describe "resource owner password credentials flow" do
+    let(:token_response_keys) { [ "access_token", "token_type", "expires_in", "refresh_token", "scope" ] }
     let(:params) { { "grant_type" => "password",
                      "client_id" => app.uid,
                      "scope" => "public project classification",
@@ -106,6 +106,56 @@ describe TokensController, type: :controller do
 
     context "a secure application" do
       let!(:app) { create(:secure_app, owner: owner) }
+
+      it 'should reject the token request with unprocessable entity' do
+        post :create, params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "client crendentials workflow" do
+    let(:token_response_keys) { [ "access_token", "token_type", "expires_in", "scope" ] }
+    let(:params) { { "grant_type" => "client_credentials",
+                     "client_id" => app.uid,
+                     "client_secret" => app.secret } }
+
+    let(:token_response) { json_response['access_token'] }
+    let(:token) { Doorkeeper::AccessToken.find_by(token: token_response) }
+    let(:req) { post :create, params }
+
+    before(:each) { req }
+
+    context "a first party application" do
+      let!(:app) { create(:first_party_app, owner: owner) }
+
+      it_behaves_like "a valid login"
+
+      it 'should return a token belonging to the application owner' do
+        expect(token.resource_owner_id).to eq(owner.id)
+      end
+
+      it 'should have the applications default scopes' do
+        expect(token.scopes).to eq(app.default_scope)
+      end
+    end
+
+    context "a secure application" do
+      let!(:app) { create(:secure_app, owner: owner) }
+
+      it_behaves_like "a valid login"
+
+      it 'should return a token belonging to the application owner' do
+        expect(token.resource_owner_id).to eq(owner.id)
+      end
+
+      it 'should have the applications default scopes' do
+        expect(token.scopes).to eq(app.default_scope)
+      end
+    end
+
+    context "an insecure application" do
+      let!(:app) { create(:application, owner: owner) }
 
       it 'should reject the token request with unprocessable entity' do
         post :create, params


### PR DESCRIPTION
Prevent applications marked insecure from using their credentials to
retrieve tokens. Make sure the token belongs to the application owner

Closes #1095