### PR TITLE
Set finished_at instead of deactivating workflows

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1415,6 +1415,7 @@ A workflow has the following attributes
 - id
 - created_at
 - updated_at
+- finished_at
 - display_name
 - tasks
 - classifications_count
@@ -1427,6 +1428,8 @@ A workflow has the following attributes
 
 *id*, *created_at*, *updated_at*, *workflow_version*, *content_language*,
 and *classifications_count* are assigned by the API
+
+*finished_at* is set by the API to a date/time when all subjects for this workflow have been retired.
 
 Three parameters: _grouped_, _prioritized_, and _pairwise_ configure
 how [Cellect](https://github.com/zooniverse/Cellect) chooses subjects

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -6,7 +6,7 @@ class WorkflowSerializer
   include MediaLinksSerializer
 
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
-             :created_at, :updated_at, :first_task, :primary_language,
+             :created_at, :updated_at, :finished_at, :first_task, :primary_language,
              :version, :content_language, :prioritized, :grouped, :pairwise,
              :retirement, :retired_set_member_subjects_count, :href, :active,
              :aggregation, :configuration

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -8,15 +8,15 @@ class RetirementWorker
     if count.retire?
       count.retire! do
         SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject_ids)
-        deactivate_workflow!(count.workflow)
+        finish_workflow!(count.workflow)
         push_counters_to_event_stream(count.workflow)
       end
     end
   end
 
-  def deactivate_workflow!(workflow)
+  def finish_workflow!(workflow, clock = Time)
     if workflow.finished?
-      Workflow.where(id: workflow.id).update_all(active: false)
+      Workflow.where(id: workflow.id).update_all(finished_at: clock.now)
     end
   end
 

--- a/db/migrate/20151201102135_add_finished_at_to_workflows.rb
+++ b/db/migrate/20151201102135_add_finished_at_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddFinishedAtToWorkflows < ActiveRecord::Migration
+  def change
+    add_column :workflows, :finished_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1262,7 +1262,8 @@ CREATE TABLE workflows (
     aggregation jsonb DEFAULT '{}'::jsonb NOT NULL,
     display_order integer,
     configuration jsonb DEFAULT '{}'::jsonb NOT NULL,
-    public_gold_standard boolean DEFAULT false
+    public_gold_standard boolean DEFAULT false,
+    finished_at timestamp without time zone
 );
 
 
@@ -2840,4 +2841,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151120161458');
 INSERT INTO schema_migrations (version) VALUES ('20151125153712');
 
 INSERT INTO schema_migrations (version) VALUES ('20151127150019');
+
+INSERT INTO schema_migrations (version) VALUES ('20151201102135');
 


### PR DESCRIPTION
Instead of deactivating, set a timestamp column. This allows us to see
which workflows are supposed to be visible but have just run out of
data. In turn, that will allow us to automatically unfinish a workflow
when more data becomes available (either due to recounts or simply
because more data is added to a subject set).
