### PR TITLE
complement search scope with a login match

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,8 +74,10 @@ class User < ActiveRecord::Base
     using: { tsearch: {
       prefix: true,
       tsvector_column: "tsv"
-      }
-    }
+      },
+      trigram: {}
+    },
+    :ranked_by => ":tsearch + (0.25 * :trigram)"
 
   def self.scope_for(action, user, opts={})
     case

--- a/db/migrate/20151117154126_add_user_login_trigram_index.rb
+++ b/db/migrate/20151117154126_add_user_login_trigram_index.rb
@@ -1,0 +1,20 @@
+class AddUserLoginTrigramIndex < ActiveRecord::Migration
+  def up
+    add_index :users, name: "users_idx_trgm_login_display_name", using: :gin, operator_class: :gin_trgm_ops,
+      expression: %((coalesce("users"."login"::text, '') || ' ' || coalesce("users"."display_name"::text, '')) gin_trgm_ops)
+
+    execute <<-SQL
+      DROP TRIGGER tsvectorupdate ON users;
+
+      CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
+      ON users FOR EACH ROW EXECUTE PROCEDURE
+      tsvector_update_trigger(
+        tsv, 'pg_catalog.english', login, display_name
+      );
+    SQL
+  end
+
+  def down
+    remove_index :users, name: "users_idx_trgm_login_display_name"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2467,6 +2467,13 @@ CREATE INDEX user_groups_display_name_trgm_index ON user_groups USING gist (disp
 
 
 --
+-- Name: users_idx_trgm_login_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX users_idx_trgm_login_display_name ON users USING gin ((((COALESCE((login)::text, ''::text) || ' '::text) || COALESCE((display_name)::text, ''::text))) gin_trgm_ops);
+
+
+--
 -- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -2774,4 +2781,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151110135415');
 INSERT INTO schema_migrations (version) VALUES ('20151111154310');
 
 INSERT INTO schema_migrations (version) VALUES ('20151116143407');
+
+INSERT INTO schema_migrations (version) VALUES ('20151117154126');
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -194,24 +194,42 @@ describe Api::V1::UsersController, type: :controller do
         context "display_name" do
           let(:index_options) { { search: user.display_name } }
 
-          it "should respond with 1 item" do
-            expect(json_response[api_resource_name].length).to eq(1)
+          it "should respond with both items in a ranked order", :aggregate_failures do
+            expect(json_response[api_resource_name].length).to eq(2)
+            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
           end
 
-          it "should respond with the correct item" do
-            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+          context "with a limited page size" do
+            let(:index_options) { { search: user.display_name, page_size: 1 } }
+
+            it "should respond with 1 item" do
+              expect(json_response[api_resource_name].length).to eq(1)
+            end
+
+            it "should respond with the correct item" do
+              expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+            end
           end
         end
 
         context "login" do
           let(:index_options) { { search: user.login } }
 
-          it "should respond with 1 item" do
-            expect(json_response[api_resource_name].length).to eq(1)
+          it "should respond with both items in a ranked order", :aggregate_failures do
+            expect(json_response[api_resource_name].length).to eq(2)
+            expect(json_response[api_resource_name][0]['login']).to eq(user.login)
           end
 
-          it "should respond with the correct item" do
-            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+          context "with a limited page size" do
+            let(:index_options) { { search: user.login, page_size: 1 } }
+
+            it "should respond with 1 item" do
+              expect(json_response[api_resource_name].length).to eq(1)
+            end
+
+            it "should respond with the correct item" do
+              expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+            end
           end
 
           context "with partial string" do
@@ -219,6 +237,16 @@ describe Api::V1::UsersController, type: :controller do
 
             it "should respond with both users" do
               expect(json_response[api_resource_name].length).to eq(2)
+            end
+          end
+
+          context "with hard to find tsvector" do
+            let(:hard_name) { "S_Powell" }
+            let(:hard_user) { create(:user, login: hard_name, display_name: hard_name )}
+            let(:index_options) { { search: hard_user.login } }
+
+            it "should respond with the hard user" do
+              expect(created_instance_id(api_resource_name)).to eq(hard_user.id.to_s)
             end
           end
         end


### PR DESCRIPTION
some logins are hard to find for tsvector, this will add the user login scope to the search whenever the search result set drops below a threshold. The only drawback is an  extra count function that i have limited but it's a db cost that should be pretty fast.