### PR TITLE
Filter out retired subjects when pulling from the queue

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -108,10 +108,14 @@ class SubjectQueue < ActiveRecord::Base
 
   def next_subjects(limit=10)
     if user_id
-      set_member_subject_ids[0..limit-1]
+      non_retired_set_member_subject_ids[0..limit-1]
     else
-      set_member_subject_ids.sample(limit)
+      non_retired_set_member_subject_ids.sample(limit)
     end
+  end
+
+  def non_retired_set_member_subject_ids
+    @non_retired_set_member_subject_ids ||= set_member_subject_ids - SubjectWorkflowCount.where(set_member_subject_id: set_member_subject_ids, workflow_id: workflow_id).where.not(retired_at: nil).pluck(:set_member_subject_id)
   end
 
   def dequeue(sms_ids)

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -114,10 +114,6 @@ class SubjectQueue < ActiveRecord::Base
     end
   end
 
-  def non_retired_set_member_subject_ids
-    @non_retired_set_member_subject_ids ||= set_member_subject_ids - SubjectWorkflowCount.where(set_member_subject_id: set_member_subject_ids, workflow_id: workflow_id).where.not(retired_at: nil).pluck(:set_member_subject_id)
-  end
-
   def dequeue(sms_ids)
     sms_ids = Array.wrap(sms_ids)
     with_optimistic_retry do
@@ -138,5 +134,11 @@ class SubjectQueue < ActiveRecord::Base
         end
       end
     end
+  end
+
+  private
+
+  def non_retired_set_member_subject_ids
+    @non_retired_set_member_subject_ids ||= set_member_subject_ids - SubjectWorkflowCount.where(set_member_subject_id: set_member_subject_ids, workflow_id: workflow_id).where.not(retired_at: nil).pluck(:set_member_subject_id)
   end
 end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -7,7 +7,6 @@ class RetirementWorker
     count = SubjectWorkflowCount.find(count_id)
     if count.retire?
       count.retire! do
-        SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject.id)
         deactivate_workflow!(count.workflow)
       end
     end

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -522,6 +522,17 @@ RSpec.describe SubjectQueue, type: :model do
       it 'should return the first subjects in the queue' do
         expect(ues.next_subjects).to eq(ues.set_member_subject_ids[0..9])
       end
+
+      it 'does not return retired subjects' do
+        subject = create(:subject)
+        retired_subject = create(:subject)
+        subject_set = create(:subject_set, subjects: [subject, retired_subject])
+
+        workflow = create(:workflow, subject_sets: [subject_set])
+        workflow.retire_subject(retired_subject.id)
+        ues = build(:subject_queue, set_member_subject_ids: subject_set.set_member_subjects.pluck(:id), workflow: workflow)
+        expect(ues.next_subjects).to eq(subject.set_member_subjects.pluck(:id))
+      end
     end
 
     context "when the queue does not have a user" do
@@ -541,6 +552,17 @@ RSpec.describe SubjectQueue, type: :model do
 
       it 'should randomly sample from the subject_ids' do
         expect(ues.next_subjects).to_not match_array(ues.set_member_subject_ids[0..9])
+      end
+
+      it 'does not return retired subjects' do
+        subject = create(:subject)
+        retired_subject = create(:subject)
+        subject_set = create(:subject_set, subjects: [subject, retired_subject])
+
+        workflow = create(:workflow, subject_sets: [subject_set])
+        workflow.retire_subject(retired_subject.id)
+        ues = build(:subject_queue, set_member_subject_ids: subject_set.set_member_subjects.pluck(:id), workflow: workflow, user: nil)
+        expect(ues.next_subjects).to eq(subject.set_member_subjects.pluck(:id))
       end
     end
   end

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -24,12 +24,6 @@ RSpec.describe RetirementWorker do
           Workflow.find(workflow.id).retired_set_member_subjects_count
         }.from(0).to(1)
       end
-
-      it "should dequeue all instances of the subject" do
-        worker.perform(count.id)
-        queue.reload
-        expect(queue.set_member_subject_ids).to_not include(sms.id)
-      end
     end
 
     context "sms is not retireable" do


### PR DESCRIPTION
This means we don't need to care about dequeueing retired subjects, and
can pay that price slowly over time when people actually start using
their queues.