### PR TITLE
workflow - proper serialised retirement defaults

### DIFF
--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -47,7 +47,10 @@ class WorkflowSerializer
   def retirement
     retire_criteria = @model.retirement
     if retire_criteria.blank?
-      { Workflow::DEFAULT_CRITERIA => Workflow::DEFAULT_OPTS }
+      {
+        criteria: Workflow::DEFAULT_CRITERIA,
+        options: Workflow::DEFAULT_OPTS
+      }
     else
       retire_criteria
     end

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -71,7 +71,11 @@ describe WorkflowSerializer do
     context "with no values set" do
 
       it 'should return the default criteria' do
-        expect(expected).to eq({"classification_count"=>{"count"=>15}})
+        defaults = {
+          criteria: "classification_count",
+          options: { "count" => 15 }
+        }
+        expect(expected).to eq(defaults)
       end
     end
 


### PR DESCRIPTION
linked to https://github.com/zooniverse/Panoptes-Front-End/pull/1679 serialize the defaults in the proper schema format.