### PR TITLE
User project preferences updates

### DIFF
--- a/app/models/user_project_preference.rb
+++ b/app/models/user_project_preference.rb
@@ -2,4 +2,18 @@ class UserProjectPreference < ActiveRecord::Base
   include Preferences
 
   preferences_for :project, :classifiers_count
+
+  def summated_activity_count
+    if legacy_count.blank?
+      activity_count
+    else
+      valid_legacy_count_values.reduce(:+)
+    end
+  end
+
+  private
+
+  def valid_legacy_count_values
+    legacy_count.values.compact
+  end
 end

--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -14,8 +14,9 @@ class UserSeenSubject < ActiveRecord::Base
   end
 
   def self.count_user_activity(user_id, workflow_ids=[])
+
     workflow_ids = Array.wrap(workflow_ids)
-    scope = UserSeenSubject.where(user_id: user_id)
+    scope = self.where(user_id: user_id)
     unless workflow_ids.empty?
       scope = scope.where(workflow_id: workflow_ids)
     end

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -8,10 +8,10 @@ class UserProjectPreferenceSerializer
   end
 
   def activity_count
-    if !@model.legacy_count.blank?
-      @model.legacy_count.values.reduce(:+)
+    if count = @model.summated_activity_count
+      count
     else
-      @model.activity_count || user_project_activity
+      user_project_activity
     end
   end
 

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -211,6 +211,15 @@ describe Api::EventsController, type: :controller do
           expect(user_project_pref.legacy_count).to eq(event_count)
         end
 
+        context "with busted per workflow count" do
+
+          it "should respond with a 422" do
+            allow(User).to receive(:find_by).and_return(user)
+            post :create, overridden_params(workflow: "", count: nil)
+            expect(response.status).to eq(422)
+          end
+        end
+
         context "with an panoptes-formatted user zooniverse_id" do
 
           it "should return success" do

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
       let!(:upps) do
         [create(:user_project_preference, user: authorized_user, project: project)]
       end
-      let(:user_seens) do
+      let!(:user_seens) do
         create(:user_seen_subject, user: authorized_user,
           workflow: project.workflows.first, build_real_subjects: false)
       end

--- a/spec/factories/user_project_preferences.rb
+++ b/spec/factories/user_project_preferences.rb
@@ -9,5 +9,14 @@ FactoryGirl.define do
     email_communication true
     preferences '{"tutorial": "done"}'
     activity_count 19
+
+    factory :legacy_user_project_preference do
+      activity_count nil
+      legacy_count '{"bars": 19, "candels": 10}'
+
+      factory :busted_legacy_user_project_preference do
+        legacy_count '{"":null, "radio":"4"}'
+      end
+    end
   end
 end

--- a/spec/models/user_project_preference_spec.rb
+++ b/spec/models/user_project_preference_spec.rb
@@ -25,4 +25,24 @@ RSpec.describe UserProjectPreference, :type => :model do
       project.reload
     end.to change{project.classifiers_count}.from(0).to(1)
   end
+
+  describe "#summated_activity_count" do
+
+    it "should summate correctly for activity_count only" do
+      upp = build(:user_project_preference)
+      expect(upp.summated_activity_count).to eq(upp.activity_count)
+    end
+
+    it "should summate correctly for legacy_count only" do
+      upp = build(:legacy_user_project_preference)
+      expected_count = upp.legacy_count.values.sum
+      expect(upp.summated_activity_count).to eq(expected_count)
+    end
+
+    it "should summate correctly for busted legacy_count only" do
+      upp = build(:busted_legacy_user_project_preference)
+      expected_count = upp.send(:valid_legacy_count_values).sum
+      expect(upp.summated_activity_count).to eq(expected_count)
+    end
+  end
 end


### PR DESCRIPTION
handle busted per workflow counts like `{ "" => nil, "bars" => 10 }` from legacy data.