### PR TITLE
Allow subject sets to be filtered by metadata

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::SubjectSetsController < Api::ApiController
+  include FilterByMetadata
+
   doorkeeper_for :create, :update, :destroy, scopes: [:project]
   resource_actions :default
   schema_type :json_schema

--- a/app/controllers/concerns/filter_by_metadata.rb
+++ b/app/controllers/concerns/filter_by_metadata.rb
@@ -1,0 +1,17 @@
+module FilterByMetadata
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :filter_by_metadata, only: :index
+  end
+
+  def filter_by_metadata
+    meta_params = params.keys.select { |k| k.to_s.match(/^metadata\..+$/) }
+
+    meta_params.each do |meta_key|
+      _, key = meta_key.to_s.split(".")
+      value = params.delete(meta_key)
+      @controlled_resources = controlled_resources.where("\"#{resource_sym}\".\"metadata\"->>:key = :value", key: key, value: value)
+    end
+  end
+end

--- a/db/migrate/20150901222924_add_index_to_metadata.rb
+++ b/db/migrate/20150901222924_add_index_to_metadata.rb
@@ -1,0 +1,5 @@
+class AddIndexToMetadata < ActiveRecord::Migration
+  def change
+    add_index :subject_sets, :metadata, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -225,7 +225,7 @@ ActiveRecord::Schema.define(version: 20150902000226) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "set_member_subjects_count", default: 0,  null: false
-    t.jsonb    "metadata",                  default: {}
+    t.jsonb    "metadata",                  default: {}, index: {name: "index_subject_sets_on_metadata", using: :gin}
     t.integer  "lock_version",              default: 0
     t.boolean  "expert_set"
   end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -55,6 +55,12 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
     it_behaves_like 'is indexable'
     it_behaves_like 'has many filterable', :workflows
+
+    it "is filterable by metadata" do
+      subject_set = create(:subject_set, metadata: { artist: "Edvard Munch"})
+      get :index, "metadata.artist" => "Edvard Munch"
+      expect(json_response["subject_sets"][0]["id"]).to eq(subject_set.id.to_s)
+    end
   end
 
   describe '#show' do


### PR DESCRIPTION
Introduced metadata filters for subject sets via a param in the form
metadata.field

Adds a gin index to subject sets