### PR TITLE
Subject uploader counter cache

### DIFF
--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -34,7 +34,6 @@ class ApiUser
   end
 
   def subject_limits
-    user.update_uploaded_subjects_count
     [user.uploaded_subjects_count, user.subject_limit]
   end
 end

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -34,6 +34,7 @@ class ApiUser
   end
 
   def subject_limits
+    user.update_uploaded_subjects_count
     [user.uploaded_subjects_count, user.subject_limit]
   end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -6,8 +6,7 @@ class Subject < ActiveRecord::Base
   has_paper_trail only: [:metadata, :locations]
 
   belongs_to :project
-  belongs_to :uploader, class_name: "User", foreign_key: "upload_user_id", touch: true,
-    counter_cache: :uploaded_subjects_count
+  belongs_to :uploader, class_name: "User", foreign_key: "upload_user_id"
   has_many :collections_subjects
   has_many :collections, through: :collections_subjects
   has_many :subject_sets, through: :set_member_subjects

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -276,8 +276,7 @@ class User < ActiveRecord::Base
     end
   end
 
-  def update_uploaded_subjects_count
-    uploaded_count = uploaded_subjects.count
-    self.update_column(:uploaded_subjects_count, uploaded_count)
+  def uploaded_subjects_count
+    Subject.unscoped.where(upload_user_id: self.id).count
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -275,4 +275,9 @@ class User < ActiveRecord::Base
       true
     end
   end
+
+  def update_uploaded_subjects_count
+    uploaded_count = uploaded_subjects.count
+    self.update_column(:uploaded_subjects_count, uploaded_count)
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -15,36 +15,12 @@ class UserSerializer
 
   media_include :avatar, :profile_header
 
-  def credited_name
-    @model.credited_name
-  end
-
-  def email
-    @model.email
-  end
-
-  def global_email_communication
-    @model.global_email_communication
-  end
-
-  def project_email_communication
-    @model.project_email_communication
-  end
-
-  def beta_email_communication
-    @model.beta_email_communication
-  end
-
   def firebase_auth_token
     FirebaseUserToken.generate(@model)
   end
 
   def max_subjects
     @model.subject_limit
-  end
-
-  def uploaded_subjects_count
-    @model.uploaded_subjects_count
   end
 
   def admin

--- a/db/migrate/20150916161203_add_index_subjects_upload_user_id.rb
+++ b/db/migrate/20150916161203_add_index_subjects_upload_user_id.rb
@@ -1,0 +1,11 @@
+class AddIndexSubjectsUploadUserId < ActiveRecord::Migration
+  def up
+    change_column :subjects, :upload_user_id, 'integer USING CAST(upload_user_id AS integer)'
+    add_index :subjects, :upload_user_id
+  end
+
+  def down
+    change_column :subjects, :upload_user_id, :string
+    remove_index :subjects, :upload_user_id
+  end
+end

--- a/db/migrate/20150916162320_remove_user_uploaded_subject_counter.rb
+++ b/db/migrate/20150916162320_remove_user_uploaded_subject_counter.rb
@@ -1,0 +1,5 @@
+class RemoveUserUploadedSubjectCounter < ActiveRecord::Migration
+  def change
+    remove_column :users, :uploaded_subjects_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150916161203) do
+ActiveRecord::Schema.define(version: 20150916162320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -336,7 +336,6 @@ ActiveRecord::Schema.define(version: 20150916161203) do
     t.boolean  "banned",                      default: false,    null: false
     t.boolean  "migrated",                    default: false
     t.boolean  "valid_email",                 default: true,     null: false
-    t.integer  "uploaded_subjects_count",     default: 0
     t.integer  "project_id"
     t.boolean  "beta_email_communication",    index: {name: "index_users_on_beta_email_communication", where: "(beta_email_communication = true)"}
     t.string   "login",                       null: false, index: {name: "index_users_on_login", unique: true, case_sensitive: false}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150908193654) do
+ActiveRecord::Schema.define(version: 20150916161203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -254,7 +254,7 @@ ActiveRecord::Schema.define(version: 20150908193654) do
     t.integer  "project_id",     index: {name: "index_subjects_on_project_id"}
     t.boolean  "migrated"
     t.integer  "lock_version",   default: 0
-    t.string   "upload_user_id"
+    t.integer  "upload_user_id", index: {name: "index_subjects_on_upload_user_id"}
   end
 
   create_table "tagged_resources", force: :cascade do |t|

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -389,11 +389,14 @@ describe Api::V1::SubjectsController, type: :controller do
     end
 
     context "when the user has exceeded the allowed number of subjects" do
-      let(:authorised_user) { create(:user, uploaded_subjects_count: 101) }
+      let(:authorised_user) { create(:user) }
       let(:upload_subjects) do
-        allow_any_instance_of(User).to receive(:update_uploaded_subjects_count)
         default_request scopes: scopes, user_id: authorised_user.id
         post :create, create_params
+      end
+
+      before(:each) do
+        allow_any_instance_of(User).to receive(:uploaded_subjects_count).and_return(101)
       end
 
       it 'should return 403' do

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-
 describe Api::V1::SubjectsController, type: :controller do
   let!(:workflow) { create(:workflow_with_subject_sets) }
   let!(:subject_set) { workflow.subject_sets.first }
@@ -392,6 +391,7 @@ describe Api::V1::SubjectsController, type: :controller do
     context "when the user has exceeded the allowed number of subjects" do
       let(:authorised_user) { create(:user, uploaded_subjects_count: 101) }
       let(:upload_subjects) do
+        allow_any_instance_of(User).to receive(:update_uploaded_subjects_count)
         default_request scopes: scopes, user_id: authorised_user.id
         post :create, create_params
       end

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe ApiUser do
   describe "above_subject_limit?" do
     let(:api_user) { ApiUser.new(user, admin: flag) }
     let(:flag) { false }
-    let(:user) { create(:user, uploaded_subjects_count: 10, subject_limit: limit) }
-
-    subject { api_user.above_subject_limit? }
+    let(:user) { create(:user, subject_limit: limit) }
 
     before(:each) do
-      allow_any_instance_of(User).to receive(:update_uploaded_subjects_count)
+      allow_any_instance_of(User).to receive(:uploaded_subjects_count).and_return(10)
     end
+
+    subject { api_user.above_subject_limit? }
 
     context "user is admin" do
       let(:flag) { true }
@@ -74,7 +74,6 @@ RSpec.describe ApiUser do
 
     it "should call the update method and return defaults" do
       aggregate_failures "limits" do
-        expect_any_instance_of(User).to receive(:update_uploaded_subjects_count).and_call_original
         expect(api_user.subject_limits).to match_array([ 0, Panoptes.max_subjects])
       end
     end

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -39,25 +39,44 @@ RSpec.describe ApiUser do
   end
 
   describe "above_subject_limit?" do
-    subject { ApiUser.new(user, admin: flag).above_subject_limit? }
+    let(:api_user) { ApiUser.new(user, admin: flag) }
     let(:flag) { false }
+    let(:user) { create(:user, uploaded_subjects_count: 10, subject_limit: limit) }
+
+    subject { api_user.above_subject_limit? }
+
+    before(:each) do
+      allow_any_instance_of(User).to receive(:update_uploaded_subjects_count)
+    end
+
     context "user is admin" do
-      let(:flag) { false }
+      let(:flag) { true }
       let(:user) { create(:user, admin: true) }
 
       it { is_expected.to be false }
     end
 
     context "user is above limit" do
-      let(:user) { create(:user, uploaded_subjects_count: 10, subject_limit: 9) }
+      let(:limit) { 9 }
 
       it { is_expected.to be true }
     end
 
     context "user is below limit" do
-      let(:user) { create(:user, uploaded_subjects_count: 10, subject_limit: 11) }
+      let(:limit) { 11 }
 
       it { is_expected.to be false }
+    end
+  end
+
+  describe "subject_limits" do
+    let(:api_user) { ApiUser.new(create(:user), admin: false) }
+
+    it "should call the update method and return defaults" do
+      aggregate_failures "limits" do
+        expect_any_instance_of(User).to receive(:update_uploaded_subjects_count).and_call_original
+        expect(api_user.subject_limits).to match_array([ 0, Panoptes.max_subjects])
+      end
     end
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -87,13 +87,6 @@ describe Subject, :type => :model do
     end
   end
 
-  describe "#uploader" do
-    it "should have a counter cache" do
-      subject.save!
-      expect(subject.uploader.uploaded_subjects_count).to eq(1)
-    end
-  end
-
   describe "#retired_for_workflow?" do
     let(:workflow) { create(:workflow) }
     let(:project) { workflow.project }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -638,25 +638,9 @@ describe User, type: :model do
     end
   end
 
-  describe "update_uploaded_subjects_count" do
-    it 'should update the count of the subjects a user has uploaded' do
-      uploader = create(:user_with_uploaded_subjects)
-      uploader.update_uploaded_subjects_count
-      expect(uploader.uploaded_subjects_count).to eq(2)
-    end
-
-    context "without updating" do
-      it 'should report the previous value' do
-        uploader = create(:user_with_uploaded_subjects, uploaded_subjects_count: 4)
-        expect(uploader.uploaded_subjects_count).to eq(4)
-      end
-    end
-  end
-
   describe "#uploaded_subjects_count" do
     it 'should have a count of the subjects a user has uploaded' do
       uploader = create(:user_with_uploaded_subjects)
-      uploader.update_uploaded_subjects_count
       expect(uploader.uploaded_subjects_count).to eq(2)
     end
   end
@@ -829,7 +813,6 @@ describe User, type: :model do
       it 'should return 1' do
         user = create(:user)
         create(:subject, uploader: user)
-        user.update_uploaded_subjects_count
         expect(user.uploaded_subjects_count).to eq(1)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -638,9 +638,25 @@ describe User, type: :model do
     end
   end
 
+  describe "update_uploaded_subjects_count" do
+    it 'should update the count of the subjects a user has uploaded' do
+      uploader = create(:user_with_uploaded_subjects)
+      uploader.update_uploaded_subjects_count
+      expect(uploader.uploaded_subjects_count).to eq(2)
+    end
+
+    context "without updating" do
+      it 'should report the previous value' do
+        uploader = create(:user_with_uploaded_subjects, uploaded_subjects_count: 4)
+        expect(uploader.uploaded_subjects_count).to eq(4)
+      end
+    end
+  end
+
   describe "#uploaded_subjects_count" do
     it 'should have a count of the subjects a user has uploaded' do
       uploader = create(:user_with_uploaded_subjects)
+      uploader.update_uploaded_subjects_count
       expect(uploader.uploaded_subjects_count).to eq(2)
     end
   end
@@ -796,6 +812,25 @@ describe User, type: :model do
       it 'should return that limit' do
         user = create(:user, subject_limit: 10)
         expect(user.subject_limit).to eq(10)
+      end
+    end
+  end
+
+  describe '#uploaded_subjects_count' do
+
+    context 'the user has no uploaded subject' do
+      it 'should return 0' do
+        user = create(:user)
+        expect(user.uploaded_subjects_count).to eq(0)
+      end
+    end
+
+    context 'the user has uploaded subject' do
+      it 'should return 1' do
+        user = create(:user)
+        create(:subject, uploader: user)
+        user.update_uploaded_subjects_count
+        expect(user.uploaded_subjects_count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
avoid trying to update this counter during subject creates. only update this value when checking for subject limits currently but it could be called at other times.