### PR TITLE
[WIP] config to disable classification count retirmenent

### DIFF
--- a/lib/retirement_schemes/classification_count.rb
+++ b/lib/retirement_schemes/classification_count.rb
@@ -4,8 +4,16 @@ module RetirementSchemes
       @count = count
     end
 
-    def retire?(count)
-      count.classifications_count >= @count
+    def retire?(sw_count)
+      if disabled?
+        false
+      else
+        sw_count.classifications_count >= @count
+      end
+    end
+
+    def disabled?
+      !!@count.to_s.match(/\Adisabled\z/i)
     end
   end
 end

--- a/spec/lib/retirement_schemes/classification_count_spec.rb
+++ b/spec/lib/retirement_schemes/classification_count_spec.rb
@@ -1,20 +1,39 @@
 require 'spec_helper'
 
 RSpec.describe RetirementSchemes::ClassificationCount do
-  subject { described_class.new(10) }
 
-  describe "#retire?" do
-    context "retirement count is less than sms classification count" do
-      it 'should be false' do
-        count = build(:subject_workflow_count, classifications_count: 9)
-        expect(subject.retire?(count)).to be(false)
+  subject { described_class.new(count_value) }
+
+  context "when using an integer for count" do
+    let(:count_value) { 10 }
+
+    describe "#retire?" do
+      context "retirement count is less than sms classification count" do
+        it 'should be false' do
+          count = build(:subject_workflow_count, classifications_count: 9)
+          expect(subject.retire?(count)).to be(false)
+        end
+      end
+
+      context "retirement count is fewer than sms classification count" do
+        it 'should be true' do
+          count = build(:subject_workflow_count, classifications_count: 11)
+          expect(subject.retire?(count)).to be(true)
+        end
       end
     end
+  end
 
-    context "retirement count is fewer than sms classification count" do
-      it 'should be true' do
-        count = build(:subject_workflow_count, classifications_count: 11)
-        expect(subject.retire?(count)).to be(true)
+  context "when using a disabled flag for count" do
+
+    describe "#retire?"  do
+      ["disabled", :disabled].each do |disabled_count_val|
+        let(:count_value) { disabled_count_val }
+
+        it 'should be false' do
+          count = build(:subject_workflow_count, classifications_count: 9)
+          expect(subject.retire?(count)).to be(false)
+        end
       end
     end
   end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -101,7 +101,7 @@ describe Workflow, :type => :model do
     context "empty" do
       let(:retirement) { Hash.new }
 
-      it "it should return a classification count scheme" do
+      it "should return a classification count scheme" do
         expect(subject.retirement_scheme).to be_a(RetirementSchemes::ClassificationCount)
       end
     end
@@ -109,8 +109,22 @@ describe Workflow, :type => :model do
     context "classification_count" do
       let(:retirement) { { 'criteria' => 'classification_count' } }
 
-      it "it should return a classification count scheme" do
+      it "should return a classification count scheme" do
         expect(subject.retirement_scheme).to be_a(RetirementSchemes::ClassificationCount)
+      end
+
+      context "disabling the retirement scheme" do
+        let(:retirement) do
+          { 'criteria' => 'classification_count', "options" => { "count" => "disabled" } }
+        end
+
+        it "should return a disabled classification count scheme" do
+          aggregate_failures "scheme" do
+            rs = subject.retirement_scheme
+            expect(rs).to be_a(RetirementSchemes::ClassificationCount)
+            expect(rs.disabled?).to eq(true)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
closes #1368 - allow workflow's with custom retirement (aggregation engine) to disable the count retirement worker.