### PR TITLE
Public aggregation access by workflow config

### DIFF
--- a/app/controllers/api/v1/aggregations_controller.rb
+++ b/app/controllers/api/v1/aggregations_controller.rb
@@ -1,15 +1,9 @@
 class Api::V1::AggregationsController < Api::ApiController
 
-  doorkeeper_for :index, :show, scopes: [:project], unless: :public_access?
   doorkeeper_for :create, :update, scopes: [:project]
   resource_actions :create, :update, :show, :index
   schema_type :json_schema
-
-  skip_before_action :check_controller_resources, only: :show,  if: :public_resource_workflow?
-
   before_action :filter_by_subject_set, only: :index
-  before_action :filter_by_public_workflows, only: :index, if: :public_workflows?
-  before_action :filter_by_public_resource_workflow, only: :show, if: :public_resource_workflow?
 
   private
 
@@ -20,46 +14,5 @@ class Api::V1::AggregationsController < Api::ApiController
         .joins(workflow: :subject_sets)
         .where(workflows: { subject_set_id: subject_set_ids } )
     end
-  end
-
-  def filter_by_public_workflows
-    @controlled_resources = Aggregation.joins(:workflow).where(workflow_id: workflow_ids)
-  end
-
-  def filter_by_public_resource_workflow
-    @controlled_resources = Aggregation.where(id: resource_ids)
-  end
-
-  def public_access?
-    public_resource_workflow? || public_workflows?
-  end
-
-  def workflow_ids
-    @workflow_ids ||= params.slice(:workflow_id, :workflow_ids)
-      .values.join(",").split(',')
-  end
-
-  def public_workflows?
-    return @public_workflows if @public_workflows
-    @public_workflows = false
-    unless workflow_ids.blank?
-      public_count = public_workflow_scope(Workflow.where(id: workflow_ids)).count
-      @public_workflows = public_count == workflow_ids.size
-    end
-  end
-
-  def public_resource_workflow?
-    return @public_resource_workflow if @public_resource_workflow
-    @public_resource_workflow = false
-    if resource_ids
-      workflow_scope = Workflow
-        .joins("LEFT OUTER JOIN aggregations ON aggregations.workflow_id = workflows.id")
-        .where('aggregations.id = ?', resource_ids)
-      @public_resource_workflow = public_workflow_scope(workflow_scope).exists?
-    end
-  end
-
-  def public_workflow_scope(scope)
-    scope.where("workflows.aggregation ->> 'public' = 'true'")
   end
 end

--- a/app/controllers/api/v1/aggregations_controller.rb
+++ b/app/controllers/api/v1/aggregations_controller.rb
@@ -1,18 +1,15 @@
 class Api::V1::AggregationsController < Api::ApiController
-  doorkeeper_for :index, scopes: [:project], unless: :public_workflows?
-  doorkeeper_for :create, :update, :show, scopes: [:project]
+
+  doorkeeper_for :index, :show, scopes: [:project], unless: :public_access?
+  doorkeeper_for :create, :update, scopes: [:project]
   resource_actions :create, :update, :show, :index
   schema_type :json_schema
 
-  before_action :filter_by_subject_set, only: :index
+  skip_before_action :check_controller_resources, only: :show,  if: :public_resource_workflow?
 
-  def scope_context
-    super.tap do |context|
-      if public_workflows?
-        context.merge!({ public_workflow_ids: workflow_ids })
-      end
-    end
-  end
+  before_action :filter_by_subject_set, only: :index
+  before_action :filter_by_public_workflows, only: :index, if: :public_workflows?
+  before_action :filter_by_public_resource_workflow, only: :show, if: :public_resource_workflow?
 
   private
 
@@ -25,6 +22,18 @@ class Api::V1::AggregationsController < Api::ApiController
     end
   end
 
+  def filter_by_public_workflows
+    @controlled_resources = Aggregation.joins(:workflow).where(workflow_id: workflow_ids)
+  end
+
+  def filter_by_public_resource_workflow
+    @controlled_resources = Aggregation.where(id: resource_ids)
+  end
+
+  def public_access?
+    public_resource_workflow? || public_workflows?
+  end
+
   def workflow_ids
     @workflow_ids ||= params.slice(:workflow_id, :workflow_ids)
       .values.join(",").split(',')
@@ -34,9 +43,23 @@ class Api::V1::AggregationsController < Api::ApiController
     return @public_workflows if @public_workflows
     @public_workflows = false
     unless workflow_ids.blank?
-      public_count = Workflow.where(id: workflow_ids)
-        .where("aggregation ->> 'public' = 'true'").count
+      public_count = public_workflow_scope(Workflow.where(id: workflow_ids)).count
       @public_workflows = public_count == workflow_ids.size
     end
+  end
+
+  def public_resource_workflow?
+    return @public_resource_workflow if @public_resource_workflow
+    @public_resource_workflow = false
+    if resource_ids
+      workflow_scope = Workflow
+        .joins("LEFT OUTER JOIN aggregations ON aggregations.workflow_id = workflows.id")
+        .where('aggregations.id = ?', resource_ids)
+      @public_resource_workflow = public_workflow_scope(workflow_scope).exists?
+    end
+  end
+
+  def public_workflow_scope(scope)
+    scope.where("workflows.aggregation ->> 'public' = 'true'")
   end
 end

--- a/app/controllers/api/v1/aggregations_controller.rb
+++ b/app/controllers/api/v1/aggregations_controller.rb
@@ -1,24 +1,39 @@
 class Api::V1::AggregationsController < Api::ApiController
-  doorkeeper_for :all, scopes: [:project]
+  doorkeeper_for :index, scopes: [:project], unless: :public_workflows?
+  doorkeeper_for :create, :update, :show, scopes: [:project]
   resource_actions :create, :update, :show, :index
   schema_type :json_schema
 
   before_action :filter_by_subject_set, only: :index
 
+  def scope_context
+    super.tap do |context|
+      if public_workflows?
+        context.merge!({ public_workflow_ids: workflow_ids })
+      end
+    end
+  end
+
+  private
+
   def filter_by_subject_set
     subject_set_ids = params.delete(:subject_set_id).try(:split, ',')
     unless subject_set_ids.blank?
       @controlled_resources = controlled_resources
-                              .joins(workflow: :subject_sets)
-                              .where(workflows: { subject_set_id: subject_set_ids } )
+        .joins(workflow: :subject_sets)
+        .where(workflows: { subject_set_id: subject_set_ids } )
     end
   end
 
-  def scope_context
-    {}.tap do |context|
-      if workflow_id = params[:workflow_id]
-        context.merge({ workflow_id: workflow_id })
-      end
-    end
+  def workflow_ids
+    @workflow_ids ||= params[:workflow_id].try(:split, ',')
+  end
+
+  def public_workflows?
+    return @public_workflows if @public_workflows
+    return false if workflow_ids.blank?
+    public_count = Workflow.where(id: workflow_ids)
+      .where("aggregation ->> 'public' = 'true'").count
+    @public_workflows = public_count == workflow_ids.size
   end
 end

--- a/app/controllers/api/v1/aggregations_controller.rb
+++ b/app/controllers/api/v1/aggregations_controller.rb
@@ -13,4 +13,12 @@ class Api::V1::AggregationsController < Api::ApiController
                               .where(workflows: { subject_set_id: subject_set_ids } )
     end
   end
+
+  def scope_context
+    {}.tap do |context|
+      if workflow_id = params[:workflow_id]
+        context.merge({ workflow_id: workflow_id })
+      end
+    end
+  end
 end

--- a/app/controllers/api/v1/aggregations_controller.rb
+++ b/app/controllers/api/v1/aggregations_controller.rb
@@ -26,14 +26,17 @@ class Api::V1::AggregationsController < Api::ApiController
   end
 
   def workflow_ids
-    @workflow_ids ||= params[:workflow_id].try(:split, ',')
+    @workflow_ids ||= params.slice(:workflow_id, :workflow_ids)
+      .values.join(",").split(',')
   end
 
   def public_workflows?
     return @public_workflows if @public_workflows
-    return false if workflow_ids.blank?
-    public_count = Workflow.where(id: workflow_ids)
-      .where("aggregation ->> 'public' = 'true'").count
-    @public_workflows = public_count == workflow_ids.size
+    @public_workflows = false
+    unless workflow_ids.blank?
+      public_count = Workflow.where(id: workflow_ids)
+        .where("aggregation ->> 'public' = 'true'").count
+      @public_workflows = public_count == workflow_ids.size
+    end
   end
 end

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -15,8 +15,9 @@ class Aggregation < ActiveRecord::Base
 
   def self.scope_for(action, user, opts={})
     if (action == :show || action == :index) && !user.is_admin?
-      merge_scope = Workflow.scope_for(:update, user, opts).or(Workflow.where("workflows.aggregation ->> 'public' = 'true'"))
-      joins(:workflow).merge(merge_scope)
+      controlled_scope = Workflow.scope_for(:update, user, opts)
+      public_workflow_scope = Workflow.where("workflows.aggregation ->> 'public' = 'true'")
+      joins(:workflow).merge(public_workflow_scope.or(controlled_scope))
     else
       super
     end

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -14,11 +14,7 @@ class Aggregation < ActiveRecord::Base
   validate :aggregation, :workflow_version_present
 
   def self.scope_for(action, user, opts={})
-    case
-    when action == :index && opts.has_key?(:public_workflow_ids)
-      workflow_ids = opts.delete(:public_workflow_ids)
-      joins(:workflow).where(workflow_id: workflow_ids)
-    when (action == :show || action == :index) && !user.is_admin?
+    if (action == :show || action == :index) && !user.is_admin?
       joins(:workflow).merge(Workflow.scope_for(:update, user, opts))
     else
       super

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -15,8 +15,9 @@ class Aggregation < ActiveRecord::Base
 
   def self.scope_for(action, user, opts={})
     case
-    when action == :index && opts[:workflow_id]
-      joins(:workflow).where(workflow_id: opts[:workflow_id])
+    when action == :index && opts.has_key?(:public_workflow_ids)
+      workflow_ids = opts.delete(:public_workflow_ids)
+      joins(:workflow).where(workflow_id: workflow_ids)
     when (action == :show || action == :index) && !user.is_admin?
       joins(:workflow).merge(Workflow.scope_for(:update, user, opts))
     else

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -14,8 +14,14 @@ class Aggregation < ActiveRecord::Base
   validate :aggregation, :workflow_version_present
 
   def self.scope_for(action, user, opts={})
-    return super unless (action == :show || action == :index) && !user.is_admin?
-    joins(:workflow).merge(Workflow.scope_for(:update, user, opts))
+    case
+    when action == :index && opts[:workflow_id]
+      joins(:workflow).where(workflow_id: opts[:workflow_id])
+    when (action == :show || action == :index) && !user.is_admin?
+      joins(:workflow).merge(Workflow.scope_for(:update, user, opts))
+    else
+      super
+    end
   end
 
   private

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -15,7 +15,8 @@ class Aggregation < ActiveRecord::Base
 
   def self.scope_for(action, user, opts={})
     if (action == :show || action == :index) && !user.is_admin?
-      joins(:workflow).merge(Workflow.scope_for(:update, user, opts))
+      merge_scope = Workflow.scope_for(:update, user, opts).or(Workflow.where("workflows.aggregation ->> 'public' = 'true'"))
+      joins(:workflow).merge(merge_scope)
     else
       super
     end

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -15,9 +15,9 @@ class Aggregation < ActiveRecord::Base
 
   def self.scope_for(action, user, opts={})
     if (action == :show || action == :index) && !user.is_admin?
-      controlled_scope = Workflow.scope_for(:update, user, opts)
-      public_workflow_scope = Workflow.where("workflows.aggregation ->> 'public' = 'true'")
-      joins(:workflow).merge(public_workflow_scope.or(controlled_scope))
+      controlled_scope = joins(:workflow).merge(Workflow.scope_for(:update, user, opts))
+      public_workflow_scope = joins(:workflow).where("workflows.aggregation ->> 'public' = 'true'")
+      public_workflow_scope.union(controlled_scope)
     else
       super
     end

--- a/db/migrate/20150730160541_add_aggregation_config_for_workflow.rb
+++ b/db/migrate/20150730160541_add_aggregation_config_for_workflow.rb
@@ -1,5 +1,6 @@
 class AddAggregationConfigForWorkflow < ActiveRecord::Migration
   def change
-    add_column :workflows, :aggregation, :json, default: {}, null: false
+    add_column :workflows, :aggregation, :jsonb, default: {}, null: false
+    add_index :workflows, name: "index_workflows_on_aggregation", expression: "(aggregation ->> 'public')"
   end
 end

--- a/db/migrate/20150730160541_add_aggregation_config_for_workflow.rb
+++ b/db/migrate/20150730160541_add_aggregation_config_for_workflow.rb
@@ -1,0 +1,5 @@
+class AddAggregationConfigForWorkflow < ActiveRecord::Migration
+  def change
+    add_column :workflows, :aggregation, :json, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150729165415) do
+ActiveRecord::Schema.define(version: 20150730160541) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -379,6 +379,7 @@ ActiveRecord::Schema.define(version: 20150729165415) do
     t.integer  "retired_set_member_subjects_count", default: 0
     t.jsonb    "retirement",                        default: {}
     t.boolean  "active",                            default: true, index: {name: "index_workflows_on_active", where: "(active = true)"}
+    t.json     "aggregation",                       default: {},    null: false
   end
 
   add_foreign_key "recents", "classifications"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -379,7 +379,8 @@ ActiveRecord::Schema.define(version: 20150730160541) do
     t.integer  "retired_set_member_subjects_count", default: 0
     t.jsonb    "retirement",                        default: {}
     t.boolean  "active",                            default: true, index: {name: "index_workflows_on_active", where: "(active = true)"}
-    t.json     "aggregation",                       default: {},    null: false
+    t.jsonb    "aggregation",                       default: {},    null: false
+    t.index name: "index_workflows_on_aggregation", expression: "(aggregation ->> 'public'::text)"
   end
 
   add_foreign_key "recents", "classifications"

--- a/lib/role_control/roled_controller.rb
+++ b/lib/role_control/roled_controller.rb
@@ -38,7 +38,7 @@ module RoleControl
     end
 
     def resource_ids
-      @resource_ids = _resource_ids
+      @resource_ids ||= _resource_ids
     end
 
     def _resource_ids

--- a/spec/controllers/api/v1/aggregations_controller_spec.rb
+++ b/spec/controllers/api/v1/aggregations_controller_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
       context "when the workflow does not have public aggregation" do
         let(:workflow) { create(:workflow) }
 
-        it "should return unauthorized" do
+        it "should return an empty resource set" do
           get :index, workflow_id: workflow.id
-          expect(response).to have_http_status(:unauthorized)
+          expect(json_response[api_resource_name].length).to eq(0)
         end
       end
 
@@ -38,18 +38,18 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
 
         context "when not supplying a workflow id" do
 
-          it "should return unauthorized" do
+          it "should return an empty resource set" do
             get :index
-            expect(response).to have_http_status(:unauthorized)
+            expect(json_response[api_resource_name].length).to eq(0)
           end
         end
 
         context "when supplying a mix of public and non public workflow ids" do
 
-          it "should return unauthorized" do
+          it "should return an empty resource set" do
             ids = [ workflow.id, private_resource.workflow_id ]
             get :index, workflow_ids: ids.join(",")
-            expect(response).to have_http_status(:unauthorized)
+            expect(json_response[api_resource_name].length).to eq(0)
           end
         end
 
@@ -76,7 +76,7 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
 
     it_behaves_like "is showable"
 
-    context "non-logged in users" do
+    context "non-logged in users", :focus do
 
       context "when the workflow does not have public aggregation" do
         let(:workflow) { create(:workflow) }

--- a/spec/controllers/api/v1/aggregations_controller_spec.rb
+++ b/spec/controllers/api/v1/aggregations_controller_spec.rb
@@ -75,6 +75,30 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
     let(:authorized_user) { resource.workflow.project.owner }
 
     it_behaves_like "is showable"
+
+    context "non-logged in users" do
+
+      context "when the workflow does not have public aggregation" do
+        let(:workflow) { create(:workflow) }
+
+        it "should return unauthorized" do
+          get :show, id: resource.id
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context "when the workflow has the public aggregation flag" do
+
+        it "should return the aggregated resource with a public workflow" do
+          resource.workflow.update_column(:aggregation, { public: true })
+          get :show, id: resource.id
+          aggregate_failures "public show" do
+            expect(json_response[api_resource_name].length).to eq(1)
+            expect(created_instance(api_resource_name)["id"]).to eq("#{resource.id}")
+          end
+        end
+      end
+    end
   end
 
   describe "create" do

--- a/spec/controllers/api/v1/aggregations_controller_spec.rb
+++ b/spec/controllers/api/v1/aggregations_controller_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 RSpec.describe Api::V1::AggregationsController, type: :controller do
   let(:api_resource_name) { 'aggregations' }
-
   let(:api_resource_attributes) { %w(id created_at updated_at aggregation) }
   let(:api_resource_links) { %w(aggregations.workflow aggregations.subject) }
 
@@ -41,6 +40,15 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
 
           it "should return unauthorized" do
             get :index
+            expect(response).to have_http_status(:unauthorized)
+          end
+        end
+
+        context "when supplying a mix of public and non public workflow ids" do
+
+          it "should return unauthorized" do
+            ids = [ workflow.id, private_resource.workflow_id ]
+            get :index, workflow_ids: ids.join(",")
             expect(response).to have_http_status(:unauthorized)
           end
         end

--- a/spec/controllers/api/v1/aggregations_controller_spec.rb
+++ b/spec/controllers/api/v1/aggregations_controller_spec.rb
@@ -17,6 +17,29 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
     let(:n_visible) { 2 }
 
     it_behaves_like "is indexable"
+
+    context "non-logged in users", :focus do
+      before(:each) do
+        get :index, workflow_id: workflow.id
+      end
+
+      context "when the workflow does not have public aggregation" do
+        let(:workflow) { create(:workflow) }
+
+        it "should return unauthorized" do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context "when the workflow has the public aggregation flag" do
+        let(:workflow) { create(:workflow, aggregation: { public: true }) }
+
+        it "should return all the workflow data" do
+          get :index, workflow_id: workflow.id
+          expect(json_response[api_resource_name].length).to eq n_visible
+        end
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/controllers/api/v1/aggregations_controller_spec.rb
+++ b/spec/controllers/api/v1/aggregations_controller_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
       context "when the workflow does not have public aggregation" do
         let(:workflow) { create(:workflow) }
 
-        it "should return unauthorized" do
+        it "should return not_found" do
           get :show, id: resource.id
-          expect(response).to have_http_status(:unauthorized)
+          expect(response).to have_http_status(:not_found)
         end
       end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -165,4 +165,24 @@ describe Workflow, :type => :model do
       end
     end
   end
+
+  describe "#aggregation" do
+    let(:workflow) { build(:workflow, aggregation: aggregation_config ) }
+
+    context "empty" do
+      let(:aggregation_config) { Hash.new }
+
+      it "should be valid" do
+        expect(workflow).to be_valid
+      end
+    end
+
+    context "with values" do
+      let(:aggregation_config) { { public: true } }
+
+      it "should be valid" do
+        expect(workflow).to be_valid
+      end
+    end
+  end
 end

--- a/spec/support/indexable.rb
+++ b/spec/support/indexable.rb
@@ -35,20 +35,20 @@ RSpec.shared_examples "is indexable" do |private_test=true|
     context 'when the authorized_user is an admin' do
       let(:authorized_user) { create(:user, admin: true) }
 
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id if authorized_user
+      end
+
       context 'when an admin param is set' do
         it 'should include the non-visible resource' do
-          default_request scopes: scopes, user_id: authorized_user.id if authorized_user
           get :index, ips.merge(admin: 'literally_anything!')
-
           expect(resource_ids).to include private_resource.id
         end
       end
 
       context 'when no admin param is set' do
         it 'should not include the non-visible resource' do
-          default_request scopes: scopes, user_id: authorized_user.id if authorized_user
           get :index, ips
-
           expect(resource_ids).to_not include private_resource.id
         end
       end


### PR DESCRIPTION
Closes #1213 - Add per workflow aggregation config object and open up the index route to allow access if the supplied workflow id is public.