### PR TITLE
replenish selection queues asap

### DIFF
--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -46,7 +46,7 @@ class SubjectQueue < ActiveRecord::Base
   end
 
   def below_minimum?
-    set_member_subject_ids.length < MINIMUM_LENGTH
+    set_member_subject_ids.length <= MINIMUM_LENGTH
   end
 
   def next_subjects(limit=10)

--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -210,8 +210,16 @@ RSpec.describe SubjectQueue, type: :model do
       end
     end
 
+    context "when equal to #{SubjectQueue::MINIMUM_LENGTH} items" do
+      let(:subject_ids) { (1..SubjectQueue::MINIMUM_LENGTH).to_a }
+
+      it 'should return true' do
+        expect(queue.below_minimum?).to be true
+      end
+    end
+
     context "when more than #{SubjectQueue::MINIMUM_LENGTH} items" do
-      let(:subject_ids) { (0..SubjectQueue::MINIMUM_LENGTH+1).to_a }
+      let(:subject_ids) { (0..SubjectQueue::MINIMUM_LENGTH).to_a }
 
       it 'should return false' do
         expect(queue.below_minimum?).to be false


### PR DESCRIPTION
Replenish the queue after a default size first selection and 1 classification comes back. This will work in tandem with stale queues to support a subject selection buffer during active classification sessions. This buffer will expire after 30 mins (currently) of classificaiton inactivity.