### PR TITLE
Add linked models to Kinesis

### DIFF
--- a/app/workers/publish_classification_worker.rb
+++ b/app/workers/publish_classification_worker.rb
@@ -20,7 +20,10 @@ class PublishClassificationWorker
   private
 
   def serialized_classification
-    @serialized_classification ||= KafkaClassificationSerializer.serialize(classification, include: ['subjects']).as_json
+    @serialized_classification ||= KafkaClassificationSerializer
+      .serialize(classification, include: ['subjects'])
+      .as_json
+      .with_indifferent_access
   end
 
   def publish_to_kafka!
@@ -32,10 +35,14 @@ class PublishClassificationWorker
   end
 
   def publish_to_kinesis!
-    KinesisPublisher.publish("classification", classification.workflow_id, kinesis_payload)
+    KinesisPublisher.publish("classification", classification.workflow_id, kinesis_data, kinesis_linked)
   end
 
-  def kinesis_payload
-    serialized_classification["classifications"][0]
+  def kinesis_data
+    serialized_classification[:classifications][0]
+  end
+
+  def kinesis_linked
+    serialized_classification[:linked]
   end
 end

--- a/lib/kinesis_publisher.rb
+++ b/lib/kinesis_publisher.rb
@@ -17,6 +17,7 @@ class KinesisPublisher
       source: 'panoptes',
       type: event_type,
       version: '1.0.0',
+      timestamp: Time.now.utc.iso8601,
       data: data,
       linked: linked
     }.to_json

--- a/lib/kinesis_publisher.rb
+++ b/lib/kinesis_publisher.rb
@@ -1,23 +1,24 @@
 class KinesisPublisher
-  def self.publish(event_type, partition_key, data)
+  def self.publish(event_type, partition_key, data, linked = {})
     return unless client
 
     client.put_record(
       stream_name: stream_name,
       partition_key: partition_key.to_s,
-      data: format_data(event_type, data)
+      data: format_data(event_type, data, linked)
     )
   rescue StandardError => ex
     # While we're still evaluating Kinesis, don't propagate this error, but do notify Honeybadger.
     Honeybadger.notify(ex)
   end
 
-  def self.format_data(event_type, data)
+  def self.format_data(event_type, data, linked)
     {
       source: 'panoptes',
       type: event_type,
       version: '1.0.0',
-      data: data
+      data: data,
+      linked: linked
     }.to_json
   end
 

--- a/spec/workers/publish_classification_worker_spec.rb
+++ b/spec/workers/publish_classification_worker_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe PublishClassificationWorker do
 
       it "should publish via kinesis" do
         publisher = class_double("KinesisPublisher").as_stubbed_const
-        expect(publisher).to receive(:publish).with("classification", classification.workflow_id, duck_type(:to_json))
+        expect(publisher).to receive(:publish)
+          .with("classification", classification.workflow_id, duck_type(:to_json), duck_type(:to_json))
         worker.perform(classification.id)
       end
     end


### PR DESCRIPTION
I started working towards having JSON-API linked models be in the stream too (Nero uses that feature of the Kafka stream). Needed a place to store some thoughts (since I won't be working all the way through them yet), so making the PR way ahead of it being ready. This'll be dependent on us wanting to complete the migration from Kafka -> Kinesis.

* Remove old `EventStream` (possibly rename `KinesisPublisher` to be `EventStream`)
* `KinesisPublisher` should just take JSON-API-conforming hashes. Since those may contain an array of models (remember, format is `{classifications: [...], linked: {...}}`), the publisher should take care of outputting one event per model in the main collection ("classifications"), passing along all (or just appropriate) linked data. I really feel like one line in the stream should always only contain one model plus linked data.
* There's a Kinesis `put_records` method for publishing multiple lines in bulk.