### PR TITLE
Non lifecycled classification worker

### DIFF
--- a/app/workers/requeue_classifications_worker.rb
+++ b/app/workers/requeue_classifications_worker.rb
@@ -1,0 +1,21 @@
+class RequeueClassificationsWorker
+
+  include Sidekiq::Worker
+  include Sidetiq::Schedulable
+
+  recurrence { hourly.minute_of_hour(0, 15, 30, 45)}
+
+  def perform
+    non_lifecycled.find_in_batches do |classifications|
+      classifications.each do |classification|
+        ClassificationLifecycle.new(classification).queue(:create)
+      end
+    end
+  end
+
+  private
+
+  def non_lifecycled
+    Classification.where(lifecycled_at: nil)
+  end
+end

--- a/db/migrate/20160106120927_add_lifecycled_at_to_classifications.rb
+++ b/db/migrate/20160106120927_add_lifecycled_at_to_classifications.rb
@@ -1,0 +1,5 @@
+class AddLifecycledAtToClassifications < ActiveRecord::Migration
+  def change
+    add_column :classifications, :lifecycled_at, :timestamp, index: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -187,7 +187,8 @@ CREATE TABLE classifications (
     gold_standard boolean,
     expert_classifier integer,
     metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    workflow_version text
+    workflow_version text,
+    lifecycled_at timestamp without time zone
 );
 
 
@@ -1883,6 +1884,13 @@ CREATE INDEX index_classifications_on_gold_standard ON classifications USING btr
 
 
 --
+-- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_classifications_on_lifecycled_at ON classifications USING btree (lifecycled_at);
+
+
+--
 -- Name: index_classifications_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2850,4 +2858,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151231123306');
 INSERT INTO schema_migrations (version) VALUES ('20160103142817');
 
 INSERT INTO schema_migrations (version) VALUES ('20160104131622');
+
+INSERT INTO schema_migrations (version) VALUES ('20160106120927');
 

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -98,6 +98,7 @@ class ClassificationLifecycle
     mark_expert_classifier
     add_seen_before_for_user
     add_project_live_state
+    add_lifecycled_at
     classification.save!
   end
 
@@ -127,6 +128,10 @@ class ClassificationLifecycle
 
   def add_project_live_state
     update_classification_metadata(:live_project, project.live)
+  end
+
+  def add_lifecycled_at
+    classification.lifecycled_at = Time.zone.now
   end
 
   def add_seen_before_for_user

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -99,32 +99,44 @@ namespace :migrate do
     end
   end
 
-  desc "Converts subject_ids array into normal join table"
-  task classification_subject_ids: :environment do
-    puts 'check precondition'
-    max_length = ActiveRecord::Base.connection.execute("SELECT max(array_length(subject_ids, 1)) as max_length FROM classifications")[0]["max_length"].to_i
+  namespace :classification do
 
-    if max_length != 1
-      raise "Does not work if any classification has more than one subject currently"
+    desc "Converts subject_ids array into normal join table"
+    task classification_subject_ids: :environment do
+      puts 'check precondition'
+      max_length = ActiveRecord::Base.connection.execute("SELECT max(array_length(subject_ids, 1)) as max_length FROM classifications")[0]["max_length"].to_i
+
+      if max_length != 1
+        raise "Does not work if any classification has more than one subject currently"
+      end
+
+      puts 'create index'
+      ActiveRecord::Base.connection.execute <<-SQL
+        CREATE INDEX temporary_migration_index on classifications ((subject_ids[1]));
+      SQL
+
+      puts 'insert into'
+      ActiveRecord::Base.connection.execute <<-SQL
+        INSERT INTO classification_subjects (classification_id, subject_id)
+        SELECT id, subject_ids[1] FROM classifications
+        WHERE subject_ids[1] IS NOT NULL AND NOT EXISTS (
+          SELECT 1 FROM classification_subjects cs WHERE cs.classification_id = classifications.id AND cs.subject_id = classifications.subject_ids[1]
+        );
+      SQL
+
+      puts 'drop index'
+      ActiveRecord::Base.connection.execute <<-SQL
+        DROP INDEX temporary_migration_index;
+      SQL
     end
 
-    puts 'create index'
-    ActiveRecord::Base.connection.execute <<-SQL
-      CREATE INDEX temporary_migration_index on classifications ((subject_ids[1]));
-    SQL
-
-    puts 'insert into'
-    ActiveRecord::Base.connection.execute <<-SQL
-      INSERT INTO classification_subjects (classification_id, subject_id)
-      SELECT id, subject_ids[1] FROM classifications
-      WHERE subject_ids[1] IS NOT NULL AND NOT EXISTS (
-        SELECT 1 FROM classification_subjects cs WHERE cs.classification_id = classifications.id AND cs.subject_id = classifications.subject_ids[1]
-      );
-    SQL
-
-    puts 'drop index'
-    ActiveRecord::Base.connection.execute <<-SQL
-      DROP INDEX temporary_migration_index;
-    SQL
+    desc "Add lifecycled at timestamps"
+    task add_lifecycled_at: :environment do
+      non_lifecycled = Classification.where(lifecycled_at: nil).select('id')
+      non_lifecycled.find_in_batches do |classifications|
+        Classification.where(id: classifications.map(&:id))
+        .update_all(lifecycled_at: Time.current.to_s(:db))
+      end
+    end
   end
 end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -600,6 +600,11 @@ describe ClassificationLifecycle do
       update_classification_data
     end
 
+    it "should call add_lifecycled_at" do
+      expect(subject).to receive(:add_lifecycled_at)
+      update_classification_data
+    end
+
     it "should call add_seen_before_for_user" do
       expect(subject).to receive(:add_seen_before_for_user)
       update_classification_data
@@ -640,6 +645,16 @@ describe ClassificationLifecycle do
         subject.add_project_live_state
         expect(classification.metadata[:live_project]).to eq(true)
       end
+    end
+  end
+
+  describe "#add_lifecycled_at" do
+
+    it "should mark the lifecycled_at timestamp" do
+      subject.add_lifecycled_at
+      prev, current = classification.changes[:lifecycled_at]
+      expect(prev).to be_nil
+      expect(current).to be_a(ActiveSupport::TimeWithZone)
     end
   end
 

--- a/spec/workers/requeue_classifications_worker_spec.rb
+++ b/spec/workers/requeue_classifications_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe RequeueClassificationsWorker do
+  let(:worker) { described_class.new }
+  let(:classification) { create(:classification) }
+  let(:lifecycled_classification) do
+    create(:classification, lifecycled_at: Time.zone.now)
+  end
+
+  it{ is_expected.to be_a Sidekiq::Worker }
+
+  describe 'schedule' do
+    it "should have a valid schedule" do
+      expect(described_class.schedule.to_s)
+      .to match(/Hourly on the 0th, 15th, 30th, and 45th minutes of the hour/)
+    end
+  end
+
+  it 'enqueues all the non-lifecycled classifications' do
+    classification
+    lifecycled_classification
+    expect_any_instance_of(ClassificationLifecycle)
+      .to receive(:queue).with(:create).once
+    worker.perform
+  end
+end


### PR DESCRIPTION
merge this only after #1577 and the data migration to mark all as processed is finished.

Introduces a scheduled worker to automatically reprocess classifications that are saved but not lifecycled (redis down / api failure but db persistence, etc).