### PR TITLE
Adds explicit requires for non-eager-autoloaded constants.

### DIFF
--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -1,3 +1,5 @@
+require 'subjects/set_member_subject_selector'
+
 class SetMemberSubject < ActiveRecord::Base
   include RoleControl::ParentalControlled
   include Linkable

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -1,3 +1,5 @@
+require 'seen_subject_remover'
+
 class SubjectQueue < ActiveRecord::Base
   include RoleControl::ParentalControlled
   include BelongsToMany

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -1,4 +1,5 @@
 require "tasks_visitors/inject_strings"
+require 'model_version'
 
 class WorkflowSerializer
   include RestPack::Serializer

--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -1,3 +1,5 @@
+require 'retirement_schemes'
+
 class CalculateProjectCompletenessWorker
   include Sidekiq::Worker
   using Refinements::RangeClamping

--- a/app/workers/enqueue_subject_queue_worker.rb
+++ b/app/workers/enqueue_subject_queue_worker.rb
@@ -1,4 +1,5 @@
 require 'subjects/cellect_client'
+require 'subjects/postgresql_selection'
 
 class EnqueueSubjectQueueWorker
   include Sidekiq::Worker

--- a/lib/belongs_to_many_association.rb
+++ b/lib/belongs_to_many_association.rb
@@ -1,3 +1,5 @@
+require 'array_association_scope'
+
 class BelongsToManyAssociation < ActiveRecord::Associations::CollectionAssociation
 
   def association_scope

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -1,3 +1,5 @@
+require 'event_stream'
+
 class ClassificationLifecycle
   class ClassificationNotPersisted < StandardError; end
 

--- a/lib/subjects/cellect_client.rb
+++ b/lib/subjects/cellect_client.rb
@@ -1,4 +1,5 @@
 require 'cellect/client'
+require 'subjects/cellect_session'
 
 module Subjects
   module CellectClient

--- a/lib/subjects/cellect_session.rb
+++ b/lib/subjects/cellect_session.rb
@@ -1,3 +1,5 @@
+require 'cellect/client'
+
 module Subjects
   class CellectSession
     NilWorkflowError = Class.new(StandardError)

--- a/spec/workers/enqueue_subject_queue_worker_spec.rb
+++ b/spec/workers/enqueue_subject_queue_worker_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'subjects/cellect_session'
 
 RSpec.describe EnqueueSubjectQueueWorker do
   subject { described_class.new }


### PR DESCRIPTION
Resolves application boot-time errors like "RuntimeError: Circular dependency detected while autoloading constant <Whatever>"

Probably not high priority, but crashing on boot is never good.