### PR TITLE
Attempt to speed up user searches

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,7 +16,13 @@ class Api::V1::UsersController < Api::ApiController
   alias_method :user, :controlled_resource
 
   search_by do |name, query|
-    query.search_name(name.join(" "))
+    search_names = name.join(" ")
+    fast_search = query.search_name_fast(search_names)
+    if fast_search.exists?
+      fast_search
+    else
+      query.search_name(search_names)
+    end
   end
 
   def me

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,14 @@ class User < ActiveRecord::Base
     },
     :ranked_by => ":tsearch + (0.25 * :trigram)"
 
+  pg_search_scope :search_name_fast,
+    against: [:login],
+    using: { tsearch: {
+      prefix: true,
+      tsvector_column: "tsv"
+      }
+    }
+
   def self.scope_for(action, user, opts={})
     case
     when user.is_admin?

--- a/db/migrate/20151127150019_sparse_index_updates.rb
+++ b/db/migrate/20151127150019_sparse_index_updates.rb
@@ -1,0 +1,6 @@
+class SparseIndexUpdates < ActiveRecord::Migration
+  def change
+    remove_index :users, column: :ouroboros_created
+    remove_index :workflows, column: :active
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2403,13 +2403,6 @@ CREATE UNIQUE INDEX index_users_on_login_with_case ON users USING btree (login);
 
 
 --
--- Name: index_users_on_ouroboros_created; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_users_on_ouroboros_created ON users USING btree (ouroboros_created) WHERE (ouroboros_created = false);
-
-
---
 -- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2456,13 +2449,6 @@ CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (it
 --
 
 CREATE INDEX index_workflow_contents_on_workflow_id ON workflow_contents USING btree (workflow_id);
-
-
---
--- Name: index_workflows_on_active; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_workflows_on_active ON workflows USING btree (active) WHERE (active = true);
 
 
 --
@@ -2849,4 +2835,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151117154126');
 INSERT INTO schema_migrations (version) VALUES ('20151120104454');
 
 INSERT INTO schema_migrations (version) VALUES ('20151120161458');
+
+INSERT INTO schema_migrations (version) VALUES ('20151127150019');
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -194,8 +194,8 @@ describe Api::V1::UsersController, type: :controller do
         context "display_name" do
           let(:index_options) { { search: user.display_name } }
 
-          it "should respond with both items in a ranked order", :aggregate_failures do
-            expect(json_response[api_resource_name].length).to eq(2)
+          it "should respond with the correct user", :aggregate_failures do
+            expect(json_response[api_resource_name].length).to eq(1)
             expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
           end
 
@@ -215,8 +215,8 @@ describe Api::V1::UsersController, type: :controller do
         context "login" do
           let(:index_options) { { search: user.login } }
 
-          it "should respond with both items in a ranked order", :aggregate_failures do
-            expect(json_response[api_resource_name].length).to eq(2)
+          it "should respond with the correct user", :aggregate_failures do
+            expect(json_response[api_resource_name].length).to eq(1)
             expect(json_response[api_resource_name][0]['login']).to eq(user.login)
           end
 


### PR DESCRIPTION
closes #1509 and attempts to address [this](https://github.com/zooniverse/Panoptes/issues/1230#issuecomment-159040608)

removes some sparse indexes that weren't used as the query was a full table scan for both and adds a layer strategy to finding users with narrow and broad scopes. Seems its a trade off between high accuracy and speed.