### PR TITLE
Reload cellect vs retire cellect

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -39,7 +39,15 @@ class Api::V1::WorkflowsController < Api::ApiController
         ReloadNonLoggedInQueueWorker.perform_async(workflow.id, subject_set_id)
       end
       if Panoptes.use_cellect?(workflow)
-        ReloadCellectWorker.perform_async(workflow.id)
+        case relation
+        when :retired_subjects, 'retired_subjects'
+          params[:retired_subjects].each do |subject_id|
+            RetireCellectWorker.perform_async(subject_id, workflow.id)
+          end
+        when :subject_sets, 'subject_sets'
+          ReloadCellectWorker.perform_async(workflow.id)
+        end
+
       end
     end
   end

--- a/app/workers/retire_cellect_worker.rb
+++ b/app/workers/retire_cellect_worker.rb
@@ -1,0 +1,15 @@
+class RetireCellectWorker
+  include Sidekiq::Worker
+
+  def perform(subject_id, workflow_id)
+    workflow = Workflow.find(workflow_id)
+    if Panoptes.use_cellect?(workflow)
+      smses = workflow.set_member_subjects.where(subject_id: subject_id)
+      smses.each do |sms|
+          Subjects::CellectClient
+          .remove_subject(subject_id, workflow_id, sms.subject_set_id)
+      end
+    end
+  rescue Subjects::CellectClient::ConnectionError, ActiveRecord::RecordNotFound
+  end
+end

--- a/spec/workers/retire_cellect_worker_spec.rb
+++ b/spec/workers/retire_cellect_worker_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe RetireCellectWorker do
+  let(:worker) { described_class.new }
+  let(:workflow) { create(:workflow_with_subjects) }
+  let(:subject) { workflow.subjects.first }
+  let(:subject_set) { subject.subject_sets.first }
+
+  describe "#perform" do
+    it "should gracefully handle a missing workflow lookup" do
+      expect{worker.perform(subject.id, -1)}.not_to raise_error
+    end
+
+    context "when cellect is off" do
+      it "should not call cellect" do
+        expect(Subjects::CellectClient).not_to receive(:remove_subject)
+        worker.perform(subject.id, workflow.id)
+      end
+    end
+
+    context "when cellect is on" do
+      before do
+        allow(Panoptes).to receive(:cellect_on).and_return(true)
+      end
+
+      it "should not call to cellect if the workflow is not set to use it" do
+        expect(Subjects::CellectClient).not_to receive(:remove_subject)
+        worker.perform(subject.id, workflow.id)
+      end
+
+      context "when the workflow is using cellect" do
+        before do
+          allow_any_instance_of(Workflow)
+          .to receive(:using_cellect?).and_return(true)
+        end
+
+        it "should request that cellect retire for the workflow and set" do
+          expect(Subjects::CellectClient)
+            .to receive(:remove_subject)
+            .with(subject.id, workflow.id, subject_set.id)
+          worker.perform(subject.id, workflow.id)
+        end
+
+        context "when cellect is unavailable" do
+          it "should handle the failure and move on" do
+            allow(Subjects::CellectClient).to receive(:remove_subject)
+              .and_raise(Subjects::CellectClient::ConnectionError)
+            expect{
+              worker.perform(subject.id, workflow.id)
+            }.not_to raise_error
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
notify the cellect client of retire events and don't force cellect to reload the whole workflow.