### PR TITLE
split the travis build up on different concerns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,41 @@ language: ruby
 cache: bundler
 sudo: false
 
+bundler_args: --without development production
+
+before_install:
+  - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
+
 before_script: &before_script
   - psql -c 'create database travis_ci_test;' -U postgres
   - mkdir -p tmp
-  - RACK_ENV=test bundle exec rake configure:travis db:setup
+  - bundle exec rake configure:travis db:setup
+  - echo Running script - bundle exec rspec $SPECS
 
 matrix:
   fast_finish: true
-  allow_failures:
   include:
     - rvm: 2.3.0
       env:
-        - SPECFOLDER=spec/controllers
-        - SPECFOLDER=spec/lib
-        - SPECFOLDER=spec/mailers
-        - SPECFOLDER=spec/middleware
-        - SPECFOLDER=spec/models
-        - SPECFOLDER=spec/requests
-        - SPECFOLDER=spec/serializers
-        - SPECFOLDER=spec/workers
+        - SPECS=spec/controllers/api/v1/[a-m]*.rb
+    - rvm: 2.3.0
+      env:
+        - SPECS=spec/controllers/api/v1/[n-s]*.rb
+    - rvm: 2.3.0
+      env:
+        - SPECS=spec/controllers/api/v1/[t-z]*.rb
+    - rvm: 2.3.0
+      env:
+        - SPECS="spec/controllers/*.rb spec/controllers/api/*.rb"
+    - rvm: 2.3.0
+      env:
+        - SPECS=spec/models
+    - rvm: 2.3.0
+      env:
+        - SPECS=spec/workers
+    - rvm: 2.3.0
+      env:
+        - SPECS="spec/serializers spec/requests spec/middleware spec/mailers spec/lib"
 
 services:
   - postgresql
@@ -28,4 +44,4 @@ services:
 addons:
   postgresql: "9.4"
 
-script: "RACK_ENV=test bundle exec rspec $SPECFOLDER"
+script: "bundle exec rspec $SPECS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - SPECS=spec/controllers/api/v1/[t-z]*.rb
     - rvm: 2.3.0
       env:
-        - SPECS="spec/controllers/**.rb spec/controllers/api/*.rb spec/models"
+        - SPECS="spec/controllers/**.rb spec/controllers/api/*.rb spec/models spec/operations"
     - rvm: 2.3.0
       env:
         - SPECS="spec/lib spec/workers spec/serializers spec/requests spec/middleware spec/mailers"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_script: &before_script
   - psql -c 'create database travis_ci_test;' -U postgres
   - mkdir -p tmp
   - bundle exec rake configure:travis db:setup
+  - find spec -maxdepth 1 -type d | grep spec/ > tmp/curr_spec_dirs.txt
+  - grep -Fxv -f spec/known_dirs.txt tmp/curr_spec_dirs.txt
   - echo Running script - bundle exec rspec $SPECS
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,15 @@ matrix:
   allow_failures:
   include:
     - rvm: 2.3.0
+      env:
+        - SPECFOLDER=spec/controllers
+        - SPECFOLDER=spec/lib
+        - SPECFOLDER=spec/mailers
+        - SPECFOLDER=spec/middleware
+        - SPECFOLDER=spec/models
+        - SPECFOLDER=spec/requests
+        - SPECFOLDER=spec/serializers
+        - SPECFOLDER=spec/workers
 
 services:
   - postgresql
@@ -19,4 +28,4 @@ services:
 addons:
   postgresql: "9.4"
 
-script: RACK_ENV=test bundle exec rspec
+script: "RACK_ENV=test bundle exec rspec $SPECFOLDER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ sudo: false
 bundler_args: --without development production
 
 before_install:
+  - mkdir -p tmp
+  - find spec -maxdepth 1 -type d | grep spec/ > tmp/curr_spec_dirs.txt
+  - if grep -Fxvc -f spec/known_dirs.txt tmp/curr_spec_dirs.txt; then echo 'Detected unkown Spec directories, check the spec/known_dirs.txt!'; exit 1; fi
   - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
 
 before_script: &before_script
   - psql -c 'create database travis_ci_test;' -U postgres
-  - mkdir -p tmp
   - bundle exec rake configure:travis db:setup
-  - find spec -maxdepth 1 -type d | grep spec/ > tmp/curr_spec_dirs.txt
-  - grep -Fxv -f spec/known_dirs.txt tmp/curr_spec_dirs.txt
   - echo Running script - bundle exec rspec $SPECS
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,10 @@ matrix:
         - SPECS=spec/controllers/api/v1/[t-z]*.rb
     - rvm: 2.3.0
       env:
-        - SPECS="spec/controllers/*.rb spec/controllers/api/*.rb"
+        - SPECS="spec/controllers/**.rb spec/controllers/api/*.rb spec/models"
     - rvm: 2.3.0
       env:
-        - SPECS=spec/models
-    - rvm: 2.3.0
-      env:
-        - SPECS=spec/workers
-    - rvm: 2.3.0
-      env:
-        - SPECS="spec/serializers spec/requests spec/middleware spec/mailers spec/lib"
+        - SPECS="spec/lib spec/workers spec/serializers spec/requests spec/middleware spec/mailers"
 
 services:
   - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'sinatra', '>= 1.3.0', require: nil
 gem 'aws-sdk-v1', '~> 1.0'
 gem 'json-schema', '~> 2.0'
 gem 'p3p', '~> 1.0'
-gem 'newrelic_rpm', '~> 3.0', require: false
 gem 'stringex', '~> 2.0'
 gem 'faraday', '~> 0.9'
 gem 'faraday_middleware', '~> 0.9'
@@ -37,11 +36,12 @@ gem 'sidekiq-congestion', '~> 0.1.0'
 gem 'sidetiq', '~> 0.6.3'
 gem 'cellect-client', '~> 1.2.0', require: false
 gem 'active_interaction', '~> 3.0.1'
+gem 'therubyracer', '~> 0.12'
+gem 'pg', '~> 0.18'
+gem 'poseidon', '~> 0.0.5'
 
-platforms :ruby do
-  gem 'therubyracer', '~> 0.12'
-  gem 'pg', '~> 0.18'
-  gem 'poseidon', '~> 0.0.5'
+group :production do
+  gem 'newrelic_rpm', '~> 3.0', require: false
 end
 
 group :development do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe Api::V1::ProjectsController, type: :controller do
   let(:user) { create(:user) }
-  let(:projects) { create_list(:project_with_contents, 2, owner: user) }
-  let(:project) { create(:project_with_contents, owner: user) }
+  let(:projects) do
+    create_list(:project_with_contents, 2, owner: user)
+  end
   let(:authorized_user) { user }
 
   let(:api_resource_name) { "projects" }
@@ -84,7 +85,6 @@ describe Api::V1::ProjectsController, type: :controller do
           it_behaves_like "filter by display_name"
 
           describe "filter by display_name substring" do
-
             let(:index_options) { {search: resource.display_name[0..2]} }
 
             it "should respond with the most relevant item first" do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -5,6 +5,7 @@ describe Api::V1::ProjectsController, type: :controller do
   let(:projects) do
     create_list(:project_with_contents, 2, owner: user)
   end
+  let(:project) { create(:project_with_contents, owner: user) }
   let(:authorized_user) { user }
 
   let(:api_resource_name) { "projects" }

--- a/spec/known_dirs.txt
+++ b/spec/known_dirs.txt
@@ -1,0 +1,12 @@
+spec/support
+spec/requests
+spec/operations
+spec/middleware
+spec/factories
+spec/models
+spec/fixtures
+spec/mailers
+spec/controllers
+spec/lib
+spec/serializers
+spec/workers


### PR DESCRIPTION
Split the spec tasks up to the concurrent build limit on travis (currently 5) to decrease the total run time (prev 23m, now ~7m).