### PR TITLE
Projects index speed up

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -26,7 +26,6 @@ class Api::V1::ProjectsController < Api::ApiController
                     :introduction,
                     :url_labels]
 
-
   before_action :add_owner_ids_to_filter_param!, only: :index
   before_action :filter_by_tags, only: :index
   before_action :downcase_slug, only: :index
@@ -45,7 +44,7 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def index
-    @controlled_resources = controlled_resources.eager_load(:tags)
+    @controlled_resources = controlled_resources.eager_load(:tags, :avatar, :background, :owner, :project_contents)
     unless params.has_key?(:sort)
       @controlled_resources = case
                               when params.has_key?(:launch_approved)

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -100,25 +100,15 @@ class Api::V1::ProjectsController < Api::ApiController
     !!params[:cards] ? [:avatar] : [:tags, :background, :avatar, :owner]
   end
 
-  def allowed_eager_loads(loads)
+  def allowed_eager_loads
     non_owner_role_params = [true, false].include?(@owner_eager_load)
     excepts = non_owner_role_params ? [:owner] : []
-    (loads - excepts).uniq
-  end
-
-  def include_eager_loads
-    [].tap do |include_loads|
-      if params.has_key?(:include)
-        includes = params.fetch(:include, "").split(",").map(&:to_sym)
-        include_loads = includes.select { |inc| controlled_resource.respond_to?(inc) }
-      end
-    end
+    (default_eager_loads - excepts).uniq
   end
 
   def eager_load_relations
-    eager_loads = allowed_eager_loads(default_eager_loads | include_eager_loads)
+    eager_loads = allowed_eager_loads
     unless eager_loads.empty?
-      controlled_resources.eager_load(*eager_loads)
       @controlled_resources = controlled_resources.eager_load(*eager_loads)
     end
   end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -96,12 +96,15 @@ class Api::V1::ProjectsController < Api::ApiController
     end
   end
 
-  def eager_load_includes
-    return unless params.has_key?(:include)
-    includes = params.fetch(:include, "").split(",").map(&:to_sym)
-    eager_loads = includes.select { |inc| controlled_resource.respond_to?(inc) }
+  def eager_load_includes(include_loads=[])
+    default_loads = !!params[:cards] ? [:avatar] : [:tags, :background, :avatar, :owner]
+    if params.has_key?(:include)
+      includes = params.fetch(:include, "").split(",").map(&:to_sym)
+      include_loads = includes.select { |inc| controlled_resource.respond_to?(inc) }
+    end
+    eager_loads = default_loads | include_loads
     unless eager_loads.empty?
-      @controlled_resources = controlled_resources.eager_load(*eager_loads)
+      @controlled_resources = controlled_resources.eager_load(*eager_loads.uniq)
     end
   end
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -97,7 +97,7 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def eager_load_includes(include_loads=[])
-    default_loads = !!params[:cards] ? [:avatar] : [:tags, :background, :avatar, :owner]
+    default_loads = !!params[:cards] ? [:avatar] : [:tags, :background, :avatar]
     if params.has_key?(:include)
       includes = params.fetch(:include, "").split(",").map(&:to_sym)
       include_loads = includes.select { |inc| controlled_resource.respond_to?(inc) }

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -26,7 +26,6 @@ class Api::V1::ProjectsController < Api::ApiController
                     :introduction,
                     :url_labels]
 
-  before_action :add_owner_ids_to_filter_param!, only: :index
   before_action :filter_by_tags, only: :index
   before_action :downcase_slug, only: :index
 
@@ -214,12 +213,7 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def index_eager_loads
-    card_eager_loads = %i(avatar project_contents)
-    if params.has_key?(:cards)
-      card_eager_loads
-    else
-      %i(tags background owner) | card_eager_loads
-    end
+    %i(owner) | params.fetch(:include, "").split(",")
   end
 
   def context

--- a/app/controllers/concerns/filter_by_current_user_roles.rb
+++ b/app/controllers/concerns/filter_by_current_user_roles.rb
@@ -12,6 +12,16 @@ module FilterByCurrentUserRoles
         .joins(:access_control_lists)
         .where(access_control_lists: {user_group_id: api_user.user.identity_group.id})
         .where.overlap(access_control_lists: { roles: roles_filter })
+      if owner_eager_load(roles_filter)
+        @controlled_resources = @controlled_resources.eager_load(:owner)
+      end
     end
+  end
+
+  private
+
+  def owner_eager_load(roles)
+    non_owner_roles = roles - ["owner"]
+    @owner_eager_load = non_owner_roles.empty?
   end
 end

--- a/app/controllers/concerns/filter_by_owner.rb
+++ b/app/controllers/concerns/filter_by_owner.rb
@@ -10,6 +10,8 @@ module FilterByOwner
     unless owner_filter.blank?
       groups = UserGroup.where(UserGroup.arel_table[:name].lower.in(owner_filter.map(&:downcase)))
       @controlled_resources = controlled_resources
+        .eager_load(:owner)
+        .joins(:owner)
         .joins(:access_control_lists)
         .where(access_control_lists: {user_group: groups})
         .where.overlap(access_control_lists: { roles: ["owner"] })

--- a/app/controllers/concerns/index_search.rb
+++ b/app/controllers/concerns/index_search.rb
@@ -2,7 +2,7 @@ module IndexSearch
   extend ActiveSupport::Concern
 
   included do
-    before_action :search, only: :index
+    before_action :search, only: :index, if: :search_query?
     @search_handlers ||= {}.with_indifferent_access
   end
 
@@ -43,5 +43,9 @@ module IndexSearch
 
   def search_handlers
     self.class.instance_variable_get(:@search_handlers)
+  end
+
+  def search_query?
+    params.has_key?(:search)
   end
 end

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -18,11 +18,11 @@ module Translatable
       "#{name}Content".constantize
     end
 
-    def load_with_languages(query, languages=nil)
+    def load_with_languages(query, languages=[])
       where_clause = "#{content_association}.language = #{table_name}.primary_language"
-      query = query.joins(content_association).eager_load(content_association)
+      query = query.eager_load(content_association)
 
-      if languages
+      if !languages.empty?
         where_clause = "#{where_clause} OR #{content_association}.language ~ ?"
         query.where(where_clause, lang_regex(languages))
       else
@@ -39,27 +39,20 @@ module Translatable
   end
 
   def content_for(languages)
-    content = nil
-    languages = Array.wrap(languages).flat_map do |lang|
-      lang.length == 2 ? lang : [lang, lang[0..1]]
-    end.uniq
-
-    languages.each do |lang|
-      content = content_association.to_a.find{ |c| c.language == lang }
-      if lang.length == 2 && !content
-        content = content_association.to_a.find do |c|
-          c.language =~ /^#{lang[0..1]}.*/
-        end
+    languages_to_sort = languages_to_sort(languages)
+    if content_association.loaded?
+      content = nil
+      languages_to_sort.find do |lang|
+        content = content_association.find { |content| content.language == lang }
       end
-
-      break if content
+      content
+    else
+      load_content_from_db(languages_to_sort)
     end
-    content = primary_content unless content
-    return content
   end
 
   def available_languages
-    content_association.select('language').map(&:language).map(&:downcase)
+    content_association.pluck(:language).map(&:downcase)
   end
 
   def content_association
@@ -67,12 +60,36 @@ module Translatable
   end
 
   def primary_content
-    @primary_content ||= if content_association.loaded?
-                           content_association.to_a.find do |content|
-                             content.language == primary_language
-                           end
-                         else
-                           content_association.where(language: primary_language).first
-                         end
+    @primary_content ||=
+      if content_association.loaded?
+        content_association.to_a.find do |content|
+          content.language == primary_language
+        end
+      else
+        content_association.where(language: primary_language).first
+      end
+  end
+
+  def load_content_from_db(languages_to_sort)
+    join_values = languages_to_sort.each_with_index.reduce([]) do |values, (lang, i)|
+      values << "('#{lang}',#{i})"
+    end
+
+    join_clause = "JOIN (VALUES #{join_values.join(",")}) as x(lang, ordering) "\
+    "ON project_contents.language = x.lang"
+    content_association.where(language: languages_to_sort)
+    .joins(join_clause)
+    .order("x.ordering")
+    .first
+  end
+
+  def languages_to_sort(languages)
+    (Array.wrap(languages) | [primary_language]).flat_map do |lang|
+      if lang.length == 2
+        lang
+      else
+        [lang, lang[0..1]]
+      end
+    end.uniq
   end
 end

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -19,7 +19,7 @@ module Translatable
     end
 
     def load_with_languages(query, languages=[])
-      query = query.joins(content_association)
+      query = query.eager_load(content_association).joins(content_association)
       where_clause = "\"#{content_association}\".\"language\" = \"#{table_name}\".\"primary_language\""
       if !languages.empty?
         where_clause = "#{where_clause} OR \"#{content_association}\".\"language\" ~ ?"

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -19,11 +19,10 @@ module Translatable
     end
 
     def load_with_languages(query, languages=[])
-      where_clause = "#{content_association}.language = #{table_name}.primary_language"
-      query = query.eager_load(content_association)
-
+      query = query.joins(content_association)
+      where_clause = "\"#{content_association}\".\"language\" = \"#{table_name}\".\"primary_language\""
       if !languages.empty?
-        where_clause = "#{where_clause} OR #{content_association}.language ~ ?"
+        where_clause = "#{where_clause} OR \"#{content_association}\".\"language\" ~ ?"
         query.where(where_clause, lang_regex(languages))
       else
         query.where(where_clause)
@@ -76,7 +75,7 @@ module Translatable
     end
 
     join_clause = "JOIN (VALUES #{join_values.join(",")}) as x(lang, ordering) "\
-    "ON project_contents.language = x.lang"
+    "ON \"project_contents\".\"language\" = x.lang"
     content_association.where(language: languages_to_sort)
     .joins(join_clause)
     .order("x.ordering")

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -13,13 +13,13 @@ class ProjectSerializer
     :href, :workflow_description, :primary_language, :tags, :experimental_tools,
     :completeness, :activity
 
+  optional :avatar_src
   can_include :workflows, :subject_sets, :owners, :project_contents,
     :project_roles, :pages
-  can_filter_by :display_name, :slug, :beta_requested, :beta_approved, :launch_requested, :launch_approved, :private
   media_include :avatar, :background, :attached_images,
     classifications_export: { include: false}, subjects_export: { include: false },
     aggregations_export: { include: false }
-
+  can_filter_by :display_name, :slug, :beta_requested, :beta_approved, :launch_requested, :launch_approved, :private
   can_sort_by :launch_date, :activity, :completeness, :classifiers_count, :updated_at
 
   def self.links
@@ -29,6 +29,14 @@ class ProjectSerializer
                                type: "project_pages"
                               }
     links
+  end
+
+  def add_links(model, data)
+    if @context[:cards]
+      data.merge!(links: {})
+    else
+      super(model, data)
+    end
   end
 
   def title
@@ -63,6 +71,14 @@ class ProjectSerializer
 
   def tags
     @model.tags.map(&:name)
+  end
+
+  def avatar_src
+    if avatar = @model.avatar
+      avatar.external_link ? avatar.external_link : "//#{ avatar.src }"
+    else
+      ""
+    end
   end
 
   def fields

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -75,7 +75,7 @@ class ProjectSerializer
 
   def avatar_src
     if avatar = @model.avatar
-      avatar.external_link ? avatar.external_link : "//#{ avatar.src }"
+      avatar.external_link ? avatar.external_link : avatar.src
     else
       ""
     end

--- a/lib/role_control/owned.rb
+++ b/lib/role_control/owned.rb
@@ -24,8 +24,8 @@ module RoleControl
                        when UserGroup
                          o
                        end
-        build_owner_control_list(user_group: owning_group,
-                                 roles: ["owner"])
+        build_owner_control_list(user_group: owning_group, roles: ["owner"])
+        @owner = nil
         super(owning_group)
       end
 

--- a/lib/role_control/owned.rb
+++ b/lib/role_control/owned.rb
@@ -25,14 +25,12 @@ module RoleControl
                          o
                        end
         build_owner_control_list(user_group: owning_group, roles: ["owner"])
-        @owner = nil
         super(owning_group)
       end
 
-      def owner
-        return @owner if @owner
-        group = super
-        @owner = if group.try(:identity?)
+      def owner(reload=nil)
+        group = super(reload)
+        if group.try(:identity?)
           group.users.first
         else
           group

--- a/lib/role_control/owned.rb
+++ b/lib/role_control/owned.rb
@@ -30,8 +30,9 @@ module RoleControl
       end
 
       def owner
+        return @owner if @owner
         group = super
-        if group.try(:identity?)
+        @owner = if group.try(:identity?)
           group.users.first
         else
           group

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -305,8 +305,7 @@ describe Api::V1::ProjectsController, type: :controller do
           end
 
           let(:index_options) do
-            {owner: project_owner.login,
-             slug: filtered_project.slug}
+            {owner: project_owner.login, slug: filtered_project.slug}
           end
 
           it "should respond with 1 item" do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -65,10 +65,8 @@ describe Api::V1::ProjectsController, type: :controller do
         let!(:new_project) do
           create(:full_project, display_name: "Non-test project", owner: project_owner)
         end
-
         let(:resource) { new_project }
         let(:ids) { json_response["projects"].map{ |p| p["id"] } }
-
 
         before(:each) do
           get :index, index_options
@@ -84,6 +82,18 @@ describe Api::V1::ProjectsController, type: :controller do
             it "should respond with the most relevant item first" do
               expect(json_response[api_resource_name].length).to eq(1)
             end
+          end
+        end
+
+        describe "cards only" do
+          let(:index_options) { { cards: true } }
+          let(:card_attrs) do
+            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links"]
+          end
+
+          it "should return only serialise the card data" do
+            card_keys = json_response[api_resource_name].map(&:keys).uniq.flatten
+            expect(card_keys).to match_array(card_attrs)
           end
         end
 

--- a/spec/lib/json_api_controller/relation_manager_spec.rb
+++ b/spec/lib/json_api_controller/relation_manager_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe JsonApiController::RelationManager do
-  # let!(:resource) { create(:subject_set_with_subjects) }
   let!(:resource) { create(:collection_with_subjects) }
 
   let(:test_class) do
@@ -110,7 +109,6 @@ describe JsonApiController::RelationManager do
       end
     end
   end
-
 
   describe "#destroy_relation" do
     let(:resource_to_remove) { resource.subjects[0..2] }

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -6,7 +6,6 @@ describe ProjectSerializer do
 
   let(:serializer) do
     s = ProjectSerializer.new
-
     s.instance_variable_set(:@model, project)
     s.instance_variable_set(:@context, context)
     s
@@ -26,6 +25,30 @@ describe ProjectSerializer do
               {"label" => "Twitter",
                "url" => "http://twitter.com/example"}]
       expect(serializer.urls).to eq(urls)
+    end
+  end
+
+  describe "#avatar_src" do
+    let(:avatar) { double("avatar", external_url: external_url, src: src) }
+    let(:src) { nil }
+    let(:external_url) { nil }
+
+    context "without external" do
+      let(:src) { "http://subject1.zooniverse.org" }
+
+      it "should return the src by default" do
+        allow(project).to receive(:avatar).and_return(avatar)
+        expect(serializer.avatar_src).to eq(src)
+      end
+    end
+
+    context "with an external url" do
+      let(:external_url) { "http://test.example.com" }
+
+      it "should return the external src if set" do
+        allow(project).to receive(:avatar).and_return(avatar)
+        expect(serializer.avatar_src).to eq(external)
+      end
     end
   end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -29,7 +29,7 @@ describe ProjectSerializer do
   end
 
   describe "#avatar_src" do
-    let(:avatar) { double("avatar", external_url: external_url, src: src) }
+    let(:avatar) { double("avatar", external_link: external_url, src: src) }
     let(:src) { nil }
     let(:external_url) { nil }
 
@@ -47,7 +47,7 @@ describe ProjectSerializer do
 
       it "should return the external src if set" do
         allow(project).to receive(:avatar).and_return(avatar)
-        expect(serializer.avatar_src).to eq(external)
+        expect(serializer.avatar_src).to eq(external_url)
       end
     end
   end


### PR DESCRIPTION
similar to #1552 but using the default v1 serializers to provide a slimmed down resource representation. I've also tried to optimise data sideloading eager loads and language queries from loaded / non-loaded associations. 

This PR uses the `?cards=true` params on the projects index route to get a cut down resource rep. Also benchmarking on my machine shows this route come in at ~85ms.

@marten @parrish thoughts? Also we could try out both this and the other PR and get the front end calling on the different override params for testing. 