### PR TITLE
Upgrade to Ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   fast_finish: true
   allow_failures:
   include:
-    - rvm: 2.2.1
+    - rvm: 2.3.0
 
 services:
   - postgresql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zooniverse/ruby:2.2.1
+FROM zooniverse/ruby:2.3.0
 
 WORKDIR /rails_app
 


### PR DESCRIPTION
Primarily to fix [this bug](https://app.honeybadger.io/projects/40595/faults/23124244) and the performance hit it causes.

2.3 also includes [the lonely operator](https://bugs.ruby-lang.org/issues/11537) and other performance improvements.