### PR TITLE
explicit pref belongs_to options

### DIFF
--- a/app/models/concerns/preferences.rb
+++ b/app/models/concerns/preferences.rb
@@ -7,9 +7,9 @@ module Preferences
   end
 
   module ClassMethods
-    def preferences_for(preference, counter_cache = false)
+    def preferences_for(preference, opts={})
       @preferences_for = preference
-      belongs_to @preferences_for, dependent: :destroy, counter_cache: counter_cache
+      belongs_to @preferences_for, **opts
       validates_presence_of @preferences_for
       validates_uniqueness_of :user_id, scope: :"#{preference}_id"
     end

--- a/app/models/user_project_preference.rb
+++ b/app/models/user_project_preference.rb
@@ -1,7 +1,7 @@
 class UserProjectPreference < ActiveRecord::Base
   include Preferences
 
-  preferences_for :project, :classifiers_count
+  preferences_for :project, counter_cache: :classifiers_count
 
   def summated_activity_count
     if legacy_count.blank?

--- a/spec/models/user_collection_preference_spec.rb
+++ b/spec/models/user_collection_preference_spec.rb
@@ -15,4 +15,15 @@ RSpec.describe UserCollectionPreference, :type => :model do
   it 'should require a user to be valid' do
     expect(build(:user_collection_preference, user: nil)).to_not be_valid
   end
+
+  describe "#destroy" do
+    let(:pref) { create(:user_collection_preference) }
+    let(:collection) { pref.collection }
+
+    it "should not cascade delete the relation", :aggregate_failures do
+      expect(collection).not_to be_nil
+      pref.destroy
+      expect(collection.reload).not_to be_nil
+    end
+  end
 end

--- a/spec/models/user_project_preference_spec.rb
+++ b/spec/models/user_project_preference_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe UserProjectPreference, :type => :model do
+RSpec.describe UserProjectPreference, type: :model do
   let(:user_project) { build(:user_project_preference) }
   let(:factory) { :user_project_preference }
 
@@ -53,6 +53,17 @@ RSpec.describe UserProjectPreference, :type => :model do
         expected_count = upp.legacy_count.values.map(&:to_i).sum
         expect(upp.summated_activity_count).to eq(expected_count)
       end
+    end
+  end
+
+  describe "#destroy" do
+    let(:pref) { create(:user_project_preference) }
+    let(:project) { pref.project }
+
+    it "should not cascade delete the relation", :aggregate_failures do
+      expect(project).not_to be_nil
+      pref.destroy
+      expect(project.reload).not_to be_nil
     end
   end
 end

--- a/spec/support/preferences.rb
+++ b/spec/support/preferences.rb
@@ -1,8 +1,8 @@
 RSpec.shared_examples "has preferences scope" do
   let!(:user) { create(:user) }
+  let(:preferences_model) { described_class.to_s.underscore }
+  let(:preferences_for) { described_class.instance_variable_get(:@preferences_for) }
   let!(:preferences) do
-    preferences_model = described_class.to_s.underscore
-    preferences_for = described_class.instance_variable_get(:@preferences_for)
     prefs_for_actor = create(preferences_model, user: user)
     public_prefs = create(preferences_model, public: true)
     private_prefs = create(preferences_model)
@@ -42,5 +42,3 @@ RSpec.shared_examples "has preferences scope" do
     end
   end
 end
-
-


### PR DESCRIPTION
don't dependant destroy a project when deleting a user project preference, allow the relation to have the correct options passed via the preferences_for method.