### PR TITLE
backwards compatable collection project links

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -4,13 +4,14 @@ class Api::V1::CollectionsController < Api::ApiController
   include IndexSearch
 
   before_action :filter_by_project_ids, only: :index
+  before_action :pluralize_project_links, only: :create
 
   doorkeeper_for :create, :update, :destroy, scopes: [:collection]
   resource_actions :default
   schema_type :strong_params
 
   allowed_params :create, :name, :display_name, :private, :favorite,
-    links: [ projects: [], subjects: [], owner: polymorphic ]
+    links: [ :project, projects: [], subjects: [], owner: polymorphic ]
 
   allowed_params :update, :name, :display_name, :private, links: [ subjects: [] ]
 
@@ -31,6 +32,15 @@ class Api::V1::CollectionsController < Api::ApiController
     if ids_string = params.delete(:project_ids)
       project_ids = ids_string.split(",")
       @controlled_resources = controlled_resources.where.overlap(project_ids: project_ids)
+    end
+  end
+
+  def pluralize_project_links
+    if project_id = params[:collections][:links].try(:delete, :project)
+      if create_params[:links][:projects]
+        raise BadLinkParams.new("Error: project_ids and project link keys must not be set together")
+      end
+      create_params[:links].merge!(projects: [project_id])
     end
   end
 end


### PR DESCRIPTION
closes https://github.com/zooniverse/Panoptes-Front-End/issues/1908 

allow the singular and pluarl link keys to be specified independently, allows for backwards compatable clients.