### PR TITLE
Disable dequeue workers and reduce queue sizes

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -4,8 +4,8 @@ class SubjectQueue < ActiveRecord::Base
   include RoleControl::ParentalControlled
   include BelongsToMany
 
-  DEFAULT_LENGTH = 100
-  MINIMUM_LENGTH = 20
+  DEFAULT_LENGTH = 20
+  MINIMUM_LENGTH = 10
 
   belongs_to :user
   belongs_to :workflow

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -7,9 +7,6 @@ class RetirementWorker
     count = SubjectWorkflowCount.find(count_id)
     if count.retire?
       count.retire! do
-        if count.workflow.project_id != 764
-          SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject_ids)
-        end
         finish_workflow!(count.workflow)
       end
       PublishRetirementEventWorker.perform_async(count.workflow.id)

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe RetirementWorker do
         }.from(0).to(1)
       end
 
-      it "should dequeue all instances of the subject" do
-        worker.perform(count.id)
-        queue.reload
-        expect(queue.set_member_subject_ids).to_not include(sms.id)
-      end
-
       it "should call the publish retire event worker" do
         expect(PublishRetirementEventWorker)
           .to receive(:perform_async)


### PR DESCRIPTION
avoid locking updates on the subject queue table with large dequeue scopes. Also changed the default queue size to be 2 x the default limit selections to reduce the chance of retired data being in them. This may push more queries into the db when selection happens on an empty queue. Something to keep in mind when running on a smaller db instance.