### PR TITLE
add notifications around duplicate being queued

### DIFF
--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -326,18 +326,16 @@ RSpec.describe SubjectQueue, type: :model do
           context "when the append queue contains a seen before" do
 
             it "should notify HB with a custom error" do
-              append_ids = [sms.id]
-              create(:user_seen_subject, user: user, workflow: workflow, subject_ids: append_ids)
+              create(:user_seen_subject, user: user, workflow: workflow, subject_ids: [sms.subject_id])
               expect(Honeybadger).to receive(:notify)
-              SubjectQueue.enqueue_update(query, append_ids)
+              SubjectQueue.enqueue_update(query, [sms.id])
             end
           end
 
           context "when the append queue does not contain a seen before" do
 
             it "should not notify HB with a custom error" do
-              seen_ids = [smses.last.id]
-              create(:user_seen_subject, user: user, workflow: workflow, subject_ids: seen_ids)
+              create(:user_seen_subject, user: user, workflow: workflow, subject_ids: [smses.last.subject_id])
               in_q = (smses - [ smses.last ]).map(&:id)
               ues.update_column(:set_member_subject_ids, in_q)
               expect(Honeybadger).to_not receive(:notify)

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -298,6 +298,32 @@ RSpec.describe SubjectQueue, type: :model do
             expect(ues.reload.set_member_subject_ids).to match_array([ sms.id ])
           end
         end
+
+        #NOTE: this can be removed when we're happy that
+        # https://github.com/zooniverse/Panoptes/issues/1069
+        # is resolved.
+        describe "duplicate error messaging" do
+
+          context "when the append queue has dups" do
+
+            it "should only have the enqueued subject id in the queue" do
+              query = SubjectQueue.where(id: ues.id)
+              expect(Honeybadger).to receive(:notify)
+              SubjectQueue.enqueue_update(query, ues.set_member_subject_ids)
+            end
+          end
+
+          context "when the append queue grows too large" do
+
+            it "should only have the enqueued subject id in the queue" do
+              query = SubjectQueue.where(id: ues.id)
+              expect(Honeybadger).to receive(:notify)
+              start = smses.last.id+1
+              append_ids = (start..start+SubjectQueue::DEFAULT_LENGTH*2).to_a
+              SubjectQueue.enqueue_update(query, append_ids)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Linked to #1069, try and get some visibility about queueing errors. This will check if
 1. a duplicate id is being enqueued to the current queue
 2. the queue is growing beyond 2 * the set default
 3. a seen before id is being enqueued

This is temporary and should be deployed after #1249 is in and the queues have been emptied. Manual inspection of the queues showed some have grown very large and may not be refreshing at all.