### PR TITLE
consistent event time format

### DIFF
--- a/app/workers/publish_classification_event_worker.rb
+++ b/app/workers/publish_classification_event_worker.rb
@@ -12,7 +12,7 @@ class PublishClassificationEventWorker
     if classification.complete?
       EventStream.push("classification",
         event_id: "classification-#{classification.id}",
-        event_time: classification.updated_at.iso8601,
+        event_time: classification.updated_at,
         classification_id: classification.id,
         project_id: classification.project.id,
         user_id: classification_user_id,

--- a/app/workers/publish_classification_event_worker.rb
+++ b/app/workers/publish_classification_event_worker.rb
@@ -12,7 +12,7 @@ class PublishClassificationEventWorker
     if classification.complete?
       EventStream.push("classification",
         event_id: "classification-#{classification.id}",
-        event_time: "#{classification.updated_at}",
+        event_time: classification.updated_at.iso8601,
         classification_id: classification.id,
         project_id: classification.project.id,
         user_id: classification_user_id,

--- a/lib/event_stream.rb
+++ b/lib/event_stream.rb
@@ -2,8 +2,18 @@ module EventStream
   def self.push(event_type, event_id: SecureRandom.uuid, event_time: Time.now.utc, **metadata)
     event_type = "panoptes.#{event_type}"
     event_id   = "#{event_type}.#{event_id}"
-    event_data = metadata.merge(event_id: event_id, event_time: event_time, event_type: event_type).to_json
+    event_data = metadata.merge(
+      event_id: event_id,
+      event_time: formatted_time(event_time),
+      event_type: event_type
+    ).to_json
 
     MultiKafkaProducer.publish('events', [event_id, event_data])
+  end
+
+  def self.formatted_time(time)
+    return time.iso8601 if time.respond_to?(:iso8601)
+    valid_time_str = Time.parse(time)
+    valid_time_str.iso8601
   end
 end

--- a/spec/lib/event_stream_spec.rb
+++ b/spec/lib/event_stream_spec.rb
@@ -23,8 +23,8 @@ describe EventStream do
         [anything, including("2015-01-02")]).once
     end
 
-    it 'ensures the event has a consistently formatted time' do
-      time = "#{Time.zone.now}"
+    it 'ensures it calls the time format method' do
+      time = Time.zone.now
       expect(EventStream).to receive(:formatted_time).with(time)
       EventStream.push(topic, event_time: time)
     end
@@ -32,7 +32,7 @@ describe EventStream do
 
   describe "::formatted_time" do
     let(:time) { Time.zone.now }
-    let(:time_str) { "#{Time.zone.now}" }
+    let(:time_str) { time.to_s }
     let(:iso_time_str) { time.iso8601 }
 
     it "should convert a string input to a standard format" do

--- a/spec/lib/event_stream_spec.rb
+++ b/spec/lib/event_stream_spec.rb
@@ -1,23 +1,64 @@
 require 'spec_helper'
 
 describe EventStream do
-  before { allow(MultiKafkaProducer).to receive(:publish) }
+  describe "::push" do
+    let(:topic) { "nosepicking" }
+    before { allow(MultiKafkaProducer).to receive(:publish) }
 
-  it 'pushes events into kafka events topic with custom metadata' do
-    EventStream.push('nosepicking', user_id: 1)
-    expect(MultiKafkaProducer).to have_received(:publish).with('events',
-      [including("panoptes.nosepicking."), including('"user_id":1')]).once
+    it 'pushes events into kafka events topic with custom metadata' do
+      EventStream.push(topic, user_id: 1)
+      expect(MultiKafkaProducer).to have_received(:publish).with('events',
+        [including("panoptes.nosepicking."), including('"user_id":1')]).once
+    end
+
+    it 'uses a custom event id' do
+      EventStream.push(topic, event_id: 1)
+      expect(MultiKafkaProducer).to have_received(:publish).with('events',
+        ["panoptes.nosepicking.1", anything]).once
+    end
+
+    it 'uses a custom event time' do
+      EventStream.push(topic, event_time: Date.new(2015, 1, 2))
+      expect(MultiKafkaProducer).to have_received(:publish).with('events',
+        [anything, including("2015-01-02")]).once
+    end
+
+    it 'ensures the event has a consistently formatted time' do
+      time = "#{Time.zone.now}"
+      expect(EventStream).to receive(:formatted_time).with(time)
+      EventStream.push(topic, event_time: time)
+    end
   end
 
-  it 'uses a custom event id' do
-    EventStream.push('nosepicking', event_id: 1)
-    expect(MultiKafkaProducer).to have_received(:publish).with('events',
-      ["panoptes.nosepicking.1", anything]).once
-  end
+  describe "::formatted_time" do
+    let(:time) { Time.zone.now }
+    let(:time_str) { "#{Time.zone.now}" }
+    let(:iso_time_str) { time.iso8601 }
 
-  it 'uses a custom event time' do
-    EventStream.push('nosepicking', event_time: Date.new(2015, 1, 2))
-    expect(MultiKafkaProducer).to have_received(:publish).with('events',
-      [anything, including("2015-01-02")]).once
+    it "should convert a string input to a standard format" do
+      formatted_time = EventStream.formatted_time(time_str)
+      expect(formatted_time).to eq(iso_time_str)
+    end
+
+    it "should convert a time input to the iso format" do
+      formatted_time = EventStream.formatted_time(time)
+      expect(formatted_time).to eq(iso_time_str)
+    end
+
+    it "should convert a DateTime input to the iso format" do
+      date_time = DateTime.now
+      formatted_time = EventStream.formatted_time(date_time)
+      expect(formatted_time).to eq(date_time.iso8601)
+    end
+
+    it "should raise an error with a weird event time string" do
+      expect {
+        EventStream.formatted_time("invalid")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "should raise an error with a non-valid time" do
+      expect { EventStream.formatted_time(-1) }.to raise_error(TypeError)
+    end
   end
 end

--- a/spec/workers/publish_classification_event_worker_spec.rb
+++ b/spec/workers/publish_classification_event_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PublishClassificationEventWorker do
       let(:payload_expectation) do
         a_hash_including(
           event_id: "classification-#{classification.id}",
-          event_time: classification.created_at.iso8601,
+          event_time: classification.updated_at,
           classification_id: classification.id,
           project_id: classification.project.id,
           user_id: Digest::SHA1.hexdigest(classification.user_id.to_s),

--- a/spec/workers/publish_classification_event_worker_spec.rb
+++ b/spec/workers/publish_classification_event_worker_spec.rb
@@ -2,9 +2,17 @@ require 'spec_helper'
 
 RSpec.describe PublishClassificationEventWorker do
   let(:worker) { described_class.new }
-  let(:classification) { create(:classification) }
+  let(:classification) { build(:classification) }
+  let(:updated_at) { Time.zone.now }
 
   describe "#perform" do
+
+    before do
+      allow(classification).to receive(:id).and_return(1)
+      allow(classification).to receive(:updated_at).and_return(updated_at)
+      allow(Classification).to receive(:find).and_return(classification)
+    end
+
     it "should gracefully handle a missing classification lookup" do
       expect{
         worker.perform(-1)
@@ -13,8 +21,7 @@ RSpec.describe PublishClassificationEventWorker do
 
     context "when classification is incomplete" do
       before do
-        allow_any_instance_of(Classification)
-        .to receive(:complete?).and_return(false)
+        allow(classification).to receive(:complete?).and_return(false)
       end
 
       it "should not publish" do

--- a/spec/workers/publish_classification_event_worker_spec.rb
+++ b/spec/workers/publish_classification_event_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PublishClassificationEventWorker do
       let(:payload_expectation) do
         a_hash_including(
           event_id: "classification-#{classification.id}",
-          event_time: "#{classification.updated_at}",
+          event_time: classification.created_at.iso8601,
           classification_id: classification.id,
           project_id: classification.project.id,
           user_id: Digest::SHA1.hexdigest(classification.user_id.to_s),


### PR DESCRIPTION
ensure a consistent event time format before serializing to kafka