### PR TITLE
preserve queue id ordering

### DIFF
--- a/spec/lib/postgresql_selection_spec.rb
+++ b/spec/lib/postgresql_selection_spec.rb
@@ -125,9 +125,7 @@ RSpec.describe PostgresqlSelection do
       it 'should select subjects in desc order of the priority field' do
         desc_priority = sms.order(priority: :desc).pluck(:id)
         result = subject.select(limit: desc_priority.size)
-        desc_priority.each_with_index do |priority, index|
-          expect(result[index]).to eq(priority)
-        end
+        expect(desc_priority).to eq(result)
       end
 
       context "with an inverted sort order param" do
@@ -135,9 +133,7 @@ RSpec.describe PostgresqlSelection do
         it 'should select subjects in inverted order of the priority field' do
           asc_priority = sms.order(priority: :asc).pluck(:id)
           result = subject.select(limit: asc_priority.size, order: :asc)
-          asc_priority.each_with_index do |priority, index|
-            expect(result[index]).to eq(priority)
-          end
+          expect(asc_priority).to eq(result)
         end
       end
     end
@@ -170,9 +166,7 @@ RSpec.describe PostgresqlSelection do
       it 'should only select subjects in the specified group' do
         result = subject.select(subject_set_id: subject_set_id)
         desc_priority = sms.limit(result.length).order(id: :desc).pluck(:id)
-        desc_priority.each_with_index do |priority, index|
-          expect(result[index]).to eq(priority)
-        end
+        expect(desc_priority).to eq(result)
       end
 
       context "with an inverted sort order param on the second set" do
@@ -181,9 +175,7 @@ RSpec.describe PostgresqlSelection do
         it 'should select subjects in inverted order of the priority field' do
           result = subject.select(subject_set_id: subject_set_id, order: :asc)
           asc_priority = sms.limit(result.length).order(id: :asc).pluck(:id)
-          asc_priority.each_with_index do |priority, index|
-            expect(result[index]).to eq(priority)
-          end
+          expect(asc_priority).to eq(result)
         end
       end
     end


### PR DESCRIPTION
closes #1241 - turns out it's hard to maintain order of arrays in postgres. All the operators i found / tried modified returned sorted lists (asc).

This will just iterate over the scoped models calling update with ruby land array ordering. These methods should not be called outside of background workers unless the scope is restrictive enough e.g. [here](https://github.com/zooniverse/Panoptes/blob/0bce1f69f7bdd192b284bfd8be31250a596fad4f/lib/subject_selector.rb#L88).

I looked into something funky in the db to keep the `update_all` command but failed to get it working properly. Any ideas for AREL / SQL optimisations here are welcome.

![image](https://cloud.githubusercontent.com/assets/295329/9117032/884ce266-3c5f-11e5-8079-51dc3511a117.png)
```
select * FROM 
unnest(array[8,7,6,1,2,5]) WITH ORDINALITY AS set1(ids, num)
full join
(select * from unnest(array[5, 55]) as ids) as set2
on set1.ids = set2.ids
order by set1.num
```