### PR TITLE
handle stale queue update error in selection

### DIFF
--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -128,17 +128,13 @@ module Subjects
     end
 
     def dequeue_ids(queue, sms_ids)
-      background_update = !queue_user
       if queue_user
-        begin
-          queue.dequeue_update(sms_ids)
-        rescue ActiveRecord::StaleObjectError
-          background_update = true
-        end
-      end
-      if background_update
+        queue.dequeue_update(sms_ids)
+      else
         DequeueSubjectQueueWorker.perform_async(queue.id, sms_ids)
       end
+    rescue ActiveRecord::StaleObjectError
+      DequeueSubjectQueueWorker.perform_async(queue.id, sms_ids)
     end
   end
 end

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -129,6 +129,7 @@ module Subjects
 
     def dequeue_ids(queue, sms_ids)
       if queue_user
+        #TODO: what happens if this raises and error?
         queue.dequeue_update(sms_ids)
       else
         DequeueSubjectQueueWorker.perform_async(queue.id, sms_ids)


### PR DESCRIPTION
may hit stale queue error when dequeuing in the request cycle for logged in users. this will catch the error and push it to the background.