### PR TITLE
api request page size defaults

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -28,10 +28,10 @@ class Classification < ActiveRecord::Base
     return all if user.is_admin?
     case action
     when :show, :index
-      query = joins(:project).merge(Project.scope_for(:update, user))
-              .merge(complete)
-              .union_all(incomplete_for_user(user))
-      query
+      joins(:project).merge(Project.scope_for(:update, user))
+      .merge(complete)
+      .union_all(incomplete_for_user(user))
+      .includes(:subjects)
     when :update, :destroy
       incomplete_for_user(user)
     when :gold_standard

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,18 @@
+module Panoptes
+  def self.page_size_limits
+    @user_limits ||= begin
+                       file = Rails.root.join('config/page_size_limits.yml')
+                       YAML.load(File.read(file))[Rails.env].symbolize_keys
+                     rescue Errno::ENOENT, NoMethodError
+                       {  }
+                     end
+  end
+
+  def self.max_page_size_limit
+    page_size_limits[:max]
+  end
+end
+
+Kaminari.configure do |config|
+  config.max_per_page = Panoptes.max_page_size_limit || nil
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,6 +1,6 @@
 module Panoptes
   def self.page_size_limits
-    @user_limits ||= begin
+    @page_limits ||= begin
                        file = Rails.root.join('config/page_size_limits.yml')
                        YAML.load(File.read(file))[Rails.env].symbolize_keys
                      rescue Errno::ENOENT, NoMethodError

--- a/config/page_size_limits.yml.hudson
+++ b/config/page_size_limits.yml.hudson
@@ -1,0 +1,5 @@
+development:
+  max: 100
+
+test:
+  max: 100

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -79,6 +79,23 @@ describe Api::V1::ClassificationsController, type: :controller do
       default_request user_id: authorized_user.id, scopes: scopes
     end
 
+    describe "#page_size" do
+      let(:response_page_size) do
+        json_response["meta"]["classifications"]["page_size"]
+      end
+
+      it "should return the requested amount" do
+        get :index, page_size: 50
+        expect(response_page_size).to eq(50)
+      end
+
+      it "should return the max limit" do
+        limit = Panoptes.max_page_size_limit
+        get :index, page_size: limit + 1
+        expect(response_page_size).to eq(limit)
+      end
+    end
+
     context "a user retrieving their own incomplete classifications" do
       let!(:classifications) { create_list(:classification, 2, user: user, completed: false) }
       let!(:private_resource) { create(:classification) }


### PR DESCRIPTION
had some very long running classification index requests causing latency spikes for the API, added sensible configurable defaults for page limits