### PR TITLE
Form project slugs to include owner name

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,7 +12,7 @@ class Project < ActiveRecord::Base
 
   EXPERT_ROLES = [:expert, :owner]
 
-  acts_as_url :display_name, sync_url: true, url_attribute: :slug, allow_duplicates: true
+  acts_as_url :slugged_name, allow_slash: true, sync_url: true, url_attribute: :slug, allow_duplicates: true
 
   has_many :workflows
   has_many :subject_sets, dependent: :destroy
@@ -90,5 +90,9 @@ class Project < ActiveRecord::Base
                           user_id: user.id,
                           section: "project-#{id}")
     end
+  end
+
+  def slugged_name
+    "#{ owner.try(:login) }/#{ display_name.gsub('/', '-') }"
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -270,4 +270,11 @@ describe Project, :type => :model do
       project.create_talk_admin(client)
     end
   end
+
+  describe '#slugged_name' do
+    let(:owner){ create :user, login: 'somebody' }
+    let(:project){ create :project, display_name: 'Some Awesome Project / Other Stuff', owner: owner }
+    subject{ project.slug }
+    it{ is_expected.to eql 'somebody/some-awesome-project-other-stuff' }
+  end
 end


### PR DESCRIPTION
As discussed in #1139

I'm not sure if/when we want this to go, but it's a pretty straightforward change.  Of course, it'll require updating the existing records as well as the front end.