### PR TITLE
add normal index for users#login

### DIFF
--- a/db/migrate/20151116143407_add_users_login_index.rb
+++ b/db/migrate/20151116143407_add_users_login_index.rb
@@ -1,0 +1,5 @@
+class AddUsersLoginIndex < ActiveRecord::Migration
+  def change
+    add_index :users, :login, unique: true, name: "index_users_on_login_with_case"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2334,6 +2334,13 @@ CREATE UNIQUE INDEX index_users_on_login ON users USING btree (lower((login)::te
 
 
 --
+-- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_users_on_login_with_case ON users USING btree (login);
+
+
+--
 -- Name: index_users_on_ouroboros_created; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2765,4 +2772,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151110101156');
 INSERT INTO schema_migrations (version) VALUES ('20151110135415');
 
 INSERT INTO schema_migrations (version) VALUES ('20151111154310');
+
+INSERT INTO schema_migrations (version) VALUES ('20151116143407');
 


### PR DESCRIPTION
user registration routes were doing full table scans and stressing the databse.