### PR TITLE
re-add classification indexes concurrently

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -45,7 +45,6 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def resources_completed?
-    #TODO: turn back indexing for this created_by scope
     Classification.created_by(api_user.user)
       .merge(Classification.complete)
       .exists?(id: resource_ids)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -19,10 +19,8 @@ class Classification < ActiveRecord::Base
   validate :metadata, :validate_metadata
   validate :validate_gold_standard
 
-  # TODO: this scope should hti and index too
-  scope :incomplete, -> { where(completed: false) }
+  scope :incomplete, -> { where("completed IS FALSE") }
   scope :created_by, -> (user) { where(user: user) }
-  # TODO: this scope is not hitting any index
   scope :complete, -> { where(completed: true) }
   scope :gold_standard, -> { where("gold_standard IS TRUE") }
 

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -28,7 +28,6 @@ class ClassificationsDumpWorker
   end
 
   def completed_project_classifications
-    # TODO: the completed scope here isn't hitting an index
     project.classifications
     .complete
     .joins(:workflow)

--- a/db/migrate/20160114135531_re_add_classification_indexes.rb
+++ b/db/migrate/20160114135531_re_add_classification_indexes.rb
@@ -1,0 +1,13 @@
+class ReAddClassificationIndexes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :classifications, :created_at, algorithm: :concurrently
+    add_index :classifications, :user_id, algorithm: :concurrently
+
+    add_index :classifications,
+    :lifecycled_at,
+    where: "(lifecycled_at IS NULL)",
+    algorithm: :concurrently
+  end
+end

--- a/db/migrate/20160114141909_add_complete_index_to_classifications.rb
+++ b/db/migrate/20160114141909_add_complete_index_to_classifications.rb
@@ -1,0 +1,10 @@
+class AddCompleteIndexToClassifications < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :classifications,
+    :completed,
+    where: "(completed IS FALSE)",
+    algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1851,6 +1851,13 @@ CREATE INDEX index_classification_subjects_on_classification_id ON classificatio
 
 
 --
+-- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_classifications_on_completed ON classifications USING btree (completed) WHERE (completed IS FALSE);
+
+
+--
 -- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2806,4 +2813,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160113133848');
 INSERT INTO schema_migrations (version) VALUES ('20160113143609');
 
 INSERT INTO schema_migrations (version) VALUES ('20160114135531');
+
+INSERT INTO schema_migrations (version) VALUES ('20160114141909');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1851,6 +1851,13 @@ CREATE INDEX index_classification_subjects_on_classification_id ON classificatio
 
 
 --
+-- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_classifications_on_created_at ON classifications USING btree (created_at);
+
+
+--
 -- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1858,10 +1865,24 @@ CREATE INDEX index_classifications_on_gold_standard ON classifications USING btr
 
 
 --
+-- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_classifications_on_lifecycled_at ON classifications USING btree (lifecycled_at) WHERE (lifecycled_at IS NULL);
+
+
+--
 -- Name: index_classifications_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_project_id ON classifications USING btree (project_id);
+
+
+--
+-- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_classifications_on_user_id ON classifications USING btree (user_id);
 
 
 --
@@ -2783,4 +2804,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160113132540');
 INSERT INTO schema_migrations (version) VALUES ('20160113133848');
 
 INSERT INTO schema_migrations (version) VALUES ('20160113143609');
+
+INSERT INTO schema_migrations (version) VALUES ('20160114135531');
 


### PR DESCRIPTION
concurrently create indexes to track created_at, lifecycle and user_id indexes (recents)

Time on my dev machine..
```
== 20160114135531 ReAddClassificationIndexes: migrating =======================
-- add_index(:classifications, :created_at, {:algorithm=>:concurrently})
   -> 15.3824s
-- add_index(:classifications, :user_id, {:algorithm=>:concurrently})
   -> 18.1663s
-- add_index(:classifications, :lifecycled_at, {:where=>"(lifecycled_at IS NULL)", :algorithm=>:concurrently})
   -> 3.0346s
== 20160114135531 ReAddClassificationIndexes: migrated (36.5836s) =============
```