### PR TITLE
Handle CRSF errors with a null session

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -42,8 +42,6 @@ module Api
     prepend_before_action ContentTypeFilter.new(*API_ACCEPTED_CONTENT_TYPES,
                                                 API_ALLOWED_METHOD_OVERRIDES)
 
-    skip_before_action :verify_authenticity_token
-
     def current_resource_owner
       if doorkeeper_token
         @current_resource_owner ||= User.find_by_id(doorkeeper_token.resource_owner_id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include JSONApiRender
   include JSONApiResponses
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
 

--- a/spec/requests/v1/api_id_spec.rb
+++ b/spec/requests/v1/api_id_spec.rb
@@ -4,18 +4,18 @@ describe 'api should only accept properly formatted ids', type: :request do
   include APIRequestHelpers
 
   let(:user) { create(:user, login: 'parrish') }
-  
+
   before(:each) do
     allow_any_instance_of(Api::ApiController)
       .to receive(:doorkeeper_token)
            .and_return(token(["public", "user"], user.id))
   end
-  
+
   describe 'when an id is not an integer' do
     before(:each) do
       get "/api/users/parrish", nil, { "HTTP_ACCEPT" => "application/vnd.api+json; version=1" }
     end
-    
+
     it 'should return 404' do
       expect(response.status).to eq(404)
     end

--- a/spec/requests/v1/api_not_found_spec.rb
+++ b/spec/requests/v1/api_not_found_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe 'when a route is missing', type: :request do
+  include APIRequestHelpers
+
+  before(:each) do
+    post "/api/classification", { classification: { something: "test" } }.to_json,
+      { "HTTP_ACCEPT" => "application/vnd.api+json; version=1", "CONTENT_TYPE" => "application/json" }
+  end
+
+  it 'should return 404' do
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'should return a json api response' do
+    expect(JSON.parse(response.body)["errors"][0]["message"]).to match(/Not Found/)
+  end
+end


### PR DESCRIPTION
We only use session to get OAuth tokens, which will fail 422 with a null
session anyway, so instead of throwing and error on non-api routes and
skipping CSRF protection on api routes, we'll just use the null_session
handling instead.

Closes #1117