### PR TITLE
Queue updates

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -52,9 +52,7 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def lifecycle(action, classification)
-    lifecycle = ClassificationLifecycle.new(classification)
-    lifecycle.dequeue_subjects
-    lifecycle.queue(action)
+    ClassificationLifecycle.new(classification).queue(action)
   end
 
   def completed_error

--- a/app/workers/dequeue_subject_queue_worker.rb
+++ b/app/workers/dequeue_subject_queue_worker.rb
@@ -1,0 +1,15 @@
+class DequeueSubjectQueueWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :high
+
+  def perform(workflow_id, sms_ids, user_id=nil, subject_set_id=nil)
+    workflow = Workflow.find(workflow_id)
+    user = User.find(user_id) if user_id
+    unless sms_ids.blank?
+      SubjectQueue.dequeue(workflow, sms_ids, user: user, set_id: subject_set_id)
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -40,13 +40,6 @@ class ClassificationLifecycle
       end
   end
 
-  def dequeue_subjects
-    sms_scope = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id)
-    sms_ids = sms_scope.pluck(:id)
-    set_id = workflow.grouped ? sms_scope.first.subject_set_id : nil
-    SubjectQueue.dequeue(workflow, sms_ids, user: user, set_id: set_id)
-  end
-
   def update_seen_subjects
     if should_update_seen? && subjects_are_unseen_by_user?
       UserSeenSubject.add_seen_subjects_for_user(**user_workflow_subject)

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -34,7 +34,7 @@ class SubjectSelector
     if set_member_subject_ids.blank?
       select_from_database
     else
-      dequeue_subject(set_member_subject_ids)
+      DequeueSubjectQueueWorker.perform_async(workflow.id, set_member_subject_ids, queue_user.try(:id), params[:subject_set_id])
       set_member_subject_ids
     end
   end
@@ -94,10 +94,5 @@ class SubjectSelector
       .find_by(user: queue_user, workflow: workflow)
     return queue if queue
     SubjectQueue.create_for_user(workflow, queue_user, set_id: params[:subject_set_id])
-  end
-
-  def dequeue_subject(set_member_subject_ids)
-    SubjectQueue.dequeue(workflow, set_member_subject_ids, user: user.user,
-      set_id: params[:subject_set_id])
   end
 end

--- a/lib/subject_selector.rb
+++ b/lib/subject_selector.rb
@@ -35,9 +35,6 @@ class SubjectSelector
       select_from_database
     else
       dequeue_subject(set_member_subject_ids)
-      if queue.below_minimum?
-        EnqueueSubjectQueueWorker.perform_async(workflow.id, queue_user.try(:id), params[:subject_set_id])
-      end
       set_member_subject_ids
     end
   end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -102,21 +102,6 @@ describe Api::V1::SubjectsController, type: :controller do
               end
             end
           end
-
-          context 'when the queue is below minimum' do
-            it 'should reload the queue' do
-              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil, nil)
-              get :index, request_params
-            end
-          end
-
-          context 'when the queue is not below minimum)' do
-            let(:sms) { create_list(:set_member_subject, 21) }
-            it 'should reload the queue' do
-              expect(EnqueueSubjectQueueWorker).to_not receive(:perform_async)
-              get :index, request_params
-            end
-          end
         end
       end
     end
@@ -177,21 +162,6 @@ describe Api::V1::SubjectsController, type: :controller do
           end
 
           it_behaves_like "an api response"
-
-          context 'when the queue is below minimum' do
-            it 'should reload the queue' do
-              expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, user.id, nil)
-              get :index, request_params
-            end
-          end
-
-          context 'when the queue is not below minimum)' do
-            let(:sms) { create_list(:set_member_subject, 21) }
-            it 'should reload the queue' do
-              expect(EnqueueSubjectQueueWorker).to_not receive(:perform_async)
-              get :index, request_params
-            end
-          end
         end
 
         context "user has classified all subjects in the workflow" do

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -25,38 +25,6 @@ describe ClassificationLifecycle do
     allow(MultiKafkaProducer).to receive(:publish)
   end
 
-  describe "#dequeue_subjects" do
-
-    it 'should dequeue the subjects' do
-      subject_queue
-      subject.dequeue_subjects
-      subject_queue.reload
-      expect(subject_queue.set_member_subject_ids).to_not include(*sms_ids)
-    end
-
-    context "complete classification" do
-      let(:classification) { create(:classification, completed: true) }
-
-      it 'should call dequeue_subject_for_user' do
-        expect(SubjectQueue).to receive(:dequeue)
-          .with(classification.workflow,
-                array_including(sms_ids),
-                user: classification.user,
-                set_id: nil)
-        subject.dequeue_subjects
-      end
-    end
-
-    context "incomplete classification" do
-      let(:classification) { create(:classification, completed: false) }
-
-      it 'should call dequeue when incomplete' do
-        expect(SubjectQueue).to receive(:dequeue)
-        subject.dequeue_subjects
-      end
-    end
-  end
-
   describe "#queue" do
 
     context "with create action" do

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SubjectSelector do
       end
     end
 
-    describe "#dequeue/enqueue after selection" do
+    describe "#dequeue after selection" do
       let(:smses) { workflow.set_member_subjects }
       let(:sms_ids) { smses.map(&:id) }
       let(:subject_queue) do
@@ -129,13 +129,6 @@ RSpec.describe SubjectSelector do
           subject_queue
         end
 
-        shared_examples "enqueues for the logged out user" do
-          it 'should enqueue for logged out user' do
-            expect(EnqueueSubjectQueueWorker).to receive(:perform_async).with(workflow.id, nil, nil)
-            subject.queued_subjects
-          end
-        end
-
         shared_examples "creates for the logged out user" do
           it 'should create for logged out user' do
             expect(SubjectQueue).to receive(:create_for_user).with(workflow, nil, set_id: nil)
@@ -149,8 +142,6 @@ RSpec.describe SubjectSelector do
             allow_any_instance_of(Workflow).to receive(:finished?).and_return(true)
           end
 
-          it_behaves_like "enqueues for the logged out user"
-
           context "when the logged_out queue doesn't exist" do
             let(:queue_owner) { user.user }
 
@@ -162,8 +153,6 @@ RSpec.describe SubjectSelector do
           before(:each) do
             allow_any_instance_of(User).to receive(:has_finished?).and_return(true)
           end
-
-          it_behaves_like "enqueues for the logged out user"
 
           context "when the logged_out queue doesn't exist" do
             let(:queue_owner) { user.user }

--- a/spec/lib/subject_selector_spec.rb
+++ b/spec/lib/subject_selector_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe SubjectSelector do
         let(:queue_owner) { user.user }
 
         it 'should call dequeue_subject for the user' do
-          expect(SubjectQueue).to receive(:dequeue)
-            .with(workflow, array_including(sms_ids), user: user.user, set_id: nil)
+          expect(DequeueSubjectQueueWorker).to receive(:perform_async)
+            .with(workflow.id, array_including(sms_ids), queue_owner.id, nil)
           subject.queued_subjects
         end
       end
@@ -117,8 +117,8 @@ RSpec.describe SubjectSelector do
         let(:user) { ApiUser.new(nil) }
 
         it 'should call dequeue_subject for the user' do
-          expect(SubjectQueue).to receive(:dequeue)
-            .with(workflow, array_including(sms_ids), user: nil, set_id: nil)
+          expect(DequeueSubjectQueueWorker).to receive(:perform_async)
+            .with(workflow.id, array_including(sms_ids), nil, nil)
           subject.queued_subjects
         end
       end

--- a/spec/workers/dequeue_subject_queue_worker_spec.rb
+++ b/spec/workers/dequeue_subject_queue_worker_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe DequeueSubjectQueueWorker do
+  subject { described_class.new }
+  let(:workflow) { create(:workflow_with_subject_set) }
+  let(:subject_set) { workflow.subject_sets.first }
+  let(:user) { workflow.project.owner }
+  let(:sms_ids) { (1..10).to_a }
+
+  describe "#perform" do
+
+    it 'should call dequeue on subject queue' do
+      expect(SubjectQueue).to receive(:dequeue).with(workflow, sms_ids, user: nil, set_id: nil)
+      subject.perform(workflow.id, sms_ids)
+    end
+
+    context "with an empty set of sms_ids" do
+
+      it "should not call dequeue" do
+        expect(SubjectQueue).not_to receive(:dequeue)
+        subject.perform(workflow.id, [])
+      end
+    end
+
+    context "when the workflow does not exist" do
+      it 'should not raise an error' do
+        expect { subject.perform(-1, sms_ids) }.to_not raise_error
+      end
+    end
+
+    context "with a user" do
+
+      it 'should call dequeue on subject queue' do
+        expect(SubjectQueue).to receive(:dequeue).with(workflow, sms_ids, user: user, set_id: nil)
+        subject.perform(workflow.id, sms_ids, user)
+      end
+    end
+
+    context "with a set id" do
+
+      it 'should call dequeue on subject queue' do
+        expect(SubjectQueue).to receive(:dequeue).with(workflow, sms_ids, user: nil, set_id: subject_set.id)
+        subject.perform(workflow.id, sms_ids, nil, subject_set.id)
+      end
+    end
+
+    context "with user and a subject set" do
+
+      it 'should call dequeue on subject queue' do
+        expect(SubjectQueue).to receive(:dequeue).with(workflow, sms_ids, user: user, set_id: subject_set.id)
+        subject.perform(workflow.id, sms_ids, user, subject_set.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Work on queue's to stop in request cycle concurrent queue updates, e.g. non-logged in user dequeues for a very active workflow. See the commit messages for more details.

1. only dequeue after selecting from the queue, on classification receipt we can assume these have been removed.
2. do not refresh the low queues when selecting. this could have re-added recetly dequeued data back into the queue and led to duplicate classifications.
3. extracted dequeue to a high priority background worker. get this out of the request / response cycle to avoid concurrent updates. dequeue's can happen in any order so we just need to make sure sidekiq is working!
4. now all low queue refreshes run after updating user seens in the background during classification lifecycle transact to avoid possibly adding duplicates that were just removed.

This may also help with the small percentage of duplicates since we may have been re-queueing subjects we've just removed when the queue was low.