### PR TITLE
Puma cluster mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (2.13.4)
+    puma (2.15.3)
     rack (1.6.4)
     rack-cors (0.4.0)
     rack-protection (1.5.3)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-server:  rm -f tmp/pids/server.pid && bundle exec rails s puma -p 80 -b 0.0.0.0
+#server:  rm -f tmp/pids/server.pid && bundle exec rails s puma -p 3000 -b 0.0.0.0
+server:  rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb
 sidekiq: rm -f tmp/pids/sidekiq.pid && nohup bundle exec sidekiq

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,60 @@
+app_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
+
+pidfile "#{app_path}/tmp/pids/server.pid"
+
+rails_env = ENV['RAILS_ENV'] || 'development'
+port = rails_env == "production" ? 81 : 3000
+environment rails_env
+state_path "#{app_path}/tmp/pids/puma.state"
+
+if rails_env == "production"
+  stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true
+end
+
+bind "tcp://0.0.0.0:#{port}"
+
+# Code to run before doing a restart. This code should
+# close log files, database connections, etc.
+#
+# This can be called multiple times to add code each time.
+#
+# on_restart do
+#   puts 'On restart...'
+# end
+
+# === Cluster mode ===
+workers 2
+
+# Code to run when a worker boots to setup the process before booting
+# the app.
+#
+# This can be called multiple times to add hooks.
+#
+on_worker_boot do
+  ActiveRecord::Base.establish_connection
+end
+
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect!
+end
+
+preload_app!
+
+# Additional text to display in process listing
+#
+tag 'panoptes_api'
+#
+# If you do not specify a tag, Puma will infer it. If you do not want Puma
+# to add a tag, use an empty string.
+
+# Verifies that all workers have checked in to the master process within
+# the given timeout. If not the worker process will be restarted. Default
+# value is 60 seconds.
+#
+# worker_timeout 60
+
+# Change the default worker timeout for booting
+#
+# If unspecified, this defaults to the value of worker_timeout.
+#
+# worker_boot_timeout 60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ panoptes:
   volumes:
     - ./:/rails_app
   ports:
-    - "3000:80"
+    - "3000:3000"
   environment:
     RAILS_ENV: development
   links:

--- a/scripts/docker/restart_puma.sh
+++ b/scripts/docker/restart_puma.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# simple script to hot restart puma, https://github.com/puma/puma#restart
+# e.g. docker exec -it 'panoptes_container_name' bash -c "/rails_app/scripts/docker/restart_puma.sh"
+pkill -F tmp/pids/server.pid -USR2

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:panoptes]
 user=root
-command=bundle exec rails s puma -p 81 -b 0.0.0.0
+command=bundle exec puma -C config/puma
 directory=/rails_app
 autorestart=true
 


### PR DESCRIPTION
~~**Don't merge this yet**~~ This is good to go now.

~~We'll need to get the logging format sorted as it's not using the rails log format any more.~~ This setup is req'd in order to use the restart_script in #1481.

Bumps puma gem, switches to running puma on it's own in clustered mode with 2 workers that use code preloading leveraging MRI COW mem savings. It should respect AR connections on boot / app restart (see config/puma.rb). 

All up this should be more resource efficient for the production nodes some simple dev benchmarking showed a speedup of the projects page load of 1-1.5s (4.5 over 5.5). Time will tell what we see in prod. I also tested some hot restarts running the whole stack in docker and both AR and redis connections didn't grow but reset and stabilised to prev values. 