### PR TITLE
Deactivate instead of destroy projects

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::ProjectsController < Api::ApiController
     :create_subjects_export, :create_aggregations_export,
     :create_workflows_export, :create_workflow_contents_export,
     scopes: [:project]
-  resource_actions :default
+  resource_actions :show, :index, :create, :update, :deactivate
   schema_type :json_schema
 
   alias_method :project, :controlled_resource

--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -3,14 +3,15 @@ class CalculateProjectCompletenessWorker
   using Refinements::RangeClamping
 
   def perform(project_id)
+    project = Project.find(project_id)
     Project.transaction do
-      project = Project.find(project_id)
-      project.workflows.all.each do |workflow|
+      project.workflows.each do |workflow|
         workflow.update_columns completeness: workflow_completeness(workflow)
       end
-
       project.update_columns completeness: project_completeness(project)
     end
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def project_completeness(project)

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -74,7 +74,7 @@ describe Api::V1::ProjectsController, type: :controller do
           get :index, index_options
         end
 
-        describe "search" do 
+        describe "search" do
           it_behaves_like "filter by display_name"
 
           describe "filter by display_name substring" do
@@ -871,8 +871,9 @@ describe Api::V1::ProjectsController, type: :controller do
 
   describe "#destroy" do
     let(:resource) { create(:full_project, owner: user) }
+    let(:instances_to_disable) { [resource] }
 
-    it_behaves_like "is destructable"
+    it_behaves_like "is deactivatable"
   end
 
   describe "versioning" do

--- a/spec/workers/calculate_project_activity_worker_spec.rb
+++ b/spec/workers/calculate_project_activity_worker_spec.rb
@@ -20,6 +20,13 @@ describe CalculateProjectActivityWorker do
       expect_any_instance_of(Project).to receive(:update_columns).with(activity: count)
       worker.perform(project.id)
     end
+
+    context "when it can't find the project" do
+      it "should fail quickly" do
+        expect(Project).not_to receive(:transaction)
+        worker.perform("-1")
+      end
+    end
   end
 
   describe '#workflow_activity' do

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -13,6 +13,13 @@ describe CalculateProjectCompletenessWorker do
 
       expect(worker.project_completeness(project)).to eq(0.5)
     end
+
+    context "when it can't find the project" do
+      it "should fail quickly" do
+        expect(Project).not_to receive(:transaction)
+        worker.perform("-1")
+      end
+    end
   end
 
   describe '#workflow_completeness' do


### PR DESCRIPTION
Seems the api allowed full project delete and some background workers were failing with missing record.  I've reworked the destroy route to just deactivate instead, note that users with rights can hard delete workflows, subject_sets and set_member_subjects so any deactivate could possibly be a shell.

I'm thinking we should keep projects around for posterity and possibly restores. Should we just allow the project to be hard deleted instead?