### PR TITLE
ensure collections default to private

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -13,6 +13,7 @@ class Collection < ActiveRecord::Base
   has_many :collection_roles, -> { where.not(roles: []) }, class_name: "AccessControlList", as: :resource
 
   validates :display_name, presence: true
+  validates :private, inclusion: { in: [true, false], message: "can't be blank" }
   ## TODO: This potential has locking issues
   validates_with UniqueForOwnerValidator
 

--- a/db/migrate/20151023103228_add_default_to_collection_private.rb
+++ b/db/migrate/20151023103228_add_default_to_collection_private.rb
@@ -1,0 +1,8 @@
+class AddDefaultToCollectionPrivate < ActiveRecord::Migration
+  def change
+    private_setting = true
+    change_column :collections, :private, :boolean, default: private_setting
+    Collection.where(private: nil).update_all(private: private_setting)
+    change_column_null :collections, :private, false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -213,7 +213,7 @@ CREATE TABLE collections (
     updated_at timestamp without time zone,
     activated_state integer DEFAULT 0 NOT NULL,
     display_name character varying,
-    private boolean,
+    private boolean DEFAULT true NOT NULL,
     lock_version integer DEFAULT 0,
     slug character varying DEFAULT ''::character varying,
     favorite boolean DEFAULT false NOT NULL
@@ -2685,4 +2685,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151009145251');
 INSERT INTO schema_migrations (version) VALUES ('20151012162248');
 
 INSERT INTO schema_migrations (version) VALUES ('20151013181750');
+
+INSERT INTO schema_migrations (version) VALUES ('20151023103228');
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -18,6 +18,17 @@ describe Collection, :type => :model do
     expect(build(:collection)).to be_valid
   end
 
+  it "should not be valid without a private setting", :aggregate_failures do
+    c = build(:collection, private: nil)
+    expect(c).to be_invalid
+    c.valid?
+    expect(c.errors[:private]).to include("can't be blank")
+  end
+
+  it "should have a valid factory" do
+    expect(build(:collection)).to be_valid
+  end
+
   it "should not be valid without a display_name" do
     aggregate_failures "display_name validation" do
       collection = build(:collection, display_name: nil)


### PR DESCRIPTION
linked to https://github.com/zooniverse/Panoptes-Front-End/pull/1822 ensure collections in panoptes default to explicit private setting.

This migration took 2 secs to run on my machine so should be good to go out as is.