### PR TITLE
Fetch and use latest AWS proxy ips on container build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # Ignore all config files
 /config/*.yml
+/config/aws_ips.json
 
 .vagrant/
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y git curl supervisor libpq-dev && \
     apt-get clean
 
+RUN mkdir config && curl "https://ip-ranges.amazonaws.com/ip-ranges.json" > config/aws_ips.json
+
 ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 

--- a/config/initializers/loadbalancer_ips.rb
+++ b/config/initializers/loadbalancer_ips.rb
@@ -1,0 +1,13 @@
+aws_ips_file_path = Rails.root.join("config/aws_ips.json")
+
+# File should always exist in prod/stag but allow testing this in dev mode if file exists
+if Rails.env.production? or Rails.env.staging? or File.exists?(aws_ips_file_path)
+  json = File.read(aws_ips_file_path)
+  data = JSON.load(json)
+
+  proxy_ips = data.fetch("prefixes")
+                  .select { |i| i.fetch("service") == "CLOUDFRONT" }
+                  .map { |i| IPAddr.new(i.fetch("ip_prefix")) }
+
+  Rails.application.config.action_dispatch.trusted_proxies = ActionDispatch::RemoteIp::TRUSTED_PROXIES + proxy_ips
+end


### PR DESCRIPTION
We could do fancier and subscribe to the SNS topic that publishes changes, but this probably works acceptably for our purposes. Just have to keep deploying ;)