### PR TITLE
use background workers to retire from queues instead of a large set of updates

### DIFF
--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -7,7 +7,10 @@ class RetirementWorker
     count = SubjectWorkflowCount.find(count_id)
     if count.retire?
       count.retire! do
-        SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject.id)
+        SubjectQueue.where(workflow: count.workflow).find_each do |sq|
+          sms_ids = [ count.set_member_subject.id ]
+          DequeueSubjectQueueWorker.perform_async(sq.workflow_id, sms_ids, sq.user_id, sq.subject_set_id)
+        end
         deactivate_workflow!(count.workflow)
       end
     end

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -25,10 +25,9 @@ RSpec.describe RetirementWorker do
         }.from(0).to(1)
       end
 
-      it "should dequeue all instances of the subject" do
+      it "should call dequeue worker for on every queue for that workflow" do
+        expect(DequeueSubjectQueueWorker).to receive(:perform_async).with(queue.workflow_id, [sms.id], queue.user_id, queue.subject_set_id)
         worker.perform(count.id)
-        queue.reload
-        expect(queue.set_member_subject_ids).to_not include(sms.id)
       end
     end
 


### PR DESCRIPTION
when retiring don't try and update all queues in one go, set a background worker to run each dequeue.

Seems the subject queues are under heavy load when the retirement worker is firing (this may be correlated to another issue though), see below. 

Also i'm not 100% that the way we're using `.update_column` in de/enqueue [here](https://github.com/zooniverse/Panoptes/blob/5b7288636a59b1d9f942561796df5e81703c708c/app/models/subject_queue.rb#L92) is respecting concurrent udpates. I'm wondering if we should move back to `.update` and using the locking column to signal underlying updates that we can rescue and retry / reschedule via sidekiq.

![image](https://cloud.githubusercontent.com/assets/295329/9720866/9515a3e0-558a-11e5-8512-9432c88129c3.png)

