### PR TITLE
[WIP] Build docker image from ruby:2.3-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
-FROM zooniverse/ruby:2.3
+FROM ruby:2.3-alpine
 
 WORKDIR /rails_app
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y git curl supervisor libpq-dev && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache git curl supervisor libxml2 libxslt libpq nodejs
 
 RUN mkdir config && curl "https://ip-ranges.amazonaws.com/ip-ranges.json" > config/aws_ips.json
 
 ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
-RUN bundle install --without development test
+RUN apk add --no-cache --virtual bundle-build \
+        libxml2-dev libxslt-dev postgresql-dev build-base && \
+    bundle config build.nokogiri --use-system-libraries && \
+    bundle config build.therubyracer --use-system-libraries && \
+    bundle install --without development test && \
+    apk del bundle-build
 
-ADD supervisord.conf /etc/supervisor/conf.d/panoptes.conf
+ADD supervisord.conf /etc/supervisor.d/panoptes.ini
 ADD ./ /rails_app
 
 RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt && rm -rf .git)

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/sh -ex
 
 cd /rails_app
 
@@ -30,5 +30,5 @@ else
     cp commit_id.txt public/
   fi
 
-  exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+  exec /usr/bin/supervisord -c /etc/supervisord.conf
 fi


### PR DESCRIPTION
This changes the Dockerfile to build `FROM ruby:2.3-alpine` -- there's really no reason for us to build our own ruby image when there's an official one, and the -alpine version is tiny. This reduces the final panoptes image size to 130 MB (down from the current 248 MB).

This will need a thorough test when it's deployed to staging. Alpine uses musl libc rather than glibc, so we'll need to make sure this doesn't have any unintended effects.