### PR TITLE
more specific non logged in queue reload events

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
   def refresh_queue(subject_set)
     if subject_set.set_member_subjects.exists?
       subject_set.workflows.each do |w|
-        ReloadNonLoggedInQueueWorker.perform_async(w.id)
+        ReloadNonLoggedInQueueWorker.perform_async(w.id, subject_set.id)
       end
     end
   end

--- a/app/workers/reload_non_logged_in_queue_worker.rb
+++ b/app/workers/reload_non_logged_in_queue_worker.rb
@@ -5,10 +5,11 @@ class ReloadNonLoggedInQueueWorker
 
   def perform(workflow_id, subject_set_id=nil)
     @workflow = Workflow.find(workflow_id)
+    queue_subject_set = workflow.grouped ? subject_set_id : nil
     subjects = PostgresqlSelection.new(workflow, nil)
-      .select(limit: SubjectQueue::DEFAULT_LENGTH, subject_set_id: subject_set_id)
+      .select(limit: SubjectQueue::DEFAULT_LENGTH, subject_set_id: queue_subject_set)
       .compact
-    SubjectQueue.reload(workflow, subjects, set_id: subject_set_id)
+    SubjectQueue.reload(workflow, subjects, set_id: queue_subject_set)
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -138,18 +138,14 @@ describe Api::V1::SubjectSetsController, type: :controller do
     context "reload subject queue" do
       let(:workflows) { [create(:workflow, project: project)] }
       let(:resource) do
-        ss = create(:subject_set,
-                    project: project,
-                    subjects: subjects)
-
-        ss.workflows = workflows
-        ss.save!
-        ss
+        create(:subject_set,project: project,subjects: subjects) do |sset|
+          sset.workflows = workflows
+        end
       end
 
       context "when the subject set has a workflow" do
         it 'should call the reload queue worker' do
-          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(workflows.first.id)
+          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(workflows.first.id, resource.id)
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets][:links].delete(:workflows)
           put :update, update_params.merge(id: resource.id)
@@ -159,7 +155,9 @@ describe Api::V1::SubjectSetsController, type: :controller do
       context "when the subject set has multiple workflows" do
         let(:workflows) { create_list(:workflow, 2, project: project) }
         it 'should call the reload queue worker' do
-          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).twice
+          workflows.each do |_workflow|
+            expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(_workflow.id, resource.id)
+          end
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets][:links].delete(:workflows)
           put :update, update_params.merge(id: resource.id)
@@ -178,7 +176,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
       context "when the subject set has multiple subjects" do
         it 'should call the reload queue worker' do
-          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(workflows.first.id)
+          expect(ReloadNonLoggedInQueueWorker).to receive(:perform_async).with(workflows.first.id, resource.id)
           default_request scopes: scopes, user_id: authorized_user.id
           update_params[:subject_sets][:links].delete(:workflows)
           put :update, update_params.merge(id: resource.id)

--- a/spec/workers/reload_non_logged_in_queue_worker_spec.rb
+++ b/spec/workers/reload_non_logged_in_queue_worker_spec.rb
@@ -3,8 +3,11 @@ require 'spec_helper'
 RSpec.describe ReloadNonLoggedInQueueWorker do
   subject { described_class.new }
   let(:workflow) { create(:workflow_with_subject_set) }
-  let!(:subjects) do
-    create_list(:set_member_subject, 100, subject_set: workflow.subject_sets.first)
+  let(:subject_set) { workflow.subject_sets.first }
+  let(:subject_ids) { (1..100).to_a}
+
+  before(:each) do
+    allow_any_instance_of(PostgresqlSelection).to receive(:select).and_return(subject_ids)
   end
 
   describe "#perform" do
@@ -25,7 +28,7 @@ RSpec.describe ReloadNonLoggedInQueueWorker do
     end
 
     context "with an existing queue" do
-      let(:os) { create(:subject).id }
+      let(:os) { subject_ids.last + 1 }
       let!(:queue) do
         create(:subject_queue,
                workflow: workflow,
@@ -33,13 +36,28 @@ RSpec.describe ReloadNonLoggedInQueueWorker do
                set_member_subject_ids: [os])
       end
 
-      before(:each) do
+      it 'should update the queued subjects' do
         subject.perform(workflow.id)
         queue.reload
+        expect(queue.set_member_subject_ids).to match_array(subject_ids)
       end
 
-      it 'should update the queued subjects' do
-        expect(queue.set_member_subject_ids).to match_array(subjects.map(&:id))
+      context "with a grouped queue" do
+        let!(:queue) do
+          create(:subject_queue,
+                 workflow: workflow,
+                 user: nil,
+                 subject_set: subject_set,
+                 set_member_subject_ids: [os])
+        end
+
+        it "should update the queue's sms ids" do
+          aggregate_failures("by set lookup") do
+            expect(SubjectQueue).to receive(:by_set).with(subject_set.id).and_call_original
+            subject.perform(workflow.id, subject_set.id)
+            expect(queue.reload.set_member_subject_ids).to match_array(subject_ids)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Only reload non-logged in queues with the subject set context as things like adding / removing subject sets, retiring subjects, etc would do a mass call to reload non-logged in queues.