### PR TITLE
Add libpg-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /rails_app
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y git curl supervisor  && \
+    apt-get install --no-install-recommends -y git curl supervisor libpq-dev && \
     apt-get clean
 
 ADD ./Gemfile /rails_app/


### PR DESCRIPTION
Was removed by zooniverse/docker-ruby#3

Don't merge yet... just waiting for the Docker build to finish to make sure that's everything we need.