### PR TITLE
Update user prefs for native panoptes projects on classification receipt

### DIFF
--- a/app/workers/classification_worker.rb
+++ b/app/workers/classification_worker.rb
@@ -15,7 +15,7 @@ class ClassificationWorker
             ClassificationCountWorker.perform_async(sid, classification.workflow.id)
           end
         end
-        create_project_preference
+        process_project_preference
       end
     else
       raise "Invalid Post-Classification Action"

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -32,13 +32,16 @@ class ClassificationLifecycle
     refresh_queue
   end
 
-  def create_project_preference
-    return unless should_create_project_preference?
-    UserProjectPreference.where(user: user, project: project)
-      .first_or_create do |up|
+  def process_project_preference
+    if should_create_project_preference?
+      existing_record = true
+      upp = UserProjectPreference.where(user: user, project: project).first_or_create do |up|
         up.email_communication = user.project_email_communication
         up.preferences = {}
+        existing_record = false
       end
+      upp.touch if existing_record
+    end
   end
 
   def update_seen_subjects

--- a/spec/workers/classification_worker_spec.rb
+++ b/spec/workers/classification_worker_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe ClassificationWorker do
         classification_worker.perform(classification.id, "create")
       end
 
-      it 'should call create_project_preferences' do
-        expect_any_instance_of(ClassificationLifecycle).to receive(:create_project_preference)
+      it 'should call process_project_preferences' do
+        expect_any_instance_of(ClassificationLifecycle).to receive(:process_project_preference)
       end
 
       it 'should call publish to kafka' do


### PR DESCRIPTION
mark upps as recently updated when we get classification for them. this will show a more realistic list on the logged in landing page / ordered stats