### PR TITLE
rename config object to configuration

### DIFF
--- a/app/schemas/workflow_create_schema.rb
+++ b/app/schemas/workflow_create_schema.rb
@@ -63,7 +63,7 @@ class WorkflowCreateSchema < JsonSchema
       type "object"
     end
 
-    property "config" do
+    property "configuration" do
       type "object"
     end
 

--- a/app/schemas/workflow_update_schema.rb
+++ b/app/schemas/workflow_update_schema.rb
@@ -58,7 +58,7 @@ class WorkflowUpdateSchema < JsonSchema
       type "object"
     end
 
-    property "config" do
+    property "configuration" do
       type "object"
     end
 

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -9,7 +9,7 @@ class WorkflowSerializer
              :created_at, :updated_at, :first_task, :primary_language,
              :version, :content_language, :prioritized, :grouped, :pairwise,
              :retirement, :retired_set_member_subjects_count, :href, :active,
-             :aggregation, :config
+             :aggregation, :configuration
 
   can_include :project, :subject_sets, :tutorial_subject, :expert_subject_sets
 

--- a/db/migrate/20151120161458_rename_workflow_config_attribute.rb
+++ b/db/migrate/20151120161458_rename_workflow_config_attribute.rb
@@ -1,0 +1,5 @@
+class RenameWorkflowConfigAttribute < ActiveRecord::Migration
+  def change
+    rename_column :workflows, :config, :configuration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1227,7 +1227,7 @@ CREATE TABLE workflows (
     active boolean DEFAULT true,
     aggregation jsonb DEFAULT '{}'::jsonb NOT NULL,
     display_order integer,
-    config jsonb DEFAULT '{}'::jsonb NOT NULL,
+    configuration jsonb DEFAULT '{}'::jsonb NOT NULL,
     public_gold_standard boolean DEFAULT false
 );
 
@@ -2783,4 +2783,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151111154310');
 INSERT INTO schema_migrations (version) VALUES ('20151116143407');
 
 INSERT INTO schema_migrations (version) VALUES ('20151117154126');
+
+INSERT INTO schema_migrations (version) VALUES ('20151120161458');
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -12,9 +12,15 @@ describe Api::V1::WorkflowsController, type: :controller do
   let(:default_params) { {format: :json} }
 
   let(:api_resource_attributes) do
-    %w(id display_name tasks classifications_count subjects_count created_at updated_at first_task primary_language content_language version grouped prioritized pairwise retirement aggregation active config)
+    %w(id display_name tasks classifications_count subjects_count
+    created_at updated_at first_task primary_language content_language
+    version grouped prioritized pairwise retirement aggregation active
+    configuration)
   end
-  let(:api_resource_links){ %w(workflows.project workflows.subject_sets workflows.tutorial_subject workflows.expert_subject_set workflows.attached_images) }
+  let(:api_resource_links)do
+    %w(workflows.project workflows.subject_sets workflows.tutorial_subject
+    workflows.expert_subject_set workflows.attached_images)
+  end
   let(:scopes) { %w(public project) }
 
   before(:each) do
@@ -73,7 +79,7 @@ describe Api::V1::WorkflowsController, type: :controller do
                    active: false,
                    retirement: { criteria: "classification_count" },
                    aggregation: { },
-                   config: { },
+                   configuration: { },
                    public_gold_standard: true,
                    tasks: {
                            interest: {
@@ -306,7 +312,7 @@ describe Api::V1::WorkflowsController, type: :controller do
                    active: true,
                    retirement: { criteria: "classification_count" },
                    aggregation: { public: true },
-                   config: { autoplay_subjects: true },
+                   configuration: { autoplay_subjects: true },
                    public_gold_standard: true,
                    tasks: {
                            interest: {

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -276,8 +276,8 @@ describe Workflow, :type => :model do
     end
   end
 
-  describe "#config" do
-    let(:workflow) { build(:workflow, config: config ) }
+  describe "#configuration" do
+    let(:workflow) { build(:workflow, configuration: config ) }
 
     context "empty" do
       let(:config) { {} }


### PR DESCRIPTION
closes #1503 - avoid serializer method name clash for config.