### PR TITLE
Gold standard filter

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::ClassificationsController < Api::ApiController
   private
 
   def filter_by_subject_id
-    subject_ids = params.delete(:subject_ids).try(:split, ',') || params.delete(:subject_id)
+    subject_ids = (params.delete(:subject_ids) || params.delete(:subject_id)).try(:split, ',')
     unless subject_ids.blank?
       @controlled_resources = controlled_resources
       .joins(:subjects)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -36,6 +36,8 @@ class Classification < ActiveRecord::Base
       incomplete_for_user(user)
     when :gold_standard
       gold_standard
+      .joins(:workflow)
+      .where("workflows.public_gold_standard = ?", true)
       .order(id: :asc)
       .distinct
     else

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -22,6 +22,7 @@ class Classification < ActiveRecord::Base
   scope :incomplete, -> { where(completed: false) }
   scope :created_by, -> (user) { where(user: user) }
   scope :complete, -> { where(completed: true) }
+  scope :gold_standard, -> { where(gold_standard: true) }
 
   def self.scope_for(action, user, opts={})
     return all if user.is_admin?
@@ -33,6 +34,10 @@ class Classification < ActiveRecord::Base
       query
     when :update, :destroy
       incomplete_for_user(user)
+    when :gold_standard
+      gold_standard
+      .order(id: :asc)
+      .distinct
     else
       none
     end

--- a/app/schemas/workflow_create_schema.rb
+++ b/app/schemas/workflow_create_schema.rb
@@ -22,6 +22,10 @@ class WorkflowCreateSchema < JsonSchema
       type "boolean"
     end
 
+    property "public_gold_standard" do
+      type "boolean"
+    end
+
     property "retirement" do
       type "object"
       additional_properties false

--- a/app/schemas/workflow_update_schema.rb
+++ b/app/schemas/workflow_update_schema.rb
@@ -21,6 +21,10 @@ class WorkflowUpdateSchema < JsonSchema
       type "boolean"
     end
 
+    property "public_gold_standard" do
+      type "boolean"
+    end
+
     property "retirement" do
       type "object"
       additional_properties false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,9 @@ Rails.application.routes.draw do
 
       json_api_resources :project_preferences
 
-      json_api_resources :classifications
+      json_api_resources :classifications do
+        get :gold_standard, on: :collection
+      end
 
       json_api_resources :memberships
 

--- a/db/migrate/20151110101156_add_gold_standard_sparse_index.rb
+++ b/db/migrate/20151110101156_add_gold_standard_sparse_index.rb
@@ -1,0 +1,5 @@
+class AddGoldStandardSparseIndex < ActiveRecord::Migration
+  def change
+    add_index :classifications, :gold_standard, where: "gold_standard IS TRUE"
+  end
+end

--- a/db/migrate/20151111154310_add_public_gold_standard_to_workflow.rb
+++ b/db/migrate/20151111154310_add_public_gold_standard_to_workflow.rb
@@ -1,0 +1,6 @@
+class AddPublicGoldStandardToWorkflow < ActiveRecord::Migration
+  def change
+    add_column :workflows, :public_gold_standard, :boolean, default: false
+    add_index :workflows, :public_gold_standard, where: "public_gold_standard IS TRUE"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2749,7 +2749,7 @@ INSERT INTO schema_migrations (version) VALUES ('20151027134345');
 
 INSERT INTO schema_migrations (version) VALUES ('20151106172531');
 
-INSERT INTO schema_migrations (version) VALUES ('20151110135415');
-
 INSERT INTO schema_migrations (version) VALUES ('20151110101156');
+
+INSERT INTO schema_migrations (version) VALUES ('20151110135415');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1226,7 +1226,8 @@ CREATE TABLE workflows (
     active boolean DEFAULT true,
     aggregation jsonb DEFAULT '{}'::jsonb NOT NULL,
     display_order integer,
-    config jsonb DEFAULT '{}'::jsonb NOT NULL
+    config jsonb DEFAULT '{}'::jsonb NOT NULL,
+    public_gold_standard boolean DEFAULT false
 );
 
 
@@ -2416,6 +2417,13 @@ CREATE INDEX index_workflows_on_project_id ON workflows USING btree (project_id)
 
 
 --
+-- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_workflows_on_public_gold_standard ON workflows USING btree (public_gold_standard) WHERE (public_gold_standard IS TRUE);
+
+
+--
 -- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2752,4 +2760,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151106172531');
 INSERT INTO schema_migrations (version) VALUES ('20151110101156');
 
 INSERT INTO schema_migrations (version) VALUES ('20151110135415');
+
+INSERT INTO schema_migrations (version) VALUES ('20151111154310');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1828,6 +1828,13 @@ CREATE INDEX index_classifications_on_created_at ON classifications USING btree 
 
 
 --
+-- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_classifications_on_gold_standard ON classifications USING btree (gold_standard) WHERE (gold_standard IS TRUE);
+
+
+--
 -- Name: index_classifications_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2743,4 +2750,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151027134345');
 INSERT INTO schema_migrations (version) VALUES ('20151106172531');
 
 INSERT INTO schema_migrations (version) VALUES ('20151110135415');
+
+INSERT INTO schema_migrations (version) VALUES ('20151110101156');
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -74,6 +74,7 @@ describe Api::V1::WorkflowsController, type: :controller do
                    retirement: { criteria: "classification_count" },
                    aggregation: { },
                    config: { },
+                   public_gold_standard: true,
                    tasks: {
                            interest: {
                                       type: "draw",
@@ -96,7 +97,6 @@ describe Api::V1::WorkflowsController, type: :controller do
     end
 
     it_behaves_like "is updatable"
-
     it_behaves_like "has updatable links"
 
     context "extracts strings from workflow" do
@@ -307,6 +307,7 @@ describe Api::V1::WorkflowsController, type: :controller do
                    retirement: { criteria: "classification_count" },
                    aggregation: { public: true },
                    config: { autoplay_subjects: true },
+                   public_gold_standard: true,
                    tasks: {
                            interest: {
                                       type: "draw",


### PR DESCRIPTION
closes #1475 
adds a new end point at `/classifications/gold_standard?workflow_id=X,subject_ids=Y` to get approved workflow(`public_gold_standard=true`) gold standard classifications. 

Note workflows must have the public flag in order to open up gold standard access. This should be a concious choice for the researchers / project owners. 