### PR TITLE
[WIP] Project tracking via links

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -26,6 +26,23 @@ class Api::V1::CollectionsController < Api::ApiController
     super(create_params)
   end
 
+  def add_relation(resource, relation, value)
+    if relation == :subjects && value.is_a?(Array)
+      added_project_ids = Subject.unscoped.uniq.where(id: value).pluck(:project_id)
+      resource.project_ids = resource.project_ids | added_project_ids
+    end
+    super
+  end
+
+  def destroy_relation(resource, relation, value)
+    if relation == :subjects
+      unlink_ids = value.split(",")
+      linked_project_ids = resource.subjects.where.not(id: unlink_ids).uniq.pluck(:project_id)
+      resource.project_ids = linked_project_ids
+    end
+    super
+  end
+
   private
 
   def filter_by_project_ids

--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -40,8 +40,9 @@ module JsonApiController
 
     def destroy_links
       resource = controlled_resources.first
-      resource_class.transaction do
+      resource_class.transaction(requires_new: true) do
         destroy_relation(resource, relation, params[:link_ids])
+        resource.save!
       end
 
       yield resource if block_given?


### PR DESCRIPTION
**DON'T MERGE THIS YET** this will break talk collection searching so we need to get a plan for before rolling this out as well.

`#destroy_links` in `updatable_resources` now also saves the updated resource to allow the collection `project_ids` to be updated.
