### PR TITLE
Aggregation config schemas to workflow for create / update actions

### DIFF
--- a/app/schemas/workflow_create_schema.rb
+++ b/app/schemas/workflow_create_schema.rb
@@ -51,6 +51,10 @@ class WorkflowCreateSchema < JsonSchema
       type "object"
     end
 
+    property "aggregation" do
+      type "object"
+    end
+
     property "links" do
       type "object"
       required "project"

--- a/app/schemas/workflow_update_schema.rb
+++ b/app/schemas/workflow_update_schema.rb
@@ -46,6 +46,10 @@ class WorkflowUpdateSchema < JsonSchema
       type "object"
     end
 
+    property "aggregation" do
+      type "object"
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -6,7 +6,8 @@ class WorkflowSerializer
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
              :created_at, :updated_at, :first_task, :primary_language,
              :version, :content_language, :prioritized, :grouped, :pairwise,
-             :retirement, :retired_set_member_subjects_count, :href, :active
+             :retirement, :retired_set_member_subjects_count, :href, :active,
+             :aggregation
 
   can_include :project, :subject_sets, :tutorial_subject, :expert_subject_sets
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -70,9 +70,8 @@ describe Api::V1::WorkflowsController, type: :controller do
        workflows: {
                    display_name: "A Better Name",
                    active: false,
-                   retirement: {
-                                criteria: "classification_count"
-                               },
+                   retirement: { criteria: "classification_count" },
+                   aggregation: { },
                    tasks: {
                            interest: {
                                       type: "draw",
@@ -287,9 +286,8 @@ describe Api::V1::WorkflowsController, type: :controller do
                    display_name: 'Test workflow',
                    first_task: 'interest',
                    active: true,
-                   retirement: {
-                                criteria: "classification_count"
-                               },
+                   retirement: { criteria: "classification_count" },
+                   aggregation: { public: true },
                    tasks: {
                            interest: {
                                       type: "draw",

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::V1::WorkflowsController, type: :controller do
   let(:authorized_user) { owner }
 
   let(:api_resource_attributes) do
-    %w(id display_name tasks classifications_count subjects_count created_at updated_at first_task primary_language content_language version grouped prioritized pairwise retirement active)
+    %w(id display_name tasks classifications_count subjects_count created_at updated_at first_task primary_language content_language version grouped prioritized pairwise retirement aggregation active)
   end
   let(:api_resource_links){ %w(workflows.project workflows.subject_sets workflows.tutorial_subject workflows.expert_subject_set workflows.attached_images) }
   let(:scopes) { %w(public project) }


### PR DESCRIPTION
closes #1239 - allow aggregation configuration object to workflows. Currently used to set the aggregations to be public, e.g. `aggregation: { "public": true }`.