### PR TITLE
Revert "use background workers to retire from queues"

### DIFF
--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -7,10 +7,7 @@ class RetirementWorker
     count = SubjectWorkflowCount.find(count_id)
     if count.retire?
       count.retire! do
-        SubjectQueue.where(workflow: count.workflow).find_each do |sq|
-          sms_ids = [ count.set_member_subject.id ]
-          DequeueSubjectQueueWorker.perform_async(sq.workflow_id, sms_ids, sq.user_id, sq.subject_set_id)
-        end
+        SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject.id)
         deactivate_workflow!(count.workflow)
       end
     end

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -25,9 +25,10 @@ RSpec.describe RetirementWorker do
         }.from(0).to(1)
       end
 
-      it "should call dequeue worker for on every queue for that workflow" do
-        expect(DequeueSubjectQueueWorker).to receive(:perform_async).with(queue.workflow_id, [sms.id], queue.user_id, queue.subject_set_id)
+      it "should dequeue all instances of the subject" do
         worker.perform(count.id)
+        queue.reload
+        expect(queue.set_member_subject_ids).to_not include(sms.id)
       end
     end
 


### PR DESCRIPTION
This reverts commit b7812bd7cb3b9f77561d431ac24dbdbba7556290.

see if this helps with the db load - just run the serial dequeue instead of spanwing lots of concurrent workers.