### PR TITLE
Save resource before retiring

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -72,7 +72,9 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   def add_relation(resource, relation, value)
     if relation == :retired_subjects && value.is_a?(Array)
+      resource.save!
       value.each {|id| resource.retire_subject(id) }
+      resource.reload
     else
       super
     end
@@ -81,7 +83,9 @@ class Api::V1::WorkflowsController < Api::ApiController
   def new_items(resource, relation, value)
     case relation
     when :retired_subjects, 'retired_subjects'
+      resource.save!
       value.flat_map {|id| resource.retire_subject(id) }
+      resource.reload
     when :subject_sets, 'subject_sets'
       items = construct_new_items(super(resource, relation, value), resource.project_id)
       if items.any? { |item| item.is_a?(SubjectSet) }

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -292,11 +292,16 @@ describe Api::V1::WorkflowsController, type: :controller do
       let(:resource) { workflow }
       let(:resource_id) { :workflow_id }
 
+      before do
+        resource.update_column :display_order, nil
+      end
+
       it_behaves_like "supports update_links" do
         it 'marks the subject as retired' do
           expect(linked_resource.retired_for_workflow?(resource)).to be_truthy
         end
       end
+
       it_behaves_like "reloads the non logged in queues"
     end
   end


### PR DESCRIPTION
Works around optimistic locking issues (retiring updates a counter on
the workflow and increments the lock version, so afterwards the
existing workflow object cannot be saved until doing a reload.