### PR TITLE
Export media state change in dump workers

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -99,12 +99,12 @@ class Api::V1::ProjectsController < Api::ApiController
 
   def create_or_update_medium(type, media_create_params=media_params)
     media_create_params['metadata'] ||= { recipients: [api_user.id] }
-    media_create_params['metadata']["state"] = 'creating'
     if medium = controlled_resource.send(type)
       medium.update!(media_create_params)
       medium.touch
       medium
     else
+      media_create_params['metadata']["state"] = 'creating'
       controlled_resource.send("create_#{type}!", media_create_params)
     end
   end

--- a/app/workers/concerns/dump_worker.rb
+++ b/app/workers/concerns/dump_worker.rb
@@ -46,7 +46,8 @@ module DumpWorker
 
   def load_medium
     m = Medium.find(@medium_id)
-    m.update!(path_opts: project_file_path, private: true, content_type: "text/csv")
+    metadata = m.metadata.merge("state" => "creating")
+    m.update!(path_opts: project_file_path, private: true, content_type: "text/csv", metadata: metadata)
     m
   end
 


### PR DESCRIPTION
closes #1421 - don't update in the request, just in the dump worker when it runs. Fixes busted links in the front end that don't show case the state is not correct but they won't run cause the rate limiter has kicked in.