### PR TITLE
Switch Puma to listen on port 81

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ RUN bundle install --without development test
 ADD supervisord.conf /etc/supervisor/conf.d/panoptes.conf
 ADD ./ /rails_app
 
-EXPOSE 80
+EXPOSE 81
 
 ENTRYPOINT /rails_app/scripts/docker/start.sh

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:panoptes]
 user=root
-command=bundle exec rails s puma -p 80 -b 0.0.0.0
+command=bundle exec rails s puma -p 81 -b 0.0.0.0
 directory=/rails_app
 autorestart=true
 


### PR DESCRIPTION
So that we can use net=host in Docker when we deploy, without it conflicting with Nginx.