### PR TITLE
fallback selection should return some data

### DIFF
--- a/app/workers/enqueue_subject_queue_worker.rb
+++ b/app/workers/enqueue_subject_queue_worker.rb
@@ -56,8 +56,8 @@ class EnqueueSubjectQueueWorker
   end
 
   def default_strategy_sms_ids
-    Subjects::PostgresqlSelection.new(workflow, user)
-    .select(limit: limit, subject_set_id: subject_set_id)
+    opts = { limit: limit, subject_set_id: subject_set_id }
+    Subjects::PostgresqlSelection.new(workflow, user, opts).select
   end
 
   def workflow_strategy

--- a/app/workers/reload_non_logged_in_queue_worker.rb
+++ b/app/workers/reload_non_logged_in_queue_worker.rb
@@ -17,7 +17,7 @@ class ReloadNonLoggedInQueueWorker
   private
 
   def selected_subject_ids(workflow, subject_set_id)
-    Subjects::PostgresqlSelection.new(workflow, nil)
-    .select(limit: SubjectQueue::DEFAULT_LENGTH, subject_set_id: subject_set_id)
+    opts = { limit: SubjectQueue::DEFAULT_LENGTH, subject_set_id: subject_set_id }
+    Subjects::PostgresqlSelection.new(workflow, nil, opts).select
   end
 end

--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -2,12 +2,12 @@ module Subjects
   class PostgresqlSelection
     attr_reader :workflow, :user, :opts
 
-    def initialize(workflow, user=nil)
-      @workflow, @user = workflow, user
+    def initialize(workflow, user=nil, options={})
+      @workflow, @user, @opts = workflow, user, options
     end
 
-    def select(options={})
-      @opts = options
+    def select(limit_override=nil)
+      @limit_override = limit_override
       results = case selection_strategy
       when :in_order
         select_results_in_order
@@ -17,8 +17,8 @@ module Subjects
       results.take(limit)
     end
 
-    def any_workflow_data(options={})
-      @opts = options
+    def any_workflow_data(limit_override=nil)
+      @limit_override = limit_override
       any_workflow_data_scope
       .order(random: [:asc, :desc].sample)
       .limit(limit)
@@ -58,7 +58,11 @@ module Subjects
     end
 
     def limit
-      @limit ||= opts.fetch(:limit, 20).to_i
+      if @limit_override
+        @limit_override
+      else
+        @limit ||= opts.fetch(:limit, 20).to_i
+      end
     end
 
     def selection_strategy

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -40,11 +40,11 @@ module Subjects
     end
 
     def fallback_selection(limit=5)
-      selector = PostgresqlSelection.new(workflow, user.user)
       opts = { limit: limit, subject_set_id: subject_set_id }
-      sms_ids = selector.select(opts)
+      selector = PostgresqlSelection.new(workflow, user.user, opts)
+      sms_ids = selector.select
       return sms_ids unless sms_ids.blank?
-      selector.any_workflow_data(opts)
+      selector.any_workflow_data
     end
 
     def needs_set_id?

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Subjects::PostgresqlSelection do
     end
   end
 
-  describe "#select" do
+  describe "selection" do
     let(:user) { User.first }
     let(:workflow) { Workflow.first }
     let(:sms) { SetMemberSubject.all }
@@ -86,109 +86,145 @@ RSpec.describe Subjects::PostgresqlSelection do
       DatabaseCleaner.clean_with(:deletion)
     end
 
-    describe "random selection" do
-      subject { Subjects::PostgresqlSelection.new(workflow, user) }
+    describe "#select" do
+      describe "random selection" do
+        subject { Subjects::PostgresqlSelection.new(workflow, user) }
 
-      it_behaves_like "select for incomplete_project"
+        it_behaves_like "select for incomplete_project"
 
-      it "should reassign the random attribute after selection" do
-        allow(subject).to receive(:reassign_random?).and_return(true)
-        expect(RandomOrderShuffleWorker).to receive(:perform_async).once
-        results = subject.select
-      end
+        it "should reassign the random attribute after selection" do
+          allow(subject).to receive(:reassign_random?).and_return(true)
+          expect(RandomOrderShuffleWorker).to receive(:perform_async).once
+          results = subject.select
+        end
 
-      it "should give up trying to construct a random list after set number of attempts" do
-        unreachable_limit = SetMemberSubject.count + 1
-        allow_any_instance_of(subject.class).to receive(:available_count).and_return(unreachable_limit + 1)
-        allow_any_instance_of(subject.class).to receive(:limit).and_return(unreachable_limit)
-        results = subject.select
-        expect(results).to eq(results)
-      end
-    end
-
-    context "grouped selection" do
-      subject { Subjects::PostgresqlSelection.new(workflow, user) }
-
-      before(:each) do
-        allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
-      end
-
-      it_behaves_like "select for incomplete_project" do
-        let(:args) { {subject_set_id: workflow.subject_sets.first.id} }
-      end
-
-      it 'should only select subjects in the specified group' do
-        create(:user_seen_subject,
-               user: user,
-               subject_ids: sms.sample(5).map(&:subject_id),
-               workflow: workflow)
-        set_id = workflow.subject_sets.first.id
-        result_ids = subject.select(subject_set_id: set_id)
-        sms_subject_ids = SetMemberSubject.where(id: result_ids).pluck(:subject_set_id)
-        expect(sms_subject_ids).to all( eq(set_id) )
-      end
-    end
-
-    describe "priority selection" do
-      subject { Subjects::PostgresqlSelection.new(workflow, user) }
-      let(:ordered) { sms.order(priority: :asc).pluck(:id) }
-
-      before(:each) do
-        update_sms_priorities
-        allow_any_instance_of(Workflow).to receive(:prioritized).and_return(true)
-      end
-
-      it_behaves_like "select for incomplete_project"
-
-      it 'should select subjects in asc order of the priority field' do
-        result = subject.select(limit: ordered.size)
-        expect(result).to eq(ordered)
-      end
-
-      it 'should ignore any order param on the priority field' do
-        result = subject.select(limit: ordered.size, order: :desc)
-        expect(result).to eq(ordered)
-      end
-
-      it 'should allow negative numbers to prepend the sort list' do
-        sms_subject = create(:subject,project: workflow.project, uploader: user)
-        sms = create(:set_member_subject, subject: sms_subject,
-          subject_set: workflow.subject_sets.first, priority: -10.to_f)
-        first_id = subject.select(limit: 1).first
-        expect(first_id).to eq(sms.id)
-      end
-    end
-
-    describe "priority and grouped selection" do
-      subject { Subjects::PostgresqlSelection.new(workflow, user) }
-
-      before(:each) do
-        %i( prioritized grouped ).each do |method|
-          allow_any_instance_of(Workflow).to receive(method).and_return(true)
+        it "should give up trying to construct a random list after set number of attempts" do
+          unreachable_limit = SetMemberSubject.count + 1
+          allow_any_instance_of(subject.class).to receive(:available_count).and_return(unreachable_limit + 1)
+          allow_any_instance_of(subject.class).to receive(:limit).and_return(unreachable_limit)
+          results = subject.select
+          expect(results).to eq(results)
         end
       end
 
-      before(:all) do
-        update_sms_priorities
-        created_workflow = Workflow.first
-        subject_set = created_workflow.subject_sets.last
-        latest_priority = SetMemberSubject.where.not(priority: nil).order(priority: :desc).limit(1).pluck(:priority).first
-        create_list(:subject, 12, project: created_workflow.project, uploader: User.first).each_with_index do |subject, index|
-          create(:set_member_subject, priority: latest_priority+index+1, subject: subject, subject_set: subject_set)
+      context "grouped selection" do
+        subject { Subjects::PostgresqlSelection.new(workflow, user) }
+
+        before(:each) do
+          allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
+        end
+
+        it_behaves_like "select for incomplete_project" do
+          let(:args) { {subject_set_id: workflow.subject_sets.first.id} }
+        end
+
+        it 'should only select subjects in the specified group' do
+          create(:user_seen_subject,
+                 user: user,
+                 subject_ids: sms.sample(5).map(&:subject_id),
+                 workflow: workflow)
+          set_id = workflow.subject_sets.first.id
+          result_ids = subject.select(subject_set_id: set_id)
+          sms_subject_ids = SetMemberSubject.where(id: result_ids).pluck(:subject_set_id)
+          expect(sms_subject_ids).to all( eq(set_id) )
         end
       end
 
-      let(:subject_set_id) { SubjectSet.first.id }
-      let(:sms) { SetMemberSubject.where(subject_set_id: subject_set_id) }
+      describe "priority selection" do
+        subject { Subjects::PostgresqlSelection.new(workflow, user) }
+        let(:ordered) { sms.order(priority: :asc).pluck(:id) }
 
-      it_behaves_like "select for incomplete_project" do
-        let(:args) { {subject_set_id: subject_set_id} }
+        before(:each) do
+          update_sms_priorities
+          allow_any_instance_of(Workflow).to receive(:prioritized).and_return(true)
+        end
+
+        it_behaves_like "select for incomplete_project"
+
+        it 'should select subjects in asc order of the priority field' do
+          result = subject.select(limit: ordered.size)
+          expect(result).to eq(ordered)
+        end
+
+        it 'should ignore any order param on the priority field' do
+          result = subject.select(limit: ordered.size, order: :desc)
+          expect(result).to eq(ordered)
+        end
+
+        it 'should allow negative numbers to prepend the sort list' do
+          sms_subject = create(:subject,project: workflow.project, uploader: user)
+          sms = create(:set_member_subject, subject: sms_subject,
+            subject_set: workflow.subject_sets.first, priority: -10.to_f)
+          first_id = subject.select(limit: 1).first
+          expect(first_id).to eq(sms.id)
+        end
       end
 
-      it 'should only select subjects in the specified group' do
-        result = subject.select(subject_set_id: subject_set_id)
-        ordered = sms.limit(result.length).order(priority: :asc).pluck(:id)
-        expect(result).to eq(ordered)
+      describe "priority and grouped selection" do
+        subject { Subjects::PostgresqlSelection.new(workflow, user) }
+
+        before(:each) do
+          %i( prioritized grouped ).each do |method|
+            allow_any_instance_of(Workflow).to receive(method).and_return(true)
+          end
+        end
+
+        before(:all) do
+          update_sms_priorities
+          created_workflow = Workflow.first
+          subject_set = created_workflow.subject_sets.last
+          latest_priority = SetMemberSubject.where.not(priority: nil).order(priority: :desc).limit(1).pluck(:priority).first
+          create_list(:subject, 12, project: created_workflow.project, uploader: User.first).each_with_index do |subject, index|
+            create(:set_member_subject, priority: latest_priority+index+1, subject: subject, subject_set: subject_set)
+          end
+        end
+
+        let(:subject_set_id) { SubjectSet.first.id }
+        let(:sms) { SetMemberSubject.where(subject_set_id: subject_set_id) }
+
+        it_behaves_like "select for incomplete_project" do
+          let(:args) { {subject_set_id: subject_set_id} }
+        end
+
+        it 'should only select subjects in the specified group' do
+          result = subject.select(subject_set_id: subject_set_id)
+          ordered = sms.limit(result.length).order(priority: :asc).pluck(:id)
+          expect(result).to eq(ordered)
+        end
+      end
+    end
+
+    describe "#any_workflow_data" do
+      subject { Subjects::PostgresqlSelection.new(workflow, user) }
+      let(:subject_set_id) { nil }
+      let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
+      let(:expected_ids) { workflow.subjects.pluck("subjects.id") }
+      let(:subject_ids) { subject.any_workflow_data(opts) }
+
+      it "should select some data from the workflow" do
+        expect(expected_ids).to include(*subject_ids)
+      end
+
+      context "grouped workflow" do
+        let(:subject_set_id) { SubjectSet.first.id }
+
+        before(:each) do
+          allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
+        end
+
+        it "should select some data from the group" do
+          expect(expected_ids).to include(*subject_ids)
+        end
+
+        context "without a subject_set_id param" do
+          let(:subject_set_id) { nil }
+
+          it "should raise an error" do
+            expect {
+              subject_ids
+            }.to raise_error(Subjects::Selector::MissingParameter)
+          end
+        end
       end
     end
   end

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -213,7 +213,9 @@ RSpec.describe Subjects::PostgresqlSelection do
     describe "#any_workflow_data" do
       let(:subject_set_id) { nil }
       let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
-      let(:expected_ids) { workflow.subjects.pluck("subjects.id") }
+      let(:expected_ids) do
+        workflow.set_member_subjects.pluck("set_member_subjects.id")
+      end
       let(:subject_ids) { subject.any_workflow_data }
 
       it "should select some data from the workflow" do

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Subjects::PostgresqlSelection do
   end
 
   shared_examples "select for incomplete_project" do
-    let(:args) { {} }
+    let(:args) { opts }
+    subject { Subjects::PostgresqlSelection.new(workflow, user, args) }
+
     let(:sms_scope) do
       if ss_id = args[:subject_set_id]
         SetMemberSubject.where(subject_set_id: ss_id)
@@ -17,6 +19,7 @@ RSpec.describe Subjects::PostgresqlSelection do
         SetMemberSubject.all
       end
     end
+
     let(:unseen_count) do
       _seen_count = if ss_id = args[:subject_set_id]
         group_sms = SetMemberSubject.where(subject_set_id: ss_id)
@@ -29,25 +32,35 @@ RSpec.describe Subjects::PostgresqlSelection do
 
     context "when a user has only seen a few subjects" do
       let(:seen_count) { 5 }
+      let(:limit) { nil }
+      let(:args) { opts.merge(limit: limit) }
       let!(:uss) do
         subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
         create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
       end
 
-      it 'should return an unseen subject' do
-        expect(uss.subject_ids).to_not include(subject.select(**args.merge(limit: 1)).first)
+      context "with a limit of 1" do
+        let(:limit) { 1 }
+
+        it 'should return an unseen subject' do
+          expect(uss.subject_ids).to_not include(subject.select.first)
+        end
       end
 
-      it 'should no have duplicates' do
-        result = subject.select(**args.merge(limit: 10))
-        expect(result).to match_array(result.to_a.uniq)
+      context "with a limit of 10" do
+        let(:limit) { 10 }
+
+        it 'should no have duplicates' do
+          result = subject.select
+          expect(result).to match_array(result.to_a.uniq)
+        end
       end
 
       #account for the loop cut off limit constructing the random sample
       it 'should always return an approximate sample of subjects up to the unseen limit' do
         unseen_count.times do |n|
           limit = n+1
-          results_size = subject.select(**args.merge(limit: limit)).length
+          results_size = subject.select(limit).length
           expect(results_size).to be_between(results_size, limit).inclusive
         end
       end
@@ -63,7 +76,7 @@ RSpec.describe Subjects::PostgresqlSelection do
       it 'should return as many subjects as possible' do
         unseen_count.times do |n|
           limit = n+unseen_count
-          results_size = subject.select(**args.merge(limit: limit)).length
+          results_size = subject.select(limit).length
           expect(results_size).to be_between(results_size, limit).inclusive
         end
       end
@@ -74,6 +87,8 @@ RSpec.describe Subjects::PostgresqlSelection do
     let(:user) { User.first }
     let(:workflow) { Workflow.first }
     let(:sms) { SetMemberSubject.all }
+    let(:opts) { {} }
+    subject { Subjects::PostgresqlSelection.new(workflow, user, opts) }
 
     before(:all) do
       uploader = create(:user)
@@ -88,8 +103,6 @@ RSpec.describe Subjects::PostgresqlSelection do
 
     describe "#select" do
       describe "random selection" do
-        subject { Subjects::PostgresqlSelection.new(workflow, user) }
-
         it_behaves_like "select for incomplete_project"
 
         it "should reassign the random attribute after selection" do
@@ -108,31 +121,29 @@ RSpec.describe Subjects::PostgresqlSelection do
       end
 
       context "grouped selection" do
-        subject { Subjects::PostgresqlSelection.new(workflow, user) }
-
+        let(:subject_set_id) { workflow.subject_sets.first.id }
+        let(:opts) { {subject_set_id: subject_set_id} }
         before(:each) do
           allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
         end
 
-        it_behaves_like "select for incomplete_project" do
-          let(:args) { {subject_set_id: workflow.subject_sets.first.id} }
-        end
+        it_behaves_like "select for incomplete_project"
 
         it 'should only select subjects in the specified group' do
           create(:user_seen_subject,
                  user: user,
                  subject_ids: sms.sample(5).map(&:subject_id),
                  workflow: workflow)
-          set_id = workflow.subject_sets.first.id
-          result_ids = subject.select(subject_set_id: set_id)
+          result_ids = subject.select
           sms_subject_ids = SetMemberSubject.where(id: result_ids).pluck(:subject_set_id)
-          expect(sms_subject_ids).to all( eq(set_id) )
+          expect(sms_subject_ids).to all( eq(subject_set_id) )
         end
       end
 
       describe "priority selection" do
-        subject { Subjects::PostgresqlSelection.new(workflow, user) }
         let(:ordered) { sms.order(priority: :asc).pluck(:id) }
+        let(:limit) { ordered.size }
+        let(:opts) { { limit: limit } }
 
         before(:each) do
           update_sms_priorities
@@ -142,26 +153,36 @@ RSpec.describe Subjects::PostgresqlSelection do
         it_behaves_like "select for incomplete_project"
 
         it 'should select subjects in asc order of the priority field' do
-          result = subject.select(limit: ordered.size)
+          result = subject.select
           expect(result).to eq(ordered)
         end
 
-        it 'should ignore any order param on the priority field' do
-          result = subject.select(limit: ordered.size, order: :desc)
-          expect(result).to eq(ordered)
+        context "with order by param" do
+          let(:opts) { { limit: ordered.size, order: :desc } }
+
+          it 'should ignore any order param on the priority field' do
+            result = subject.select
+            expect(result).to eq(ordered)
+          end
         end
 
-        it 'should allow negative numbers to prepend the sort list' do
-          sms_subject = create(:subject,project: workflow.project, uploader: user)
-          sms = create(:set_member_subject, subject: sms_subject,
-            subject_set: workflow.subject_sets.first, priority: -10.to_f)
-          first_id = subject.select(limit: 1).first
-          expect(first_id).to eq(sms.id)
+        context "with 1 limit for prepend test" do
+          let(:limit) { 1 }
+
+          it 'should allow negative numbers to prepend the sort list' do
+            sms_subject = create(:subject,project: workflow.project, uploader: user)
+            sms = create(:set_member_subject, subject: sms_subject,
+              subject_set: workflow.subject_sets.first, priority: -10.to_f)
+            first_id = subject.select.first
+            expect(first_id).to eq(sms.id)
+          end
         end
       end
 
       describe "priority and grouped selection" do
-        subject { Subjects::PostgresqlSelection.new(workflow, user) }
+        let(:opts) { { subject_set_id: subject_set_id } }
+        let(:subject_set_id) { SubjectSet.first.id }
+        let(:sms) { SetMemberSubject.where(subject_set_id: subject_set_id) }
 
         before(:each) do
           %i( prioritized grouped ).each do |method|
@@ -179,15 +200,10 @@ RSpec.describe Subjects::PostgresqlSelection do
           end
         end
 
-        let(:subject_set_id) { SubjectSet.first.id }
-        let(:sms) { SetMemberSubject.where(subject_set_id: subject_set_id) }
-
-        it_behaves_like "select for incomplete_project" do
-          let(:args) { {subject_set_id: subject_set_id} }
-        end
+        it_behaves_like "select for incomplete_project"
 
         it 'should only select subjects in the specified group' do
-          result = subject.select(subject_set_id: subject_set_id)
+          result = subject.select
           ordered = sms.limit(result.length).order(priority: :asc).pluck(:id)
           expect(result).to eq(ordered)
         end
@@ -195,11 +211,10 @@ RSpec.describe Subjects::PostgresqlSelection do
     end
 
     describe "#any_workflow_data" do
-      subject { Subjects::PostgresqlSelection.new(workflow, user) }
       let(:subject_set_id) { nil }
       let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
       let(:expected_ids) { workflow.subjects.pluck("subjects.id") }
-      let(:subject_ids) { subject.any_workflow_data(opts) }
+      let(:subject_ids) { subject.any_workflow_data }
 
       it "should select some data from the workflow" do
         expect(expected_ids).to include(*subject_ids)

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Subjects::Selector do
   let(:workflow) { create(:workflow_with_subjects) }
   let(:user) { ApiUser.new(create(:user)) }
   let(:smses) { create_list(:set_member_subject, 10).reverse }
-
+  let(:params) { {} }
   let(:subject_queue) do
     create(:subject_queue,
            workflow: workflow,
@@ -13,7 +13,7 @@ RSpec.describe Subjects::Selector do
            set_member_subjects: smses)
   end
 
-  subject { described_class.new(user, workflow, {}, Subject.all)}
+  subject { described_class.new(user, workflow, params, Subject.all)}
 
   describe "#queued_subjects" do
 
@@ -45,7 +45,8 @@ RSpec.describe Subjects::Selector do
     context "when the params page size is set as a string" do
       let(:size) { 2 }
       subject do
-        described_class.new(user, workflow, {page_size: "#{size}"}, Subject.all)
+        params = { page_size: "#{size}" }
+        described_class.new(user, workflow, params, Subject.all)
       end
 
       it 'should return the page_size number of subjects' do
@@ -60,32 +61,48 @@ RSpec.describe Subjects::Selector do
         create(:subject_queue,
                workflow: workflow,
                user: user.user,
-               subject_set: nil,
+               subject_set: queue_subject_set,
                set_member_subjects: [])
       end
-      let!(:subjects) { create_list(:set_member_subject, 10, subject_set: workflow.subject_sets.first) }
+      let(:subject_set) { workflow.subject_sets.first }
+      let(:queue_subject_set) { nil }
+
+      before do
+        create_list(:set_member_subject, 10, subject_set: subject_set)
+        subject_queue
+      end
 
       it 'should return 5 subjects' do
-        subject_queue
         subjects, _ = subject.queued_subjects
         expect(subjects.length).to eq(5)
       end
 
       context "when the database selection strategy returns an empty set" do
-        let(:non_logged_in_queue) do
-          create(:subject_queue,
-                 workflow: workflow,
-                 user: nil,
-                 subject_set: nil,
-                 set_member_subjects: smses)
+        let(:queue_subject_set) { subject_set }
+
+        before do
+          allow_any_instance_of(Subjects::PostgresqlSelection)
+          .to receive(:select).and_return([])
         end
 
-        it 'should fallback to the non-logged in queue data' do
-          allow_any_instance_of(Subjects::PostgresqlSelection).to receive(:select).and_return([])
-          subject_queue
-          non_logged_in_queue
+        it 'should fallback to selecting some data' do
           subjects, _context = subject.queued_subjects
-          expect(smses.map(&:subject)).to include(*subjects)
+          expect(workflow.subjects).to include(*subjects)
+        end
+
+        context "and the workflow is grouped" do
+          let(:params) { { subject_set_id: subject_set.id } }
+          let(:expected_ids) do
+            workflow
+            .set_member_subjects.where(subject_set: subject_set)
+            .pluck("set_member_subjects.subject_id")
+          end
+
+          it 'should fallback to selecting some grouped data' do
+            allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
+            subjects, _context = subject.queued_subjects
+            expect(expected_ids).to include(*subjects.map(&:id))
+          end
         end
       end
     end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -83,13 +83,12 @@ RSpec.describe Subjects::Selector do
         before do
           allow_any_instance_of(Subjects::PostgresqlSelection)
           .to receive(:select).and_return([])
+          expect_any_instance_of(Subjects::PostgresqlSelection)
+            .to receive(:any_workflow_data)
+            .and_call_original
         end
 
         it 'should fallback to selecting some data' do
-          expect_any_instance_of(Subjects::PostgresqlSelection)
-            .to receive(:any_workflow_data)
-            .with(limit: 5, subject_set_id: nil)
-            .and_call_original
           subjects, _context = subject.queued_subjects
         end
 
@@ -99,10 +98,6 @@ RSpec.describe Subjects::Selector do
 
           it 'should fallback to selecting some grouped data' do
             allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
-            expect_any_instance_of(Subjects::PostgresqlSelection)
-              .to receive(:any_workflow_data)
-              .with(limit: 5, subject_set_id: subject_set_id)
-              .and_call_original
             subjects, _context = subject.queued_subjects
           end
         end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -86,22 +86,24 @@ RSpec.describe Subjects::Selector do
         end
 
         it 'should fallback to selecting some data' do
+          expect_any_instance_of(Subjects::PostgresqlSelection)
+            .to receive(:any_workflow_data)
+            .with(limit: 5, subject_set_id: nil)
+            .and_call_original
           subjects, _context = subject.queued_subjects
-          expect(workflow.subjects).to include(*subjects)
         end
 
         context "and the workflow is grouped" do
-          let(:params) { { subject_set_id: subject_set.id } }
-          let(:expected_ids) do
-            workflow
-            .set_member_subjects.where(subject_set: subject_set)
-            .pluck("set_member_subjects.subject_id")
-          end
+          let(:subject_set_id) { subject_set.id }
+          let(:params) { { subject_set_id: subject_set_id } }
 
           it 'should fallback to selecting some grouped data' do
             allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
+            expect_any_instance_of(Subjects::PostgresqlSelection)
+              .to receive(:any_workflow_data)
+              .with(limit: 5, subject_set_id: subject_set_id)
+              .and_call_original
             subjects, _context = subject.queued_subjects
-            expect(expected_ids).to include(*subjects.map(&:id))
           end
         end
       end


### PR DESCRIPTION
non-logged in queues may not replenish via the subject selector for grouped selection. So this will now instead just return some data from the workflow taking into account the group if set.