### PR TITLE
remove cache counters

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,9 +1,9 @@
 class Classification < ActiveRecord::Base
   include BelongsToMany
 
-  belongs_to :project, counter_cache: true
+  belongs_to :project
   belongs_to :user, counter_cache: true
-  belongs_to :workflow, counter_cache: true
+  belongs_to :workflow
   belongs_to :user_group, counter_cache: true
   belongs_to_many :subjects
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -106,7 +106,7 @@ describe Project, :type => :model do
     it_behaves_like "it has a classifications assocation"
   end
 
-  describe "#classifcations_count" do
+  describe "#classifcations_count", :disabled do
     let(:relation_instance) { project }
 
     it_behaves_like "it has a cached counter for classifications"

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -71,7 +71,7 @@ describe Workflow, :type => :model do
     it_behaves_like "it has a classifications assocation"
   end
 
-  describe "#classifcations_count" do
+  describe "#classifcations_count", :disabled do
     let(:relation_instance) { workflow }
 
     it_behaves_like "it has a cached counter for classifications"


### PR DESCRIPTION
seems the project / worfklow counter cache from classifications are causing lots of deadlocked updates and slowing the api nodes down. Removing to see if this is the problem.