### PR TITLE
update queues using optimistic locking with retires

### DIFF
--- a/app/models/concerns/with_optimistic_retry.rb
+++ b/app/models/concerns/with_optimistic_retry.rb
@@ -9,12 +9,9 @@ module WithOptimisticRetry
       yield
     rescue ActiveRecord::StaleObjectError => e
       begin
-        # Reload lock_version in particular.
         reload
         retries -= 1
-      rescue ActiveRecord::RecordNotFound
-        # If the record is gone there is nothing to do.
-      else      
+      else
         if retries > 0
           retry
         else

--- a/app/models/concerns/with_optimistic_retry.rb
+++ b/app/models/concerns/with_optimistic_retry.rb
@@ -1,0 +1,26 @@
+# http://apidock.com/rails/ActiveRecord/Persistence/reload
+module WithOptimisticRetry
+
+  private
+
+  def with_optimistic_retry(retries=nil)
+    retries ||= 10
+    begin
+      yield
+    rescue ActiveRecord::StaleObjectError => e
+      begin
+        # Reload lock_version in particular.
+        reload
+        retries -= 1
+      rescue ActiveRecord::RecordNotFound
+        # If the record is gone there is nothing to do.
+      else      
+        if retries > 0
+          retry
+        else
+          raise e
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
update queues respecting stale versions with a retry component. hopefully we won’t see too many re-raised stale object errors in sidekiq but with the combination of retires in code and sidekiq we should get consistent data in the queues.

we can always look at serializable transaction isolation level as well but thought i'd try this method first.