### PR TITLE
Add private_profile flag to users

### DIFF
--- a/app/models/concerns/preferences.rb
+++ b/app/models/concerns/preferences.rb
@@ -16,7 +16,14 @@ module Preferences
 
     def scope_for(action, user, opts={})
       return all if user.is_admin?
-      user.send("#{@preferences_for}_preferences")
+      case action
+      when "show", "index"
+        self.joins(:user, @preferences_for).where(:users => {private_profile: false},
+          @preferences_for.to_s.pluralize => {private: false})
+          .or(user.send("#{@preferences_for}_preferences"))
+      else
+        user.send("#{@preferences_for}_preferences")
+      end
     end
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -6,7 +6,8 @@ class UserSerializer
   attributes :id, :login, :display_name, :credited_name, :email, :created_at,
     :updated_at, :type, :firebase_auth_token, :global_email_communication,
     :project_email_communication, :beta_email_communication,
-    :max_subjects, :uploaded_subjects_count, :admin, :href, :login_prompt
+    :max_subjects, :uploaded_subjects_count, :admin, :href, :login_prompt,
+    :private_profile
 
   can_include :classifications, :project_preferences, :collection_preferences,
     projects: { param: "owner", value: "login" },

--- a/db/migrate/20150727212724_add_private_profile_to_users.rb
+++ b/db/migrate/20150727212724_add_private_profile_to_users.rb
@@ -1,0 +1,5 @@
+class AddPrivateProfileToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :private_profile, :boolean, index: { where: "(private_profile = true)" }, default: false
+  end
+end

--- a/db/migrate/20150727212724_add_private_profile_to_users.rb
+++ b/db/migrate/20150727212724_add_private_profile_to_users.rb
@@ -1,5 +1,5 @@
 class AddPrivateProfileToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :private_profile, :boolean, index: { where: "(private_profile = true)" }, default: false
+    add_column :users, :private_profile, :boolean, index: { where: "(private_profile = false)" }, default: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -341,6 +341,7 @@ ActiveRecord::Schema.define(version: 20150730160541) do
     t.string   "api_key"
     t.boolean  "ouroboros_created",           default: false, index: {name: "index_users_on_ouroboros_created", where: "(ouroboros_created = false)"}
     t.integer  "subject_limit"
+    t.boolean  "private_profile",             default: false, index: {name: "index_users_on_private_profile", where: "(private_profile = true)"}
     t.index name: "users_idx_trgm_login_display_name", using: :gin, expression: "((COALESCE((login)::text, ''::text) || ' '::text) || COALESCE((display_name)::text, ''::text))"
   end
 

--- a/spec/factories/user_collection_preferences.rb
+++ b/spec/factories/user_collection_preferences.rb
@@ -1,7 +1,11 @@
 FactoryGirl.define do
   factory :user_collection_preference do
+    transient do
+      public false
+    end
+
+    user { create(:user, private_profile: !public) }
     preferences '{"display": "grid"}'
-    user
     collection
   end
 end

--- a/spec/factories/user_project_preferences.rb
+++ b/spec/factories/user_project_preferences.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :user_project_preference do
-    user
+    transient do
+      public false
+    end
+
+    user { create(:user, private_profile: !public) }
     project
     email_communication true
     preferences '{"tutorial": "done"}'

--- a/spec/models/user_project_preference_spec.rb
+++ b/spec/models/user_project_preference_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe UserProjectPreference, :type => :model do
   let(:user_project) { build(:user_project_preference) }
   let(:factory) { :user_project_preference }
 
+  it_behaves_like "has preferences scope"
+
   it 'should have a valid factory' do
     expect(user_project).to be_valid
   end

--- a/spec/support/preferences.rb
+++ b/spec/support/preferences.rb
@@ -1,0 +1,46 @@
+RSpec.shared_examples "has preferences scope" do
+  let!(:user) { create(:user) }
+  let!(:preferences) do
+    preferences_model = described_class.to_s.underscore
+    preferences_for = described_class.instance_variable_get(:@preferences_for)
+    prefs_for_actor = create(preferences_model, user: user)
+    public_prefs = create(preferences_model, public: true)
+    private_prefs = create(preferences_model)
+    private_parent = create(preferences_model, public: true,
+      preferences_for => create(preferences_for, private: true))
+    [prefs_for_actor, public_prefs, private_prefs, private_parent]
+  end
+  let(:action) { actions.sample }
+
+  subject{ described_class.scope_for(action, user) }
+
+  context "when action is index or show" do
+    let(:actions) { ["index", "show"] }
+
+    it 'should return preferences for the acting user' do
+      expect(subject).to include(preferences[0])
+    end
+
+    it 'should return public preferences' do
+      expect(subject).to include(preferences[1])
+    end
+
+    it 'should not include private preference' do
+      expect(subject).to_not include(preferences[2])
+    end
+
+    it 'should not include preference belonging to a private model' do
+      expect(subject).to_not include(preferences[3])
+    end
+  end
+
+  context "when action is update or destroy" do
+    let(:actions) { ["update", "destroy"] }
+
+    it 'should only return the prefs for the acting user' do
+      expect(subject).to match_array(preferences.slice(0,1))
+    end
+  end
+end
+
+


### PR DESCRIPTION
Allows users to mark their classification counts (and possibly future
parts of their profile) as private

Closes #1066