### PR TITLE
Add a cache for model version

### DIFF
--- a/app/models/concerns/cache_model_version.rb
+++ b/app/models/concerns/cache_model_version.rb
@@ -1,0 +1,21 @@
+module CacheModelVersion
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :update_workflow_version_cache
+  end
+
+  def current_version_number
+    super || calculate_model_version
+  end
+
+  private
+
+  def update_workflow_version_cache
+    update_column(:current_version_number, calculate_model_version)
+  end
+
+  def calculate_model_version
+    ModelVersion.version_number(self)
+  end
+end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -5,6 +5,7 @@ class Workflow < ActiveRecord::Base
   include SubjectCounts
   include ExtendedCacheKey
   include RankedModel
+  include CacheModelVersion
 
   has_paper_trail only: [:tasks, :grouped, :pairwise, :prioritized]
 

--- a/app/models/workflow_content.rb
+++ b/app/models/workflow_content.rb
@@ -1,5 +1,6 @@
 class WorkflowContent < ActiveRecord::Base
   include TranslatedContent
+  include CacheModelVersion
 
   validates_presence_of :strings, :language
 end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -25,11 +25,15 @@ class WorkflowSerializer
   end
 
   def version
-    "#{ModelVersion.version_number(@model)}.#{ModelVersion.version_number(content)}"
+    "#{@model.current_version_number}.#{content_version}"
   end
 
   def content_language
     content.language if content
+  end
+
+  def content_version
+    content.try(:current_version_number) || ModelVersion.default_version_num
   end
 
   def tasks

--- a/db/migrate/20160113133848_alter_workflows_add_version.rb
+++ b/db/migrate/20160113133848_alter_workflows_add_version.rb
@@ -1,0 +1,6 @@
+class AlterWorkflowsAddVersion < ActiveRecord::Migration
+  def change
+    add_column :workflows, :current_version_number, :string
+    add_column :workflow_contents, :current_version_number, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1216,7 +1216,8 @@ CREATE TABLE workflow_contents (
     language character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    strings json DEFAULT '{}'::json NOT NULL
+    strings json DEFAULT '{}'::json NOT NULL,
+    current_version_number character varying
 );
 
 
@@ -1267,7 +1268,8 @@ CREATE TABLE workflows (
     public_gold_standard boolean DEFAULT false,
     finished_at timestamp without time zone,
     completeness double precision DEFAULT 0.0 NOT NULL,
-    activity integer DEFAULT 0 NOT NULL
+    activity integer DEFAULT 0 NOT NULL,
+    current_version_number character varying
 );
 
 
@@ -2817,4 +2819,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160107143209');
 INSERT INTO schema_migrations (version) VALUES ('20160111112417');
 
 INSERT INTO schema_migrations (version) VALUES ('20160113120732');
+
+INSERT INTO schema_migrations (version) VALUES ('20160113133848');
 

--- a/lib/formatter/csv/workflow.rb
+++ b/lib/formatter/csv/workflow.rb
@@ -23,6 +23,7 @@ module Formatter
       end
 
       def version
+        # Deals with old versions of workflows, so can't use the cached current_version_number
         ModelVersion.version_number(workflow)
       end
 

--- a/lib/formatter/csv/workflow_content.rb
+++ b/lib/formatter/csv/workflow_content.rb
@@ -25,6 +25,7 @@ module Formatter
       end
 
       def version
+        # Deals with old versions of contents, so can't use the cached current_version_number
         ModelVersion.version_number(workflow_content)
       end
 

--- a/spec/models/workflow_content_spec.rb
+++ b/spec/models/workflow_content_spec.rb
@@ -6,23 +6,30 @@ RSpec.describe WorkflowContent, :type => :model do
 
   it_behaves_like "is translated content"
 
-  describe "versioning" do
+  describe "versioning", versioning: true do
     subject do
       create(:workflow_content)
     end
 
     it { is_expected.to be_versioned }
 
-    it 'should track changes to strings', versioning: true do
+    it 'should track changes to strings' do
       new_strings = %w(some stuff)
       subject.update!(strings: new_strings)
       expect(subject.previous_version.strings).to_not eq(new_strings)
     end
 
-    it 'should not track changes to langauges', versioning: true do
+    it 'should not track changes to langauges' do
       new_lang = 'en'
       subject.update!(language: new_lang)
       expect(subject.previous_version).to be_nil
+    end
+
+    it 'caches the new version number', :aggregate_failures do
+      previous_number = subject.current_version_number
+      subject.update!(strings: %w(foo bar))
+      expect(subject.current_version_number).to eq(previous_number + 1)
+      expect(subject.current_version_number).to eq(ModelVersion.version_number(subject))
     end
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -81,21 +81,28 @@ describe Workflow, :type => :model do
     it_behaves_like "it has a classifications assocation"
   end
 
-  describe "versioning" do
+  describe "versioning", versioning: true do
     let(:workflow) { create(:workflow) }
 
     it { is_expected.to be_versioned }
 
-    it 'should track changes to tasks', versioning: true do
+    it 'should track changes to tasks' do
       new_tasks = { blha: 'asdfasd', quera: "asdfas" }
       workflow.update!(tasks: new_tasks)
       expect(workflow.previous_version.tasks).to_not eq(new_tasks)
     end
 
-    it 'should not track changes to primary_language', versioning: true do
+    it 'should not track changes to primary_language' do
       new_lang = 'en'
       workflow.update!(primary_language: new_lang)
       expect(workflow.previous_version).to be_nil
+    end
+
+    it 'caches the new version number', :aggregate_failures do
+      previous_number = workflow.current_version_number
+      workflow.update!(tasks: {blha: 'asdfasd', quera: "asdfas"})
+      expect(workflow.current_version_number).to eq(previous_number + 1)
+      expect(workflow.current_version_number).to eq(ModelVersion.version_number(workflow))
     end
   end
 

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -43,7 +43,6 @@ describe WorkflowSerializer do
     end
 
     describe "#version", versioning: true do
-
       it "should use a 1 suffix for missing content versions" do
         version_num = workflow.versions.last.index + 1
         expect(serializer.version).to eq("#{version_num}.1")


### PR DESCRIPTION
Instantiating old Papertrail versions is slow, and we need this for
every workflow we return. Caching this makes it faster.