### PR TITLE
ignore redis failure on classification create

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hashie (3.4.3)
     hitimes (1.2.3)
-    honeybadger (2.3.1)
+    honeybadger (2.5.1)
     http (0.9.8)
       addressable (~> 2.3)
       http-cookie (~> 1.0)

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -61,6 +61,8 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   def lifecycle(action, classification)
     ClassificationLifecycle.new(classification).queue(action)
+  rescue Redis::CannotConnectError => e
+    Honeybadger.notify(e)
   end
 
   def completed_error

--- a/app/workers/honeybadger_worker.rb
+++ b/app/workers/honeybadger_worker.rb
@@ -1,9 +1,0 @@
-class HoneybadgerWorker
-  include Sidekiq::Worker
-
-  sidekiq_options queue: :data_high
-
-  def perform(notice)
-    Honeybadger.sender.send_to_honeybadger(notice)
-  end
-end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -281,6 +281,19 @@ describe Api::V1::ClassificationsController, type: :controller do
         it_behaves_like "a classification create"
       end
     end
+
+    context "when redis is unavailable" do
+      it 'should not raise an error but still report it' do
+        stub_content_filter
+        allow_any_instance_of(ClassificationLifecycle)
+          .to receive(:queue)
+          .and_raise(Redis::CannotConnectError)
+        expect(Honeybadger).to receive(:notify)
+        expect do
+          setup_create_request
+        end.not_to raise_error
+      end
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
don't 500 that may cause a duplicate classification submission instead just carry on as the lifecycle event will eventually fire but still go ahead and notify that redis is down.