### PR TITLE
handle empty database subject selection

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -13,7 +13,8 @@ module Api
       Api::NoMediaError,
       RoleControl::AccessDenied,
       SubjectSelector::MissingSubjectQueue,
-      SubjectSelector::MissingSubjectSet,                  with: :not_found
+      SubjectSelector::MissingSubjectSet,
+      SubjectSelector::EmptyDatabaseSelect,                with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
     rescue_from Api::LiveProjectChanges,                   with: :forbidden
     rescue_from Api::NotLoggedIn,

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe SubjectSelector do
         subjects, _ = subject.queued_subjects
         expect(subjects.length).to eq(5)
       end
+
+      context "when the database selection returns an empty set" do
+
+        it 'should raise the an error when ordering by an empty set' do
+          allow_any_instance_of(PostgresqlSelection).to receive(:select).and_return([])
+          subject_queue
+          message = "No data available for selection"
+          expect { subject.queued_subjects }.to raise_error(SubjectSelector::EmptyDatabaseSelect, message)
+        end
+      end
     end
 
     describe "#dequeue/enqueue after selection" do

--- a/spec/support/dump_worker.rb
+++ b/spec/support/dump_worker.rb
@@ -92,7 +92,8 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
     end
 
     it 'should email the users in the recipients hash' do
-      expect(mailer_class).to receive(:perform_async).with(anything, anything, receivers.map(&:email))
+      expect(mailer_class).to receive(:perform_async)
+        .with(anything, anything, array_including(receivers.map(&:email)))
       worker.perform(project.id, medium.id)
     end
   end


### PR DESCRIPTION
don't try and idx an empty array and raise an error to indicate no data to select from for the client