### PR TITLE
skip csrf token auth on /users/sign_out json request

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < Devise::SessionsController
+  skip_before_filter :verify_authenticity_token, only: [:destroy], if: :json_request?
   after_filter :set_csrf_headers, only: [:create, :destroy]
   after_filter :set_csrf_headers, only: :new, if: :json_request?
 


### PR DESCRIPTION
support log out via json cors requests. will require us to whitelist the cors domains that can access this route.