### PR TITLE
Pass in the permissions scope to the fast project serializer

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def fast_index
-    render json_api: FastProjectSerializer.new(params).serialize
+    render json_api: FastProjectSerializer.new(controlled_resources, params).serialize
   end
 
   def index

--- a/lib/fast_project_serializer.rb
+++ b/lib/fast_project_serializer.rb
@@ -1,7 +1,8 @@
 class FastProjectSerializer
-  attr_accessor :params
+  attr_accessor :scope, :params
 
-  def initialize(params)
+  def initialize(scope, params)
+    @scope = scope
     @params = params
   end
 
@@ -21,7 +22,7 @@ class FastProjectSerializer
   end
 
   def query
-    @query ||= Project.where(launch_approved: true)
+    @query ||= scope.where(launch_approved: true)
       .order(:launched_row_order)
       .eager_load(:avatar, :project_contents)
   end

--- a/spec/lib/fast_project_serializer_spec.rb
+++ b/spec/lib/fast_project_serializer_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe FastProjectSerializer, type: :serializer do
   let(:params){ { } }
-  let(:serializer){ FastProjectSerializer.new params }
+  let(:scope){ Project } # fake the ACL'd scope
+  let(:serializer){ FastProjectSerializer.new scope, params }
 
   describe '#initialize' do
     let(:params){ { foo: 'bar' } }


### PR DESCRIPTION
Updates #1552 to use the permissions scope from the query.

Performance hit is around 20-25 ms for this (basically double).