### PR TITLE
Allow sorting by number of people that have classified

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -19,7 +19,7 @@ class ProjectSerializer
     classifications_export: { include: false}, subjects_export: { include: false },
     aggregations_export: { include: false }
 
-  can_sort_by :completeness, :updated_at
+  can_sort_by :completeness, :classifiers_count, :updated_at
 
   def self.links
     links = super


### PR DESCRIPTION
Sadly Restpack doesn't support customizing the parameters used for each sorting, so I can't really call this "popularity" outward-facing, unless anyone has any ideas?