### PR TITLE
correctly handle aggregation export media updates

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -34,8 +34,8 @@ class Api::V1::MediaController < Api::ApiController
   def update
     error_unless_exists
     set_controlled_resources
-    send_aggregation_ready_email
     super
+    send_aggregation_ready_email
   end
 
   def destroy
@@ -147,6 +147,7 @@ class Api::V1::MediaController < Api::ApiController
   end
 
   def media_exists?
+    return false unless media
     case association_numeration
     when :single
       media.exists?
@@ -164,9 +165,10 @@ class Api::V1::MediaController < Api::ApiController
   end
 
   def send_aggregation_ready_email
-    finished = params[:media][:metadata].try(:[], "state") == "ready"
-    if params[:media_name] == "aggregations_export" && finished
-      AggregationDataMailerWorker.perform_async(params[:id])
+    return unless params[:media_name] == "aggregations_export"
+    export = media.first
+    if export.metadata.try(:[], "state") == "ready"
+      AggregationDataMailerWorker.perform_async(export.id)
     end
   end
 end

--- a/app/workers/aggregation_data_mailer_worker.rb
+++ b/app/workers/aggregation_data_mailer_worker.rb
@@ -7,6 +7,8 @@ class AggregationDataMailerWorker
   def perform(media_id)
     @medium = Medium.find(media_id)
     AggregationDataMailer.aggregation_data(project, media_get_url, emails).deliver
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def project

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -159,17 +159,26 @@ RSpec.describe Api::V1::MediaController, type: :controller do
 
           after(:each) do
             default_request scopes: scopes, user_id: authorized_user.id
-            put :update, update_params.merge(id: resource.id)
+            put :update, update_params
           end
 
           it 'should send an email' do
-            expect(AggregationDataMailerWorker).to receive(:perform_async)
+            expect(AggregationDataMailerWorker).to receive(:perform_async).with(resource.id)
           end
 
           context "when the update is not finished" do
             let(:metadata) { { metadata: { "state" => "uploading" } } }
 
             it 'should not send an email' do
+              expect(AggregationDataMailerWorker).not_to receive(:perform_async)
+            end
+          end
+
+          context "when aggregation media resource is missing" do
+            let(:resource) { nil }
+
+            it 'should not send an email', :aggreate_failures do
+              expect(subject).not_to receive(:send_aggregation_ready_email)
               expect(AggregationDataMailerWorker).not_to receive(:perform_async)
             end
           end

--- a/spec/workers/aggregations_data_email_worker_spec.rb
+++ b/spec/workers/aggregations_data_email_worker_spec.rb
@@ -8,4 +8,11 @@ RSpec.describe AggregationDataMailerWorker do
   it 'should deliver the mail' do
     expect{ subject.perform(media.id) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
+
+  context "when the media can't be found" do
+
+    it 'should not deliver the mail' do
+      expect{ subject.perform(nil) }.not_to change{ ActionMailer::Base.deliveries.count }
+    end
+  end
 end


### PR DESCRIPTION
aggregation engine uses update url's like `https://panoptes.zooniverse.org/api/projects/1154/aggregations_export` that don't have a media resource id. this PR correctly handles the media resource lookup for sending the aggregation export success email.