### PR TITLE
correctly link singular project

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -36,11 +36,12 @@ class Api::V1::CollectionsController < Api::ApiController
   end
 
   def pluralize_project_links
-    if project_id = params[:collections][:links].try(:delete, :project)
-      if create_params[:links][:projects]
+    collection_params = params[:collections]
+    if project_id = collection_params[:links].try(:delete, :project)
+      if collection_params[:links][:projects]
         raise BadLinkParams.new("Error: project_ids and project link keys must not be set together")
       end
-      create_params[:links].merge!(projects: [project_id])
+      collection_params[:links].merge!(projects: [project_id])
     end
   end
 end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -158,8 +158,10 @@ describe Api::V1::CollectionsController, type: :controller do
         post :create, create_params
       end
 
-      it "should return created" do
+      it "should return created", :aggregate_failures do
         expect(response).to have_http_status(:created)
+        created_links = created_instance(api_resource_name)["links"]
+        expect(created_links.has_key?("projects")).to be_truthy
       end
 
       context "when passing inconsistent project links" do


### PR DESCRIPTION
ensure project links work on collection create, fixes a bug that @simoneduca found in the api.