### PR TITLE
Subject Queue enqueue duplicates and unbound growth

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -8,19 +8,19 @@ class Api::V1::WorkflowsController < Api::ApiController
   schema_type :json_schema
 
   def create
-    super { |workflow| refresh_queue(workflow) }
+    super { |workflow| reload_queue(workflow) }
   end
 
   def update
-    super { |workflow| refresh_queue(workflow) }
+    super { |workflow| reload_queue(workflow) }
   end
 
   def update_links
-    super { |workflow| refresh_queue(workflow) }
+    super { |workflow| reload_queue(workflow) }
   end
 
   def destroy_links
-    super { |workflow| refresh_queue(workflow) }
+    super { |workflow| reload_queue(workflow) }
   end
 
   private
@@ -34,7 +34,10 @@ class Api::V1::WorkflowsController < Api::ApiController
     end
   end
 
-  def refresh_queue(workflow)
+  def reload_queue(workflow)
+    if workflow.set_member_subjects.exists?
+      ReloadNonLoggedInQueueWorker.perform_async(workflow.id)
+    end
   end
 
   def build_update_hash(update_params, id)

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -7,11 +7,6 @@ class Api::V1::WorkflowsController < Api::ApiController
   resource_actions :default
   schema_type :json_schema
 
-  def show
-    load_queue
-    super
-  end
-
   def create
     super { |workflow| refresh_queue(workflow) }
   end
@@ -40,11 +35,6 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def refresh_queue(workflow)
-    ReloadNonLoggedInQueueWorker.perform_async(workflow.id) if workflow.set_member_subjects.exists?
-  end
-
-  def load_queue
-    EnqueueSubjectQueueWorker.perform_async(params[:id], api_user.id)
   end
 
   def build_update_hash(update_params, id)

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -368,16 +368,16 @@ describe Api::V1::WorkflowsController, type: :controller do
     it_behaves_like "is showable"
 
     context "with a logged in user" do
-      it "should load a user's subject queue" do
-        expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(resource.id.to_s, authorized_user.id)
+      it "should not load a user's subject queue" do
+        expect(EnqueueSubjectQueueWorker).not_to receive(:perform_async)
         default_request scopes: scopes, user_id: authorized_user.id
         get :show, id: resource.id
       end
     end
 
     context "with a logged out user" do
-      it "should load the general subject queue" do
-        expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(resource.id.to_s, nil)
+      it "should not load the general subject queue" do
+        expect(EnqueueSubjectQueueWorker).not_to receive(:perform_async)
         get :show, id: resource.id
       end
     end


### PR DESCRIPTION
Vestigal cellect behaviour to load data, panoptes should not enqueue on every workflow show event. This was adding dups to the queues and growing the queues past expected sizes. 

Happy to add a check on queue sizes via enqueue if needed in future but it'd be nice to see if this PR cleans up the erroneous behaviour we're seeing.