### PR TITLE
pg search indexes

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -28,6 +28,6 @@ class Collection < ActiveRecord::Base
 
   pg_search_scope :search_display_name,
     against: :display_name,
-    using: { trigram: { threshold: 0.1 } },
+    using: :trigram,
     ranked_by: ":trigram"
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -74,8 +74,9 @@ class Project < ActiveRecord::Base
 
   pg_search_scope :search_display_name,
     against: :display_name,
-    using: { tsearch: {
-        prefix: true,
+    using: {
+      tsearch: {
+        dictionary: "english",
         tsvector_column: "tsv"
       },
       trigram: {}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ActiveRecord::Base
   can_be_linked :project, :scope_for, :update, :user
   can_be_linked :collection, :scope_for, :update, :user
 
-  pg_search_scope :search_login,
+  pg_search_scope :search_name,
     against: [:login],
     using: {
       tsearch: {

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -45,7 +45,7 @@ class UserGroup < ActiveRecord::Base
               roles: [ :group_admin, :collection_editor ]
 
   pg_search_scope :search_name,
-    against: [:name, :display_name],
+    against: :display_name,
     using: :trigram,
     ranked_by: ":trigram"
 

--- a/db/migrate/20160103142817_ensure_trigram_searc_indexes.rb
+++ b/db/migrate/20160103142817_ensure_trigram_searc_indexes.rb
@@ -1,0 +1,27 @@
+class EnsureTrigramSearcIndexes < ActiveRecord::Migration
+  def up
+    tables = %i(projects collections user_groups)
+    tables.each do |table|
+      remove_index table, name: "#{table}_display_name_trgm_index"
+      execute <<-SQL
+        CREATE INDEX "index_#{table}_display_name_trgrm"
+        ON "#{table}"
+        USING gin(
+          coalesce("#{table}"."display_name"::text, '')
+          gin_trgm_ops
+        );
+      SQL
+    end
+  end
+
+  def down
+    tables = %i(projects collections user_groups)
+    tables.each do |table|
+      remove_index table, name: "index_#{table}_display_name_trgrm"
+      add_index table, :display_name,
+        name: "#{table}_display_name_trgm_index",
+        operator_class: :gist_trgm_ops,
+        using: :gist
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1792,13 +1792,6 @@ CREATE UNIQUE INDEX classification_subjects_pk ON classification_subjects USING 
 
 
 --
--- Name: collections_display_name_trgm_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX collections_display_name_trgm_index ON collections USING gist (display_name gist_trgm_ops);
-
-
---
 -- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1922,6 +1915,13 @@ CREATE INDEX index_classifications_on_workflow_id ON classifications USING btree
 --
 
 CREATE INDEX index_classifications_on_workflow_version ON classifications USING btree (workflow_version);
+
+
+--
+-- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_collections_display_name_trgrm ON collections USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
@@ -2062,6 +2062,13 @@ CREATE INDEX index_project_pages_on_language ON project_pages USING btree (langu
 --
 
 CREATE INDEX index_project_pages_on_project_id ON project_pages USING btree (project_id);
+
+
+--
+-- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_projects_display_name_trgrm ON projects USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
@@ -2317,6 +2324,13 @@ CREATE INDEX index_user_collection_preferences_on_user_id ON user_collection_pre
 
 
 --
+-- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_user_groups_display_name_trgrm ON user_groups USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
+
+
+--
 -- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2485,13 +2499,6 @@ CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tu
 
 
 --
--- Name: projects_display_name_trgm_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX projects_display_name_trgm_index ON projects USING gist (display_name gist_trgm_ops);
-
-
---
 -- Name: tags_name_trgm_idx; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2503,13 +2510,6 @@ CREATE INDEX tags_name_trgm_idx ON tags USING gin (name gin_trgm_ops);
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
-
-
---
--- Name: user_groups_display_name_trgm_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX user_groups_display_name_trgm_index ON user_groups USING gist (display_name gist_trgm_ops);
 
 
 --
@@ -2846,6 +2846,8 @@ INSERT INTO schema_migrations (version) VALUES ('20151207145728');
 INSERT INTO schema_migrations (version) VALUES ('20151210134819');
 
 INSERT INTO schema_migrations (version) VALUES ('20151231123306');
+
+INSERT INTO schema_migrations (version) VALUES ('20160103142817');
 
 INSERT INTO schema_migrations (version) VALUES ('20160104131622');
 


### PR DESCRIPTION
waiting on #1565 - i reviewed the use of search indexes and made some changes. 

1. notably never use a trigram threshold as it currently will [not use an index](https://github.com/Casecommons/pg_search/issues/278).
2. don't use prefixes for tsvectors just use the trigram properly for fuzzy matches.
3. user_groups only search the display name for trigrams to keep the index size down.
4. use gin trigram op indexes, i couldn't get the derived pg_search queries to use the gist indexes.