### PR TITLE
explicit queue build for the subject set

### DIFF
--- a/app/workers/reload_non_logged_in_queue_worker.rb
+++ b/app/workers/reload_non_logged_in_queue_worker.rb
@@ -22,6 +22,6 @@ class ReloadNonLoggedInQueueWorker
       .select(limit: SubjectQueue::DEFAULT_LENGTH, subject_set_id: set)
       .compact
 
-    SubjectQueue.reload(workflow, subjects, set: set)
+    SubjectQueue.reload(workflow, subjects, set_id: set)
   end
 end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -44,7 +44,7 @@ class ClassificationLifecycle
     sms = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id).pluck(:id, :subject_set_id)
     sms_ids = sms.map(&:first)
     set_id = workflow.grouped ? sms.map { |s| s[1] }.first : nil
-    SubjectQueue.dequeue(workflow, sms_ids, user: user, set: set_id)
+    SubjectQueue.dequeue(workflow, sms_ids, user: user, set_id: set_id)
   end
 
   def update_seen_subjects

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -80,7 +80,7 @@ class SubjectSelector
     when queue.nil?
       queue = SubjectQueue.create_for_user(workflow, queue_user, set: params[:subject_set_id])
     when queue.below_minimum?
-      EnqueueSubjectQueueWorker.perform_async(workflow.id, queue_user.try(:id))
+      EnqueueSubjectQueueWorker.perform_async(workflow.id, queue_user.try(:id), params[:subject_set_id])
     end
     [queue, context]
   end

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -78,7 +78,7 @@ class SubjectSelector
 
     case
     when queue.nil?
-      queue = SubjectQueue.create_for_user(workflow, queue_user, set: params[:subject_set_id])
+      queue = SubjectQueue.create_for_user(workflow, queue_user, set_id: params[:subject_set_id])
     when queue.below_minimum?
       EnqueueSubjectQueueWorker.perform_async(workflow.id, queue_user.try(:id), params[:subject_set_id])
     end
@@ -87,6 +87,6 @@ class SubjectSelector
 
   def dequeue_subject(set_member_subject_ids)
     SubjectQueue.dequeue(workflow, set_member_subject_ids, user: user.user,
-      set: params[:subject_set_id])
+      set_id: params[:subject_set_id])
   end
 end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -105,7 +105,7 @@ describe Api::V1::SubjectsController, type: :controller do
 
           context 'when the queue is below minimum' do
             it 'should reload the queue' do
-              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
+              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil, nil)
               get :index, request_params
             end
           end
@@ -180,7 +180,7 @@ describe Api::V1::SubjectsController, type: :controller do
 
           context 'when the queue is below minimum' do
             it 'should reload the queue' do
-              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, user.id)
+              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, user.id, nil)
               get :index, request_params
             end
           end

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SubjectSelector do
       it 'should create a new queue from the logged out queue' do
         subject_queue
         expect(SubjectQueue).to receive(:create_for_user)
-          .with(workflow, user.user, set: nil).and_call_original
+          .with(workflow, user.user, set_id: nil).and_call_original
         subject.queued_subjects
       end
 
@@ -97,7 +97,7 @@ RSpec.describe SubjectSelector do
 
         it 'should call dequeue_subject for the user' do
           expect(SubjectQueue).to receive(:dequeue)
-            .with(workflow, array_including(sms_ids), user: user.user, set: nil)
+            .with(workflow, array_including(sms_ids), user: user.user, set_id: nil)
           subject.queued_subjects
         end
       end
@@ -108,7 +108,7 @@ RSpec.describe SubjectSelector do
 
         it 'should call dequeue_subject for the user' do
           expect(SubjectQueue).to receive(:dequeue)
-            .with(workflow, array_including(sms_ids), user: nil, set: nil)
+            .with(workflow, array_including(sms_ids), user: nil, set_id: nil)
           subject.queued_subjects
         end
       end
@@ -121,14 +121,14 @@ RSpec.describe SubjectSelector do
 
         shared_examples "enqueues for the logged out user" do
           it 'should enqueue for logged out user' do
-            expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
+            expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil, nil)
             subject.queued_subjects
           end
         end
 
         shared_examples "creates for the logged out user" do
           it 'should create for logged out user' do
-            expect(SubjectQueue).to receive(:create_for_user).with(workflow, nil, set: nil)
+            expect(SubjectQueue).to receive(:create_for_user).with(workflow, nil, set_id: nil)
             #non-logged in queue won't exist
             expect { subject.queued_subjects }.to raise_error(SubjectSelector::MissingSubjectQueue)
           end

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SubjectQueue, type: :model do
     context "when no logged out queue" do
 
       it 'should attempt to build a logged out queue' do
-        expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil)
+        expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil, nil)
         SubjectQueue.create_for_user(workflow, user)
       end
 
@@ -100,7 +100,7 @@ RSpec.describe SubjectQueue, type: :model do
         end
 
         before(:each) do
-          SubjectQueue.reload(workflow, smses, set: subject_set.id)
+          SubjectQueue.reload(workflow, smses, set_id: subject_set.id)
           queue.reload
           not_updated_queue.reload
         end
@@ -116,7 +116,7 @@ RSpec.describe SubjectQueue, type: :model do
 
       context "when no queue exists" do
         before(:each) do
-          SubjectQueue.reload(workflow, smses, set: subject_set.id)
+          SubjectQueue.reload(workflow, smses, set_id: subject_set.id)
         end
 
         subject { SubjectQueue.find_by(workflow: workflow, subject_set: subject_set) }

--- a/spec/workers/enqueue_subject_queue_worker_spec.rb
+++ b/spec/workers/enqueue_subject_queue_worker_spec.rb
@@ -3,6 +3,8 @@ require "spec_helper"
 RSpec.describe EnqueueSubjectQueueWorker do
   subject { described_class.new }
   let(:workflow) { create(:workflow_with_subject_set) }
+  let(:subject_set) { workflow.subject_sets.first }
+  let(:user) { workflow.project.owner }
 
   describe "#perform" do
 
@@ -30,6 +32,24 @@ RSpec.describe EnqueueSubjectQueueWorker do
         expect do
           subject.perform(-1)
         end.to_not raise_error
+      end
+    end
+
+    context "with a user" do
+
+      it 'should create a subject queue for the user' do
+        subject.perform(workflow.id, user.id)
+        queue = SubjectQueue.by_user_workflow(user, workflow).first
+        expect(queue.set_member_subject_ids.length).to eq(100)
+      end
+    end
+
+    context "with user and a subject set" do
+
+      it 'should create a per user subject set queue' do
+        subject.perform(workflow.id, user.id, subject_set.id)
+        queue = SubjectQueue.by_set(subject_set.id).by_user_workflow(user, workflow).first
+        expect(queue.set_member_subject_ids.length).to eq(100)
       end
     end
 


### PR DESCRIPTION
don't assume building on all subject sets for a workflow, allow them to be explicitly specified.