### PR TITLE
Add user group ids to classifications

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,6 +257,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def non_identity_user_group_ids
+    memberships.where(identity: false).pluck(:user_group_id)
+  end
+
   def panoptes_zoo_id
     "panoptes-#{ id }"
   end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -86,6 +86,7 @@ class ClassificationLifecycle
     mark_expert_classifier
     add_seen_before_for_user
     add_project_live_state
+    add_user_groups
     add_lifecycled_at
     classification.save!
   end
@@ -116,6 +117,11 @@ class ClassificationLifecycle
 
   def add_project_live_state
     update_classification_metadata(:live_project, project.live)
+  end
+
+  def add_user_groups
+    return if classification.anonymous?
+    update_classification_metadata(:user_group_ids, user.non_identity_user_group_ids)
   end
 
   def add_lifecycled_at


### PR DESCRIPTION
This is so we can associate classifications with user groups (in post-processing done by education api)