### PR TITLE
spec timestamp updates

### DIFF
--- a/spec/models/subject_queue_spec.rb
+++ b/spec/models/subject_queue_spec.rb
@@ -118,6 +118,12 @@ RSpec.describe SubjectQueue, type: :model do
       sq.update_ids(1)
       expect(sq.reload.set_member_subject_ids).to eq([1])
     end
+
+    it "should touch the updated_at timestamp if the attribute changes" do
+      expect {
+        sq.update_ids(1)
+      }.to change{ sq.updated_at }
+    end
   end
 
   describe "#enqueue_update" do


### PR DESCRIPTION
make sure we use an attribute update that also touches the updated_at timestamp, as this is used to determine if a queue is stale and thus if a queue is used.