### PR TITLE
extract only expert roles for classification marking

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,7 +11,7 @@ class Project < ActiveRecord::Base
   include RankedModel
   include SluggedName
 
-  EXPERT_ROLES = [:expert, :owner]
+  EXPERT_ROLES = [:owner, :expert]
 
   has_many :tutorials
   has_many :workflows
@@ -80,9 +80,12 @@ class Project < ActiveRecord::Base
   ranks :beta_row_order
 
   def expert_classifier_level(classifier)
-    expert_role = project_roles.where(user_group: classifier.identity_group)
-      .where.overlap(roles: EXPERT_ROLES)
-    expert_role.first.try(:roles).try(:first).try(:to_sym)
+    expert_roles = project_roles.where(user_group: classifier.identity_group)
+      .where
+      .overlap(roles: EXPERT_ROLES)
+    if roles = expert_roles.first.try(:roles)
+      (EXPERT_ROLES & roles.map(&:to_sym)).first
+    end
   end
 
   def expert_classifier?(classifier)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -198,6 +198,18 @@ describe Project, :type => :model do
       end
     end
 
+    context "when they are a moderator and an expert project collaborator" do
+      let!(:roles) { ["moderator", "expert"] }
+
+      it '#expert_classifier_level should be :expert' do
+        expect(project.expert_classifier_level(project_user)).to eq(:expert)
+      end
+
+      it "#expert_classifier? should be truthy" do
+        expect(project.expert_classifier?(project_user)).to be_truthy
+      end
+    end
+
     context "when they have no role on the project" do
 
       it '#expert_classifier_level should be nil' do


### PR DESCRIPTION
select only the first expert role a user has on a project from the prioritized list of EXPERT_ROLES. This fixes some broken gold standard classification workers in the backend.