### PR TITLE
config cors middleware from yaml file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,18 @@ module Panoptes
     config.middleware.insert_before ActionDispatch::ParamsParser, "RejectPatchRequests"
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.middleware.insert_before ActionDispatch::ParamsParser, "CatchApiJsonParseErrors"
+
+    config.middleware.insert_before 0, Rack::Cors do
+      Array.wrap(Panoptes.cors_config.allows).each do |allow_config|
+        allow do
+          origins allow_config["origins"]
+          resource allow_config["resource"],
+            headers: Panoptes.cors_config.headers,
+            methods: Panoptes.cors_config.request_methods,
+            expose: Panoptes.cors_config.expose,
+            max_age: Panoptes.cors_config.max_age
+        end
+      end
+    end
   end
 end

--- a/config/cors_config.yml.hudson
+++ b/config/cors_config.yml.hudson
@@ -1,0 +1,20 @@
+default: &default
+  headers: :any
+  request_methods: [ delete, get, post, options, put, head ]
+  expose: [ETag]
+  max_age: 300
+  allows:
+    - {origins: '*', resource: '*'}
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+#example to add more explicit origins and resources
+another_env:
+  <<: *default
+  allows:
+    - { origins: !ruby/regexp '/^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.[0-9]+\.[0-9]+\.[0-9]+|[a-z0-9-]+\.example\.org)(:\d+)?$/', resource: '*' }
+    - { origins: '*', resource: '/api/*' }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,15 +35,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  config.middleware.insert_before 0, Rack::Cors do
-    allow do
-      origins '*'
-      resource '*',
-        headers: CorsConfig.request_headers,
-        methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers,
-        max_age: CorsConfig.max_age
-    end
-  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,24 +89,4 @@ Rails.application.configure do
   config.logstasher.enabled = true
   # Enable logging of controller params
   config.logstasher.log_controller_parameters = true
-
-  config.middleware.insert_before 0, Rack::Cors do
-    allow do
-      origins /^https?:\/\/([a-z0-9-]+\.)?zooniverse\.org(:\d+)?$/
-      resource '*',
-        headers: CorsConfig.request_headers,
-        methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers,
-        max_age: CorsConfig.max_age
-    end
-
-    allow do
-      origins '*'
-      resource '/api/*',
-        headers: CorsConfig.request_headers,
-        methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers,
-        max_age: CorsConfig.max_age
-    end
-  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -85,17 +85,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.middleware.insert_before 0, Rack::Cors do
-    allow do
-      origins(/^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.[0-9]+\.[0-9]+\.[0-9]+|[a-z0-9-]+\.zooniverse\.org)(:\d+)?$/)
-      resource '*',
-        headers: CorsConfig.request_headers,
-        methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers,
-        max_age: CorsConfig.max_age
-    end
-  end
-
   # Enable the logstasher logs for the current environment
   config.logstasher.enabled = true
   # Enable logging of controller params

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,15 +45,4 @@ Rails.application.configure do
   config.to_prepare do
     Doorkeeper::ApplicationsController.helper Doorkeeper::Helpers::Controller
   end
-
-  config.middleware.insert_before 0, Rack::Cors do
-    allow do
-      origins '*'
-      resource '/api/*',
-        headers: CorsConfig.request_headers,
-        methods: CorsConfig.request_methods,
-        expose: CorsConfig.expose_headers,
-        max_age: CorsConfig.max_age
-    end
-  end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,8 +1,14 @@
 require 'ostruct'
-cors_config = ActiveSupport::HashWithIndifferentAccess.new.tap do |cors|
-  cors[:request_headers] = :any
-  cors[:request_methods] = %i(delete get post options put head)
-  cors[:expose_headers] = %w(ETag)
-  cors[:max_age] = 300
+module Panoptes
+  def self.cors_config
+    @cors_config ||=OpenStruct
+      .new(**begin
+        file = Rails.root.join('config/cors_config.yml')
+        YAML.load(File.read(file))[Rails.env].symbolize_keys
+      rescue Errno::ENOENT, NoMethodError
+        {  }
+      end)
+  end
 end
-CorsConfig = OpenStruct.new(cors_config)
+
+Panoptes.cors_config


### PR DESCRIPTION
closes #1233 - Replace env specific hard coded configs for a derived envs from the yaml file. the yaml file requires requires some care to conform to the expected format