### PR TITLE
Fav filtering

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::CollectionsController < Api::ApiController
   private
 
   def filter_by_project_ids
-    if ids_string = params.delete(:project_ids)
+    if ids_string = (params.delete(:project_ids) || params.delete(:project_id)).try(:split, ',')
       project_ids = ids_string.split(",")
       @controlled_resources = controlled_resources.where.overlap(project_ids: project_ids)
     end

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -4,13 +4,14 @@ class Api::V1::CollectionsController < Api::ApiController
   include IndexSearch
 
   before_action :filter_by_project_ids, only: :index
+  before_action :pluralize_project_links, only: :create
 
   doorkeeper_for :create, :update, :destroy, scopes: [:collection]
   resource_actions :default
   schema_type :strong_params
 
   allowed_params :create, :name, :display_name, :private, :favorite,
-    links: [ projects: [], subjects: [], owner: polymorphic ]
+    links: [ :project, projects: [], subjects: [], owner: polymorphic ]
 
   allowed_params :update, :name, :display_name, :private, links: [ subjects: [] ]
 
@@ -31,6 +32,15 @@ class Api::V1::CollectionsController < Api::ApiController
     if ids_string = params.delete(:project_ids)
       project_ids = ids_string.split(",")
       @controlled_resources = controlled_resources.where.overlap(project_ids: project_ids)
+    end
+  end
+
+  def pluralize_project_links
+    if project_id = params[:collections][:links].try(:delete, :project)
+      if create_params[:links][:projects]
+        raise BadLinkParams.new("Error: project_ids and project link keys must not be set together")
+      end
+      create_params[:links].merge!(projects: [project_id])
     end
   end
 end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -50,14 +50,13 @@ describe Api::V1::CollectionsController, type: :controller do
           let(:filter_ids) { project_ids.join(",") }
         end
       end
-    end
 
-    context "it is filterable by favorite" do
-      let!(:favorite_col) { create(:collection, favorite: true) }
+      context "filtering on singular resource" do
+        let(:expected_filtered_ids) { [ collections.first.id.to_s ] }
 
-      it 'should only return the favorite collection' do
-        get :index, favorite: true
-        expect(json_response[api_resource_name].map{ |r| r['id'] }).to match_array([favorite_col.id.to_s])
+        it_behaves_like 'has many filterable', :projects do
+          let(:filter_ids) { collections.first.project_ids.first }
+        end
       end
     end
 


### PR DESCRIPTION
closes #1485 and based on #1486 create a backwards compatible api for existing projects (e.g. wildcam) when finding fav collections by project id.