### PR TITLE
Queue improvements

### DIFF
--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -77,9 +77,9 @@ class SubjectSelector
 
     case
     when queue.nil?
-      queue = SubjectQueue.create_for_user(workflow, user.user, set: params[:subject_set_id])
+      queue = SubjectQueue.create_for_user(workflow, queue_user, set: params[:subject_set_id])
     when queue.below_minimum?
-      EnqueueSubjectQueueWorker.perform_async(workflow.id, user.id)
+      EnqueueSubjectQueueWorker.perform_async(workflow.id, queue_user.try(:id))
     end
     [queue, context]
   end


### PR DESCRIPTION
Ensure the queue that data is being added to is for the right user and that we only update the sms_ids when new data is coming in.

Should fix the unbound queue growth and queueing seen_ids for users when they've finished the workflow.