### PR TITLE
Make debugging with pry more awesome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ end
 group :development, :test do
   gem 'foreman'
   gem 'pry-rails'
+  gem 'pry-byebug'
+  gem 'pry-stack_explorer'
   gem 'spring'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,10 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     bcrypt (3.1.10)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    byebug (8.2.2)
     cellect-client (1.2.0)
       celluloid (= 0.16.0)
       celluloid-io (= 0.16.0)
@@ -77,6 +80,7 @@ GEM
       redis (>= 3.1)
     connection_pool (2.2.0)
     database_cleaner (1.3.0)
+    debug_inspector (0.0.2)
     devise (3.5.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -220,8 +224,14 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     puma (2.15.3)
     rack (1.6.4)
     rack-cors (0.4.0)
@@ -401,7 +411,9 @@ DEPENDENCIES
   pg_search
   poseidon (~> 0.0.5)
   postgres_ext (~> 2.4.0)
+  pry-byebug
   pry-rails
+  pry-stack_explorer
   puma (~> 2.0)
   rack-cors (~> 0.3)
   rails (~> 4.2.5)


### PR DESCRIPTION
* byebug adds commands like `step` (step-into), `next` (step-over), `continue`, `finish`. Also adds ability to set more breakpoints once you're in a pry session.

* stack_explorer adds `show-stack`, `up` and `down` to inspect state higher up in the call stack. byebug adds some of this, but that only works with a stack that starts at the point the pry started, so you can't look at state higher up the call chain, hence this additional gem.