### PR TITLE
Faster user search on login field

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::UsersController < Api::ApiController
 
   search_by do |name, query|
     search_names = name.join(" ")
-    login_search = query.where("lower(login) = '#{search_names.downcase}'")
+    login_search = query.where("lower(login) = ?", search_names.downcase)
     if login_search.exists?
       login_search
     else

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,7 +16,13 @@ class Api::V1::UsersController < Api::ApiController
   alias_method :user, :controlled_resource
 
   search_by do |name, query|
-    query.search_name(name.join(" "))
+    search_names = name.join(" ")
+    login_search = query.where("lower(login) = '#{search_names.downcase}'")
+    if login_search.exists?
+      login_search
+    else
+      query.search_name(search_names)
+    end
   end
 
   def me

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::UsersController < Api::ApiController
     if login_search.exists?
       login_search
     else
-      query.search_name(search_names)
+      query.full_search_login(search_names)
     end
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,13 +16,7 @@ class Api::V1::UsersController < Api::ApiController
   alias_method :user, :controlled_resource
 
   search_by do |name, query|
-    search_names = name.join(" ")
-    fast_search = query.search_name_fast(search_names)
-    if fast_search.exists?
-      fast_search
-    else
-      query.search_name(search_names)
-    end
+    query.search_name(name.join(" "))
   end
 
   def me

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,22 +70,14 @@ class User < ActiveRecord::Base
   can_be_linked :collection, :scope_for, :update, :user
 
   pg_search_scope :search_name,
-    against: [:login, :display_name],
-    using: { tsearch: {
-      prefix: true,
-      tsvector_column: "tsv"
-      },
-      trigram: {}
-    },
-    :ranked_by => ":tsearch + (0.25 * :trigram)"
-
-  pg_search_scope :search_name_fast,
     against: [:login],
-    using: { tsearch: {
-      prefix: true,
-      tsvector_column: "tsv"
-      }
-    }
+    using: {
+      tsearch: {
+        tsvector_column: "tsv"
+      },
+      trigram: { threshold: 0.8 }
+    },
+    ranked_by: ":trigram + (0.25 * :tsearch)"
 
   def self.scope_for(action, user, opts={})
     case

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,7 +160,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_by_lower_login(login)
-    find_by("lower(login) = '#{login.downcase}'")
+    find_by("lower(login) = ?", login.downcase)
   end
 
   def subject_limit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,11 +73,10 @@ class User < ActiveRecord::Base
     against: [:login],
     using: {
       tsearch: {
+        dictionary: "english",
         tsvector_column: "tsv"
-      },
-      trigram: { threshold: 0.8 }
-    },
-    ranked_by: ":trigram + (0.25 * :tsearch)"
+      }
+    }
 
   def self.scope_for(action, user, opts={})
     case

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ActiveRecord::Base
   can_be_linked :project, :scope_for, :update, :user
   can_be_linked :collection, :scope_for, :update, :user
 
-  pg_search_scope :search_name,
+  pg_search_scope :search_login,
     against: [:login],
     using: {
       tsearch: {
@@ -77,6 +77,21 @@ class User < ActiveRecord::Base
         tsvector_column: "tsv"
       }
     }
+
+  pg_search_scope :fuzzy_search_login,
+    against: [:login],
+    using: { trigram: {} }
+
+  pg_search_scope :full_search_login,
+    against: [:login],
+    using: {
+      tsearch: {
+        dictionary: "english",
+        tsvector_column: "tsv"
+      },
+      trigram: {}
+    },
+    ranked_by: ":tsearch + (0.25 * :trigram)"
 
   def self.scope_for(action, user, opts={})
     case

--- a/db/migrate/20150706185722_add_trigram_index_to_login.rb
+++ b/db/migrate/20150706185722_add_trigram_index_to_login.rb
@@ -1,7 +1,9 @@
 class AddTrigramIndexToLogin < ActiveRecord::Migration
-  def change
+  def up
     remove_index :users, name: "users_display_name_trgm_index"
-    add_index :users, name: "users_idx_trgm_login_display_name", using: :gin, operator_class: :gin_trgm_ops,
-      expression: %((coalesce("users"."login"::text, '') || ' ' || coalesce("users"."display_name"::text, '')) gin_trgm_ops)
+    execute <<-SQL
+      CREATE INDEX users_idx_trgm_login_display_name ON users
+      USING gin((coalesce("users"."login"::text, '') || ' ' || coalesce("users"."display_name"::text, '')) gin_trgm_ops);
+    SQL
   end
 end

--- a/db/migrate/20151117154126_add_user_login_trigram_index.rb
+++ b/db/migrate/20151117154126_add_user_login_trigram_index.rb
@@ -1,9 +1,8 @@
 class AddUserLoginTrigramIndex < ActiveRecord::Migration
   def up
-    add_index :users, name: "users_idx_trgm_login_display_name", using: :gin, operator_class: :gin_trgm_ops,
-      expression: %((coalesce("users"."login"::text, '') || ' ' || coalesce("users"."display_name"::text, '')) gin_trgm_ops)
-
     execute <<-SQL
+      CREATE INDEX users_idx_trgm_login_display_name ON users
+      USING gin((coalesce("users"."login"::text, '') || ' ' || coalesce("users"."display_name"::text, '')) gin_trgm_ops);
       DROP TRIGGER tsvectorupdate ON users;
 
       CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE

--- a/db/migrate/20151231123306_modify_user_trigram_search_index.rb
+++ b/db/migrate/20151231123306_modify_user_trigram_search_index.rb
@@ -1,0 +1,27 @@
+class ModifyUserTrigramSearchIndex < ActiveRecord::Migration
+  def up
+    remove_index :users, name: "users_idx_trgm_login_display_name"
+    execute <<-SQL
+      DROP TRIGGER tsvectorupdate ON users;
+
+      CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
+      ON users FOR EACH ROW EXECUTE PROCEDURE
+      tsvector_update_trigger(tsv, 'pg_catalog.english', login);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE INDEX users_idx_trgm_login_display_name ON users
+      USING gin((coalesce("users"."login"::text, '') || ' ' || coalesce("users"."display_name"::text, '')) gin_trgm_ops);
+
+      DROP TRIGGER tsvectorupdate ON users;
+
+      CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
+      ON users FOR EACH ROW EXECUTE PROCEDURE
+      tsvector_update_trigger(
+        tsv, 'pg_catalog.english', login, display_name
+      );
+    SQL
+  end
+end

--- a/db/migrate/20151231123306_modify_user_trigram_search_index.rb
+++ b/db/migrate/20151231123306_modify_user_trigram_search_index.rb
@@ -2,6 +2,9 @@ class ModifyUserTrigramSearchIndex < ActiveRecord::Migration
   def up
     remove_index :users, name: "users_idx_trgm_login_display_name"
     execute <<-SQL
+      CREATE INDEX users_idx_trgm_login
+      ON users USING gin(coalesce("users"."login"::text, '') gin_trgm_ops);
+
       DROP TRIGGER tsvectorupdate ON users;
 
       CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
@@ -11,6 +14,7 @@ class ModifyUserTrigramSearchIndex < ActiveRecord::Migration
   end
 
   def down
+    remove_index :users, name: "users_idx_trgm_login"
     execute <<-SQL
       CREATE INDEX users_idx_trgm_login_display_name ON users
       USING gin((coalesce("users"."login"::text, '') || ' ' || coalesce("users"."display_name"::text, '')) gin_trgm_ops);

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2513,24 +2513,17 @@ CREATE INDEX user_groups_display_name_trgm_index ON user_groups USING gist (disp
 
 
 --
--- Name: users_idx_trgm_login_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX users_idx_trgm_login_display_name ON users USING gin ((((COALESCE((login)::text, ''::text) || ' '::text) || COALESCE((display_name)::text, ''::text))) gin_trgm_ops);
-
-
---
--- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'login', 'display_name');
-
-
---
 -- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'display_name');
+
+
+--
+-- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'login');
 
 
 --
@@ -2844,6 +2837,8 @@ INSERT INTO schema_migrations (version) VALUES ('20151207111508');
 INSERT INTO schema_migrations (version) VALUES ('20151207145728');
 
 INSERT INTO schema_migrations (version) VALUES ('20151210134819');
+
+INSERT INTO schema_migrations (version) VALUES ('20151231123306');
 
 INSERT INTO schema_migrations (version) VALUES ('20160104131622');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2513,17 +2513,17 @@ CREATE INDEX user_groups_display_name_trgm_index ON user_groups USING gist (disp
 
 
 --
--- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'display_name');
-
-
---
 -- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX users_idx_trgm_login ON users USING gin ((COALESCE((login)::text, ''::text)) gin_trgm_ops);
+
+
+--
+-- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'display_name');
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2520,6 +2520,13 @@ CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON projects FOR EACH ROW E
 
 
 --
+-- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX users_idx_trgm_login ON users USING gin ((COALESCE((login)::text, ''::text)) gin_trgm_ops);
+
+
+--
 -- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -187,14 +187,12 @@ describe Api::V1::UsersController, type: :controller do
 
       describe "search" do
         context "by display_name" do
-          context "matching login field " do
+          context "fuzzy matching against the login field " do
             let(:display_name) { user.display_name }
             let(:index_options) { { search: display_name } }
 
-            it "should respond with the login user match", :aggregate_failures do
-              api_resources = json_response[api_resource_name]
-              expect(api_resources.length).to eq(1)
-              expect(api_resources[0]['display_name']).to eq(display_name)
+            it "should respond with both login matches" do
+              expect(json_response[api_resource_name].length).to eq(2)
             end
           end
 
@@ -223,25 +221,41 @@ describe Api::V1::UsersController, type: :controller do
             end
 
             it "should respond with the correct item" do
-              expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+              result = json_response[api_resource_name][0]['display_name']
+              expect(result).to eq(user.display_name)
             end
           end
 
-          context "with partial string" do
-            let(:index_options) { { search: user.login[0..1] } }
+          context "with partial strings" do
+            let(:index_options) { { search: partial } }
 
-            it "should not find any users" do
-              expect(json_response[api_resource_name].length).to eq(0)
+            context "partials that don't hit any trigrams" do
+              let(:partial) { user.login[0..1] }
+
+              it "should not find any users" do
+                expect(json_response[api_resource_name].length).to eq(0)
+              end
+            end
+
+            context "partials that match the trigrams" do
+              let(:partial) { user.login[0..2] }
+
+              it "should find both users" do
+                expect(json_response[api_resource_name].length).to eq(2)
+              end
             end
           end
 
           context "with hard to find tsvector" do
             let(:hard_name) { "S_Powell" }
-            let(:hard_user) { create(:user, login: hard_name, display_name: hard_name )}
+            let(:hard_user) do
+              create(:user, login: hard_name, display_name: hard_name)
+            end
             let(:index_options) { { search: hard_user.login } }
 
             it "should respond with the hard user" do
-              expect(created_instance_id(api_resource_name)).to eq(hard_user.id.to_s)
+              result_id = created_instance_id(api_resource_name)
+              expect(result_id).to eq(hard_user.id.to_s)
             end
           end
         end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -186,29 +186,28 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       describe "search" do
+        context "by display_name" do
+          context "matching login field " do
+            let(:display_name) { user.display_name }
+            let(:index_options) { { search: display_name } }
 
-        context "display_name" do
-          let(:index_options) { { search: user.display_name } }
-
-          it "should respond with the correct user", :aggregate_failures do
-            expect(json_response[api_resource_name].length).to eq(1)
-            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+            it "should respond with the login user match", :aggregate_failures do
+              api_resources = json_response[api_resource_name]
+              expect(api_resources.length).to eq(1)
+              expect(api_resources[0]['display_name']).to eq(display_name)
+            end
           end
 
-          context "with a limited page size" do
-            let(:index_options) { { search: user.display_name, page_size: 1 } }
+          context "non-matching display_name or login" do
+            let(:index_options) { { search: "bill murray" } }
 
-            it "should respond with 1 item" do
-              expect(json_response[api_resource_name].length).to eq(1)
-            end
-
-            it "should respond with the correct item" do
-              expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+            it "should not return any data" do
+              expect(json_response[api_resource_name].length).to eq(0)
             end
           end
         end
 
-        context "login" do
+        context "by login" do
           let(:index_options) { { search: user.login } }
 
           it "should respond with the correct user", :aggregate_failures do
@@ -231,8 +230,8 @@ describe Api::V1::UsersController, type: :controller do
           context "with partial string" do
             let(:index_options) { { search: user.login[0..1] } }
 
-            it "should respond with both users" do
-              expect(json_response[api_resource_name].length).to eq(2)
+            it "should not find any users" do
+              expect(json_response[api_resource_name].length).to eq(0)
             end
           end
 


### PR DESCRIPTION
closes #1554 - limit user search scopes to login field only, removed the prefix matching and updated trigram to use indexes. This will now attempt to find a user by login field and if missing try and match on a full search using tsvectors and trigram (fuzzy). 

Note, tsvectors can return large, similar rank results sets for similar strings so the fuzzy matching is used in the rank to tie break, in my testing it worked well so limiting the page size (like the front-end does) should return the most relevant hits first.