### PR TITLE
Access queue in order they were built for a logged in user

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -112,6 +112,10 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def next_subjects(limit=10)
-    set_member_subject_ids.sample(limit)
+    if user_id
+      set_member_subject_ids[0..limit-1]
+    else
+      set_member_subject_ids.sample(limit)
+    end
   end
 end

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe SubjectQueue, type: :model do
       end
 
       it 'should return the first subjects in the queue' do
-        expect(ues.next_subjects).to_not match_array(ues.set_member_subject_ids[0..9])
+        expect(ues.next_subjects).to match_array(ues.set_member_subject_ids[0..9])
       end
     end
 

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe SubjectQueue, type: :model do
       end
 
       it 'should return the first subjects in the queue' do
-        expect(ues.next_subjects).to match_array(ues.set_member_subject_ids[0..9])
+        expect(ues.next_subjects).to eq(ues.set_member_subject_ids[0..9])
       end
     end
 


### PR DESCRIPTION
Revert "Always return randomly selected subjects from the queue, since the queue is always sorted by id"

This reverts commit 0f9e41a6383590be807ec87cf3b66428b14aa6e3.

This will be needed for priority queues.