### PR TITLE
rework commit_id.txt build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .jbundler
 .vagrant
 .ruby-gemset

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN bundle install --without development test
 ADD supervisord.conf /etc/supervisor/conf.d/panoptes.conf
 ADD ./ /rails_app
 
+RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt && rm -rf .git)
+
 EXPOSE 81
 
 ENTRYPOINT /rails_app/scripts/docker/start.sh

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -25,6 +25,10 @@ else
       bundle exec rake assets:precompile
   fi
 
-  TERM=xterm git log --format="%H" -n 1 > public/commit_id.txt
+  if [ -f "commit_id.txt" ]
+  then
+    cp commit_id.txt public/
+  fi
+
   exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
 fi


### PR DESCRIPTION
build the latest commit tag during the docker build and then copy across to public on start.

This is needed since docker hub now respects the .dockerignore file and the .git data isn't available at runtime in the resulting images.