### PR TITLE
Cellect notification workers

### DIFF
--- a/app/workers/reload_cellect_worker.rb
+++ b/app/workers/reload_cellect_worker.rb
@@ -2,12 +2,13 @@ require 'subjects/cellect_client'
 
 class ReloadCellectWorker
   include Sidekiq::Worker
+  sidekiq_options retry: 3
 
   def perform(workflow_id)
     workflow = Workflow.find(workflow_id)
     if Panoptes.use_cellect?(workflow)
       Subjects::CellectClient.reload_workflow(workflow_id)
     end
-  rescue Subjects::CellectClient::ConnectionError, ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordNotFound
   end
 end

--- a/app/workers/retire_cellect_worker.rb
+++ b/app/workers/retire_cellect_worker.rb
@@ -3,6 +3,8 @@ require 'subjects/cellect_client'
 class RetireCellectWorker
   include Sidekiq::Worker
 
+  sidekiq_options retry: 6
+
   def perform(subject_id, workflow_id)
     workflow = Workflow.find(workflow_id)
     if Panoptes.use_cellect?(workflow)
@@ -12,6 +14,6 @@ class RetireCellectWorker
         Subjects::CellectClient.remove_subject(*params)
       end
     end
-  rescue Subjects::CellectClient::ConnectionError, ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordNotFound
   end
 end

--- a/app/workers/retire_cellect_worker.rb
+++ b/app/workers/retire_cellect_worker.rb
@@ -2,8 +2,7 @@ require 'subjects/cellect_client'
 
 class RetireCellectWorker
   include Sidekiq::Worker
-
-  sidekiq_options retry: 6
+  sidekiq_options retry: 3
 
   def perform(subject_id, workflow_id)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/retire_cellect_worker.rb
+++ b/app/workers/retire_cellect_worker.rb
@@ -1,3 +1,5 @@
+require 'subjects/cellect_client'
+
 class RetireCellectWorker
   include Sidekiq::Worker
 
@@ -6,8 +8,8 @@ class RetireCellectWorker
     if Panoptes.use_cellect?(workflow)
       smses = workflow.set_member_subjects.where(subject_id: subject_id)
       smses.each do |sms|
-          Subjects::CellectClient
-          .remove_subject(subject_id, workflow_id, sms.subject_set_id)
+        params = [ subject_id, workflow_id, sms.subject_set_id ]
+        Subjects::CellectClient.remove_subject(*params)
       end
     end
   rescue Subjects::CellectClient::ConnectionError, ActiveRecord::RecordNotFound

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -1,5 +1,3 @@
-require 'subjects/cellect_client'
-
 class RetirementWorker
   include Sidekiq::Worker
 
@@ -34,10 +32,7 @@ class RetirementWorker
 
   def notify_cellect(count)
     if Panoptes.use_cellect?(count.workflow)
-      count.set_member_subjects.each do |sms|
-        cellect_params = [ sms.subject_id, count.workflow.id, sms.subject_set_id ]
-        Subjects::CellectClient.remove_subject(*cellect_params)
-      end
+      RetireCellectWorker.perform_async(count.subject_id, count.workflow.id)
     end
   rescue Subjects::CellectClient::ConnectionError
   end

--- a/app/workers/seen_cellect_worker.rb
+++ b/app/workers/seen_cellect_worker.rb
@@ -2,7 +2,7 @@ require 'subjects/cellect_client'
 
 class SeenCellectWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 6
+  sidekiq_options retry: 3
 
   def perform(workflow_id, user_id, subject_id)
     return if user_id.nil?

--- a/app/workers/seen_cellect_worker.rb
+++ b/app/workers/seen_cellect_worker.rb
@@ -1,0 +1,15 @@
+require 'subjects/cellect_client'
+
+class SeenCellectWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: 6
+
+  def perform(workflow_id, user_id, subject_id)
+    return if user_id.nil?
+    workflow = Workflow.find(workflow_id)
+    if Panoptes.use_cellect?(workflow)
+      Subjects::CellectClient.add_seen(workflow.id, user_id, subject_id)
+    end
+  rescue ActiveRecord::RecordNotFound
+  end
+end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -423,8 +423,8 @@ describe ClassificationLifecycle do
         subject.update_seen_subjects
       end
 
-      it "should not call cellect by default" do
-        expect(Subjects::CellectClient).not_to receive(:add_seen)
+      it "should not call cellect seen worker" do
+        expect(SeenCellectWorker).not_to receive(:perform_async)
         subject.update_seen_subjects
       end
 
@@ -433,8 +433,8 @@ describe ClassificationLifecycle do
           allow(Panoptes).to receive(:cellect_on).and_return(true)
         end
 
-        it "should not call cellect by default" do
-          expect(Subjects::CellectClient).not_to receive(:add_seen)
+        it "should not call the worker by default" do
+          expect(SeenCellectWorker).not_to receive(:perform_async)
           subject.update_seen_subjects
         end
 
@@ -444,20 +444,13 @@ describe ClassificationLifecycle do
             .to receive(:using_cellect?).and_return(true)
           end
 
-          it "should tell cellect for each subject_id" do
+          it "should call cellect seen worker for each subject id" do
             classification.subject_ids.each do |subject_id|
-              expect(Subjects::CellectClient).to receive(:add_seen)
+              expect(SeenCellectWorker)
+              .to receive(:perform_async)
               .with(seen_params[:workflow].id, seen_params[:user].id, subject_id)
             end
             subject.update_seen_subjects
-          end
-
-          it "should ignore cellect errors" do
-            allow(Subjects::CellectClient).to receive(:add_seen)
-              .and_raise(Subjects::CellectClient::ConnectionError)
-            expect {
-              subject.update_seen_subjects
-            }.to_not raise_error
           end
         end
       end

--- a/spec/workers/reload_cellect_worker_spec.rb
+++ b/spec/workers/reload_cellect_worker_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe ReloadCellectWorker do
   let(:worker) { described_class.new }
   let(:workflow) { create(:workflow) }
 
+  it "should be retryable 3 times" do
+    retry_count = worker.class.get_sidekiq_options['retry']
+    expect(retry_count).to eq(3)
+  end
+
   describe "#perform" do
 
     it "should gracefully handle a missing workflow lookup" do
@@ -37,14 +42,6 @@ RSpec.describe ReloadCellectWorker do
           expect(Subjects::CellectClient).to receive(:reload_workflow)
             .with(workflow.id)
           worker.perform(workflow.id)
-        end
-
-        context "when cellect is unavailable" do
-          it "should handle the failure and move on" do
-            allow(Subjects::CellectClient).to receive(:reload_workflow)
-              .and_raise(Subjects::CellectClient::ConnectionError)
-            expect{worker.perform(workflow.id)}.not_to raise_error
-          end
         end
       end
     end

--- a/spec/workers/retire_cellect_worker_spec.rb
+++ b/spec/workers/retire_cellect_worker_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe RetireCellectWorker do
   let(:subject) { workflow.subjects.first }
   let(:subject_set) { subject.subject_sets.first }
 
-  it "should be retryable 6 times" do
+  it "should be retryable 3 times" do
     retry_count = worker.class.get_sidekiq_options['retry']
-    expect(retry_count).to eq(6)
+    expect(retry_count).to eq(3)
   end
 
   describe "#perform" do

--- a/spec/workers/seen_cellect_worker_spec.rb
+++ b/spec/workers/seen_cellect_worker_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe SeenCellectWorker do
+  let(:worker) { described_class.new }
+  let(:workflow) { create(:workflow_with_subjects) }
+  let(:subject) { workflow.subjects.first }
+  let(:user_id) { 1 }
+
+  it "should be retryable 6 times" do
+    retry_count = worker.class.get_sidekiq_options['retry']
+    expect(retry_count).to eq(6)
+  end
+
+  describe "#perform" do
+    it "should gracefully handle a missing workflow lookup" do
+      expect{
+        worker.perform(-1, user_id, subject.id)
+      }.not_to raise_error
+    end
+
+    context "when cellect is off" do
+      it "should not call cellect" do
+        expect(Subjects::CellectClient).not_to receive(:add_seen)
+        worker.perform(workflow.id, user_id, subject.id)
+      end
+    end
+
+    context "when cellect is on" do
+      before do
+        allow(Panoptes).to receive(:cellect_on).and_return(true)
+      end
+
+      it "should not call to cellect if the workflow is not set to use it" do
+        expect(Subjects::CellectClient).not_to receive(:add_seen)
+        worker.perform(workflow.id, user_id, subject.id)
+      end
+
+      context "when the workflow is using cellect" do
+        before do
+          allow_any_instance_of(Workflow)
+          .to receive(:using_cellect?).and_return(true)
+        end
+
+        it "should not call to cellect if the user is nil" do
+          expect(Subjects::CellectClient).not_to receive(:add_seen)
+          worker.perform(workflow.id, nil, subject.id)
+        end
+
+        it "should request that cellect add the seen for the subject" do
+          expect(Subjects::CellectClient)
+            .to receive(:add_seen)
+            .with(workflow.id, user_id, subject.id)
+          worker.perform(workflow.id, user_id, subject.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/workers/seen_cellect_worker_spec.rb
+++ b/spec/workers/seen_cellect_worker_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe SeenCellectWorker do
   let(:subject_id) { 2 }
   let(:user_id) { 1 }
 
-  it "should be retryable 6 times" do
+  it "should be retryable 3 times" do
     retry_count = worker.class.get_sidekiq_options['retry']
-    expect(retry_count).to eq(6)
+    expect(retry_count).to eq(3)
   end
 
   describe "#perform" do

--- a/spec/workers/seen_cellect_worker_spec.rb
+++ b/spec/workers/seen_cellect_worker_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe SeenCellectWorker do
   let(:worker) { described_class.new }
-  let(:workflow) { create(:workflow_with_subjects) }
-  let(:subject) { workflow.subjects.first }
+  let(:workflow) { create(:workflow) }
+  let(:subject_id) { 2 }
   let(:user_id) { 1 }
 
   it "should be retryable 6 times" do
@@ -14,14 +14,14 @@ RSpec.describe SeenCellectWorker do
   describe "#perform" do
     it "should gracefully handle a missing workflow lookup" do
       expect{
-        worker.perform(-1, user_id, subject.id)
+        worker.perform(-1, user_id, subject_id)
       }.not_to raise_error
     end
 
     context "when cellect is off" do
       it "should not call cellect" do
         expect(Subjects::CellectClient).not_to receive(:add_seen)
-        worker.perform(workflow.id, user_id, subject.id)
+        worker.perform(workflow.id, user_id, subject_id)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe SeenCellectWorker do
 
       it "should not call to cellect if the workflow is not set to use it" do
         expect(Subjects::CellectClient).not_to receive(:add_seen)
-        worker.perform(workflow.id, user_id, subject.id)
+        worker.perform(workflow.id, user_id, subject_id)
       end
 
       context "when the workflow is using cellect" do
@@ -43,14 +43,14 @@ RSpec.describe SeenCellectWorker do
 
         it "should not call to cellect if the user is nil" do
           expect(Subjects::CellectClient).not_to receive(:add_seen)
-          worker.perform(workflow.id, nil, subject.id)
+          worker.perform(workflow.id, nil, subject_id)
         end
 
         it "should request that cellect add the seen for the subject" do
           expect(Subjects::CellectClient)
             .to receive(:add_seen)
-            .with(workflow.id, user_id, subject.id)
-          worker.perform(workflow.id, user_id, subject.id)
+            .with(workflow.id, user_id, subject_id)
+          worker.perform(workflow.id, user_id, subject_id)
         end
       end
     end


### PR DESCRIPTION
closes #1592 - extract the cellect communications to their own workers with a small retry limit on them. If cellect is down then when it comes back up it should reload the correct data state from the db so these messages should only really be retried for a period of small network outage. 

Happy to bump the retry count taking into account this, https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry.