### PR TITLE
Prepend queue ids

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3213,7 +3213,7 @@ Removes the queue entirely
 + Response 204
 
 ## Add subject links [/subject_queues/{id}/links/subjects]
-Add subjects to a queue.
+Prepend subjects to a queue.
 
 ### Add links [POST]
 A user is permitted to add subjects if they are the project owner or

--- a/app/controllers/api/v1/subject_queues_controller.rb
+++ b/app/controllers/api/v1/subject_queues_controller.rb
@@ -13,8 +13,21 @@ class Api::V1::SubjectQueuesController < Api::ApiController
     when "subjects", :subjects
       relation = SetMemberSubject.link_to_resource(resource, api_user, *args)
         .where(subject_id: value)
+        .order("idx(array[#{value.join(',')}], set_member_subjects.subject_id)")
 
       relation_or_error(relation, true)
+    else
+      super
+    end
+  end
+
+  def add_relation(resource, relation, value)
+    if relation == :subjects && value.is_a?(Array)
+      curr_ids = resource.set_member_subject_ids
+      uniq_incoming_ids = value.uniq
+      new_ids = new_items(resource, relation, uniq_incoming_ids).map(&:id)
+      non_dup_prepend_ids = new_ids | curr_ids
+      resource.set_member_subject_ids = non_dup_prepend_ids
     else
       super
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,7 @@ Rails.application.routes.draw do
 
       json_api_resources :collections, links: [:subjects]
 
-      json_api_resources :subject_queues, links: [:set_member_subjects]
+      json_api_resources :subject_queues, links: [:subjects]
 
       json_api_resources :tags, only: [:index, :show]
     end

--- a/spec/controllers/api/v1/subject_queues_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_queues_controller_spec.rb
@@ -12,6 +12,7 @@ describe Api::V1::SubjectQueuesController, type: :controller do
   let!(:set_member_subjects) do
     create_list(:set_member_subject, 3, subject_set: workflow.subject_sets.first)
   end
+  let(:set_member_subject_ids) { set_member_subjects.map(&:id) }
   let(:subjects) { set_member_subjects.map(&:subject) }
   let(:subject_ids) { subjects.map(&:id) }
 
@@ -34,9 +35,7 @@ describe Api::V1::SubjectQueuesController, type: :controller do
 
   describe "#update" do
     let(:test_attr) { :set_member_subject_ids }
-    let(:test_attr_value) { subject_ids }
-    let(:test_relation_ids) { subject_ids }
-    let(:test_relation) { :set_member_subjects }
+    let(:test_attr_value) { set_member_subject_ids }
     let(:update_params) do
       { subject_queues:
           {
@@ -49,7 +48,11 @@ describe Api::V1::SubjectQueuesController, type: :controller do
 
     it_behaves_like "is updatable"
 
-    it_behaves_like "has updatable links"
+    it_behaves_like "has updatable links" do
+      let(:stringified_test_relation_ids) { set_member_subject_ids.map(&:to_s) }
+      let(:test_relation_ids) { subject_ids }
+      let(:test_relation) { :set_member_subjects }
+    end
   end
 
   describe "#update_links" do
@@ -64,11 +67,13 @@ describe Api::V1::SubjectQueuesController, type: :controller do
     let!(:resource) do
       create(:subject_queue, workflow: workflow, subject_set: nil, set_member_subject_ids: q_sms_ids)
     end
-    let(:expected_ids) { rev_subject_ids | q_sms_ids }
+    let(:sms_ids) { set_member_subjects.map(&:id) }
+    let(:expected_ids) { sms_ids.reverse | q_sms_ids }
 
     it_behaves_like "supports update_links" do
       let!(:old_ids) { resource.set_member_subject_ids }
       let(:linked_resources) { updated_resource.set_member_subjects }
+      let(:stringified_test_relation_ids) { sms_ids.map(&:to_s) }
 
       it "prepend the ids and remove dups" do
         expect(updated_resource.set_member_subject_ids).to eq(expected_ids)
@@ -78,7 +83,7 @@ describe Api::V1::SubjectQueuesController, type: :controller do
 
   describe "#create" do
     let(:test_attr) { :set_member_subject_ids }
-    let(:test_attr_value) { subjects.map(&:id) }
+    let(:test_attr_value) { set_member_subject_ids }
     let(:create_params) do
       {
        subject_queues: {

--- a/spec/controllers/api/v1/subject_queues_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_queues_controller_spec.rb
@@ -68,7 +68,7 @@ describe Api::V1::SubjectQueuesController, type: :controller do
 
     it_behaves_like "supports update_links" do
       let!(:old_ids) { resource.set_member_subject_ids }
-      let(:linked_resource) { updated_resource.set_member_subjects }
+      let(:linked_resources) { updated_resource.set_member_subjects }
 
       it "prepend the ids and remove dups" do
         expect(updated_resource.set_member_subject_ids).to eq(expected_ids)

--- a/spec/controllers/api/v1/subject_queues_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_queues_controller_spec.rb
@@ -9,8 +9,11 @@ describe Api::V1::SubjectQueuesController, type: :controller do
   let(:project) { create(:project, owner: authorized_user) }
   let(:workflow) { create(:workflow_with_subject_set, project: project) }
   let(:resource) { create(:subject_queue, workflow: workflow, subject_set: nil) }
-  let!(:subjects) { create(:subject); create_list(:set_member_subject, 3, subject_set: workflow.subject_sets.first) }
-  let(:subject_ids) { subjects.map(&:subject_id).map(&:to_s) }
+  let!(:set_member_subjects) do
+    create_list(:set_member_subject, 3, subject_set: workflow.subject_sets.first)
+  end
+  let(:subjects) { set_member_subjects.map(&:subject) }
+  let(:subject_ids) { subjects.map(&:id) }
 
   let(:scopes) { %w(public project) }
   let(:resource_class) { SubjectQueue }
@@ -31,18 +34,46 @@ describe Api::V1::SubjectQueuesController, type: :controller do
 
   describe "#update" do
     let(:test_attr) { :set_member_subject_ids }
-    let(:test_attr_value) { subjects.map(&:id) }
+    let(:test_attr_value) { subject_ids }
+    let(:test_relation_ids) { subject_ids }
+    let(:test_relation) { :set_member_subjects }
     let(:update_params) do
-      {
-        subject_queues: {
-                             links: {
-                                     subjects: subject_ids
-                                    }
-                            }
+      { subject_queues:
+          {
+            links: {
+              subjects: subject_ids
+            }
+          }
       }
     end
-    
+
     it_behaves_like "is updatable"
+
+    it_behaves_like "has updatable links"
+  end
+
+  describe "#update_links" do
+    let(:rev_subject_ids) { subject_ids.reverse }
+    let(:test_attr_value) { rev_subject_ids }
+    let(:test_relation_ids) { rev_subject_ids * 2 }
+    let(:test_relation) { :subjects }
+    let(:resource_id) { :subject_queue_id }
+    let(:q_sms_ids) do
+      Array.wrap(create(:set_member_subject, subject_set: workflow.subject_sets.first).id)
+    end
+    let!(:resource) do
+      create(:subject_queue, workflow: workflow, subject_set: nil, set_member_subject_ids: q_sms_ids)
+    end
+    let(:expected_ids) { rev_subject_ids | q_sms_ids }
+
+    it_behaves_like "supports update_links" do
+      let!(:old_ids) { resource.set_member_subject_ids }
+      let(:linked_resource) { updated_resource.set_member_subjects }
+
+      it "prepend the ids and remove dups" do
+        expect(updated_resource.set_member_subject_ids).to eq(expected_ids)
+      end
+    end
   end
 
   describe "#create" do
@@ -59,7 +90,7 @@ describe Api::V1::SubjectQueuesController, type: :controller do
                             }
       }
     end
-      
+
     it_behaves_like "is creatable"
   end
 

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -79,7 +79,7 @@ RSpec.shared_examples "supports update_links" do
   let!(:old_ids) { resource.send(test_relation).map(&:id) }
   let(:updated_resource) { resource.reload }
   let(:stringified_test_relation_ids) { Array.wrap(test_relation_ids).map(&:to_s) }
-  let(:linked_resource) { updated_resource.send(test_relation) }
+  let(:linked_resources) { updated_resource.send(test_relation) }
 
   before(:each) do
     default_request scopes: scopes, user_id: authorized_user.id
@@ -92,12 +92,12 @@ RSpec.shared_examples "supports update_links" do
   end
 
   it 'should update any included links' do
-    updated_relation_ids = UpdatableResource.extract_linked_resource_ids(linked_resource)
+    updated_relation_ids = UpdatableResource.extract_linked_resource_ids(linked_resources)
     expect(updated_relation_ids).to include(*stringified_test_relation_ids)
   end
 
   it 'should retain pre-existing links' do
-    expect(linked_resource.map(&:id)).to include(*old_ids)
+    expect(linked_resources.map(&:id)).to include(*old_ids)
   end
 end
 

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -79,6 +79,7 @@ RSpec.shared_examples "supports update_links" do
   let!(:old_ids) { resource.send(test_relation).map(&:id) }
   let(:updated_resource) { resource.reload }
   let(:stringified_test_relation_ids) { Array.wrap(test_relation_ids).map(&:to_s) }
+  let(:linked_resource) { updated_resource.send(test_relation) }
 
   before(:each) do
     default_request scopes: scopes, user_id: authorized_user.id
@@ -91,13 +92,12 @@ RSpec.shared_examples "supports update_links" do
   end
 
   it 'should update any included links' do
-    linked_resource = updated_resource.send(test_relation)
     updated_relation_ids = UpdatableResource.extract_linked_resource_ids(linked_resource)
     expect(updated_relation_ids).to include(*stringified_test_relation_ids)
   end
 
   it 'should retain pre-existing links' do
-    expect(updated_resource.send(test_relation).map(&:id)).to include(*old_ids)
+    expect(linked_resource.map(&:id)).to include(*old_ids)
   end
 end
 


### PR DESCRIPTION
closes #1245 - does what it says on the tin.

I'd rather have a `has_many :subjects, through: :set_member_subjects` relation on SubjectQueue working but the has_many_through scope didn't work with the belongs_to_many link.