### PR TITLE
Count subjects directly, not individual set members

### DIFF
--- a/app/controllers/api/v1/set_member_subjects_controller.rb
+++ b/app/controllers/api/v1/set_member_subjects_controller.rb
@@ -5,16 +5,4 @@ class Api::V1::SetMemberSubjectsController < Api::ApiController
 
   allowed_params :create, :priority, links: [:subject, :subject_set, retired_workflows: []]
   allowed_params :update, :priority, links: [retired_workflows: []]
-
-  def create
-    super { |set_member_subject| set_member_subject.retire_associated_subject_workflow_counts }
-  end
-
-  def update
-    super { |set_member_subject| set_member_subject.retire_associated_subject_workflow_counts }
-  end
-
-  def update_links
-    super { |set_member_subject| set_member_subject.retire_associated_subject_workflow_counts }
-  end
 end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -86,7 +86,6 @@ class Api::V1::SubjectSetsController < Api::ApiController
   private
 
   def remove_linked_set_member_subjects(resource, set_member_subjects)
-    SubjectWorkflowCount.where(set_member_subject: set_member_subjects).delete_all
     QueueRemovalWorker.perform_async(set_member_subjects.pluck(:id), resource.workflows.pluck(:id))
     CountResetWorker.perform_async(resource.id)
     set_member_subjects.delete_all

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -42,9 +42,17 @@ class SetMemberSubject < ActiveRecord::Base
   end
 
   def self.non_retired_for_workflow(workflow)
-    by_workflow(workflow)
-    .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.subject_id = set_member_subjects.subject_id")
-    .where('subject_workflow_counts.id IS NULL OR subject_workflow_counts.retired_at IS NULL')
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      by_workflow(workflow)
+        .joins("LEFT OUTER JOIN subject_workflow_counts swc1 ON swc1.set_member_subject_id = set_member_subjects.id")
+        .joins("LEFT OUTER JOIN subject_workflow_counts swc2 ON swc2.subject_id = set_member_subjects.subject_id")
+        .where('swc1.id IS NULL OR swc1.retired_at IS NULL')
+        .where('swc2.id IS NULL OR swc2.retired_at IS NULL')
+    else
+      by_workflow(workflow)
+      .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.subject_id = set_member_subjects.subject_id")
+      .where('subject_workflow_counts.id IS NULL OR subject_workflow_counts.retired_at IS NULL')
+    end
   end
 
   def self.unseen_for_user_by_workflow(user, workflow)

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -65,6 +65,15 @@ class SetMemberSubject < ActiveRecord::Base
     retired_workflows.pluck(:id)
   end
 
+  def retired_workflows
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      workflow_ids = SubjectWorkflowCount.retired.by_subject(subject_id).pluck(:workflow_id)
+      Workflow.where(id: workflow_ids)
+    else
+      super
+    end
+  end
+
   def retired_workflows=(workflows_to_retire)
     workflows_to_retire.each do |workflow|
       workflow.retire_subject(subject)

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -4,9 +4,10 @@ class SetMemberSubject < ActiveRecord::Base
 
   belongs_to :subject_set, counter_cache: true, touch: true
   belongs_to :subject
-  has_many :subject_workflow_counts, dependent: :destroy
   has_many :workflows, through: :subject_set
-  has_many :retired_subject_workflow_counts, -> { retired }, class_name: 'SubjectWorkflowCount'
+
+  has_many :subject_workflow_counts, through: :subject
+  has_many :retired_subject_workflow_counts, -> { retired }, through: :subject, class_name: 'SubjectWorkflowCount', source: 'subject_workflow_counts'
   has_many :retired_workflows, through: :retired_subject_workflow_counts, source: :workflow
 
   validates_presence_of :subject_set, :subject
@@ -42,7 +43,7 @@ class SetMemberSubject < ActiveRecord::Base
 
   def self.non_retired_for_workflow(workflow)
     by_workflow(workflow)
-    .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.set_member_subject_id = set_member_subjects.id")
+    .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.subject_id = set_member_subjects.subject_id")
     .where('subject_workflow_counts.id IS NULL OR subject_workflow_counts.retired_at IS NULL')
   end
 
@@ -53,7 +54,7 @@ class SetMemberSubject < ActiveRecord::Base
   end
 
   def retire_workflow(workflow)
-    count = subject_workflow_counts.find_or_create_by!(workflow_id: workflow.id)
+    count = SubjectWorkflowCount.find_or_create_by!(workflow_id: workflow.id, subject_id: subject_id)
     count.retire!
   end
 
@@ -62,9 +63,15 @@ class SetMemberSubject < ActiveRecord::Base
   end
 
   def retire_associated_subject_workflow_counts
-    retired_subject_workflow_counts.each(&:retire!)
-    subject_workflow_counts.reset
-    workflows.reset
+    # retired_subject_workflow_counts.each(&:retire!)
+    # subject_workflow_counts.reset
+    # workflows.reset
+  end
+
+  def retired_workflows=(workflows_to_retire)
+    workflows_to_retire.each do |workflow|
+      workflow.retire_subject(subject)
+    end
   end
 
   def remove_from_queues

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -53,11 +53,6 @@ class SetMemberSubject < ActiveRecord::Base
     .where('user_seen_subjects.id IS NULL OR (NOT "set_member_subjects"."subject_id" = ANY("user_seen_subjects"."subject_ids"))')
   end
 
-  def retire_workflow(workflow)
-    count = SubjectWorkflowCount.find_or_create_by!(workflow_id: workflow.id, subject_id: subject_id)
-    count.retire!
-  end
-
   def retired_workflow_ids
     retired_workflows.pluck(:id)
   end

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -62,12 +62,6 @@ class SetMemberSubject < ActiveRecord::Base
     retired_workflows.pluck(:id)
   end
 
-  def retire_associated_subject_workflow_counts
-    # retired_subject_workflow_counts.each(&:retire!)
-    # subject_workflow_counts.reset
-    # workflows.reset
-  end
-
   def retired_workflows=(workflows_to_retire)
     workflows_to_retire.each do |workflow|
       workflow.retire_subject(subject)

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -11,7 +11,7 @@ class Subject < ActiveRecord::Base
   has_many :collections, through: :collections_subjects
   has_many :subject_sets, through: :set_member_subjects
   has_many :set_member_subjects
-  has_many :subject_workflow_counts
+  has_many :subject_workflow_counts, dependent: :destroy
   has_many :locations, -> { where(type: 'subject_location') },
     class_name: "Medium", as: :linked
   has_many :recents, dependent: :destroy

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -31,7 +31,16 @@ class Subject < ActiveRecord::Base
 
   def retired_for_workflow?(workflow)
     if workflow && workflow.is_a?(Workflow) && workflow.persisted?
-      SubjectWorkflowCount.retired.by_subject_workflow(self.id, workflow.id).present?
+      if SubjectWorkflowCount::BACKWARDS_COMPAT
+        (SubjectWorkflowCount.retired.by_subject_workflow(self.id, workflow.id).present?) ||
+          (set_member_subjects.joins("INNER JOIN subject_workflow_counts ON subject_workflow_counts.set_member_subject_id = set_member_subjects.id")
+                              .where(subject_workflow_counts: {workflow_id: workflow.id})
+                              .where(subject_set_id: workflow.subject_sets.pluck(:id))
+                              .where.not(subject_workflow_counts: {retired_at: nil})
+                              .any?)
+      else
+        SubjectWorkflowCount.retired.by_subject_workflow(self.id, workflow.id).present?
+      end
     else
       false
     end

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -66,9 +66,10 @@ class SubjectQueue < ActiveRecord::Base
     enqueue_update(where(workflow: workflow), sms_ids)
   end
 
-  def self.dequeue_for_all(workflow, sms_id)
-    return if sms_id.blank?
-    dequeue_update(where(workflow: workflow), sms_id)
+  def self.dequeue_for_all(workflow, sms_ids)
+    return if sms_ids.blank?
+    sms_ids = Array.wrap(sms_ids)
+    dequeue_update(where(workflow: workflow), sms_ids)
   end
 
   def self.create_for_user(workflow, user, set_id: nil)

--- a/app/models/subject_workflow_count.rb
+++ b/app/models/subject_workflow_count.rb
@@ -1,19 +1,18 @@
 class SubjectWorkflowCount < ActiveRecord::Base
-  belongs_to :set_member_subject
   belongs_to :subject
   belongs_to :workflow
 
   scope :retired, -> { where.not(retired_at: nil) }
 
-  validates_presence_of :set_member_subject, :workflow
-  validates_uniqueness_of :set_member_subject_id, scope: :workflow_id
+  validates_presence_of :subject, :workflow
+  validates_uniqueness_of :subject_id, scope: :workflow_id
 
   def self.by_set(subject_set_id)
-    joins(:subject => :set_member_subject).where(set_member_subjects: {subject_set_id: subject_set_id})
+    joins(:subject => :set_member_subjects).where(set_member_subjects: {subject_set_id: subject_set_id})
   end
 
   def self.by_subject_workflow(subject_id, workflow_id)
-    where(subject_id: subject_id, workflow_id: workflow_id)
+    where(subject_id: subject_id, workflow_id: workflow_id).first
   end
 
   def retire?
@@ -32,5 +31,9 @@ class SubjectWorkflowCount < ActiveRecord::Base
 
   def retired?
     retired_at.present?
+  end
+
+  def set_member_subject_ids
+    subject.set_member_subjects.pluck(:id)
   end
 end

--- a/app/models/subject_workflow_count.rb
+++ b/app/models/subject_workflow_count.rb
@@ -1,18 +1,42 @@
 class SubjectWorkflowCount < ActiveRecord::Base
+  # TODO Switch to false after old data has been backported and then remove altogether
+  # Need to do multiple joins or conditions when this is active, might a little slower
+  # so don't keep compat mode on for too long.
+  BACKWARDS_COMPAT = true
+
   belongs_to :subject
   belongs_to :workflow
 
   scope :retired, -> { where.not(retired_at: nil) }
 
-  validates_presence_of :subject, :workflow
-  validates_uniqueness_of :subject_id, scope: :workflow_id
+  if BACKWARDS_COMPAT
+    # Cannot validate presence in this case (while we're migrating old data columns will be nillable)
+    validates_uniqueness_of :set_member_subject_id, scope: :workflow_id
+    validates_uniqueness_of :subject_id, scope: :workflow_id
+  else
+    validates :subject, presence: true, uniqueness: {scope: :workflow_id}
+  end
+
+  validates :workflow, presence: true
 
   def self.by_set(subject_set_id)
-    joins(:subject => :set_member_subjects).where(set_member_subjects: {subject_set_id: subject_set_id})
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      joins("LEFT OUTER JOIN set_member_subjects sms1 ON subject_workflow_counts.set_member_subject_id = sms1.id")
+        .joins("LEFT OUTER JOIN set_member_subjects sms2 ON subject_workflow_counts.subject_id = sms2.subject_id")
+        .where("(sms1.id IS NOT NULL AND sms1.subject_set_id = ?) OR (sms2.id IS NOT NULL AND sms2.subject_set_id = ?)", subject_set_id, subject_set_id)
+    else
+      joins(:subject => :set_member_subjects).where(set_member_subjects: {subject_set_id: subject_set_id})
+    end
   end
 
   def self.by_subject_workflow(subject_id, workflow_id)
-    where(subject_id: subject_id, workflow_id: workflow_id).first
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      joins("LEFT OUTER JOIN set_member_subjects sms1 ON subject_workflow_counts.set_member_subject_id = sms1.id")
+        .where("(sms1.id IS NOT NULL AND sms1.subject_id = ? AND subject_workflow_counts.workflow_id = ?) OR (subject_workflow_counts.subject_id = ? AND subject_workflow_counts.workflow_id = ?)", subject_id, workflow_id, subject_id, workflow_id)
+        .first
+    else
+      where(subject_id: subject_id, workflow_id: workflow_id).first
+    end
   end
 
   def retire?
@@ -34,6 +58,12 @@ class SubjectWorkflowCount < ActiveRecord::Base
   end
 
   def set_member_subject_ids
-    subject.set_member_subjects.pluck(:id)
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      ids = [set_member_subject_id]
+      ids += subject.set_member_subjects.pluck(:id) if subject_id
+      ids.flatten.compact
+    else
+      subject.set_member_subjects.pluck(:id)
+    end
   end
 end

--- a/app/models/subject_workflow_count.rb
+++ b/app/models/subject_workflow_count.rb
@@ -1,5 +1,6 @@
 class SubjectWorkflowCount < ActiveRecord::Base
   belongs_to :set_member_subject
+  belongs_to :subject
   belongs_to :workflow
 
   scope :retired, -> { where.not(retired_at: nil) }
@@ -8,12 +9,11 @@ class SubjectWorkflowCount < ActiveRecord::Base
   validates_uniqueness_of :set_member_subject_id, scope: :workflow_id
 
   def self.by_set(subject_set_id)
-    joins(:set_member_subject).where(set_member_subjects: {subject_set_id: subject_set_id})
+    joins(:subject => :set_member_subject).where(set_member_subjects: {subject_set_id: subject_set_id})
   end
 
   def self.by_subject_workflow(subject_id, workflow_id)
-    joins(:set_member_subject).where(set_member_subjects: {subject_id: subject_id},
-                                     workflow_id: workflow_id)
+    where(subject_id: subject_id, workflow_id: workflow_id)
   end
 
   def retire?

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -51,12 +51,12 @@ class Workflow < ActiveRecord::Base
   end
 
   def retired_subjects
-    subject_workflow_counts.retired.includes(:set_member_subject => :subject).map { |swc| swc.set_member_subject.subject }
+    subject_workflow_counts.retired.includes(:subject).map(&:subject)
   end
 
   def retire_subject(subject_id)
-    set_member_subjects.where(subject_id: subject_id).each do |sms|
-      count = subject_workflow_counts.where(set_member_subject_id: sms.id, workflow_id: id).first_or_create!
+    if set_member_subjects.where(subject_id: subject_id).any?
+      count = subject_workflow_counts.where(subject_id: subject_id, workflow_id: id).first_or_create!
       count.retire!
     end
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -51,13 +51,35 @@ class Workflow < ActiveRecord::Base
   end
 
   def retired_subjects
-    subject_workflow_counts.retired.includes(:subject).map(&:subject)
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      subjects = []
+      subjects += subject_workflow_counts.retired.includes(:subject).map(&:subject)
+      subjects += SetMemberSubject.includes(:subject).where(id: subject_workflow_counts.retired.pluck(:set_member_subject_id)).map(&:subject)
+      subjects.compact
+    else
+      subject_workflow_counts.retired.includes(:subject).map(&:subject)
+    end
   end
 
   def retire_subject(subject_id)
-    if set_member_subjects.where(subject_id: subject_id).any?
-      count = subject_workflow_counts.where(subject_id: subject_id, workflow_id: id).first_or_create!
-      count.retire!
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      if set_member_subjects.where(subject_id: subject_id).any?
+        count = subject_workflow_counts.where(subject_id: subject_id, workflow_id: id).first
+
+        if count
+          count.retire!
+        else
+          set_member_subjects.where(subject_id: subject_id).each do |sms|
+            count = subject_workflow_counts.where(set_member_subject_id: sms.id, workflow_id: id).first_or_create!
+            count.retire!
+          end
+        end
+      end
+    else
+      if set_member_subjects.where(subject_id: subject_id).any?
+        count = subject_workflow_counts.where(subject_id: subject_id, workflow_id: id).first_or_create!
+        count.retire!
+      end
     end
   end
 

--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -3,9 +3,23 @@ class ClassificationCountWorker
 
   def perform(subject_id, workflow_id)
     if Workflow.find(workflow_id).project.live
-      count = SubjectWorkflowCount.find_or_create_by!(subject_id: subject_id, workflow_id: workflow_id)
-      SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
-      RetirementWorker.perform_async(count.id)
+
+      if SubjectWorkflowCount::BACKWARDS_COMPAT
+        SetMemberSubject.by_subject_workflow(subject_id, workflow_id).find_each do |sms|
+          count = SubjectWorkflowCount.find_or_create_by!(set_member_subject_id: sms.id, workflow_id: workflow_id)
+          SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
+          RetirementWorker.perform_async(count.id)
+        end
+
+        if count = SubjectWorkflowCount.find_by(subject_id: subject_id, workflow_id: workflow_id)
+          SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
+          RetirementWorker.perform_async(count.id)
+        end
+      else
+        count = SubjectWorkflowCount.find_or_create_by!(subject_id: subject_id, workflow_id: workflow_id)
+        SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
+        RetirementWorker.perform_async(count.id)
+      end
     end
   rescue ActiveRecord::RecordNotFound
     nil

--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -3,11 +3,9 @@ class ClassificationCountWorker
 
   def perform(subject_id, workflow_id)
     if Workflow.find(workflow_id).project.live
-      SetMemberSubject.by_subject_workflow(subject_id, workflow_id).find_each do |sms|
-        count = SubjectWorkflowCount.find_or_create_by!(set_member_subject_id: sms.id, workflow_id: workflow_id)
-        SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
-        RetirementWorker.perform_async(count.id)
-      end
+      count = SubjectWorkflowCount.find_or_create_by!(subject_id: subject_id.id, workflow_id: workflow_id)
+      SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
+      RetirementWorker.perform_async(count.id)
     end
   rescue ActiveRecord::RecordNotFound
     nil

--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -3,7 +3,7 @@ class ClassificationCountWorker
 
   def perform(subject_id, workflow_id)
     if Workflow.find(workflow_id).project.live
-      count = SubjectWorkflowCount.find_or_create_by!(subject_id: subject_id.id, workflow_id: workflow_id)
+      count = SubjectWorkflowCount.find_or_create_by!(subject_id: subject_id, workflow_id: workflow_id)
       SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
       RetirementWorker.perform_async(count.id)
     end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -7,7 +7,7 @@ class RetirementWorker
     count = SubjectWorkflowCount.find(count_id)
     if count.retire?
       count.retire! do
-        SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject.id)
+        SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject_ids)
         deactivate_workflow!(count.workflow)
       end
     end

--- a/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
+++ b/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
@@ -8,10 +8,10 @@ class AlterSubjectWorkflowCountsAddSubjectId < ActiveRecord::Migration
       INSERT INTO subject_workflow_counts (subject_id, workflow_id, classifications_count, created_at, updated_at, retired_at)
       SELECT sms.subject_id,
              workflow_id,
-             SUM(classifications_count) AS classifications_count,
+             MAX(classifications_count) AS classifications_count,
              MIN(swc.created_at) AS created_at,
              MAX(swc.updated_at) AS updated_at,
-            MIN(swc.retired_at) AS retired_at
+             MIN(swc.retired_at) AS retired_at
       FROM subject_workflow_counts swc
       INNER JOIN set_member_subjects sms ON swc.set_member_subject_id = sms.id
       GROUP BY sms.subject_id, workflow_id

--- a/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
+++ b/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
@@ -1,7 +1,7 @@
 class AlterSubjectWorkflowCountsAddSubjectId < ActiveRecord::Migration
   def up
     add_column :subject_workflow_counts, :subject_id, :integer, index: true
-    add_foreign_key :subject_workflow_counts, :subjects
+    add_foreign_key :subject_workflow_counts, :subjects, on_delete: :restrict
 
     # Create new aggregated (per subject) SWC records
     execute <<-END

--- a/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
+++ b/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
@@ -1,0 +1,33 @@
+class AlterSubjectWorkflowCountsAddSubjectId < ActiveRecord::Migration
+  def up
+    add_column :subject_workflow_counts, :subject_id, :integer, index: true
+    add_foreign_key :subject_workflow_counts, :subjects
+
+    # Create new aggregated (per subject) SWC records
+    execute <<-END
+      INSERT INTO subject_workflow_counts (subject_id, workflow_id, classifications_count, created_at, updated_at, retired_at)
+      SELECT sms.subject_id,
+             workflow_id,
+             SUM(classifications_count) AS classifications_count,
+             MIN(swc.created_at) AS created_at,
+             MAX(swc.updated_at) AS updated_at,
+            MIN(swc.retired_at) AS retired_at
+      FROM subject_workflow_counts swc
+      INNER JOIN set_member_subjects sms ON swc.set_member_subject_id = sms.id
+      GROUP BY sms.subject_id, workflow_id
+      ORDER BY classifications_count DESC
+    END
+
+    # Remove old SWCs
+    execute <<-END
+      DELETE FROM subject_workflow_counts WHERE subject_id IS NULL AND set_member_subject_id IS NOT NULL;
+    END
+
+    add_index :subject_workflow_counts, [:subject_id, :workflow_id], unique: true
+    change_column_null :subject_workflow_counts, :subject_id, false
+  end
+
+  def down
+    remove_column :subject_workflow_counts, :subject_id
+  end
+end

--- a/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
+++ b/db/migrate/20150827124834_alter_subject_workflow_counts_add_subject_id.rb
@@ -3,28 +3,9 @@ class AlterSubjectWorkflowCountsAddSubjectId < ActiveRecord::Migration
     add_column :subject_workflow_counts, :subject_id, :integer, index: true
     add_foreign_key :subject_workflow_counts, :subjects, on_delete: :restrict
 
-    # Create new aggregated (per subject) SWC records
-    execute <<-END
-      INSERT INTO subject_workflow_counts (subject_id, workflow_id, classifications_count, created_at, updated_at, retired_at)
-      SELECT sms.subject_id,
-             workflow_id,
-             MAX(classifications_count) AS classifications_count,
-             MIN(swc.created_at) AS created_at,
-             MAX(swc.updated_at) AS updated_at,
-             MIN(swc.retired_at) AS retired_at
-      FROM subject_workflow_counts swc
-      INNER JOIN set_member_subjects sms ON swc.set_member_subject_id = sms.id
-      GROUP BY sms.subject_id, workflow_id
-      ORDER BY classifications_count DESC
-    END
-
-    # Remove old SWCs
-    execute <<-END
-      DELETE FROM subject_workflow_counts WHERE subject_id IS NULL AND set_member_subject_id IS NOT NULL;
-    END
-
-    add_index :subject_workflow_counts, [:subject_id, :workflow_id], unique: true
-    change_column_null :subject_workflow_counts, :subject_id, false
+    # Follow-up migration should:
+    #    add_index :subject_workflow_counts, [:subject_id, :workflow_id], unique: true
+    #    change_column_null :subject_workflow_counts, :subject_id, false
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,8 +243,10 @@ ActiveRecord::Schema.define(version: 20150916162320) do
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
     t.datetime "retired_at"
+    t.integer  "subject_id",            null: false, index: {name: "index_subject_workflow_counts_on_subject_id"}
   end
   add_index "subject_workflow_counts", ["set_member_subject_id", "workflow_id"], name: "index_subject_workflow_counts_on_sms_id_and_workflow_id", unique: true
+  add_index "subject_workflow_counts", ["subject_id", "workflow_id"], name: "index_subject_workflow_counts_on_subject_id_and_workflow_id", unique: true
 
   create_table "subjects", force: :cascade do |t|
     t.string   "zooniverse_id",  index: {name: "index_subjects_on_zooniverse_id", unique: true}
@@ -392,6 +394,7 @@ ActiveRecord::Schema.define(version: 20150916162320) do
   add_foreign_key "subject_sets_workflows", "subject_sets"
   add_foreign_key "subject_sets_workflows", "workflows"
   add_foreign_key "subject_workflow_counts", "set_member_subjects"
+  add_foreign_key "subject_workflow_counts", "subjects"
   add_foreign_key "subject_workflow_counts", "workflows"
   add_foreign_key "tagged_resources", "tags"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -394,7 +394,7 @@ ActiveRecord::Schema.define(version: 20150916162320) do
   add_foreign_key "subject_sets_workflows", "subject_sets"
   add_foreign_key "subject_sets_workflows", "workflows"
   add_foreign_key "subject_workflow_counts", "set_member_subjects"
-  add_foreign_key "subject_workflow_counts", "subjects"
+  add_foreign_key "subject_workflow_counts", "subjects", on_delete: :restrict
   add_foreign_key "subject_workflow_counts", "workflows"
   add_foreign_key "tagged_resources", "tags"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,10 +243,9 @@ ActiveRecord::Schema.define(version: 20150916162320) do
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
     t.datetime "retired_at"
-    t.integer  "subject_id",            null: false, index: {name: "index_subject_workflow_counts_on_subject_id"}
+    t.integer  "subject_id",            index: {name: "index_subject_workflow_counts_on_subject_id"}
   end
   add_index "subject_workflow_counts", ["set_member_subject_id", "workflow_id"], name: "index_subject_workflow_counts_on_sms_id_and_workflow_id", unique: true
-  add_index "subject_workflow_counts", ["subject_id", "workflow_id"], name: "index_subject_workflow_counts_on_subject_id_and_workflow_id", unique: true
 
   create_table "subjects", force: :cascade do |t|
     t.string   "zooniverse_id",  index: {name: "index_subjects_on_zooniverse_id", unique: true}

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -40,10 +40,7 @@ module Formatter
       end
 
       def retired_in_workflow
-        SubjectWorkflowCount.where(set_member_subject: sms)
-          .where.not(retired_at: nil)
-          .pluck(:workflow_id)
-          .to_json
+        SubjectWorkflowCount.retired.where(subject_id: subject_id).pluck(:workflow_id).to_json
       end
 
       def metadata
@@ -52,7 +49,7 @@ module Formatter
 
       def classifications_by_workflow
         sms.subject_set.workflows.map do |workflow|
-          count = SubjectWorkflowCount.find_by(set_member_subject: sms, workflow: workflow)
+          count = SubjectWorkflowCount.by_subject_workflow(self.id, workflow.id)
             .try(:classifications_count) || 0
           {workflow.id => count}
         end.reduce(&:merge).to_json

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -49,7 +49,7 @@ module Formatter
 
       def classifications_by_workflow
         sms.subject_set.workflows.map do |workflow|
-          count = SubjectWorkflowCount.by_subject_workflow(self.id, workflow.id)
+          count = SubjectWorkflowCount.by_subject_workflow(subject_id, workflow.id)
             .try(:classifications_count) || 0
           {workflow.id => count}
         end.reduce(&:merge).to_json

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -40,7 +40,14 @@ module Formatter
       end
 
       def retired_in_workflow
-        SubjectWorkflowCount.retired.where(subject_id: subject_id).pluck(:workflow_id).to_json
+        if SubjectWorkflowCount::BACKWARDS_COMPAT
+          workflow_ids = []
+          workflow_ids += SubjectWorkflowCount.where(set_member_subject_id: sms.id).where.not(retired_at: nil).pluck(:workflow_id)
+          workflow_ids += SubjectWorkflowCount.retired.where(subject_id: subject_id).pluck(:workflow_id)
+          workflow_ids.uniq.to_json
+        else
+          SubjectWorkflowCount.retired.where(subject_id: subject_id).pluck(:workflow_id).to_json
+        end
       end
 
       def metadata

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -147,4 +147,31 @@ namespace :migrate do
       end
     end
   end
+
+  task :subject_workflow_counts do
+    SubjectWorkflowCount.transaction do
+      # Not too sure how atomic INSERT INTO ... SELECT is in Postgresql (and couldn't find anything)
+      ActiveRecord::Base.connection.execute "LOCK TABLE subject_workflow_counts IN EXCLUSIVE MODE"
+
+      # Create new aggregated (per subject) SWC records
+      ActiveRecord::Base.connection.execute <<-END
+        INSERT INTO subject_workflow_counts (subject_id, workflow_id, classifications_count, created_at, updated_at, retired_at)
+        SELECT sms.subject_id,
+               workflow_id,
+               MAX(classifications_count) AS classifications_count,
+               MIN(swc.created_at) AS created_at,
+               MAX(swc.updated_at) AS updated_at,
+               MIN(swc.retired_at) AS retired_at
+        FROM subject_workflow_counts swc
+        INNER JOIN set_member_subjects sms ON swc.set_member_subject_id = sms.id
+        GROUP BY sms.subject_id, workflow_id
+        ORDER BY classifications_count DESC
+      END
+
+      # Remove old SWCs
+      ActiveRecord::Base.connection.execute <<-END
+        DELETE FROM subject_workflow_counts WHERE subject_id IS NULL AND set_member_subject_id IS NOT NULL;
+      END
+    end
+  end
 end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -7,14 +7,6 @@ shared_examples "cleans up the linked set member subjects" do
     expect(SetMemberSubject.where(id: linked_sms_ids)).to be_empty
   end
 
-  it 'should destroy all subject workflow counts' do
-    swc = create(:subject_workflow_count,
-                 set_member_subject: sms.first,
-                 workflow: subject_set.workflows.first)
-    delete_resources
-    expect(SubjectWorkflowCount.exists?(swc.id)).to be false
-  end
-
   it 'should queue a removal workfer' do
     expect(QueueRemovalWorker).to receive(:perform_async).with(sms.map(&:id),
                                                                subject_set.workflows.pluck(:id))

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -186,8 +186,11 @@ describe Api::V1::SubjectsController, type: :controller do
 
           let!(:sms) do
             create_list(:set_member_subject, 2,
-                        retired_subject_workflow_counts: [build(:subject_workflow_count, retired_at: Time.now, workflow: workflow)],
                         subject_set: subject_set)
+          end
+
+          let!(:counts) do
+            sms.map {|s| create(:subject_workflow_count, subject: s.subject, workflow: workflow, retired_at: Time.now) }
           end
 
           let!(:seen_subjects) do

--- a/spec/factories/subject_workflow_counts.rb
+++ b/spec/factories/subject_workflow_counts.rb
@@ -3,13 +3,13 @@ FactoryGirl.define do
     transient do
       link_subject_sets true
     end
-    set_member_subject
+    subject
     workflow
     classifications_count 1
 
     after(:build) do |swc, env|
       if env.link_subject_sets && swc.workflow && swc.workflow.subject_sets.empty?
-        swc.workflow.subject_sets << swc.set_member_subject.subject_set
+        swc.workflow.subject_sets += swc.subject.subject_sets
       end
     end
   end

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Formatter::Csv::Subject do
   let(:sms) { create(:set_member_subject, subject_set: subject_set, subject: loc_subject) }
   let!(:swc) do
     create :subject_workflow_count, classifications_count: 10, workflow: workflow,
-      set_member_subject: sms, retired_at: DateTime.now
+      subject: loc_subject, retired_at: DateTime.now
   end
 
   def ordered_subject_locations
@@ -22,12 +22,12 @@ RSpec.describe Formatter::Csv::Subject do
   end
 
   let(:fields) do
-    [sms.subject_id,
+    [loc_subject.id,
      project.id,
      [workflow.id].to_json,
      subject_set.id,
      ordered_subject_locations.to_json,
-     sms.subject.metadata.to_json,
+     loc_subject.metadata.to_json,
      {workflow.id => 10}.to_json,
      [workflow.id].to_json]
   end

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -39,7 +39,7 @@ describe SetMemberSubject, :type => :model do
 
       before(:each) do
         workflow.update!(retired_set_member_subjects_count: sms.length)
-        sms.each { |i| i.retire_workflow(workflow) }
+        sms.each { |i| workflow.retire_subject(i.subject) }
       end
 
       it 'should select retired subjects' do
@@ -68,7 +68,7 @@ describe SetMemberSubject, :type => :model do
 
     context "when workflow is unfinished" do
       let!(:retired_sms) do
-        create(:set_member_subject, subject_set: subject_set).tap { |sms| sms.retire_workflow(workflow) }
+        create(:set_member_subject, subject_set: subject_set).tap { |sms| workflow.retire_subject(sms.subject) }
       end
 
       it 'should select active subjects' do
@@ -185,20 +185,6 @@ describe SetMemberSubject, :type => :model do
 
     it "should belong to a subject" do
       expect(set_member_subject.subject).to be_a(Subject)
-    end
-  end
-
-  describe "#retire_workflow" do
-    it 'should add the workflow the retired_workflows relationship' do
-      sms = set_member_subject
-      sms.save!
-      workflow1 = sms.subject_set.workflows.first
-      workflow2 = create(:workflow, subject_sets: [sms.subject_set])
-      create(:subject_workflow_count, subject: sms.subject, workflow: workflow1)
-      create(:subject_workflow_count, subject: sms.subject, workflow: workflow2)
-      sms.retire_workflow(workflow1)
-      sms.reload
-      expect(sms.retired_workflows).to eq([workflow1])
     end
   end
 

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -124,40 +124,18 @@ describe SetMemberSubject, :type => :model do
   end
 
   describe ":non_retired_for_workflow" do
-    let(:count) { create(:subject_workflow_count) }
-    let(:workflow) { count.workflow }
+    let(:set_member_subject) { create(:set_member_subject) }
+    let(:workflow) { create(:workflow, subject_sets: [set_member_subject.subject_set]) }
+    let(:count) { create(:subject_workflow_count, subject: set_member_subject.subject, workflow: workflow) }
     let!(:another_workflow_sms) { create(:set_member_subject) }
 
     context "when none are retired" do
-
       it "should return the workflow's non retired sms" do
-        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to include(count.set_member_subject)
+        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to include(set_member_subject)
       end
     end
 
     context "when the workflow sms is retired" do
-
-      it "should return an empty set" do
-        count.retire!
-        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to be_empty
-      end
-    end
-  end
-
-  describe ":non_retired_for_workflow" do
-    let(:count) { create(:subject_workflow_count) }
-    let(:workflow) { count.workflow }
-    let!(:another_workflow_sms) { create(:set_member_subject) }
-
-    context "when none are retired" do
-
-      it "should return the workflow's non retired sms" do
-        expect(SetMemberSubject.non_retired_for_workflow(workflow)).to include(count.set_member_subject)
-      end
-    end
-
-    context "when the workflow sms is retired" do
-
       it "should return an empty set" do
         count.retire!
         expect(SetMemberSubject.non_retired_for_workflow(workflow)).to be_empty
@@ -216,8 +194,8 @@ describe SetMemberSubject, :type => :model do
       sms.save!
       workflow1 = sms.subject_set.workflows.first
       workflow2 = create(:workflow, subject_sets: [sms.subject_set])
-      create(:subject_workflow_count, set_member_subject: sms, workflow: workflow1)
-      create(:subject_workflow_count, set_member_subject: sms, workflow: workflow2)
+      create(:subject_workflow_count, subject: sms.subject, workflow: workflow1)
+      create(:subject_workflow_count, subject: sms.subject, workflow: workflow2)
       sms.retire_workflow(workflow1)
       sms.reload
       expect(sms.retired_workflows).to eq([workflow1])

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -129,6 +129,13 @@ describe SetMemberSubject, :type => :model do
     let(:count) { create(:subject_workflow_count, subject: set_member_subject.subject, workflow: workflow) }
     let!(:another_workflow_sms) { create(:set_member_subject) }
 
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      it 'should not return duplicate sms' do
+        count2 = create(:subject_workflow_count, set_member_subject_id: set_member_subject.id, workflow: workflow)
+        expect(SetMemberSubject.non_retired_for_workflow(workflow).size).to eq(1)
+      end
+    end
+
     context "when none are retired" do
       it "should return the workflow's non retired sms" do
         expect(SetMemberSubject.non_retired_for_workflow(workflow)).to include(set_member_subject)

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -108,6 +108,25 @@ describe Subject, :type => :model do
       expect(subject.retired_for_workflow?(SubjectSet.new)).to eq(false)
     end
 
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      context "with an old SubjectWorkflowCount" do
+        let(:swc) { instance_double("SubjectWorkflowCount") }
+        before(:each) do
+          allow(SubjectWorkflowCount).to receive(:find_by).and_return(swc)
+        end
+
+        it "should be true when the swc is retired" do
+          create(:subject_workflow_count, workflow: workflow, set_member_subject_id: subject.set_member_subjects.first.id, retired_at: DateTime.now)
+          expect(subject.retired_for_workflow?(workflow)).to eq(true)
+        end
+
+        it "should be false when the sec is not retired" do
+          allow(swc).to receive(:retired?).and_return(false)
+          expect(subject.retired_for_workflow?(workflow)).to eq(false)
+        end
+      end
+    end
+
     context "with a SubjectWorkflowCount" do
       let(:swc) { instance_double("SubjectWorkflowCount") }
       before(:each) do

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -115,32 +115,12 @@ describe Subject, :type => :model do
       end
 
       it "should be true when the swc is retired" do
-        create(:subject_workflow_count, workflow: workflow, set_member_subject: subject.set_member_subjects.first, retired_at: DateTime.now)
+        create(:subject_workflow_count, workflow: workflow, subject: subject, retired_at: DateTime.now)
         expect(subject.retired_for_workflow?(workflow)).to eq(true)
       end
 
       it "should be false when the sec is not retired" do
         allow(swc).to receive(:retired?).and_return(false)
-        expect(subject.retired_for_workflow?(workflow)).to eq(false)
-      end
-    end
-
-    context "when the subject belongs to multiple workflows" do
-      let!(:another_workflow) { create(:workflow, project: project) }
-      let(:another_subject_set) do
-        create(:subject_set, project: project, workflows: [another_workflow])
-      end
-      let!(:another_set_member_subject) do
-        create(:set_member_subject, subject_set: another_subject_set, subject: subject)
-      end
-
-      it "should be retired when it looks up the correct set_member_subject" do
-        create(:subject_workflow_count, workflow: workflow, set_member_subject: subject.set_member_subjects.first, retired_at: DateTime.now)
-        expect(subject.retired_for_workflow?(workflow)).to eq(true)
-      end
-
-      it "should not be retired when it looks up the incorrect set_member_subject" do
-        create(:subject_workflow_count, workflow: workflow, set_member_subject: another_subject_set.set_member_subjects.last, retired_at: DateTime.now)
         expect(subject.retired_for_workflow?(workflow)).to eq(false)
       end
     end

--- a/spec/models/subject_workflow_count_spec.rb
+++ b/spec/models/subject_workflow_count_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe SubjectWorkflowCount, type: :model do
     expect(build(:subject_workflow_count)).to be_valid
   end
 
-  it 'should not be valid without a set_member_subject' do
-    swc = build(:subject_workflow_count, set_member_subject: nil, link_subject_sets: false)
+  it 'should not be valid without a subject' do
+    swc = build(:subject_workflow_count, subject: nil, link_subject_sets: false)
     expect(swc).to_not be_valid
   end
 
@@ -33,12 +33,6 @@ RSpec.describe SubjectWorkflowCount, type: :model do
       count.retire!
       count.reload
       expect(count.retired?).to be_truthy
-    end
-
-    it 'should add the workflow the set_member_subjects retired list' do
-      count.retire!
-      count.reload
-      expect(count.set_member_subject.retired_workflows).to include(count.workflow)
     end
 
     it 'should increment the workflow retired subjects counter' do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -151,12 +151,12 @@ describe Workflow, :type => :model do
 
     context 'when the subject has a workflow count' do
       it 'marks as retired' do
-        create(:subject_workflow_count, set_member_subject: subject.set_member_subjects.first, workflow: workflow)
+        create(:subject_workflow_count, subject: subject, workflow: workflow)
         workflow.retire_subject(subject.id)
 
         aggregate_failures do
           expect(subject.retired_for_workflow?(workflow)).to be_truthy
-          expect(SubjectWorkflowCount.retired.count).to eq(2)
+          expect(SubjectWorkflowCount.retired.count).to eq(1)
         end
       end
     end
@@ -167,7 +167,7 @@ describe Workflow, :type => :model do
 
         aggregate_failures do
           expect(subject.retired_for_workflow?(workflow)).to be_truthy
-          expect(SubjectWorkflowCount.retired.count).to eq(2)
+          expect(SubjectWorkflowCount.retired.count).to eq(1)
         end
       end
     end
@@ -181,7 +181,7 @@ describe Workflow, :type => :model do
 
         aggregate_failures do
           expect(subject.retired_for_workflow?(workflow)).to be_truthy
-          expect(SubjectWorkflowCount.retired.count).to eq(2)
+          expect(SubjectWorkflowCount.retired.count).to eq(1)
           expect(SubjectWorkflowCount.order(:id).pluck(:retired_at)).to eq(retired_ats)
         end
       end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -163,6 +163,7 @@ describe Workflow, :type => :model do
 
     context 'when the subject does not have a workflow count' do
       it 'marks as retired' do
+        stub_const("SubjectWorkflowCount::BACKWARDS_COMPAT", false)
         workflow.retire_subject(subject.id)
 
         aggregate_failures do
@@ -174,9 +175,9 @@ describe Workflow, :type => :model do
 
     context 'when the subject is already retired' do
       it 'leaves the retirement timestamp as it was' do
+        stub_const("SubjectWorkflowCount::BACKWARDS_COMPAT", false)
         workflow.retire_subject(subject.id)
         retired_ats = SubjectWorkflowCount.order(:id).pluck(:retired_at)
-
         workflow.retire_subject(subject.id)
 
         aggregate_failures do
@@ -194,6 +195,24 @@ describe Workflow, :type => :model do
         workflow.retire_subject(subject.id)
         expect(SubjectWorkflowCount.count).to eq(0)
       end
+    end
+  end
+
+  describe '#retired_subjects' do
+    if SubjectWorkflowCount::BACKWARDS_COMPAT
+      it 'returns through sms association' do
+        sms = create(:set_member_subject)
+        swc = create(:subject_workflow_count, set_member_subject_id: sms.id, subject: nil, link_subject_sets: false, retired_at: Time.now)
+
+        expect(swc.workflow.retired_subjects).to eq([sms.subject])
+      end
+    end
+
+    it 'returns through subject association' do
+      sms = create(:set_member_subject)
+      swc = create(:subject_workflow_count, subject: sms.subject, retired_at: Time.now)
+
+      expect(swc.workflow.retired_subjects).to eq([sms.subject])
     end
   end
 

--- a/spec/workers/classification_count_worker_spec.rb
+++ b/spec/workers/classification_count_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ClassificationCountWorker do
 
       context "when the count model exists" do
         let!(:count) do
-          create(:subject_workflow_count, set_member_subject: sms, workflow_id: workflow_id)
+          create(:subject_workflow_count, subject: sms.subject, workflow_id: workflow_id)
         end
 
         it 'should increment the classifications_count' do
@@ -52,7 +52,7 @@ RSpec.describe ClassificationCountWorker do
       let(:project) { create(:full_project, live: false) }
 
       let!(:count) do
-        create(:subject_workflow_count, set_member_subject: sms, workflow_id: workflow_id)
+        create(:subject_workflow_count, subject: sms.subject, workflow_id: workflow_id)
       end
 
       it 'should not increment the count' do

--- a/spec/workers/classification_count_worker_spec.rb
+++ b/spec/workers/classification_count_worker_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ClassificationCountWorker do
         end
 
         before(:each) do
+          stub_const("SubjectWorkflowCount::BACKWARDS_COMPAT", false)
           worker.perform(sms.subject_id, workflow_id)
         end
 

--- a/spec/workers/classification_count_worker_spec.rb
+++ b/spec/workers/classification_count_worker_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ClassificationCountWorker do
 
       context "when the count does not exist" do
         subject do
-          SubjectWorkflowCount.where(set_member_subject: sms,
+          SubjectWorkflowCount.where(subject_id: sms.subject_id,
                                      workflow_id: workflow_id).first
         end
 

--- a/spec/workers/count_reset_worker_spec.rb
+++ b/spec/workers/count_reset_worker_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe CountResetWorker do
     it 'should reset the workflow retired count' do
       workflow = workflows.first
       workflow.update! retired_set_member_subjects_count: 100
-      
+
       sms.take(2).each do |s|
-        opts = { set_member_subject: s, workflow: workflow, retired_at: Time.now, link_subject_sets: false}
+        opts = { subject: s.subject, workflow: workflow, retired_at: Time.now, link_subject_sets: false}
         create(:subject_workflow_count, opts)
       end
 

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 RSpec.describe RetirementWorker do
   let(:worker) { described_class.new }
-  let(:count) { create(:subject_workflow_count) }
-  let(:sms) { count.set_member_subject }
-  let(:workflow) { count.workflow }
+  let(:sms) { create :set_member_subject }
+  let(:workflow) { create :workflow, subject_sets: [sms.subject_set] }
+  let(:count) { create(:subject_workflow_count, subject: sms.subject, workflow: workflow) }
   let!(:queue) { create(:subject_queue, workflow: workflow, set_member_subject_ids: [sms.id]) }
 
   describe "#perform" do
@@ -43,8 +43,6 @@ RSpec.describe RetirementWorker do
   end
 
   describe "#deactive_workflow!" do
-    let(:workflow) { count.workflow }
-
     context "workflow is finsihed" do
       it 'should set workflow.active to false' do
         allow(workflow).to receive(:finished?).and_return(true)


### PR DESCRIPTION
This isn't actually a difference in counting styles, because we used to increment counters and mark retirement on all SMSes for a subject-workflow pair. This just removes that so that we just have a single SWC for each pair.

Fixes #1162