### PR TITLE
Reorder worker priorities

### DIFF
--- a/app/workers/enqueue_subject_queue_worker.rb
+++ b/app/workers/enqueue_subject_queue_worker.rb
@@ -3,7 +3,9 @@ require 'subjects/cellect_client'
 class EnqueueSubjectQueueWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  # SGL-PRIORITY
+  # sidekiq_options queue: :high
+  sidekiq_options queue: :really_high
 
   sidekiq_options congestion: Panoptes::SubjectEnqueue.congestion_opts.merge({
     key: ->(workflow_id, user_id, subject_set_id) {

--- a/app/workers/reload_cellect_worker.rb
+++ b/app/workers/reload_cellect_worker.rb
@@ -2,7 +2,10 @@ require 'subjects/cellect_client'
 
 class ReloadCellectWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 3, queue: :data_high
+
+  # SGL-PRIORITY
+  # sidekiq_options retry: 3, queue: :data_high
+  sidekiq_options retry: 3, queue: :high
 
   def perform(workflow_id)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/reload_non_logged_in_queue_worker.rb
+++ b/app/workers/reload_non_logged_in_queue_worker.rb
@@ -3,7 +3,9 @@ require 'subjects/postgresql_selection'
 class ReloadNonLoggedInQueueWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :data_high
+  # SGL-PRIORITY
+  # sidekiq_options queue: :data_high
+  sidekiq_options queue: :high
 
   attr_reader :workflow
 

--- a/app/workers/retire_cellect_worker.rb
+++ b/app/workers/retire_cellect_worker.rb
@@ -2,7 +2,10 @@ require 'subjects/cellect_client'
 
 class RetireCellectWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 3, queue: :data_high
+
+  # SGL-PRIORITY
+  # sidekiq_options retry: 3, queue: :data_high
+  sidekiq_options retry: 3, queue: :high
 
   def perform(subject_id, workflow_id)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/seen_cellect_worker.rb
+++ b/app/workers/seen_cellect_worker.rb
@@ -2,7 +2,10 @@ require 'subjects/cellect_client'
 
 class SeenCellectWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 3, queue: :data_high
+
+  # SGL-PRIORITY
+  # sidekiq_options retry: 3, queue: :data_high
+  sidekiq_options retry: 3, queue: :high
 
   def perform(workflow_id, user_id, subject_id)
     return if user_id.nil?


### PR DESCRIPTION
- High priority for filling Cellect subject queues (`:really_high`)
- Moves Cellect subject lifecycle workers from `:data_high` to `:high`

A config change will change the sidekiq queue priority from:

```
queues = [
  'data_high',
  'high',
  'data_medium',
  'medium',
  'default',
  'data_low',
  'low'
]
```

to: 

```
queues = [
  'really_high',
  'high',
  'data_high',
  'data_medium',
  # 'medium', # unused
  'default',
  'data_low',
  # 'low' # unused
]
```

Changes are tagged with
``` ruby
# SGL-PRIORITY
```

so we can revert them easily when the API instances are running the workers again.