### PR TITLE
Fix owner role filter

### DIFF
--- a/app/controllers/concerns/filter_by_current_user_roles.rb
+++ b/app/controllers/concerns/filter_by_current_user_roles.rb
@@ -13,7 +13,7 @@ module FilterByCurrentUserRoles
         .where(access_control_lists: {user_group_id: api_user.user.identity_group.id})
         .where.overlap(access_control_lists: { roles: roles_filter })
       if owner_eager_load(roles_filter)
-        @controlled_resources = @controlled_resources.eager_load(:owner)
+        @controlled_resources = @controlled_resources.preload(:owner)
       end
     end
   end

--- a/spec/factories/subject_sets.rb
+++ b/spec/factories/subject_sets.rb
@@ -13,7 +13,10 @@ FactoryGirl.define do
 
     factory :subject_set_with_subjects do
       after(:create) do |sg|
-        create_list(:set_member_subject, 2, subject_set: sg)
+        2.times do |i|
+          subject = create(:subject, project: sg.project, uploader: sg.project.owner)
+          create(:set_member_subject, subject_set: sg, subject: subject)
+        end
       end
     end
   end


### PR DESCRIPTION
closes #1646 - uses preload to create a valid sql query when filtering only on the owner role. I've taken the streamline the projects_controller testing state as well, should be less cruft in the db for each test run.