### PR TITLE
Move project/workflow classifications counter updates to ratelimited

### DIFF
--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -7,10 +7,8 @@ class ClassificationCountWorker
     if workflow.project.live
       count = SubjectWorkflowCount.find_or_create_by!(subject_id: subject_id, workflow_id: workflow_id)
       SubjectWorkflowCount.increment_counter(:classifications_count, count.id)
-      if workflow.project_id != 764
-        Project.increment_counter :classifications_count, workflow.project.id
-        Workflow.increment_counter :classifications_count, workflow.id
-      end
+
+      ProjectClassificationsCountWorker.perform_async(workflow.project.id)
       RetirementWorker.perform_async(count.id)
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -1,0 +1,25 @@
+class ProjectClassificationsCountWorker
+  include Sidekiq::Worker
+
+  sidekiq_options congestion: {
+    interval: 60,
+    max_in_interval: 1,
+    min_delay: 0,
+    reject_with: :cancel,
+    key: ->(project_id) {
+      "project_#{project_id}_classifications_count_worker"
+    }
+  }
+
+  def perform(project_id)
+    project = Project.find(project_id)
+
+    counts = project.workflows.map do |workflow|
+      count = workflow.subject_workflow_counts.sum(:classifications_count)
+      workflow.update_column :classifications_count, count
+      count
+    end
+
+    project.update_column(:classifications_count, counts.sum)
+  end
+end

--- a/spec/workers/classification_count_worker_spec.rb
+++ b/spec/workers/classification_count_worker_spec.rb
@@ -42,13 +42,8 @@ RSpec.describe ClassificationCountWorker do
         end
       end
 
-      it 'should increment the classifications counter on the project' do
-        expect(Project).to receive(:increment_counter).with(:classifications_count, project.id)
-        worker.perform(sms.subject_id, workflow_id)
-      end
-
-      it 'should increment the classifications counter on the workflow' do
-        expect(Workflow).to receive(:increment_counter).with(:classifications_count, workflow_id)
+      it 'queues up a count update for project and workflow' do
+        expect(ProjectClassificationsCountWorker).to receive(:perform_async).with(project.id)
         worker.perform(sms.subject_id, workflow_id)
       end
 

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe ProjectClassificationsCountWorker do
+  let(:worker) { described_class.new }
+  let(:workflow) { create(:workflow) }
+  let(:project) { workflow.project }
+  let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
+
+  let!(:swc) do
+    create :subject_workflow_count, subject: subject, workflow: workflow, classifications_count: 5
+  end
+
+  describe "#perform" do
+    it 'updates the project counter' do
+      expect { worker.perform(project.id) }
+        .to change { project.reload.classifications_count }
+        .from(0).to(5)
+    end
+
+    it 'updates the workflow counter' do
+      expect { worker.perform(project.id) }
+        .to change { workflow.reload.classifications_count }
+        .from(0).to(5)
+    end
+  end
+end


### PR DESCRIPTION
@parrish should we do `track_rejected` on this?