### PR TITLE
subject queue workers

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
   def refresh_queue(subject_set)
     if subject_set.set_member_subjects.exists?
       subject_set.workflows.each do |w|
-        ReloadQueueWorker.perform_async(w.id)
+        ReloadNonLoggedInQueueWorker.perform_async(w.id)
       end
     end
   end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -40,11 +40,11 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def refresh_queue(workflow)
-    ReloadQueueWorker.perform_async(workflow.id) if workflow.set_member_subjects.exists?
+    ReloadNonLoggedInQueueWorker.perform_async(workflow.id) if workflow.set_member_subjects.exists?
   end
 
   def load_queue
-    SubjectQueueWorker.perform_async(params[:id], api_user.id)
+    EnqueueSubjectQueueWorker.perform_async(params[:id], api_user.id)
   end
 
   def build_update_hash(update_params, id)

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -78,7 +78,7 @@ class SubjectQueue < ActiveRecord::Base
                      set_member_subject_ids: logged_out_queue.set_member_subject_ids)
       queue if queue.persisted?
     else
-      SubjectQueueWorker.perform_async(workflow.id, nil)
+      EnqueueSubjectQueueWorker.perform_async(workflow.id, nil)
       nil
     end
   end

--- a/app/workers/empty_subject_queue_worker.rb
+++ b/app/workers/empty_subject_queue_worker.rb
@@ -1,7 +1,7 @@
 class EmptySubjectQueueWorker
   include Sidekiq::Worker
 
-  def perform(workflow_id)
+  def perform(workflow_id=nil)
     queue_scope = SubjectQueue.all
      if workflow_id
       workflow = Workflow.find(workflow_id)

--- a/app/workers/empty_subject_queue_worker.rb
+++ b/app/workers/empty_subject_queue_worker.rb
@@ -1,0 +1,14 @@
+class EmptySubjectQueueWorker
+  include Sidekiq::Worker
+
+  def perform(workflow_id)
+    queue_scope = SubjectQueue.all
+     if workflow_id
+      workflow = Workflow.find(workflow_id)
+      queue_scope = SubjectQueue.where(workflow: workflow)
+    end
+    queue_scope.update_all(set_member_subject_ids: [])
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+end

--- a/app/workers/enqueue_subject_queue_worker.rb
+++ b/app/workers/enqueue_subject_queue_worker.rb
@@ -1,4 +1,4 @@
-class SubjectQueueWorker
+class EnqueueSubjectQueueWorker
   include Sidekiq::Worker
 
   attr_reader :workflow, :user, :limit

--- a/app/workers/reload_non_logged_in_queue_worker.rb
+++ b/app/workers/reload_non_logged_in_queue_worker.rb
@@ -1,4 +1,4 @@
-class ReloadQueueWorker
+class ReloadNonLoggedInQueueWorker
   include Sidekiq::Worker
 
   attr_reader :workflow

--- a/lib/postgresql_selection.rb
+++ b/lib/postgresql_selection.rb
@@ -51,19 +51,23 @@ class PostgresqlSelection
   end
 
   def select_results_randomly
-    results = []
     enough_available = limit < available_count
     if enough_available
-      until results.length >= limit do
-        results = results | sample.limit(limit).pluck(:id)
-      end
+      construct_random_sample_to_limit
     else
-      results = available.pluck(:id).shuffle
+      available.pluck(:id).shuffle
     end
-    results
   end
 
   def select_results_in_order
     available.limit(limit).pluck(:id)
+  end
+
+  def construct_random_sample_to_limit
+    results = []
+    until results.length >= limit do
+      results = results | sample.limit(limit).pluck(:id)
+    end
+    results
   end
 end

--- a/lib/set_member_subject_selector.rb
+++ b/lib/set_member_subject_selector.rb
@@ -1,6 +1,8 @@
 class SetMemberSubjectSelector
   attr_reader :workflow, :user
-  SELECT_FIELDS = '"set_member_subjects"."id", "set_member_subjects"."random"'
+  SELECT_FIELDS = '"set_member_subjects"."id",' +
+  '"set_member_subjects"."random",' +
+  '"set_member_subjects"."priority"'
 
   def initialize(workflow, user)
     @workflow = workflow

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -79,7 +79,7 @@ class SubjectSelector
     when queue.nil?
       queue = SubjectQueue.create_for_user(workflow, user.user, set: params[:subject_set_id])
     when queue.below_minimum?
-      SubjectQueueWorker.perform_async(workflow.id, user.id)
+      EnqueueSubjectQueueWorker.perform_async(workflow.id, user.id)
     end
     [queue, context]
   end

--- a/lib/tasks/subject_queue.rake
+++ b/lib/tasks/subject_queue.rake
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+namespace :subject_queue do
+
+  desc "empty all subject queues"
+  task empty_all_queues: :environment do
+    EmptySubjectQueueWorker.new.perform
+  end
+
+  desc "Empty all workflow subject queues"
+  task :empty_all_workflow_queues, [:workflow_id ] => [:environment] do |t, args|
+    EmptySubjectQueueWorker.new.perform(args[:workflow_id])
+  end
+end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -143,7 +143,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
       context "when the subject set has a workflow" do
         it 'should call the reload queue worker' do
-          expect(ReloadQueueWorker).to receive(:perform_async).with(workflows.first.id)
+          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(workflows.first.id)
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets][:links].delete(:workflows)
           put :update, update_params.merge(id: resource.id)
@@ -153,7 +153,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
       context "when the subject set has multiple workflows" do
         let(:workflows) { create_list(:workflow, 2, project: project) }
         it 'should call the reload queue worker' do
-          expect(ReloadQueueWorker).to receive(:perform_async).twice
+          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).twice
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets][:links].delete(:workflows)
           put :update, update_params.merge(id: resource.id)
@@ -163,7 +163,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
       context "when the subject set has no workflows" do
         let(:workflows) { [] }
         it 'should not call the reload queue worker' do
-          expect(ReloadQueueWorker).to_not receive(:perform_async)
+          expect(ReloadNonLoggedInQueueWorker).to_not receive(:perform_async)
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets][:links].delete(:workflows)
           put :update, update_params.merge(id: resource.id)
@@ -172,7 +172,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
       context "when the subject set has multiple subjects" do
         it 'should call the reload queue worker' do
-          expect(ReloadQueueWorker).to receive(:perform_async).with(workflows.first.id)
+          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(workflows.first.id)
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets][:links].delete(:workflows)
           put :update, update_params.merge(id: resource.id)
@@ -182,7 +182,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
       context "when the subject set has no subjects" do
         let(:subjects) { [] }
         it 'should not call the reload queue worker' do
-          expect(ReloadQueueWorker).to_not receive(:perform_async)
+          expect(ReloadNonLoggedInQueueWorker).to_not receive(:perform_async)
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets].delete(:links)
           put :update, update_params.merge(id: resource.id)

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -105,7 +105,7 @@ describe Api::V1::SubjectsController, type: :controller do
 
           context 'when the queue is below minimum' do
             it 'should reload the queue' do
-              expect(SubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
+              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
               get :index, request_params
             end
           end
@@ -113,7 +113,7 @@ describe Api::V1::SubjectsController, type: :controller do
           context 'when the queue is not below minimum)' do
             let(:sms) { create_list(:set_member_subject, 21) }
             it 'should reload the queue' do
-              expect(SubjectQueueWorker).to_not receive(:perform_async)
+              expect(EnqueueSubjectQueueWorker).to_not receive(:perform_async)
               get :index, request_params
             end
           end
@@ -180,7 +180,7 @@ describe Api::V1::SubjectsController, type: :controller do
 
           context 'when the queue is below minimum' do
             it 'should reload the queue' do
-              expect(SubjectQueueWorker).to receive(:perform_async).with(workflow.id, user.id)
+              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, user.id)
               get :index, request_params
             end
           end
@@ -188,7 +188,7 @@ describe Api::V1::SubjectsController, type: :controller do
           context 'when the queue is not below minimum)' do
             let(:sms) { create_list(:set_member_subject, 21) }
             it 'should reload the queue' do
-              expect(SubjectQueueWorker).to_not receive(:perform_async)
+              expect(EnqueueSubjectQueueWorker).to_not receive(:perform_async)
               get :index, request_params
             end
           end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -199,7 +199,7 @@ describe Api::V1::WorkflowsController, type: :controller do
         let(:subject_set) { create(:subject_set_with_subjects, project: resource.project) }
 
         it 'should call the reload queue worker' do
-          expect(ReloadQueueWorker).to receive(:perform_async).with(resource.id)
+          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(resource.id)
           default_request scopes: scopes, user_id: authorized_user.id
           put :update, update_params.merge(id: resource.id)
         end
@@ -207,7 +207,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
       context "when the workflow has no subjects" do
         it "should not queue the worker" do
-          expect(ReloadQueueWorker).to_not receive(:perform_async).with(resource.id)
+          expect(ReloadNonLoggedInQueueWorker).to_not receive(:perform_async).with(resource.id)
           default_request scopes: scopes, user_id: authorized_user.id
           put :update, update_params.merge(id: resource.id)
         end
@@ -216,7 +216,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
     context "without authorized user" do
       it 'should not call the reload queue worker' do
-        expect(ReloadQueueWorker).to_not receive(:perform_async).with(resource.id)
+        expect(ReloadNonLoggedInQueueWorker).to_not receive(:perform_async).with(resource.id)
         default_request scopes: scopes, user_id: create(:user).id
         put :update, update_params.merge(id: resource.id)
       end
@@ -369,7 +369,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
     context "with a logged in user" do
       it "should load a user's subject queue" do
-        expect(SubjectQueueWorker).to receive(:perform_async).with(resource.id.to_s, authorized_user.id)
+        expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(resource.id.to_s, authorized_user.id)
         default_request scopes: scopes, user_id: authorized_user.id
         get :show, id: resource.id
       end
@@ -377,7 +377,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
     context "with a logged out user" do
       it "should load the general subject queue" do
-        expect(SubjectQueueWorker).to receive(:perform_async).with(resource.id.to_s, nil)
+        expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(resource.id.to_s, nil)
         get :show, id: resource.id
       end
     end

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SubjectQueue, type: :model do
     context "when no logged out queue" do
 
       it 'should attempt to build a logged out queue' do
-        expect(SubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
+        expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
         SubjectQueue.create_for_user(workflow, user)
       end
 

--- a/spec/workers/empty_subject_queue_worker_spec.rb
+++ b/spec/workers/empty_subject_queue_worker_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe EmptySubjectQueueWorker do
+  let(:workflow) { create(:workflow_with_subject_set) }
+  let(:user) { workflow.project.owner }
+  let(:sms) do
+    subject = create(:subject, project: workflow.project)
+    create(:set_member_subject, subject: subject,
+      subject_set: workflow.subject_sets.first)
+  end
+  let(:another_workflow) { create(:workflow) }
+  let!(:queues) do
+    [ workflow, another_workflow ].map do |w|
+      create(:subject_queue, workflow: w, user: [user,nil].sample,
+        set_member_subject_ids: [sms.id])
+    end
+  end
+
+  subject { described_class.new }
+
+  describe "#perform" do
+    let(:queue_sms_ids) { queues.map(&:reload).map(&:set_member_subject_ids) }
+    let(:empty_queues) { queue_sms_ids.map(&:empty?) }
+
+    context "with no workflow id" do
+
+      it 'should empty all the subject queues' do
+        subject.perform(nil)
+        expect(empty_queues).to all( be true )
+      end
+    end
+
+    context "with a non-existant workflow id" do
+      let(:w_id) { Workflow.last.id + 1 }
+
+      it 'should not raise an error' do
+        expect { subject.perform(w_id) }.not_to raise_error
+      end
+
+      it 'should not empty all subject queues' do
+        subject.perform(w_id)
+        expect(empty_queues).to all( be false )
+      end
+    end
+
+    context "with a workflow id" do
+
+      it 'should empty all the worfklow subject queues' do
+        subject.perform(workflow.id)
+        aggregate_failures "only workflow qs" do
+          expect(empty_queues.first).to be true
+          expect(empty_queues.last).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/workers/empty_subject_queue_worker_spec.rb
+++ b/spec/workers/empty_subject_queue_worker_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe EmptySubjectQueueWorker do
     context "with no workflow id" do
 
       it 'should empty all the subject queues' do
-        subject.perform(nil)
+        subject.perform
         expect(empty_queues).to all( be true )
       end
     end

--- a/spec/workers/enqueue_subject_queue_worker_spec.rb
+++ b/spec/workers/enqueue_subject_queue_worker_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SubjectQueueWorker do
+RSpec.describe EnqueueSubjectQueueWorker do
   subject { described_class.new }
   let(:workflow) { create(:workflow_with_subject_set) }
 

--- a/spec/workers/reload_non_logged_in_queue_worker_spec.rb
+++ b/spec/workers/reload_non_logged_in_queue_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ReloadQueueWorker do
+RSpec.describe ReloadNonLoggedInQueueWorker do
   subject { described_class.new }
   let(:workflow) { create(:workflow_with_subject_set) }
   let!(:subjects) do
@@ -44,4 +44,3 @@ RSpec.describe ReloadQueueWorker do
     end
   end
 end
-


### PR DESCRIPTION
I've had a few cases recently when i've had to empty existing queues, so i've added more explicit existing subject queue worker names and added worker to empty workflow queues. Also added a rake task to run them.