### PR TITLE
respect prioritized workflows in next subjects

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -105,6 +105,10 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def next_subjects(limit=10)
-    set_member_subject_ids.sample(limit)
+    if workflow.prioritized
+      set_member_subject_ids[0..limit-1]
+    else
+      set_member_subject_ids.sample(limit)
+    end
   end
 end


### PR DESCRIPTION
select from head of queue if workflow is prioritized and randomly sample if not.