### PR TITLE
Publish events to Kafka

### DIFF
--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -9,6 +9,7 @@ class RetirementWorker
       count.retire! do
         SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject_ids)
         deactivate_workflow!(count.workflow)
+        publish_to_event_stream(count.workflow)
       end
     end
   end
@@ -17,5 +18,14 @@ class RetirementWorker
     if workflow.finished?
       Workflow.where(id: workflow.id).update_all(active: false)
     end
+  end
+
+  def publish_to_event_stream(workflow)
+    EventStream.push('workflow_counters', Time.now,
+      project_id: workflow.project_id,
+      workflow_id: workflow.id,
+      subjects_count: workflow.subjects_count,
+      retired_subjects_count: workflow.retired_subjects_count,
+      classifications_count: workflow.classifications_count)
   end
 end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -9,7 +9,7 @@ class RetirementWorker
       count.retire! do
         SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject_ids)
         deactivate_workflow!(count.workflow)
-        publish_to_event_stream(count.workflow)
+        push_counters_to_event_stream(count.workflow)
       end
     end
   end
@@ -20,8 +20,8 @@ class RetirementWorker
     end
   end
 
-  def publish_to_event_stream(workflow)
-    EventStream.push('workflow_counters', Time.now,
+  def push_counters_to_event_stream(workflow)
+    EventStream.push('workflow_counters',
       project_id: workflow.project_id,
       workflow_id: workflow.id,
       subjects_count: workflow.subjects_count,

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -28,6 +28,7 @@ class ClassificationLifecycle
       create_recent
       update_seen_subjects
       publish_to_kafka
+      publish_to_event_stream
     end
     #to avoid duplicates in queue, do not refresh the queue before updating seen subjects
     refresh_queue
@@ -73,6 +74,13 @@ class ClassificationLifecycle
     return unless classification.complete?
     classification_json = KafkaClassificationSerializer.serialize(classification, include: ['subjects']).to_json
     MultiKafkaProducer.publish('classifications', [classification.project.id, classification_json])
+  end
+
+  def publish_to_event_stream
+    EventStream.push('classification', classification.updated_at,
+      classification_id: classification.id,
+      project_id: classification.project.id,
+      user_id: Digest::SHA1.hexdigest(classification.user_id.to_s || classification.user_ip.to_s))
   end
 
   def update_classification_data

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -77,7 +77,11 @@ class ClassificationLifecycle
   end
 
   def publish_to_event_stream
-    EventStream.push('classification', classification.updated_at,
+    return unless classification.complete?
+
+    EventStream.push('classification',
+      event_id: "classification-#{classification.id}",
+      event_time: classification.updated_at,
       classification_id: classification.id,
       project_id: classification.project.id,
       user_id: Digest::SHA1.hexdigest(classification.user_id.to_s || classification.user_ip.to_s))

--- a/lib/event_stream.rb
+++ b/lib/event_stream.rb
@@ -1,0 +1,9 @@
+module EventStream
+  def self.push(event_type, event_time, metadata = {})
+    event_id   = SecureRandom.uuid
+    event_type = "panoptes.#{event_type}"
+    event_data = metadata.merge(event_id: event_id, event_time: event_time, event_type: event_type).to_json
+
+    MultiKafkaProducer.publish('events', [event_id, event_data])
+  end
+end

--- a/lib/event_stream.rb
+++ b/lib/event_stream.rb
@@ -1,7 +1,7 @@
 module EventStream
-  def self.push(event_type, event_time, metadata = {})
-    event_id   = SecureRandom.uuid
+  def self.push(event_type, event_id: SecureRandom.uuid, event_time: Time.now.utc, **metadata)
     event_type = "panoptes.#{event_type}"
+    event_id   = "#{event_type}.#{event_id}"
     event_data = metadata.merge(event_id: event_id, event_time: event_time, event_type: event_type).to_json
 
     MultiKafkaProducer.publish('events', [event_id, event_data])

--- a/lib/multi_kafka_producer.rb
+++ b/lib/multi_kafka_producer.rb
@@ -27,6 +27,7 @@ module MultiKafkaProducer
   KAFKAS = { kafka: 'jruby-kafka', poseidon: 'poseidon' }
 
   def self.default_adapter
+    return :null if Rails.env.test?
     return :kafka if defined? ::Kafka
     return :poseidon if defined? ::Poseidon
 

--- a/lib/multi_kafka_producer.rb
+++ b/lib/multi_kafka_producer.rb
@@ -27,7 +27,6 @@ module MultiKafkaProducer
   KAFKAS = { kafka: 'jruby-kafka', poseidon: 'poseidon' }
 
   def self.default_adapter
-    return :null if Rails.env.test?
     return :kafka if defined? ::Kafka
     return :poseidon if defined? ::Poseidon
 

--- a/spec/lib/event_stream_spec.rb
+++ b/spec/lib/event_stream_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe EventStream do
+  before { allow(MultiKafkaProducer).to receive(:publish) }
+
+  it 'pushes events into kafka events topic with custom metadata' do
+    EventStream.push('nosepicking', user_id: 1)
+    expect(MultiKafkaProducer).to have_received(:publish).with('events',
+      [including("panoptes.nosepicking."), including('"user_id":1')]).once
+  end
+
+  it 'uses a custom event id' do
+    EventStream.push('nosepicking', event_id: 1)
+    expect(MultiKafkaProducer).to have_received(:publish).with('events',
+      ["panoptes.nosepicking.1", anything]).once
+  end
+
+  it 'uses a custom event time' do
+    EventStream.push('nosepicking', event_time: Date.new(2015, 1, 2))
+    expect(MultiKafkaProducer).to have_received(:publish).with('events',
+      [anything, including("2015-01-02")]).once
+  end
+end

--- a/spec/lib/multi_kafka_producer_spec.rb
+++ b/spec/lib/multi_kafka_producer_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 shared_examples "default adapter" do
   it 'should set the default adapter for the platform' do
+    allow(Rails.env).to receive(:test?).and_return(false)
     MultiKafkaProducer.adapter =  nil
     expect(adapter).to be(expected_adapter)
   end
@@ -16,13 +17,13 @@ end
 
 describe MultiKafkaProducer do
   let(:adapter) { MultiKafkaProducer.adapter }
-  
+
   if RUBY_PLATFORM == 'java'
     let(:expected_adapter) { MultiKafkaProducer::Kafka }
   else
     let(:expected_adapter) { MultiKafkaProducer::Poseidon }
   end
-  
+
   describe "::adapter=" do
     context "a string" do
       if RUBY_PLATFORM == 'java'
@@ -30,7 +31,7 @@ describe MultiKafkaProducer do
       else
         let(:adapter_name) { 'poseidon' }
       end
-      
+
       it_behaves_like "loads by name"
     end
 
@@ -40,7 +41,7 @@ describe MultiKafkaProducer do
       else
         let(:adapter_name) { :poseidon }
       end
-      
+
       it_behaves_like "loads by name"
     end
 
@@ -67,9 +68,9 @@ describe MultiKafkaProducer do
     before(:each) do
       allow(MultiKafkaProducer).to receive(:adapter).and_return(adapter)
     end
-    
+
     let(:adapter) { double({ connected?: true }) }
-    
+
     it 'should call connect on the adapter with the supplied args' do
       expect(adapter).to receive(:connect)
         .with("client-id", "broker1", "broker2")
@@ -84,7 +85,7 @@ describe MultiKafkaProducer do
 
     context "connected adapter" do
       let(:adapter) { double({ connected?: true }) }
-      
+
       it 'should call publish on the adapter with the supplied args' do
         expect(adapter).to receive(:publish).with('topic', [['key', 'msg']])
         MultiKafkaProducer.publish('topic', ['key', 'msg'])
@@ -93,7 +94,7 @@ describe MultiKafkaProducer do
 
     context "disconnected adapter" do
       let(:adapter) { double({ connected?: false, adapter_name: "blerg" }) }
-      
+
       it 'should raise an exception when the adapter is not connected' do
         expect do
           MultiKafkaProducer.publish('topic', ['key', 'msg'])

--- a/spec/lib/multi_kafka_producer_spec.rb
+++ b/spec/lib/multi_kafka_producer_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 shared_examples "default adapter" do
   it 'should set the default adapter for the platform' do
-    allow(Rails.env).to receive(:test?).and_return(false)
     MultiKafkaProducer.adapter =  nil
     expect(adapter).to be(expected_adapter)
   end

--- a/spec/lib/multi_kafka_producer_spec.rb
+++ b/spec/lib/multi_kafka_producer_spec.rb
@@ -14,7 +14,7 @@ shared_examples "loads by name" do
   end
 end
 
-describe MultiKafkaProducer do
+describe MultiKafkaProducer, kafka: true do
   let(:adapter) { MultiKafkaProducer.adapter }
 
   if RUBY_PLATFORM == 'java'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,6 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     DatabaseCleaner.strategy = :transaction
     ActionMailer::Base.deliveries.clear
-    MultiKafkaProducer.adapter = nil
 
     # Clears out the jobs for tests using the fake testing
     Sidekiq::Worker.clear_all

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     DatabaseCleaner.strategy = :transaction
     ActionMailer::Base.deliveries.clear
+    MultiKafkaProducer.adapter = nil
 
     # Clears out the jobs for tests using the fake testing
     Sidekiq::Worker.clear_all

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,15 @@ RSpec.configure do |config|
     else
       Sidekiq::Testing.fake!
     end
+
+    case example.metadata[:kafka]
+    when nil
+      MultiKafkaProducer.adapter = :null
+    when true
+      MultiKafkaProducer.adapter = nil
+    else
+      MultiKafkaProducer.adapter = example.metadata[:kafka]
+    end
   end
 
   config.before(:each, no_transaction: true) do

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe RetirementWorker do
       end
 
       context "when the workflow optimistic lock is updated" do
-
         it 'should save the changes and not raise an error' do
           allow(workflow).to receive(:finished?).and_return(true)
           Workflow.find(workflow.id).touch
@@ -68,6 +67,18 @@ RSpec.describe RetirementWorker do
           worker.deactivate_workflow!(workflow)
         end.to_not change{Workflow.find(workflow.id).active}
       end
+    end
+  end
+
+  describe "#push_counters_to_event_stream" do
+    before(:each) do
+      allow(EventStream).to receive(:push)
+    end
+
+    it 'should publish new counts to event stream upon retiring' do
+      allow_any_instance_of(SubjectWorkflowCount).to receive(:retire?).and_return(true)
+      worker.perform(count)
+      expect(EventStream).to have_received(:push).once
     end
   end
 end


### PR DESCRIPTION
Two events are implemented:

* a classification is made: publish an event to indicate this. the event-id is derived from the record id, so that duplicates aren't possible. this allows us to build histograms of how many classifications we see per timeslot

* a subject is retired: publish the current values of various counters, so that we can chart these over time later.