### PR TITLE
Kafka classification stream using AMS instead of RestPack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'doorkeeper', '~> 1.4.1'
 gem 'devise', '~> 3.0'
 gem 'versionist', '~> 1.0'
 gem 'rack-cors', '~> 0.3', require: 'rack/cors'
-gem 'restpack_serializer', github: "edpaget/restpack_serializer", branch: "dev" # API
-gem 'active_model_serializers', '0.10.0.rc2'
+gem 'restpack_serializer', github: "edpaget/restpack_serializer", branch: "dev" # REST API
+gem 'active_model_serializers', '0.10.0.rc2' # Kafka
 gem 'paper_trail', '~> 3.0'
 gem 'omniauth', '~> 1.0'
 gem 'omniauth-facebook', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'doorkeeper', '~> 1.4.1'
 gem 'devise', '~> 3.0'
 gem 'versionist', '~> 1.0'
 gem 'rack-cors', '~> 0.3', require: 'rack/cors'
-gem 'restpack_serializer', github: "edpaget/restpack_serializer", branch: "dev"
+gem 'restpack_serializer', github: "edpaget/restpack_serializer", branch: "dev" # API
+gem 'active_model_serializers', '0.10.0.rc2'
 gem 'paper_trail', '~> 3.0'
 gem 'omniauth', '~> 1.0'
 gem 'omniauth-facebook', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,8 @@ GEM
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
     active_record_union (1.1.0)
       activerecord (>= 4.0)
+    active_model_serializers (0.10.0.rc2)
+      activemodel (>= 4.0)
     activejob (4.2.3)
       activesupport (= 4.2.3)
       globalid (>= 0.3.0)
@@ -324,6 +326,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_union (~> 1.1.0)
+  active_model_serializers (= 0.10.0.rc2)
   activerecord-import (~> 0.8)
   activerecord-jdbcmysql-adapter
   activerecord-jdbcpostgresql-adapter

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,8 +1,11 @@
 class Classification < ActiveRecord::Base
+  include BelongsToMany
+
   belongs_to :project, counter_cache: true
   belongs_to :user, counter_cache: true
   belongs_to :workflow, counter_cache: true
   belongs_to :user_group, counter_cache: true
+  belongs_to_many :subjects
 
   has_many :recents, dependent: :destroy
 

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModel::Serializer.config.adapter = :json_api

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -52,7 +52,7 @@ class ClassificationLifecycle
 
   def publish_to_kafka
     return unless classification.complete?
-    classification_json = ClassificationSerializer.serialize(classification).to_json
+    classification_json = KafkaClassificationSerializer.serialize(classification)
     MultiKafkaProducer.publish('classifications', [classification.project.id, classification_json])
   end
 

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -52,7 +52,7 @@ class ClassificationLifecycle
 
   def publish_to_kafka
     return unless classification.complete?
-    classification_json = KafkaClassificationSerializer.serialize(classification)
+    classification_json = KafkaClassificationSerializer.serialize(classification, include: ['subjects']).to_json
     MultiKafkaProducer.publish('classifications', [classification.project.id, classification_json])
   end
 

--- a/lib/kafka_classification_serializer.rb
+++ b/lib/kafka_classification_serializer.rb
@@ -6,10 +6,10 @@ class KafkaClassificationSerializer < ActiveModel::Serializer
 
   attributes :id, :annotations, :created_at, :metadata
 
-  belongs_to :project, serializer: KafkaProjectSerializer, embed: :ids
+  belongs_to :project, serializer: KafkaProjectSerializer
   belongs_to :user, serializer: KafkaUserSerializer
   belongs_to :workflow, serializer: KafkaWorkflowSerializer
-  has_many   :subjects, serializer: KafkaSubjectSerializer, embed: :ids
+  has_many   :subjects, serializer: KafkaSubjectSerializer
 
   def metadata
     object.metadata.merge(workflow_version: object.workflow_version)

--- a/lib/kafka_classification_serializer.rb
+++ b/lib/kafka_classification_serializer.rb
@@ -14,8 +14,4 @@ class KafkaClassificationSerializer < ActiveModel::Serializer
   def metadata
     object.metadata.merge(workflow_version: object.workflow_version)
   end
-
-  def subjects
-    Subject.where(id: object.subject_ids)
-  end
 end

--- a/lib/kafka_classification_serializer.rb
+++ b/lib/kafka_classification_serializer.rb
@@ -1,8 +1,7 @@
 class KafkaClassificationSerializer < ActiveModel::Serializer
-  def self.serialize(classification)
+  def self.serialize(classification, options = {})
     serializer = new(classification)
-    adapter = Serialization::V1Adapter.new(serializer)
-    adapter.to_json
+    Serialization::V1Adapter.new(serializer, options)
   end
 
   attributes :id, :annotations, :created_at, :metadata

--- a/lib/kafka_classification_serializer.rb
+++ b/lib/kafka_classification_serializer.rb
@@ -1,0 +1,22 @@
+class KafkaClassificationSerializer < ActiveModel::Serializer
+  def self.serialize(classification)
+    serializer = new(classification)
+    adapter = Serialization::V1Adapter.new(serializer)
+    adapter.to_json
+  end
+
+  attributes :id, :annotations, :created_at, :metadata
+
+  belongs_to :project, serializer: KafkaProjectSerializer, embed: :ids
+  belongs_to :user, serializer: KafkaUserSerializer
+  belongs_to :workflow, serializer: KafkaWorkflowSerializer
+  has_many   :subjects, serializer: KafkaSubjectSerializer, embed: :ids
+
+  def metadata
+    object.metadata.merge(workflow_version: object.workflow_version)
+  end
+
+  def subjects
+    Subject.where(id: object.subject_ids)
+  end
+end

--- a/lib/kafka_project_serializer.rb
+++ b/lib/kafka_project_serializer.rb
@@ -1,0 +1,3 @@
+class KafkaProjectSerializer < ActiveModel::Serializer
+  attributes :id, :name, :created_at
+end

--- a/lib/kafka_subject_serializer.rb
+++ b/lib/kafka_subject_serializer.rb
@@ -1,3 +1,3 @@
 class KafkaSubjectSerializer < ActiveModel::Serializer
-  attributes :id, :created_at
+  attributes :id, :metadata, :created_at, :updated_at
 end

--- a/lib/kafka_subject_serializer.rb
+++ b/lib/kafka_subject_serializer.rb
@@ -1,0 +1,3 @@
+class KafkaSubjectSerializer < ActiveModel::Serializer
+  attributes :id, :created_at
+end

--- a/lib/kafka_user_serializer.rb
+++ b/lib/kafka_user_serializer.rb
@@ -1,0 +1,3 @@
+class KafkaUserSerializer < ActiveModel::Serializer
+  attributes :id, :login
+end

--- a/lib/kafka_workflow_serializer.rb
+++ b/lib/kafka_workflow_serializer.rb
@@ -1,0 +1,3 @@
+class KafkaWorkflowSerializer < ActiveModel::Serializer
+  attributes :id, :created_at
+end

--- a/lib/serialization/v1_adapter.rb
+++ b/lib/serialization/v1_adapter.rb
@@ -153,11 +153,3 @@ module Serialization
     end
   end
 end
-
-# {"classifications"=>[
-#    {"id"=>"",
-#     "annotations"=>[{"task"=>"an_annotation", "value"=>true}, {"task"=>"another_one", "value"=>[1, 2]}],
-#     "created_at"=>nil,
-#     "metadata"=>{"user_agent"=>"cURL", "started_at"=>"2015-08-18 14:15:08 UTC", "finished_at"=>"2015-08-18 14:16:08 UTC", "user_language"=>"en", "workflow_version"=>"15.15"},
-#     "href"=>"/classifications/",
-#     "links"=>{"project"=>"1", "user"=>"1", "workflow"=>"1", "subjects"=>["1", "2"]}}]}

--- a/lib/serialization/v1_adapter.rb
+++ b/lib/serialization/v1_adapter.rb
@@ -1,0 +1,159 @@
+require 'active_model/serializer/adapter/json_api/fragment_cache'
+
+module Serialization
+  class V1Adapter < ActiveModel::Serializer::Adapter
+    def initialize(serializer, options = {})
+      super
+      serializer.root = true
+      @hash = { serializer.type => [] }
+
+      if fields = options.delete(:fields)
+        @fieldset = ActiveModel::Serializer::Fieldset.new(fields, serializer.json_key)
+      else
+        @fieldset = options[:fieldset]
+      end
+    end
+
+    def serializable_hash(options = {})
+      if serializer.respond_to?(:each)
+        serializer.each do |s|
+          result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash
+          @hash[serializer.type] << result[serializer.type]
+
+          if result[:included]
+            @hash[:included] ||= []
+            @hash[:included] |= result[:included]
+          end
+        end
+      else
+        @hash[serializer.type] = [attributes_for_serializer(serializer, @options)]
+        add_resource_links(@hash[serializer.type][0], serializer)
+      end
+      @hash
+    end
+
+    def fragment_cache(cached_hash, non_cached_hash)
+      root = false if @options.include?(:include)
+      JsonApi::FragmentCache.new().fragment_cache(root, cached_hash, non_cached_hash)
+    end
+
+    private
+
+    def add_links(resource, name, serializers)
+      resource[:links] ||= {}
+      resource[:links][name] = serializers.map { |serializer| serializer.id.to_s }
+    end
+
+    def add_link(resource, name, serializer, val=nil)
+      resource[:links] ||= {}
+      resource[:links][name] = nil
+
+      if serializer && serializer.object
+        resource[:links][name]= serializer.id.to_s
+      end
+    end
+
+    def add_included(resource_name, serializers, parent = nil)
+      unless serializers.respond_to?(:each)
+        return unless serializers.object
+        serializers = Array(serializers)
+      end
+      resource_path = [parent, resource_name].compact.join('.')
+      if include_assoc?(resource_path)
+        @hash[:included] ||= []
+
+        serializers.each do |serializer|
+          attrs = attributes_for_serializer(serializer, @options)
+
+          add_resource_links(attrs, serializer, add_included: false)
+
+          @hash[:included].push(attrs) unless @hash[:included].include?(attrs)
+        end
+      end
+
+      serializers.each do |serializer|
+        serializer.each_association do |name, association, opts|
+          add_included(name, association, resource_path) if association
+        end if include_nested_assoc? resource_path
+      end
+    end
+
+    def attributes_for_serializer(serializer, options)
+      if serializer.respond_to?(:each)
+        result = []
+        serializer.each do |object|
+          options[:fields] = @fieldset && @fieldset.fields_for(serializer)
+          result << cache_check(object) do
+            options[:required_fields] = [:id, :type]
+            attributes = object.attributes(options)
+            attributes[:id] = attributes[:id].to_s
+            attributes[:href] = "/#{serializer.type}/#{object.id}"
+            attributes.delete(:type)
+            result << attributes
+          end
+        end
+      else
+        options[:fields] = @fieldset && @fieldset.fields_for(serializer)
+        options[:required_fields] = [:id, :type]
+        result = cache_check(serializer) do
+          result = serializer.attributes(options)
+          result[:id] = result[:id].to_s
+          result[:href] = "/#{serializer.type}/#{serializer.id}"
+          result.delete(:type)
+          result
+        end
+      end
+      result
+    end
+
+    def include_assoc?(assoc)
+      return false unless @options[:include]
+      check_assoc("#{assoc}$")
+    end
+
+    def include_nested_assoc?(assoc)
+      return false unless @options[:include]
+      check_assoc("#{assoc}.")
+    end
+
+    def check_assoc(assoc)
+      include_opt = @options[:include]
+      include_opt = include_opt.split(',') if include_opt.is_a?(String)
+      include_opt.any? do |s|
+        s.match(/^#{assoc.gsub('.', '\.')}/)
+      end
+    end
+
+    def add_resource_links(attrs, serializer, options = {})
+      options[:add_included] = options.fetch(:add_included, true)
+
+      serializer.each_association do |name, association, opts|
+        attrs[:links] ||= {}
+
+        if association.respond_to?(:each)
+          add_links(attrs, name, association)
+        else
+          if opts[:virtual_value]
+            add_link(attrs, name, nil, opts[:virtual_value])
+          else
+            add_link(attrs, name, association)
+          end
+        end
+
+        if options[:add_included]
+          Array(association).each do |association|
+            add_included(name, association)
+          end
+        end
+      end
+    end
+  end
+end
+
+# {"classifications"=>[
+#    {"id"=>"",
+#     "annotations"=>[{"task"=>"an_annotation", "value"=>true}, {"task"=>"another_one", "value"=>[1, 2]}],
+#     "created_at"=>nil,
+#     "metadata"=>{"user_agent"=>"cURL", "started_at"=>"2015-08-18 14:15:08 UTC", "finished_at"=>"2015-08-18 14:16:08 UTC", "user_language"=>"en", "workflow_version"=>"15.15"},
+#     "href"=>"/classifications/",
+#     "links"=>{"project"=>"1", "user"=>"1", "workflow"=>"1", "subjects"=>["1", "2"]}}]}

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -270,7 +270,7 @@ describe ClassificationLifecycle do
     context "when classificaiton is completed" do
 
       it 'should publish to kafka' do
-        serialized = ClassificationSerializer.serialize(classification).to_json
+        serialized = KafkaClassificationSerializer.serialize(classification, include: 'subjects').to_json
         expect(MultiKafkaProducer).to receive(:publish)
           .with('classifications', [classification.project.id, serialized])
       end

--- a/spec/lib/kafka_classification_serializer_spec.rb
+++ b/spec/lib/kafka_classification_serializer_spec.rb
@@ -2,14 +2,20 @@ require 'spec_helper'
 
 describe KafkaClassificationSerializer do
   let(:classification) { create(:classification) }
+  let(:serializer) { KafkaClassificationSerializer.new(Classification.find(classification.id)) }
+  let(:adapter) { Serialization::V1Adapter.new(serializer) }
 
   it 'is a substitute for ClassificationSerializer' do
-    serializer = KafkaClassificationSerializer.new(Classification.find(classification.id))
-    adapter = Serialization::V1Adapter.new(serializer)
-
     new_json = adapter.to_json
     old_json = ClassificationSerializer.serialize(classification).to_json
 
     expect(JSON.load(new_json)).to eq(JSON.load(old_json))
+  end
+
+  it 'can process includes' do
+    subject = create(:subject)
+    classification.subject_ids = [subject.id]
+    adapter = described_class.serialize(classification, include: ['subjects'])
+    expect(adapter.as_json[:linked]['subjects'].size).to eq(1)
   end
 end

--- a/spec/lib/kafka_classification_serializer_spec.rb
+++ b/spec/lib/kafka_classification_serializer_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe KafkaClassificationSerializer do
+  let(:classification) { create(:classification) }
+
+  it 'is a substitute for ClassificationSerializer' do
+    serializer = KafkaClassificationSerializer.new(Classification.find(classification.id))
+    adapter = Serialization::V1Adapter.new(serializer)
+
+    new_json = adapter.to_json
+    old_json = ClassificationSerializer.serialize(classification).to_json
+
+    expect(JSON.load(new_json)).to eq(JSON.load(old_json))
+  end
+end


### PR DESCRIPTION
The V1Adapter I've added is compatible (for this case, in general there might be a few minor differences with RestPack, haven't exhaustively checked) with output from RestPack. The V1Adapter is basically a copy of an older AMS adapter from before they started working towards JSON-API 1.0, with a few naming changes to be like RestPack.

AMS has a built-in JsonApi adapter (which I've made default in initializer) which follows the 1.0 spec for JSON-API.

Apart from that, AMS "just works" with things like belongs_to_many, has support for virtual associations as well, just define a method on the serializer and state at the top that it has_many or belongs_to that method name.

Fixes #1072