### PR TITLE
add admin only per project front end tools

### DIFF
--- a/app/schemas/project_create_schema.rb
+++ b/app/schemas/project_create_schema.rb
@@ -90,6 +90,13 @@ class ProjectCreateSchema < JsonSchema
       type "string"
     end
 
+    property "experimental_tools" do
+      type "array"
+      items do
+        type "string"
+      end
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/app/schemas/project_update_schema.rb
+++ b/app/schemas/project_update_schema.rb
@@ -98,6 +98,13 @@ class ProjectUpdateSchema < JsonSchema
       type "string"
     end
 
+    property "experimental_tools" do
+      type "array"
+      items do
+        type "string"
+      end
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -8,7 +8,7 @@ class ProjectSerializer
     :title, :description, :introduction, :private, :retired_subjects_count,
     :configuration, :live, :urls, :migrated, :classifiers_count, :slug, :redirect,
     :beta_requested, :beta_approved, :launch_requested, :launch_approved,
-    :href, :workflow_description, :primary_language, :tags
+    :href, :workflow_description, :primary_language, :tags, :experimental_tools
 
   can_include :workflows, :subject_sets, :owners, :project_contents,
     :project_roles, :pages

--- a/db/migrate/20151005093746_add_experimental_tools_to_project.rb
+++ b/db/migrate/20151005093746_add_experimental_tools_to_project.rb
@@ -1,0 +1,5 @@
+class AddExperimentalToolsToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :experimental_tools, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150921130111) do
+ActiveRecord::Schema.define(version: 20151005093746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 20150921130111) do
     t.boolean  "beta_approved",         default: false, index: {name: "index_projects_on_beta_approved"}
     t.integer  "launched_row_order",    index: {name: "index_projects_on_launched_row_order"}
     t.integer  "beta_row_order",        index: {name: "index_projects_on_beta_row_order"}
+    t.string   "experimental_tools",    default: [],                 array: true
   end
 
   create_table "recents", force: :cascade do |t|

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -384,11 +384,11 @@ describe Api::V1::ProjectsController, type: :controller do
         it_behaves_like "admin only option", :redirect, "http://example.com"
       end
 
-      describe "approved option" do
+      describe "launch approved option" do
         it_behaves_like "admin only option", :launch_approved, true
       end
 
-      describe "approved option" do
+      describe "beta approved option" do
         it_behaves_like "admin only option", :beta_approved, true
       end
 
@@ -398,6 +398,10 @@ describe Api::V1::ProjectsController, type: :controller do
 
       describe "beta_row_order_position option" do
         it_behaves_like "admin only option", :beta_row_order_position, 10
+      end
+
+      describe "experiemntal_tools option" do
+        it_behaves_like "admin only option", :experimental_tools, ["survey"]
       end
 
       describe "create talk admin" do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::V1::ProjectsController, type: :controller do
      "updated_at", "created_at", "available_languages", "title",
      "description", "introduction", "migrated","private", "live",
      "retired_subjects_count", "urls", "classifiers_count", "redirect",
-     "workflow_description", "tags" ]
+     "workflow_description", "tags", "experimental_tools" ]
   end
   let(:api_resource_links) do
     [ "projects.workflows",


### PR DESCRIPTION
closes #1385. Allow the front end to wire up experimental tool features for a project.