### PR TITLE
Expose ports for easier debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ postgres:
   environment:
     - "POSTGRES_USER=panoptes"
     - "POSTGRES_PASSWORD=panoptes"
+  ports:
+    - "5432:5432"
 
 zookeeper:
   image: zooniverse/zookeeper
@@ -21,6 +23,8 @@ kafka:
 
 cassandra:
   image: cassandra
+  ports:
+    - "9042:9042"
 
 panoptes:
   dockerfile: Dockerfile.dev


### PR DESCRIPTION
I'm happy to change the ports if it collides with anyone's docker containers, but this just makes it so much easier to open a postgresql shell etc. I keep making this change and then not committing it, so I figured it'd poll opinions on a PR.