### PR TITLE
Resolves #1514 should not increment classifiers count every time a user performs an action

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -33,9 +33,10 @@ module Api
       response_status = :unprocessable_entity
       if event_params_check
         if upp = user_project_preference
+          was_new = upp.new_record?
           upp.legacy_count[create_params[:workflow]] = create_params[:count]
           if upp.save
-            Project.increment_counter :classifiers_count, upp.project_id
+            Project.increment_counter :classifiers_count, upp.project_id if was_new
             response_status = :ok
           end
         end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -171,6 +171,11 @@ describe Api::EventsController, type: :controller do
           end.to change { UserProjectPreference.count }.from(0).to(1)
         end
 
+        it "should increment the project's classifiers count", :focus do
+          expect(Project).to receive(:increment_counter).with(:classifiers_count, project.id)
+          post :create, first_visit_event_params
+        end
+
         context "with an unknown user zooniverse_id" do
 
           it "should not create the user project preference model (upp)" do
@@ -238,6 +243,11 @@ describe Api::EventsController, type: :controller do
             expect do
               post :create, event_params
             end.to_not change { UserProjectPreference.count }.from(1)
+          end
+
+          it "should not increment the project's classifiers count", :focus do
+            expect(Project).to_not receive(:increment_counter)
+            post :create, event_params
           end
 
           it "should overwrite the upp legacy_count to the correct value" do

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -171,7 +171,7 @@ describe Api::EventsController, type: :controller do
           end.to change { UserProjectPreference.count }.from(0).to(1)
         end
 
-        it "should increment the project's classifiers count", do
+        it "should increment the project's classifiers count" do
           expect(Project).to receive(:increment_counter).with(:classifiers_count, project.id)
           post :create, first_visit_event_params
         end
@@ -245,7 +245,7 @@ describe Api::EventsController, type: :controller do
             end.to_not change { UserProjectPreference.count }.from(1)
           end
 
-          it "should not increment the project's classifiers count", do
+          it "should not increment the project's classifiers count" do
             expect(Project).to_not receive(:increment_counter)
             post :create, event_params
           end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -171,7 +171,7 @@ describe Api::EventsController, type: :controller do
           end.to change { UserProjectPreference.count }.from(0).to(1)
         end
 
-        it "should increment the project's classifiers count", :focus do
+        it "should increment the project's classifiers count", do
           expect(Project).to receive(:increment_counter).with(:classifiers_count, project.id)
           post :create, first_visit_event_params
         end
@@ -245,7 +245,7 @@ describe Api::EventsController, type: :controller do
             end.to_not change { UserProjectPreference.count }.from(1)
           end
 
-          it "should not increment the project's classifiers count", :focus do
+          it "should not increment the project's classifiers count", do
             expect(Project).to_not receive(:increment_counter)
             post :create, event_params
           end


### PR DESCRIPTION
Spec changes were already provided by Cam Allen

Because calling upp.save automatically unsets upp.new_record? I capture the state of upp.new_record? in was_new and then decide whether or not to increment the counter based on that value.