### PR TITLE
Kinesis evaluation

### DIFF
--- a/app/workers/publish_classification_worker.rb
+++ b/app/workers/publish_classification_worker.rb
@@ -32,7 +32,7 @@ class PublishClassificationWorker
   end
 
   def publish_to_kinesis!
-    KinesisPublisher.publish("classification", classification.project.id, kinesis_payload)
+    KinesisPublisher.publish("classification", classification.workflow_id, kinesis_payload)
   end
 
   def kinesis_payload

--- a/app/workers/publish_retirement_event_worker.rb
+++ b/app/workers/publish_retirement_event_worker.rb
@@ -7,13 +7,16 @@ class PublishRetirementEventWorker
 
   def perform(workflow_id)
     workflow = Workflow.find(workflow_id)
-    EventStream.push('workflow_counters',
+    counters = {
       project_id: workflow.project_id,
       workflow_id: workflow.id,
       subjects_count: workflow.subjects_count,
       retired_subjects_count: workflow.retired_subjects_count,
       classifications_count: workflow.classifications_count
-    )
+    }
+
+    EventStream.push('workflow_counters', counters)
+    KinesisPublisher.publish('workflow_counters', workflow.id, counters)
   rescue ActiveRecord::RecordNotFound
   end
 end

--- a/config/initializers/kinesis.rb
+++ b/config/initializers/kinesis.rb
@@ -1,0 +1,6 @@
+case Rails.env
+when "development", "test"
+  # no client
+when "staging", "production"
+  KinesisPublisher.client = AWS::Kinesis::Client.new
+end

--- a/lib/kafka_classification_serializer.rb
+++ b/lib/kafka_classification_serializer.rb
@@ -13,6 +13,10 @@ class KafkaClassificationSerializer < ActiveModel::Serializer
   belongs_to :workflow, serializer: KafkaWorkflowSerializer
   has_many   :subjects, serializer: KafkaSubjectSerializer
 
+  def user_ip
+    object.user_ip.to_s
+  end
+
   def metadata
     object.metadata.merge(workflow_version: object.workflow_version)
   end

--- a/lib/kafka_classification_serializer.rb
+++ b/lib/kafka_classification_serializer.rb
@@ -6,7 +6,7 @@ class KafkaClassificationSerializer < ActiveModel::Serializer
     Serialization::V1Adapter.new(serializer, options)
   end
 
-  attributes :id, :annotations, :created_at, :metadata
+  attributes :id, :created_at, :updated_at, :user_ip, :annotations, :metadata
 
   belongs_to :project, serializer: KafkaProjectSerializer
   belongs_to :user, serializer: KafkaUserSerializer

--- a/lib/kinesis_publisher.rb
+++ b/lib/kinesis_publisher.rb
@@ -1,0 +1,35 @@
+class KinesisPublisher
+  def self.publish(event_type, partition_key, data)
+    return unless client
+
+    client.put_record(
+      stream_name: stream_name,
+      partition_key: partition_key.to_s,
+      data: format_data(event_type, data)
+    )
+  rescue StandardError => ex
+    # While we're still evaluating Kinesis, don't propagate this error, but do notify Honeybadger.
+    Honeybadger.notify(ex)
+  end
+
+  def self.format_data(event_type, data)
+    {
+      source: 'panoptes',
+      type: event_type,
+      version: '1.0.0',
+      data: data
+    }.to_json
+  end
+
+  def self.client
+    @client
+  end
+
+  def self.client=(client)
+    @client = client
+  end
+
+  def self.stream_name
+    ENV.fetch('KINESIS_STREAM')
+  end
+end

--- a/lib/kinesis_publisher.rb
+++ b/lib/kinesis_publisher.rb
@@ -30,6 +30,6 @@ class KinesisPublisher
   end
 
   def self.stream_name
-    ENV.fetch('KINESIS_STREAM')
+    ENV.fetch('KINESIS_STREAM') { "panoptes-#{Rails.env}" }
   end
 end

--- a/spec/lib/kafka_classification_serializer_spec.rb
+++ b/spec/lib/kafka_classification_serializer_spec.rb
@@ -5,13 +5,6 @@ describe KafkaClassificationSerializer do
   let(:serializer) { KafkaClassificationSerializer.new(Classification.find(classification.id)) }
   let(:adapter) { Serialization::V1Adapter.new(serializer) }
 
-  it 'is a substitute for ClassificationSerializer' do
-    new_json = adapter.to_json
-    old_json = ClassificationSerializer.serialize(classification).to_json
-
-    expect(JSON.load(new_json)).to eq(JSON.load(old_json))
-  end
-
   it 'can process includes' do
     subject = create(:subject)
     classification.subject_ids = [subject.id]

--- a/spec/workers/publish_classification_worker_spec.rb
+++ b/spec/workers/publish_classification_worker_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe PublishClassificationWorker do
 
       it "should publish via kinesis" do
         publisher = class_double("KinesisPublisher").as_stubbed_const
-        expect(publisher).to receive(:publish).with("classification", classification.project.id, duck_type(:to_json))
+        expect(publisher).to receive(:publish).with("classification", classification.workflow_id, duck_type(:to_json))
         worker.perform(classification.id)
       end
     end

--- a/spec/workers/publish_retirement_event_worker_spec.rb
+++ b/spec/workers/publish_retirement_event_worker_spec.rb
@@ -25,5 +25,11 @@ RSpec.describe PublishRetirementEventWorker do
         .with("workflow_counters", payload_expectation)
       worker.perform(workflow.id)
     end
+
+    it "should publish via EventStream" do
+      expect(KinesisPublisher).to receive(:publish)
+        .with("workflow_counters", workflow.id, payload_expectation)
+      worker.perform(workflow.id)
+    end
   end
 end

--- a/spec/workers/publish_retirement_event_worker_spec.rb
+++ b/spec/workers/publish_retirement_event_worker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PublishRetirementEventWorker do
       worker.perform(workflow.id)
     end
 
-    it "should publish via EventStream" do
+    it "should publish via Kinesis" do
       expect(KinesisPublisher).to receive(:publish)
         .with("workflow_counters", workflow.id, payload_expectation)
       worker.perform(workflow.id)


### PR DESCRIPTION
**Please note that this will also start pushing `user_ip` into Kafka's `classifications` topic** (This should be fine, Nero is the only one reading from that topic, since ZooEventStats is using the `events` topic.

Both Kinesis and Kafka use the same serializer. I'm doing this so that we can stop having a separate `PublishClassificationEventWorker` (if/when we migrate), instead moving the onus on the stream consumer to pluck items out of the global stream that it cares about (by looking at `type` field) and choose how to publish that. I'll make that change when I swap ZooEventStats over from Kafka to Kinesis.