### PR TITLE
add column without an index build in the transaction

### DIFF
--- a/db/migrate/20160106120927_add_lifecycled_at_to_classifications.rb
+++ b/db/migrate/20160106120927_add_lifecycled_at_to_classifications.rb
@@ -1,5 +1,5 @@
 class AddLifecycledAtToClassifications < ActiveRecord::Migration
   def change
-    add_column :classifications, :lifecycled_at, :timestamp, index: true
+    add_column :classifications, :lifecycled_at, :timestamp
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1884,13 +1884,6 @@ CREATE INDEX index_classifications_on_gold_standard ON classifications USING btr
 
 
 --
--- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_classifications_on_lifecycled_at ON classifications USING btree (lifecycled_at);
-
-
---
 -- Name: index_classifications_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 


### PR DESCRIPTION
split the index build out, add_column took < 1s on my dev box. I will generate this index with a concurrent outside a transcation block in a sep PR. 