### PR TITLE
make priority sort order static

### DIFF
--- a/lib/postgresql_selection.rb
+++ b/lib/postgresql_selection.rb
@@ -25,7 +25,7 @@ class PostgresqlSelection
       query = query.where(subject_set_id: opts[:subject_set_id])
     end
     if workflow.prioritized
-      query = query.order(priority: opts.fetch(:order, :desc))
+      query = query.order(priority: :asc)
     end
     @available = query
   end


### PR DESCRIPTION
sort by ascending order for priority to allow open ended lists and prepend via negative numbers.