### PR TITLE
update search add prefixes for users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,7 +71,11 @@ class User < ActiveRecord::Base
 
   pg_search_scope :search_name,
     against: [:login, :display_name],
-    using: { tsearch: { tsvector_column: "tsv" } }
+    using: { tsearch: {
+      prefix: true,
+      tsvector_column: "tsv"
+      }
+    }
 
   def self.scope_for(action, user, opts={})
     case

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -189,8 +189,41 @@ describe Api::V1::UsersController, type: :controller do
         end
       end
 
-    end
+      describe "search" do
 
+        context "display_name" do
+          let(:index_options) { { search: user.display_name } }
+
+          it "should respond with 1 item" do
+            expect(json_response[api_resource_name].length).to eq(1)
+          end
+
+          it "should respond with the correct item" do
+            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+          end
+        end
+
+        context "login" do
+          let(:index_options) { { search: user.login } }
+
+          it "should respond with 1 item" do
+            expect(json_response[api_resource_name].length).to eq(1)
+          end
+
+          it "should respond with the correct item" do
+            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+          end
+
+          context "with partial string" do
+            let(:index_options) { { search: user.login[0..1] } }
+
+            it "should respond with both users" do
+              expect(json_response[api_resource_name].length).to eq(2)
+            end
+          end
+        end
+      end
+    end
 
     describe "overridden serialiser instance assocation links" do
       let(:user){ users.sample }


### PR DESCRIPTION
closes #1230 - search by field prefixes to widen the result scope, https://github.com/Casecommons/pg_search#prefix-postgresql-84-and-newer-only