### PR TITLE
rework SMS selector

### DIFF
--- a/app/models/concerns/subject_counts.rb
+++ b/app/models/concerns/subject_counts.rb
@@ -10,7 +10,7 @@ module SubjectCounts
   end
 
   def finished?
-    @finished ||= if subject_sets.empty?
+    @finished ||= if subject_sets.empty? || subjects_count == 0
       false
     else
       retired_subjects_count >= subjects_count

--- a/lib/subjects/set_member_subject_selector.rb
+++ b/lib/subjects/set_member_subject_selector.rb
@@ -16,29 +16,24 @@ module Subjects
                   elsif select_from_all?
                     select_all_workflow_set_member_subjects
                   else
-                    select_non_retired_unseen_for_user
+                    select_data_for_the_user
                   end
-      if all_user_unseen_data_is_retired?(selection)
-        selection = select_unseen_for_user
-      end
       selection.select(SELECT_FIELDS)
-    end
-
-    def select_from_all?
-      !user ||
-      user_has_not_seen_workflow_subjects? ||
-      workflow.finished? ||
-      user.has_finished?(workflow)
     end
 
     private
 
-    def all_user_unseen_data_is_retired?(selection)
-      user && !selection.exists?
+    def select_from_all?
+      !user || workflow.finished? || user.has_finished?(workflow)
     end
 
-    def user_has_not_seen_workflow_subjects?
-      !user.user_seen_subjects.where(workflow: workflow).exists?
+    def select_data_for_the_user
+      scope = select_non_retired_unseen_for_user
+      if scope.exists?
+        scope
+      else
+        select_unseen_for_user
+      end
     end
 
     def select_non_retired

--- a/spec/lib/subjects/set_member_subject_selector_spec.rb
+++ b/spec/lib/subjects/set_member_subject_selector_spec.rb
@@ -1,106 +1,130 @@
 require 'spec_helper'
 
 describe Subjects::SetMemberSubjectSelector do
-  let(:project) { create :project, workflows: build_list(:workflow, 1) }
-  let(:subject_set) { create :subject_set, project: project }
-  let(:subject) { create :subject, project: project, subject_sets: [subject_set]}
-  let(:seen_subject) { create(:subject, project: project, subject_sets: [subject_set]) }
 
+  def update_set_sms_count(subject_set)
+    sms_count = subject_set.set_member_subjects.count
+    subject_set.update_attribute(:set_member_subjects_count, sms_count)
+  end
+
+  let(:project) { create(:project_with_workflow) }
+  let(:workflow) { project.workflows.first }
+  let(:subject_set) do
+    create(:subject_set, workflows: [workflow], project: project)
+  end
+  let!(:subject) do
+    create(:subject, project: project, subject_sets: [subject_set])
+  end
+  let(:seen_subject) do
+    create(:subject, project: project, subject_sets: [subject_set])
+  end
+  let(:non_retired_unseen) do
+    create(:subject, project: project, subject_sets: [subject_set])
+  end
   let(:count) do
-    create(:subject_workflow_count, subject: subject, workflow: project.workflows.first)
+    create(:subject_workflow_count, subject: subject, workflow: workflow)
   end
   let(:user) { create(:user) }
   let(:user_seen_subject) do
-    create(:user_seen_subject, user: user, workflow: count.workflow, subject_ids: [seen_subject.id])
+    create(:user_seen_subject, user: user, workflow: workflow, subject_ids: [seen_subject.id])
   end
   let(:selector_class) { Subjects::SetMemberSubjectSelector }
 
   before do
-    count.workflow.subject_sets = count.subject.subject_sets
-    count.workflow.save!
+    non_retired_unseen
+    update_set_sms_count(subject_set)
   end
 
   context 'when there is no user' do
-    let(:workflow) { create(:workflow_with_subjects) }
     let(:selector) { selector_class.new(workflow, nil) }
 
     context 'when the workflow is not finished' do
       it 'should select from the non retired remaining subjects' do
-        expect(SetMemberSubject).to receive(:non_retired_for_workflow)
-          .with(workflow).and_call_original
+        expect(SetMemberSubject)
+          .to receive(:non_retired_for_workflow)
+          .with(workflow)
+          .and_call_original
         selector.set_member_subjects
       end
+    end
 
-      context "when the workflow is finished" do
-
-        it "should select the whole set of workflow set_member_subjects" do
-          allow(workflow).to receive(:finished?).and_return(true)
-          aggregate_failures "select all" do
-            expect(selector).to receive(:select_all_workflow_set_member_subjects)
-              .and_call_original
-            expect(selector.set_member_subjects)
-              .to match_array(workflow.set_member_subjects)
-          end
-        end
+    context "when the workflow is finished" do
+      it "should select the whole set of workflow set_member_subjects", :aggregate_failures do
+        allow(workflow).to receive(:finished?).and_return(true)
+        expect(selector)
+          .to receive(:select_all_workflow_set_member_subjects)
+          .and_call_original
+        expect(selector.set_member_subjects)
+          .to match_array(workflow.set_member_subjects)
       end
+    end
 
-      context "when there all the data is retired" do
-
-        it "should not attempt to select the unseen for a user" do
-          allow(selector).to receive(:select_non_retired)
-            .and_return(SetMemberSubject.none)
-          aggregate_failures "select" do
-            expect(selector).not_to receive(:select_unseen_for_user)
-            expect(selector.set_member_subjects).to be_empty
-          end
-        end
+    context "when there all the data is retired" do
+      it "should not attempt to select the unseen for a user", :aggregate_failures do
+        allow(selector).to receive(:select_non_retired)
+          .and_return(SetMemberSubject.none)
+        expect(selector).not_to receive(:select_unseen_for_user)
+        expect(selector.set_member_subjects).to be_empty
       end
     end
   end
 
-  context 'when there is a user and they have participated before' do
-    before do
-      allow_any_instance_of(selector_class).to receive(:select_from_all?)
-        .and_return(false)
-    end
-
+  context 'when there is a user' do
     let(:sms_to_classify) do
-      selector_class.new(count.workflow, user).set_member_subjects
+      selector_class.new(workflow, user).set_member_subjects
     end
 
-    it 'does not include subjects that have been seen' do
-      user_seen_subject
-      expect(sms_to_classify).to eq([count.subject.set_member_subjects.first])
-    end
-
-    it 'does not include subjects that are retired' do
-      sms = create(:set_member_subject, subject_set: subject_set)
-      count.retire!
-      expect(sms_to_classify).to eq([sms])
-    end
-
-    context "when a user has seen all non-retired" do
-
-      before(:each) do
-        user_seen_subject
-        create(:subject_workflow_count, subject: seen_subject, workflow: count.workflow)
-        count.retire!
+    context "they have not participated before" do
+      it 'does not include subjects that are retired' do
+        retired_sms = count.set_member_subjects
+        count.touch(:retired_at)
+        expect(sms_to_classify).not_to include(*retired_sms)
       end
+    end
 
-      it "should return something to classify" do
-        expect(sms_to_classify).to_not be_empty
+    context "they have participated before" do
+      before do
+        user_seen_subject
+        update_set_sms_count(subject_set)
       end
 
       it 'does not include subjects the user has seen' do
-        user_seen_subject
-        expect(sms_to_classify).to eq([count.subject.set_member_subjects.first])
+        expect(sms_to_classify).not_to include(seen_subject)
       end
-    end
 
-    context "when there are set_member_subjects from other workfow" do
-      it "should only return set_member_subjects from the set workflow" do
-        sms = create(:set_member_subject)
-        expect(sms_to_classify).to eq([count.subject.set_member_subjects.first])
+      it 'does not include subjects that are retired' do
+        retired_sms = count.set_member_subjects
+        count.touch(:retired_at)
+        expect(sms_to_classify).not_to include(*retired_sms)
+      end
+
+      context "when a user has seen all non-retired" do
+        before(:each) do
+          UserSeenSubject.add_seen_subjects_for_user(
+            user: user,
+            workflow: workflow,
+            subject_ids: non_retired_unseen.id
+          )
+          count.touch(:retired_at)
+        end
+
+        it "should return something to classify" do
+          expect(sms_to_classify).to_not be_empty
+        end
+
+        it 'returns only the retired data the user has not seen' do
+          expect(sms_to_classify).to match_array(subject.set_member_subjects)
+        end
+      end
+
+      context "when there are set_member_subjects from another workfow" do
+        it "should only return set_member_subjects from the set workflow" do
+          sms = create(:set_member_subject)
+          workflow_smses = [ subject, non_retired_unseen]
+            .map(&:set_member_subjects)
+            .flatten
+          expect(sms_to_classify).to match_array(workflow_smses)
+        end
       end
     end
   end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -252,16 +252,27 @@ describe Workflow, :type => :model do
   end
 
   describe "#finished?" do
-    it 'should be true when and retired count is equal or greater than the subject count ' do
-      subject_relation.retired_set_member_subjects_count = subject_relation.subjects_count
-      subject_relation.save!
-      expect(subject_relation).to be_finished
-    end
-
     context "when no subject_sets relation exist" do
       it 'should be false' do
-        allow(workflow).to receive(:subjects_count).and_return(0)
-        expect(workflow.finished?).to eq(false)
+        allow(subject_relation).to receive(:subject_sets).and_return([])
+        expect(subject_relation).not_to be_finished
+      end
+    end
+
+    context "when retired count is equal or greater than the subject count" do
+      before do
+        allow(subject_relation)
+          .to receive(:retired_set_member_subjects_count)
+          .and_return(subject_relation.subjects_count)
+      end
+
+      it 'should be true' do
+        expect(subject_relation).to be_finished
+      end
+
+      it 'should be false when the subject_count is 0' do
+        allow(subject_relation).to receive(:subjects_count).and_return(0)
+        expect(subject_relation).not_to be_finished
       end
     end
   end


### PR DESCRIPTION
closes #1661 - new users should not see retired data and a fix for the workflow.finished? check.

Also turns out i hate my future self and wrote some hard to understand specs a while back...past_cam--