### PR TITLE
Persist example status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bin/**
 *~
 .jbundler/
 .DS_Store
+spec/examples.txt
 
 #ignore the api commit file
 public/commit_id.txt

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.use_transactional_fixtures = false
+  config.example_status_persistence_file_path = "./spec/examples.txt"
 
   config.filter_run_excluding disabled: true
 


### PR DESCRIPTION
This enables the rspec options —only-failures and —next-failure