### PR TITLE
Only use cellect when global config and the workflow settings match

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -41,7 +41,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
     if subject_set.set_member_subjects.exists?
       subject_set.workflows.each do |w|
         ReloadNonLoggedInQueueWorker.perform_async(w.id, subject_set.id)
-        if Panoptes.cellect_on && w.using_cellect?
+        if Panoptes.use_cellect?(w)
           ReloadCellectWorker.perform_async(w.id)
         end
       end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -41,7 +41,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
     if subject_set.set_member_subjects.exists?
       subject_set.workflows.each do |w|
         ReloadNonLoggedInQueueWorker.perform_async(w.id, subject_set.id)
-        if Panoptes.cellect_on
+        if Panoptes.cellect_on && w.using_cellect?
           ReloadCellectWorker.perform_async(w.id)
         end
       end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::WorkflowsController < Api::ApiController
       reload_queue_subject_sets(workflow).each do |subject_set_id|
         ReloadNonLoggedInQueueWorker.perform_async(workflow.id, subject_set_id)
       end
-      if Panoptes.cellect_on && workflow.using_cellect?
+      if Panoptes.use_cellect?(workflow)
         ReloadCellectWorker.perform_async(workflow.id)
       end
     end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::WorkflowsController < Api::ApiController
       reload_queue_subject_sets(workflow).each do |subject_set_id|
         ReloadNonLoggedInQueueWorker.perform_async(workflow.id, subject_set_id)
       end
-      if Panoptes.cellect_on
+      if Panoptes.cellect_on && workflow.using_cellect?
         ReloadCellectWorker.perform_async(workflow.id)
       end
     end

--- a/app/workers/reload_cellect_worker.rb
+++ b/app/workers/reload_cellect_worker.rb
@@ -2,8 +2,11 @@ class ReloadCellectWorker
   include Sidekiq::Worker
 
   def perform(workflow_id)
-    return unless Panoptes.cellect_on
-    Subjects::CellectClient.reload_workflow(workflow_id)
-  rescue Subjects::CellectClient::ConnectionError
+    workflow = Workflow.find(workflow_id)
+    if Panoptes.cellect_on && workflow.using_cellect?
+      Subjects::CellectClient.reload_workflow(workflow_id)
+    end
+  rescue Subjects::CellectClient::ConnectionError,
+    ActiveRecord::RecordNotFound
   end
 end

--- a/app/workers/reload_cellect_worker.rb
+++ b/app/workers/reload_cellect_worker.rb
@@ -3,10 +3,9 @@ class ReloadCellectWorker
 
   def perform(workflow_id)
     workflow = Workflow.find(workflow_id)
-    if Panoptes.cellect_on && workflow.using_cellect?
+    if Panoptes.use_cellect?(workflow)
       Subjects::CellectClient.reload_workflow(workflow_id)
     end
-  rescue Subjects::CellectClient::ConnectionError,
-    ActiveRecord::RecordNotFound
+  rescue Subjects::CellectClient::ConnectionError, ActiveRecord::RecordNotFound
   end
 end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -31,7 +31,7 @@ class RetirementWorker
   end
 
   def notify_cellect(count)
-    if Panoptes.cellect_on && count.workflow.using_cellect?
+    if Panoptes.use_cellect?(count.workflow)
       count.set_member_subjects.each do |sms|
         cellect_params = [ sms.subject_id, count.workflow.id, sms.subject_set_id ]
         Subjects::CellectClient.remove_subject(*cellect_params)

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -31,10 +31,11 @@ class RetirementWorker
   end
 
   def notify_cellect(count)
-    return unless Panoptes.cellect_on
-    count.set_member_subjects.each do |sms|
-      cellect_params = [ sms.subject_id, count.workflow.id, sms.subject_set_id ]
-      Subjects::CellectClient.remove_subject(*cellect_params)
+    if Panoptes.cellect_on && count.workflow.using_cellect?
+      count.set_member_subjects.each do |sms|
+        cellect_params = [ sms.subject_id, count.workflow.id, sms.subject_set_id ]
+        Subjects::CellectClient.remove_subject(*cellect_params)
+      end
     end
   rescue Subjects::CellectClient::ConnectionError
   end

--- a/config/initializers/cellect.rb
+++ b/config/initializers/cellect.rb
@@ -6,4 +6,8 @@ module Panoptes
   def self.cellect_min_pool_size
     @cellect_min_pool_size ||= (ENV["CELLECT_MIN_POOL_SIZE"] || 10000).to_i
   end
+
+  def self.use_cellect?(workflow)
+    cellect_on && workflow.using_cellect?
+  end
 end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -50,7 +50,7 @@ class ClassificationLifecycle
   def update_seen_subjects
     if should_update_seen? && subjects_are_unseen_by_user?
       UserSeenSubject.add_seen_subjects_for_user(**user_workflow_subject)
-      if Panoptes.cellect_on && workflow.using_cellect?
+      if Panoptes.use_cellect?(workflow)
         subject_ids.each do |subject_id|
           Subjects::CellectClient.add_seen(workflow.id, user.try(:id), subject_id)
         end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -155,10 +155,21 @@ describe Api::V1::SubjectSetsController, type: :controller do
           expect(ReloadCellectWorker).not_to receive(:perform_async)
         end
 
-        it 'should call the reload cellect worker when cellect is on' do
-          allow(Panoptes).to receive(:cellect_on).and_return(true)
-          expect(ReloadCellectWorker).to receive(:perform_async)
-          .with(workflow_id)
+        context "when cellect is on" do
+          before do
+            allow(Panoptes).to receive(:cellect_on).and_return(true)
+          end
+
+          it 'should not call reload cellect worker' do
+            expect(ReloadCellectWorker).not_to receive(:perform_async)
+          end
+
+          it 'should call reload cellect worker when workflow uses cellect' do
+            allow_any_instance_of(Workflow)
+              .to receive(:using_cellect?).and_return(true)
+            expect(ReloadCellectWorker)
+              .to receive(:perform_async).with(workflow_id)
+          end
         end
       end
 
@@ -181,11 +192,22 @@ describe Api::V1::SubjectSetsController, type: :controller do
           expect(ReloadCellectWorker).not_to receive(:perform_async)
         end
 
-        it 'should call the reload cellect worker when cellect is on' do
-          allow(Panoptes).to receive(:cellect_on).and_return(true)
-          workflows.each do |_workflow|
-            expect(ReloadCellectWorker).to receive(:perform_async)
-            .with(_workflow.id)
+        context "when cellect is on" do
+          before do
+            allow(Panoptes).to receive(:cellect_on).and_return(true)
+          end
+
+          it 'should not call reload cellect worker' do
+            expect(ReloadCellectWorker).not_to receive(:perform_async)
+          end
+
+          it 'should call reload cellect worker when workflow uses cellect' do
+            allow_any_instance_of(Workflow)
+              .to receive(:using_cellect?).and_return(true)
+            workflows.each do |_workflow|
+              expect(ReloadCellectWorker).to receive(:perform_async)
+              .with(_workflow.id)
+            end
           end
         end
       end
@@ -202,8 +224,8 @@ describe Api::V1::SubjectSetsController, type: :controller do
           expect(ReloadNonLoggedInQueueWorker).to_not receive(:perform_async)
         end
 
-        it 'should not call the reload cellect worker when cellect is on' do
-          allow(Panoptes).to receive(:cellect_on).and_return(true)
+        it 'should not attempt to call cellect', :aggregate_failures do
+          expect(Panoptes).not_to receive(:use_cellect?)
           expect(ReloadCellectWorker).not_to receive(:perform_async)
         end
       end
@@ -220,8 +242,8 @@ describe Api::V1::SubjectSetsController, type: :controller do
           expect(ReloadNonLoggedInQueueWorker).to_not receive(:perform_async)
         end
 
-        it 'should not call the reload cellect worker when cellect is on' do
-          allow(Panoptes).to receive(:cellect_on).and_return(true)
+        it 'should not attempt to call cellect', :aggregate_failures do
+          expect(Panoptes).not_to receive(:use_cellect?)
           expect(ReloadCellectWorker).not_to receive(:perform_async)
         end
       end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -423,18 +423,27 @@ describe ClassificationLifecycle do
         .with(seen_params)
       end
 
-      it "should not tell cellect by default" do
+      it "should not call cellect by default" do
         expect(Subjects::CellectClient).not_to receive(:add_seen)
       end
 
-      context "when the workflow is using cellect" do
-        it "should tell cellect for each subject_id" do
+      context "when cellect is on" do
+        before do
           allow(Panoptes).to receive(:cellect_on).and_return(true)
-          allow(classification.workflow).to receive(:using_cellect?)
-          .and_return(true)
-          classification.subject_ids.each do |subject_id|
-            expect(Subjects::CellectClient).to receive(:add_seen)
-            .with(seen_params[:workflow].id, seen_params[:user].id, subject_id)
+        end
+
+        it "should not call cellect by default" do
+          expect(Subjects::CellectClient).not_to receive(:add_seen)
+        end
+
+        context "when the workflow is using cellect" do
+          it "should tell cellect for each subject_id" do
+            allow(classification.workflow)
+              .to receive(:using_cellect?).and_return(true)
+            classification.subject_ids.each do |subject_id|
+              expect(Subjects::CellectClient).to receive(:add_seen)
+              .with(seen_params[:workflow].id, seen_params[:user].id, subject_id)
+            end
           end
         end
       end

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe RetirementWorker do
       context "when the workflow is using cellect" do
         before do
           allow(Panoptes).to receive(:cellect_on).and_return(true)
-          allow(workflow).to receive(:using_cellect?).and_return(true)
+          allow_any_instance_of(Workflow)
+          .to receive(:using_cellect?).and_return(true)
         end
 
         it "should tell cellect for each subject_id" do


### PR DESCRIPTION
check that cellect is on and the workflow is configured to use cellect.