### PR TITLE
re-enable disabled job after the worker api change

### DIFF
--- a/app/workers/dequeue_subject_queue_worker.rb
+++ b/app/workers/dequeue_subject_queue_worker.rb
@@ -10,8 +10,6 @@ class DequeueSubjectQueueWorker
     }.merge({key: -> (queue_id, sms_ids) { "queue_#{ queue_id }_dequeue" }})
 
   def perform(queue_id, sms_ids)
-    # @note REVERT after https://github.com/zooniverse/Panoptes/pull/1676 is deployed
-    return nil if Rails.env.production?
     return if sms_ids.blank?
     queue = SubjectQueue.find(queue_id)
     queue.dequeue_update(sms_ids)

--- a/app/workers/enqueue_subject_queue_worker.rb
+++ b/app/workers/enqueue_subject_queue_worker.rb
@@ -16,8 +16,6 @@ class EnqueueSubjectQueueWorker
   attr_reader :queue, :workflow, :user, :subject_set_id, :limit, :selection_strategy
 
   def perform(queue_id, limit=SubjectQueue::DEFAULT_LENGTH, strategy_override=nil)
-    # @note REVERT after https://github.com/zooniverse/Panoptes/pull/1676 is deployed
-    return nil if Rails.env.production?
     @queue = SubjectQueue.find(queue_id)
     @workflow = queue.workflow
     @user = queue.user


### PR DESCRIPTION
Merge after the latest build / deploy - revert a temp workaround for production sidekiq jobs