### PR TITLE
update s3 headers for data dump exports

### DIFF
--- a/app/services/media_storage/aws_adapter.rb
+++ b/app/services/media_storage/aws_adapter.rb
@@ -65,6 +65,9 @@ module MediaStorage
                         acl: opts[:private] ? 'private' : 'public-read'
                        }
       upload_options[:content_encoding] = 'gzip' if opts[:compressed]
+      if opts[:content_disposition]
+        upload_options[:content_disposition] = opts[:content_disposition]
+      end
       object(path).write(**upload_options)
     end
 

--- a/app/workers/concerns/dump_worker.rb
+++ b/app/workers/concerns/dump_worker.rb
@@ -70,18 +70,27 @@ module DumpWorker
   end
 
   def create_medium
-    Medium.create!(content_type: "text/csv",
-                   type: dump_type,
-                   path_opts: project_file_path,
-                   linked: project,
-                   metadata: { state: 'creating' },
-                   private: true)
+    Medium.create!(
+      content_type: "text/csv",
+      type: dump_type,
+      path_opts: project_file_path,
+      linked: project,
+      metadata: { state: 'creating' },
+      private: true,
+      content_disposition: content_disposition
+    )
   end
 
   def load_medium
     m = Medium.find(@medium_id)
     metadata = m.metadata.merge("state" => "creating")
-    m.update!(path_opts: project_file_path, private: true, content_type: "text/csv", metadata: metadata)
+    m.update!(
+      path_opts: project_file_path,
+      private: true,
+      content_type: "text/csv",
+      content_disposition: content_disposition,
+      metadata: metadata
+    )
     m
   end
 
@@ -100,5 +109,10 @@ module DumpWorker
       end
       gz.close
     end
+  end
+
+  def content_disposition
+    name = project.slug.split("/")[1]
+    "attachment; filename='#{name}-#{dump_target}.csv'"
   end
 end

--- a/db/migrate/20160303163658_add_medium_fields_for_s3_path_details.rb
+++ b/db/migrate/20160303163658_add_medium_fields_for_s3_path_details.rb
@@ -1,0 +1,5 @@
+class AddMediumFieldsForS3PathDetails < ActiveRecord::Migration
+  def change
+    add_column :media, :content_disposition, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -330,7 +330,8 @@ CREATE TABLE media (
     updated_at timestamp without time zone NOT NULL,
     metadata jsonb,
     put_expires integer,
-    get_expires integer
+    get_expires integer,
+    content_disposition character varying
 );
 
 
@@ -2818,4 +2819,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160114135531');
 INSERT INTO schema_migrations (version) VALUES ('20160114141909');
 
 INSERT INTO schema_migrations (version) VALUES ('20160202155708');
+
+INSERT INTO schema_migrations (version) VALUES ('20160303163658');
 

--- a/spec/services/media_storage/aws_adapter_spec.rb
+++ b/spec/services/media_storage/aws_adapter_spec.rb
@@ -119,6 +119,23 @@ RSpec.describe MediaStorage::AwsAdapter do
         adapter.put_file("src", file_path, content_type: content_type, private: false, compressed: true)
       end
     end
+
+    context "when opts[:content_disposition] is set" do
+      let(:disposition) { "attachment; filename='fname.ext'" }
+
+      it 'should call write with the content_disposition set' do
+        expect(obj_double)
+          .to receive(:write)
+          .with(
+            file: file_path,
+            content_type: content_type,
+            acl: 'public-read',
+            content_disposition: disposition
+          )
+        put_opts = { content_type: content_type, content_disposition: disposition }
+        adapter.put_file("src", file_path, put_opts)
+      end
+    end
   end
 
   context "when missing an s3 object path" do


### PR DESCRIPTION
closes #1694 put the content disposition to the s3 resource via the medium attributes, currently only set via the dump workers but could be expanded out to other media resources.