### PR TITLE
do not leave invalid blank logins

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -224,6 +224,7 @@ class User < ActiveRecord::Base
     if ouroboros_created
       counter = 0
       sanitized_login = User.sanitize_login(display_name)
+      sanitized_login = panoptes_zoo_id if sanitized_login.blank?
       self.login = sanitized_login
       until no_other_logins_exist?(login) || counter == DUP_LOGIN_SANITATION_ATTEMPTS
         self.login = "#{ sanitized_login }-#{ counter += 1 }"
@@ -234,8 +235,12 @@ class User < ActiveRecord::Base
     end
   end
 
+  def panoptes_zoo_id
+    "panoptes-#{ id }"
+  end
+
   def set_zooniverse_id
-    self.zooniverse_id ||= "panoptes-#{ id }"
+    self.zooniverse_id ||= panoptes_zoo_id
     if zooniverse_id_changed?
       self.update_column(:zooniverse_id, self.zooniverse_id)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -666,6 +666,21 @@ describe User, type: :model do
       expect(user).to be_valid
     end
 
+    context "when the login is all unicode" do
+
+      it "should use the zooniverse id for login field instead of leaving it blank" do
+        non_ascii = "ẉơŕƌé"
+        User.skip_callback :validation, :before, :update_ouroboros_created
+        dup_user = build(:ouroboros_created_user, display_name: non_ascii, login: non_ascii)
+        dup_user.save(validate: false)
+        User.set_callback :validation, :before, :update_ouroboros_created
+        aggregate_failures "dup user" do
+          expect(dup_user).to be_valid
+          expect(dup_user.login).to eq("panoptes-#{dup_user.id}")
+        end
+      end
+    end
+
     context "when the ouroboros created user has a clashing sanitized login" do
       let(:dup_user) do
         build(:ouroboros_created_user, display_name: "#{user.login}é")


### PR DESCRIPTION
clean up empty sanitized logins from ouroboros by using the zooniverse id. 

I'm not sure if we should have the sanitize method in ouroboros as well so we don't end up with unicode logins in the db. that said any attempt to login on the new infrastructure *should* clean these up anyway.