### PR TITLE
pass the user not the api_user to the subject selector

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def selector
-    @selector ||= Subjects::Selector.new(api_user,
+    @selector ||= Subjects::Selector.new(api_user.user,
       workflow,
       params,
       controlled_resources)

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -63,7 +63,7 @@ module Subjects
 
     def fallback_selection(limit=5)
       opts = { limit: limit, subject_set_id: subject_set_id }
-      selector = PostgresqlSelection.new(workflow, user.user, opts)
+      selector = PostgresqlSelection.new(workflow, user, opts)
       sms_ids = selector.select
       return sms_ids unless sms_ids.blank?
       selector.any_workflow_data
@@ -96,17 +96,17 @@ module Subjects
     end
 
     def finished_workflow?
-      @finished_workflow ||= workflow.finished? || user.has_finished?(workflow)
+      @finished_workflow ||= workflow.finished? || user && user.has_finished?(workflow)
     end
 
     def queue_user
-      @queue_user ||= finished_workflow? ? nil : user.user
+      @queue_user ||= finished_workflow? ? nil : user
     end
 
     def queue_context
       @queue_context ||= {
         workflow: workflow,
-        user_seen: UserSeenSubject.where(user: user.user, workflow: workflow)
+        user_seen: UserSeenSubject.where(user: user, workflow: workflow)
       }
     end
 

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Subjects::Selector do
   let(:workflow) { create(:workflow_with_subjects) }
-  let(:user) { ApiUser.new(create(:user)) }
+  let(:user) { create(:user) }
   let(:smses) { create_list(:set_member_subject, 10).reverse }
   let(:params) { {} }
   let(:subject_queue) do
@@ -26,7 +26,7 @@ RSpec.describe Subjects::Selector do
       it 'should create a new queue from the logged out queue' do
         subject_queue
         expect(SubjectQueue).to receive(:create_for_user)
-          .with(workflow, user.user, set_id: nil).and_call_original
+          .with(workflow, user, set_id: nil).and_call_original
         subject.get_subjects
       end
 
@@ -68,7 +68,7 @@ RSpec.describe Subjects::Selector do
       let(:subject_queue) do
         create(:subject_queue,
                workflow: workflow,
-               user: user.user,
+               user: user,
                set_member_subject_ids: (1..10).to_a)
       end
       before do
@@ -89,7 +89,7 @@ RSpec.describe Subjects::Selector do
       let(:subject_queue) do
         create(:subject_queue,
                workflow: workflow,
-               user: user.user,
+               user: user,
                subject_set: queue_subject_set,
                set_member_subjects: [])
       end
@@ -147,7 +147,7 @@ RSpec.describe Subjects::Selector do
       before(:each) { subject_queue }
 
       context "when the user has a queue" do
-        let(:queue_owner) { user.user }
+        let(:queue_owner) { user }
 
         it 'should dequeue the ids from the users queue' do
           expect{
@@ -160,7 +160,7 @@ RSpec.describe Subjects::Selector do
 
       context "when the queue has no user" do
         let(:queue_owner) { nil }
-        let(:user) { ApiUser.new(nil) }
+        let(:user) { nil }
 
         # anonymous site users can cause a lot of contention on updates
         # to the non-logged in queues, use the rate limiter in sidekiq to
@@ -200,7 +200,7 @@ RSpec.describe Subjects::Selector do
           end
 
           context "when the logged_out queue doesn't exist" do
-            let(:queue_owner) { user.user }
+            let(:queue_owner) { user }
 
             it_behaves_like "creates for the logged out user"
           end
@@ -212,7 +212,7 @@ RSpec.describe Subjects::Selector do
           end
 
           context "when the logged_out queue doesn't exist" do
-            let(:queue_owner) { user.user }
+            let(:queue_owner) { user }
 
             it_behaves_like "creates for the logged out user"
           end


### PR DESCRIPTION
this should fix the no method errors introduced from #1682 & #1676 