### PR TITLE
raise error when no data available for selection

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -15,7 +15,8 @@ module Api
       Api::NoMediaError,
       RoleControl::AccessDenied,
       Subjects::Selector::MissingSubjectQueue,
-      Subjects::Selector::MissingSubjectSet,               with: :not_found
+      Subjects::Selector::MissingSubjectSet,
+      Subjects::Selector::MissingSubjects,                 with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
     rescue_from Api::LiveProjectChanges,                   with: :forbidden
     rescue_from Api::NotLoggedIn,

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -70,8 +70,8 @@ describe Api::V1::SubjectsController, type: :controller do
       context "a queued request" do
         let!(:sms) { create_list(:set_member_subject, 2, subject_set: subject_set) }
         let(:request_params) { { sort: 'queued', workflow_id: workflow.id.to_s } }
-        context "with queued subjects" do
 
+        context "with queued subjects" do
           context "when firing the request before the test" do
             before(:each) do
               get :index, request_params
@@ -99,6 +99,21 @@ describe Api::V1::SubjectsController, type: :controller do
               it 'should return a page of 2 objects' do
                 expect(json_response[api_resource_name].length).to eq(2)
               end
+            end
+          end
+
+          context "with no data to select from" do
+            before do
+              allow_any_instance_of(Workflow)
+              .to receive(:set_member_subjects)
+              .and_return([])
+            end
+
+            it 'should return an error message', :aggregate_failures do
+              get :index, request_params
+              expect(response.status).to eq(404)
+              error_body = "No data available for selection"
+              expect(response.body).to eq(json_error_message(error_body))
             end
           end
         end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe Subjects::Selector do
             "no subject set is associated with this workflow")
         end
       end
+
+      context "when the subject sets have no data" do
+
+        it 'should raise the an error' do
+          allow_any_instance_of(Workflow)
+            .to receive(:set_member_subjects).and_return([])
+          message = "No data available for selection"
+          expect {
+            subject.queued_subjects
+          }.to raise_error(Subjects::Selector::MissingSubjects, message)
+        end
+      end
     end
 
     context "when the params page size is set as a string" do


### PR DESCRIPTION
closes #1586 - error gracefully with a useful message.