### PR TITLE
Add fallback to compile assets on start

### DIFF
--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -20,6 +20,11 @@ else
     git pull
   fi
 
+  if [ ! -d public/assets ]
+  then
+      bundle exec rake assets:precompile
+  fi
+
   TERM=xterm git log --format="%H" -n 1 > public/commit_id.txt
   exec /usr/bin/supervisord
 fi


### PR DESCRIPTION
To temporarily work around a bug in Docker which can stop the assets
container from being created during build. It should be rare that this
happens, and worst case this will just add a couple of minutes to the
deploy time.