### PR TITLE
avoid the association assignment via link_params

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   def build_resource_for_create(create_params)
     super do |body_params, link_params|
-      link_params[:user] = api_user.user
+      body_params[:user_id] = api_user.id
       body_params[:user_ip] = request_ip
       body_params[:subject_ids] = link_params.delete(:subjects)
       body_params[:workflow_version] = body_params[:metadata].delete(:workflow_version)

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -276,6 +276,7 @@ describe Api::V1::ClassificationsController, type: :controller do
 
       context "with subject_ids" do
         let(:create_action) { setup_create_request }
+        let(:user) { nil }
 
         it_behaves_like "a classification create"
       end

--- a/spec/support/classification_events.rb
+++ b/spec/support/classification_events.rb
@@ -20,6 +20,12 @@ shared_context "a classification create" do
     expect(Classification.find(created_classification_id).workflow_version).to eq("1.1")
   end
 
+  it "should set the user correctly" do
+    create_action
+    c = Classification.find(created_instance_id("classifications"))
+    expect(c.user_id).to eq(user.try(:id))
+  end
+
   it "should create the classification" do
     expect do
       create_action
@@ -41,13 +47,6 @@ shared_context "a classification lifecycle event" do
   it "should call the classification lifecycle queue method" do
     expect(lifecycle).to receive(:queue).with(:create)
     create_action
-  end
-
-  it "should set the user" do
-    create_action
-    id = created_instance_id("classifications")
-    expect(Classification.find(created_classification_id)
-            .user.id).to eq(user.id)
   end
 end
 


### PR DESCRIPTION
if the user has a valid token they'll have the correct it