### PR TITLE
Scope enqueues/dequeues to subject set

### DIFF
--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -41,8 +41,10 @@ class ClassificationLifecycle
   end
 
   def dequeue_subjects
-    sms_ids = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id).pluck(:id)
-    SubjectQueue.dequeue(workflow, sms_ids, user: user)
+    sms = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id).pluck(:id, :subject_set_id)
+    sms_ids = sms.map(&:first)
+    set_id = workflow.grouped ? sms.map { |s| s[1] }.first : nil
+    SubjectQueue.dequeue(workflow, sms_ids, user: user, set: set_id)
   end
 
   def update_seen_subjects

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -86,6 +86,7 @@ class SubjectSelector
   end
 
   def dequeue_subject(set_member_subject_ids)
-    SubjectQueue.dequeue(workflow, set_member_subject_ids, user: user.user)
+    SubjectQueue.dequeue(workflow, set_member_subject_ids, user: user.user,
+      set: params[:subject_set_id])
   end
 end

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe SubjectSelector do
 
         it 'should call dequeue_subject for the user' do
           expect(SubjectQueue).to receive(:dequeue)
-            .with(workflow, array_including(sms_ids), user: user.user)
+            .with(workflow, array_including(sms_ids), user: user.user, set: nil)
           subject.queued_subjects
         end
       end
@@ -108,7 +108,7 @@ RSpec.describe SubjectSelector do
 
         it 'should call dequeue_subject for the user' do
           expect(SubjectQueue).to receive(:dequeue)
-            .with(workflow, array_including(sms_ids), user: nil)
+            .with(workflow, array_including(sms_ids), user: nil, set: nil)
           subject.queued_subjects
         end
       end


### PR DESCRIPTION
This was making the subject and classification routes unbearably slow.

For grouped workflows we can assume that subjects are only queued in
their respective group queue and make sure we're only dequeuing from
that install of all the queues