### PR TITLE
Add project, workflow, workflow_content and user into stream

### DIFF
--- a/app/serializers/event_stream_serializers/classification_serializer.rb
+++ b/app/serializers/event_stream_serializers/classification_serializer.rb
@@ -7,12 +7,30 @@ module EventStreamSerializers
       Serialization::V1Adapter.new(serializer, options)
     end
 
-    attributes :id, :created_at, :updated_at, :user_ip, :annotations, :metadata
+    attributes :id, :created_at, :updated_at, :user_ip, :workflow_version, :gold_standard,
+               :expert_classifier, :annotations, :metadata
 
-    belongs_to :project,  serializer: EventStreamSerializers::ProjectSerializer
-    belongs_to :user,     serializer: EventStreamSerializers::UserSerializer
-    belongs_to :workflow, serializer: EventStreamSerializers::WorkflowSerializer
-    has_many   :subjects, serializer: EventStreamSerializers::SubjectSerializer
+    belongs_to :project,          serializer: EventStreamSerializers::ProjectSerializer
+    belongs_to :user,             serializer: EventStreamSerializers::UserSerializer
+    belongs_to :workflow,         serializer: EventStreamSerializers::WorkflowSerializer
+    belongs_to :workflow_content, serializer: EventStreamSerializers::WorkflowContentSerializer
+    has_many   :subjects,         serializer: EventStreamSerializers::SubjectSerializer
+
+    def workflow
+      version = workflow_version.split(".")[0].to_i
+
+      latest    = object.workflow
+      versioned = latest.versions.offset(version).first.try(:reify)
+      versioned || latest
+    end
+
+    def workflow_content
+      version = workflow_version.split(".")[1].to_i
+
+      latest    = object.workflow.primary_content
+      versioned = latest.versions.offset(version).first.try(:reify)
+      versioned || latest
+    end
 
     def user_ip
       object.user_ip.to_s

--- a/app/serializers/event_stream_serializers/project_serializer.rb
+++ b/app/serializers/event_stream_serializers/project_serializer.rb
@@ -1,5 +1,5 @@
 module EventStreamSerializers
   class ProjectSerializer < ActiveModel::Serializer
-    attributes :id, :name, :created_at
+    attributes :id, :display_name, :created_at
   end
 end

--- a/app/serializers/event_stream_serializers/workflow_content_serializer.rb
+++ b/app/serializers/event_stream_serializers/workflow_content_serializer.rb
@@ -1,0 +1,5 @@
+module EventStreamSerializers
+  class WorkflowContentSerializer < ActiveModel::Serializer
+    attributes :id, :strings, :created_at, :updated_at
+  end
+end

--- a/app/serializers/event_stream_serializers/workflow_serializer.rb
+++ b/app/serializers/event_stream_serializers/workflow_serializer.rb
@@ -1,5 +1,5 @@
 module EventStreamSerializers
   class WorkflowSerializer < ActiveModel::Serializer
-    attributes :id, :created_at
+    attributes :id, :display_name, :tasks, :created_at
   end
 end

--- a/app/workers/publish_classification_worker.rb
+++ b/app/workers/publish_classification_worker.rb
@@ -17,7 +17,7 @@ class PublishClassificationWorker
 
   def serialized_classification
     @serialized_classification ||= EventStreamSerializers::ClassificationSerializer
-      .serialize(classification, include: ['subjects'])
+      .serialize(classification, include: ['project', 'workflow', 'workflow_content', 'user', 'subjects'])
       .as_json
       .with_indifferent_access
   end

--- a/spec/serializers/event_stream_serializers/classification_serializer_spec.rb
+++ b/spec/serializers/event_stream_serializers/classification_serializer_spec.rb
@@ -11,4 +11,32 @@ describe EventStreamSerializers::ClassificationSerializer do
     adapter = described_class.serialize(classification, include: ['subjects'])
     expect(adapter.as_json[:linked]['subjects'].size).to eq(1)
   end
+
+  context 'versioned resources' do
+    before(:each) do
+      PaperTrail.enabled = true
+    end
+
+    after(:each) do
+      PaperTrail.enabled = false
+    end
+
+    it 'links the correct version of the workflow' do
+      classification.update! annotations: [{"task" => "interest", "value" => []}], workflow_version: '1.1'
+      old_tasks = classification.workflow.tasks
+      classification.workflow.update!(tasks: {"new_task" => {}})
+
+      adapter = described_class.serialize(classification, include: ['workflow'])
+      expect(adapter.as_json[:linked]['workflows'][0][:tasks]).to eq(old_tasks)
+    end
+
+    it 'links the correct version of the workflow content' do
+      classification.update! annotations: [{"task" => "interest", "value" => []}], workflow_version: '1.1'
+      old_strings = classification.workflow.primary_content.strings
+      classification.workflow.primary_content.update!(strings: {"foo" => "BAR"})
+
+      adapter = described_class.serialize(classification, include: ['workflow_content'])
+      expect(adapter.as_json[:linked]['workflow_contents'][0][:strings]).to eq(old_strings)
+    end
+  end
 end

--- a/spec/workers/publish_classification_worker_spec.rb
+++ b/spec/workers/publish_classification_worker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PublishClassificationWorker do
     end
 
     describe "internal classification event stream" do
-      let(:serialiser_opts) { { include: ['subjects'] } }
+      let(:serialiser_opts) { { include: ['project', 'workflow', 'workflow_content', 'user', 'subjects'] } }
 
       it "should format the data using the serializer" do
         expect(EventStreamSerializers::ClassificationSerializer)


### PR DESCRIPTION
I still intend to look at compressing this data down, but I'll handle that with an update to the ZooStream gem (and need to make Nero/ZooStats forwards-compatible first).