### PR TITLE
Guard retirement

### DIFF
--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -5,7 +5,7 @@ class RetirementWorker
 
   def perform(count_id)
     count = SubjectWorkflowCount.find(count_id)
-    if count.retire?
+    if count.retire? && !count.retired?
       count.retire! do
         if count.workflow.project_id != 764
           SubjectQueue.dequeue_for_all(count.workflow, count.set_member_subject_ids)

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe RetirementWorker do
         expect(sms.retired_workflows).to_not include(workflow)
       end
     end
+
+    context 'when the sms is already retired' do
+      before(:each) do
+        allow(SubjectWorkflowCount).to receive(:find).with(count.id).and_return count
+        allow(count).to receive(:retire?).and_return true
+        allow(count).to receive(:retired_at).and_return 1.minute.ago.utc
+      end
+
+      it 'should not retire the subject for the workflow' do
+        expect(count).to_not receive :retire!
+        worker.perform count.id
+      end
+    end
   end
 
   describe "#finish_workflow!" do


### PR DESCRIPTION
Scenario is:
  - 3 people classify the same subject simultaneously.
  - The subject will retire after the next classification
  - The subject will attempt to retire and dequeue 3 times

This just adds a check to ensure it's not already retired.

I'm sure it's possible for a race condition to allow multiple retirements in cases of very high concurrency, but this should take care of the majority of them.