### PR TITLE
Lifecycle at window

### DIFF
--- a/app/workers/requeue_classifications_worker.rb
+++ b/app/workers/requeue_classifications_worker.rb
@@ -1,5 +1,4 @@
 class RequeueClassificationsWorker
-
   include Sidekiq::Worker
   include Sidetiq::Schedulable
 
@@ -16,6 +15,8 @@ class RequeueClassificationsWorker
   private
 
   def non_lifecycled
-    Classification.where(lifecycled_at: nil)
+    Classification
+    .where(lifecycled_at: nil)
+    .where("created_at <= ?", Panoptes.lifecycled_live_window.minutes.ago)
   end
 end

--- a/app/workers/requeue_classifications_worker.rb
+++ b/app/workers/requeue_classifications_worker.rb
@@ -7,7 +7,7 @@ class RequeueClassificationsWorker
   def perform
     non_lifecycled.find_in_batches do |classifications|
       classifications.each do |classification|
-        ClassificationLifecycle.new(classification).queue(:create)
+        ClassificationWorker.perform_async(classification.id, :create)
       end
     end
   end

--- a/config/initializers/panoptes.rb
+++ b/config/initializers/panoptes.rb
@@ -1,5 +1,7 @@
 module Panoptes
   def self.lifecycled_live_window
-    @lifecycled_live_window ||= (ENV["LIVE_WINDOW"] || 15)
+    return @lifecycled_live_window if @lifecycled_live_window
+    window = ENV["LIVE_WINDOW"].to_i
+    @lifecycled_live_window = (window == 0 ? 15 : window)
   end
 end

--- a/config/initializers/panoptes.rb
+++ b/config/initializers/panoptes.rb
@@ -1,0 +1,5 @@
+module Panoptes
+  def self.lifecycled_live_window
+    @lifecycled_live_window ||= (ENV["LIVE_WINDOW"] || 15)
+  end
+end

--- a/spec/workers/classification_worker_spec.rb
+++ b/spec/workers/classification_worker_spec.rb
@@ -44,8 +44,17 @@ RSpec.describe ClassificationWorker do
         expect_any_instance_of(ClassificationLifecycle).to receive(:update_seen_subjects)
       end
 
-      context "when a user has seen the subjects before" do
+      context "when the lifecycled_at field is set" do
+        let(:classification) do
+          create(:classification, lifecycled_at: Time.zone.now)
+        end
 
+        it "should abort the worker asap" do
+          expect(ClassificationLifecycle).not_to receive(:new)
+        end
+      end
+
+      context "when a user has seen the subjects before" do
         it 'should not call the classification count worker' do
           create(:user_seen_subject,
                  user: classification.user,
@@ -56,8 +65,7 @@ RSpec.describe ClassificationWorker do
       end
 
       context "when a user is anonymous" do
-
-        let!(:classification) { create(:classification, user: nil) }
+        let(:classification) { create(:classification, user: nil) }
 
         it 'should call the classification count worker' do
           expect(ClassificationCountWorker).to receive(:perform_async).twice

--- a/spec/workers/requeue_classifications_worker_spec.rb
+++ b/spec/workers/requeue_classifications_worker_spec.rb
@@ -16,11 +16,32 @@ describe RequeueClassificationsWorker do
     end
   end
 
-  it 'enqueues all the non-lifecycled classifications' do
-    classification
-    lifecycled_classification
-    expect_any_instance_of(ClassificationLifecycle)
-      .to receive(:queue).with(:create).once
-    worker.perform
+  describe "perform" do
+    before do
+      classification
+      lifecycled_classification
+    end
+
+    it 'should not enqueue live data that is in the process of queueing' do
+      expect_any_instance_of(ClassificationLifecycle).not_to receive(:queue)
+      worker.perform
+    end
+
+    context "with non-lifecycled classification outside the live window" do
+      let(:outside_live_window) do
+        Panoptes.lifecycled_live_window.minutes.ago
+      end
+      let(:classification) do
+        c = create(:classification)
+        c.update_column(:created_at, outside_live_window)
+        c
+      end
+
+      it 'enqueues all the non-lifecycled classifications' do
+        expect_any_instance_of(ClassificationLifecycle)
+          .to receive(:queue).with(:create).once
+        worker.perform
+      end
+    end
   end
 end

--- a/spec/workers/requeue_classifications_worker_spec.rb
+++ b/spec/workers/requeue_classifications_worker_spec.rb
@@ -23,7 +23,7 @@ describe RequeueClassificationsWorker do
     end
 
     it 'should not enqueue live data that is in the process of queueing' do
-      expect_any_instance_of(ClassificationLifecycle).not_to receive(:queue)
+      expect(ClassificationWorker).not_to receive(:perform_async)
       worker.perform
     end
 
@@ -38,8 +38,10 @@ describe RequeueClassificationsWorker do
       end
 
       it 'enqueues all the non-lifecycled classifications' do
-        expect_any_instance_of(ClassificationLifecycle)
-          .to receive(:queue).with(:create).once
+        expect(ClassificationWorker)
+          .to receive(:perform_async)
+          .with(classification.id, :create)
+          .once
         worker.perform
       end
     end


### PR DESCRIPTION
closes #1593 - only back process classifications that were skipped due to redis / api errors by ignoring the live stream via a window period (configurable via the ENV["LIVE_WINDOW"] var).