### PR TITLE
treat counts as numbers

### DIFF
--- a/app/models/user_project_preference.rb
+++ b/app/models/user_project_preference.rb
@@ -14,6 +14,6 @@ class UserProjectPreference < ActiveRecord::Base
   private
 
   def valid_legacy_count_values
-    legacy_count.values.compact
+    legacy_count.values.compact.map(&:to_i)
   end
 end

--- a/spec/models/user_project_preference_spec.rb
+++ b/spec/models/user_project_preference_spec.rb
@@ -44,5 +44,15 @@ RSpec.describe UserProjectPreference, :type => :model do
       expected_count = upp.send(:valid_legacy_count_values).sum
       expect(upp.summated_activity_count).to eq(expected_count)
     end
+
+    context "when the count is a string" do
+      let(:legacy_count) { '{"bars": 19, "candels": "10"}' }
+
+      it "should summate correctly for legacy counts" do
+        upp = build(:legacy_user_project_preference, legacy_count: legacy_count)
+        expected_count = upp.legacy_count.values.map(&:to_i).sum
+        expect(upp.summated_activity_count).to eq(expected_count)
+      end
+    end
   end
 end


### PR DESCRIPTION
some migrated activity counts are actually strings..