### PR TITLE
Optimize exports

### DIFF
--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -12,11 +12,20 @@ class ClassificationsDumpWorker
     if @project = Project.find(project_id)
       @medium_id = medium_id
       begin
-        csv_formatter = Formatter::Csv::Classification.new(project, obfuscate_private_details: obfuscate_private_details)
         CSV.open(csv_file_path, 'wb') do |csv|
-          csv << csv_formatter.class.headers
-          completed_project_classifications.find_each do |classification|
-            csv << csv_formatter.to_array(classification)
+          cache = ClassificationDumpCache.new
+          formatter = Formatter::Csv::Classification.new(project, cache, obfuscate_private_details: obfuscate_private_details)
+
+          csv <<  formatter.class.headers
+
+          completed_project_classifications.find_in_batches do |group|
+            subject_ids = group.flat_map(&:subject_ids).uniq
+            workflow_ids = group.map(&:workflow_id).uniq
+
+            cache.reset_subjects(Subject.where(id: subject_ids).load)
+            cache.reset_subject_workflow_counts(SubjectWorkflowCount.retired.where(subject_id: subject_ids, workflow_id: workflow_ids).load)
+
+            group.each { |classification| csv << formatter.to_array(classification) }
           end
         end
         to_gzip

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -24,8 +24,8 @@ class ClassificationsDumpWorker
         set_ready_state
         send_email
       ensure
-        FileUtils.rm(csv_file_path)
-        FileUtils.rm(gzip_file_path)
+        FileUtils.rm(csv_file_path) rescue nil
+        FileUtils.rm(gzip_file_path) rescue nil
       end
     end
   end

--- a/lib/classification_dump_cache.rb
+++ b/lib/classification_dump_cache.rb
@@ -1,0 +1,43 @@
+class ClassificationDumpCache
+  def initialize
+    @workflows = {}
+    @workflow_contents = {}
+
+    @subjects = {}
+    @subject_workflow_counts = {}
+  end
+
+  def reset_subjects(subjects)
+    @subjects = subjects.map {|subject| [subject.id, subject] }.to_h
+  end
+
+  def reset_subject_workflow_counts(subject_workflow_counts)
+    @subject_workflow_counts = subject_workflow_counts.group_by(&:subject_id)
+  end
+
+  def subject(subject_id)
+    @subjects[subject_id]
+  end
+
+  def retired?(subject_id, workflow_id)
+    (@subject_workflow_counts[subject_id] || []).find {|swc| swc.workflow_id == workflow_id }
+  end
+
+  def workflow_at_version(workflow_id, version)
+    @workflows[workflow_id] ||= {}
+    @workflows[workflow_id][version] ||= begin
+      workflow = Workflow.find(workflow_id)
+      old_version = workflow.versions[version].try(:reify)
+      old_version || workflow
+    end
+  end
+
+  def workflow_content_at_version(workflow_content_id, version)
+    @workflow_contents[workflow_content_id] ||= {}
+    @workflow_contents[workflow_content_id][version] ||= begin
+      workflow_content = WorkflowContent.find(workflow_content_id)
+      old_version = workflow_content.versions[version].try(:reify)
+      old_version || workflow_content
+    end
+  end
+end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -1,11 +1,12 @@
 module Formatter
   module Csv
     class AnnotationForCsv
-      attr_reader :classification, :annotation
+      attr_reader :classification, :annotation, :cache
 
-      def initialize(classification, annotation)
+      def initialize(classification, annotation, cache)
         @classification = classification
         @annotation = annotation.dup.with_indifferent_access
+        @cache = cache
       end
 
       def to_h
@@ -53,19 +54,19 @@ module Formatter
       end
 
       def primary_content_at_version
-        model_at_version(classification.workflow.primary_content, 1)
+        cache.workflow_content_at_version(classification.workflow.primary_content.id, content_version)
       end
 
       def workflow_at_version
-        model_at_version(classification.workflow, 0)
+        cache.workflow_at_version(classification.workflow_id, workflow_version)
       end
 
-      def model_at_version(version, vers_index)
-        version_num = classification.workflow_version.split(".")[vers_index].to_i
-        if old_vers = version.versions[version_num].try(:reify)
-          version = old_vers
-        end
-        version
+      def workflow_version
+        classification.workflow_version.split(".")[0].to_i
+      end
+
+      def content_version
+        classification.workflow_version.split(".")[1].to_i
       end
 
       def task

--- a/lib/formatter/csv/classification.rb
+++ b/lib/formatter/csv/classification.rb
@@ -43,7 +43,7 @@ module Formatter
           subjects = ::Subject.where(id: classification.subject_ids)
           subjects.each do |subject|
             retired_data = { retired: subject.retired_for_workflow?(workflow) }
-            subjects_and_metadata[subject.id] = subject.metadata.merge(retired_data)
+            subjects_and_metadata[subject.id] = retired_data.reverse_merge!(subject.metadata)
           end
         end.to_json
       end

--- a/lib/formatter/csv/classification.rb
+++ b/lib/formatter/csv/classification.rb
@@ -1,7 +1,7 @@
 module Formatter
   module Csv
     class Classification
-      attr_reader :classification, :project, :obfuscate, :salt
+      attr_reader :classification, :project, :cache, :obfuscate, :salt
 
       delegate :user_id, :workflow, :workflow_id, :created_at, :gold_standard,
         :workflow_version, to: :classification
@@ -11,8 +11,9 @@ module Formatter
            created_at gold_standard expert metadata annotations subject_data)
       end
 
-      def initialize(project, obfuscate_private_details: true)
+      def initialize(project, cache, obfuscate_private_details: true)
         @project = project
+        @cache = cache
         @obfuscate = obfuscate_private_details
         @salt = Time.now.to_i
       end
@@ -40,9 +41,8 @@ module Formatter
 
       def subject_data
         {}.tap do |subjects_and_metadata|
-          subjects = ::Subject.where(id: classification.subject_ids)
-          subjects.each do |subject|
-            retired_data = { retired: subject.retired_for_workflow?(workflow) }
+          classification.subject_ids.map {|id| cache.subject(id) }.each do |subject|
+            retired_data = { retired: cache.retired?(subject.id, workflow.id) }
             subjects_and_metadata[subject.id] = retired_data.reverse_merge!(subject.metadata)
           end
         end.to_json
@@ -54,7 +54,7 @@ module Formatter
 
       def annotations
         classification.annotations.map do |annotation|
-          AnnotationForCsv.new(classification, annotation).to_h
+          AnnotationForCsv.new(classification, annotation, cache).to_h
         end.to_json
       end
 

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe ClassificationsDumpWorker do
   let(:worker) { described_class.new }
   let(:workflow) { create(:workflow) }
   let(:project) { workflow.project }
+  let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
   let!(:classifications) do
-    create_list(:classification, 5, project: project, workflow: workflow, build_real_subjects: false)
+    create_list(:classification, 5, project: project, workflow: workflow, subject_ids: [subject.id], build_real_subjects: false)
   end
 
   describe "#perform" do


### PR DESCRIPTION
Most importantly I've added a cache for the reified old versions of workflows and contents. This seemed to be amazingly slow even if dealing with the latest version. I'm also preloading subjects and handling the check for retiredness less stupidly.