### PR TITLE
Clean up PostgresqlSelection

### DIFF
--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -30,4 +30,3 @@ module Subjects
     end
   end
 end
-

--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -7,11 +7,11 @@ module Subjects
     end
 
     def any_workflow_data
-      any_workflow_data_scope
-      .order(random: [:asc, :desc].sample)
-      .limit(limit)
-      .pluck("set_member_subjects.id")
-      .shuffle
+      any_workflow_data_scope \
+        .order(random: [:asc, :desc].sample)
+        .limit(limit)
+        .pluck("set_member_subjects.id")
+        .shuffle
     end
 
     private

--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -1,0 +1,33 @@
+module Subjects
+  class FallbackSelection
+    attr_reader :workflow, :limit, :options
+
+    def initialize(workflow, limit, options = {})
+      @workflow, @limit, @options = workflow, limit, options
+    end
+
+    def any_workflow_data
+      any_workflow_data_scope
+      .order(random: [:asc, :desc].sample)
+      .limit(limit)
+      .pluck("set_member_subjects.id")
+      .shuffle
+    end
+
+    private
+
+    def any_workflow_data_scope
+      scope = workflow.set_member_subjects
+      if workflow.grouped
+        if subject_set_id = options[:subject_set_id]
+          scope = scope.where(subject_set_id: subject_set_id)
+        else
+          msg = "subject_set_id parameter missing for grouped workflow"
+          raise Subjects::Selector::MissingParameter.new(msg)
+        end
+      end
+      scope
+    end
+  end
+end
+

--- a/lib/subjects/postgresql_in_order_selection.rb
+++ b/lib/subjects/postgresql_in_order_selection.rb
@@ -1,0 +1,15 @@
+module Subjects
+  class PostgresqlInOrderSelection
+    attr_reader :available, :limit
+
+    def initialize(available, limit)
+      @available = available
+      @limit = limit
+    end
+
+    def select
+      available.order(priority: :asc).limit(limit).pluck(:id)
+    end
+  end
+end
+

--- a/lib/subjects/postgresql_in_order_selection.rb
+++ b/lib/subjects/postgresql_in_order_selection.rb
@@ -12,4 +12,3 @@ module Subjects
     end
   end
 end
-

--- a/lib/subjects/postgresql_random_selection.rb
+++ b/lib/subjects/postgresql_random_selection.rb
@@ -44,4 +44,3 @@ module Subjects
     end
   end
 end
-

--- a/lib/subjects/postgresql_random_selection.rb
+++ b/lib/subjects/postgresql_random_selection.rb
@@ -1,0 +1,47 @@
+module Subjects
+  class PostgresqlRandomSelection
+    attr_reader :available, :limit
+
+    def initialize(available, limit)
+      @available = available
+      @limit = limit
+    end
+
+    def select
+      enough_available = limit < available_count
+      if enough_available
+        ids = sample.pluck(:id).sample(limit)
+        if reassign_random?
+          RandomOrderShuffleWorker.perform_async(ids)
+        end
+        ids
+      else
+        available.pluck(:id).shuffle
+      end
+    end
+
+    private
+
+    def available_count
+      @available_count ||= available.except(:select).count
+    end
+
+    def sample(query=available)
+      direction = [:asc, :desc].sample
+      query.order(random: direction).limit(focus_set_window_size)
+    end
+
+    def focus_set_window_size
+      @focus_set_window_size ||=
+        [
+          (available_count * 0.5).ceil,
+          Panoptes::SubjectSelection.focus_set_window_size
+        ].min
+    end
+
+    def reassign_random?
+      rand <= Panoptes::SubjectSelection.index_rebuild_rate
+    end
+  end
+end
+

--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -18,12 +18,7 @@ module Subjects
     end
 
     def any_workflow_data(limit_override=nil)
-      @limit_override = limit_override
-      any_workflow_data_scope
-      .order(random: [:asc, :desc].sample)
-      .limit(limit)
-      .pluck("set_member_subjects.id")
-      .shuffle
+      FallbackSelection.new(workflow, limit, opts).any_workflow_data
     end
 
     private
@@ -59,19 +54,6 @@ module Subjects
 
     def select_results_in_order
       PostgresqlInOrderSelection.new(available, limit).select
-    end
-
-    def any_workflow_data_scope
-      scope = workflow.set_member_subjects
-      if workflow.grouped
-        if subject_set_id = opts[:subject_set_id]
-          scope = scope.where(subject_set_id: subject_set_id)
-        else
-          msg = "subject_set_id parameter missing for grouped workflow"
-          raise Subjects::Selector::MissingParameter.new(msg)
-        end
-      end
-      scope
     end
   end
 end

--- a/spec/lib/subjects/fallback_selection_spec.rb
+++ b/spec/lib/subjects/fallback_selection_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Subjects::FallbackSelection do
+  let(:user) { User.first }
+  let(:workflow) { Workflow.first }
+  let(:sms) { SetMemberSubject.all }
+  let(:opts) { {} }
+  let(:selector) { Subjects::FallbackSelection.new(workflow, 5, opts) }
+
+  before do
+    uploader = create(:user)
+    created_workflow = create(:workflow_with_subject_sets)
+    create_list(:subject, 25, project: created_workflow.project, uploader: uploader).each do |subject|
+      create(:set_member_subject, subject: subject, subject_set: created_workflow.subject_sets.first)
+    end
+  end
+
+  describe "#any_workflow_data" do
+    let(:subject_set_id) { nil }
+    let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
+    let(:expected_ids) do
+      workflow.set_member_subjects.pluck("set_member_subjects.id")
+    end
+    let(:subject_ids) { selector.any_workflow_data }
+
+    it "should select some data from the workflow" do
+      expect(expected_ids).to include(*subject_ids)
+    end
+
+    context "grouped workflow" do
+      let(:subject_set_id) { SubjectSet.first.id }
+
+      before do
+        allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
+      end
+
+      it "should select some data from the group" do
+        expect(expected_ids).to include(*subject_ids)
+      end
+
+      context "without a subject_set_id param" do
+        let(:subject_set_id) { nil }
+
+        it "should raise an error" do
+          expect {
+            subject_ids
+          }.to raise_error(Subjects::Selector::MissingParameter)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/lib/subjects/postgresql_in_order_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_in_order_selection_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe Subjects::PostgresqlInOrderSelection do
+  let(:project) { create :project }
+  let(:workflow) { create(:workflow_with_subject_sets, project: project) }
+  let(:uploader) { workflow.project.owner }
+  let(:subject_set) { workflow.subject_sets.first }
+  let(:available) { SetMemberSubject.all }
+  let(:limit) { 10 }
+  let(:selector) { Subjects::PostgresqlInOrderSelection.new(available, limit) }
+
+  before do
+    create_list(:subject, 25, project: project, uploader: uploader).each do |subject|
+      create(:set_member_subject, subject: subject, subject_set: subject_set)
+    end
+  end
+
+  def update_sms_priorities
+    SetMemberSubject.where(priority: nil).each_with_index do |sms, index|
+      sms.update_column(:priority, index+1)
+    end
+  end
+
+  describe "priority selection" do
+    let(:ordered) { available.order(priority: :asc).pluck(:id) }
+    let(:limit) { available.size }
+
+    before do
+      update_sms_priorities
+    end
+
+    it 'should select subjects in asc order of the priority field' do
+      result = selector.select
+      expect(result).to eq(ordered)
+    end
+
+    context "with 1 limit for prepend test" do
+      let(:limit) { 1 }
+
+      it 'should allow negative numbers to prepend the sort list' do
+        sms_subject = create(:subject, project: project, uploader: uploader)
+        sms = create(:set_member_subject, subject: sms_subject, subject_set: subject_set, priority: -10.to_f)
+        first_id = selector.select.first
+        expect(first_id).to eq(sms.id)
+      end
+    end
+  end
+
+end
+

--- a/spec/lib/subjects/postgresql_in_order_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_in_order_selection_spec.rb
@@ -45,6 +45,4 @@ RSpec.describe Subjects::PostgresqlInOrderSelection do
       end
     end
   end
-
 end
-

--- a/spec/lib/subjects/postgresql_random_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_random_selection_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe Subjects::PostgresqlRandomSelection do
+  let(:available) { SetMemberSubject.all }
+  let(:opts) { {} }
+  subject { Subjects::PostgresqlRandomSelection.new(available, 10) }
+
+  before do
+    uploader = create(:user)
+    created_workflow = create(:workflow_with_subject_sets)
+    create_list(:subject, 25, project: created_workflow.project, uploader: uploader).each do |subject|
+      create(:set_member_subject, subject: subject, subject_set: created_workflow.subject_sets.first)
+    end
+  end
+
+  describe "random selection" do
+    it "should reassign the random attribute after selection" do
+      allow(Panoptes::SubjectSelection).to receive(:index_rebuild_rate).and_return(1)
+      expect(RandomOrderShuffleWorker).to receive(:perform_async).once
+      subject.select
+    end
+
+    it "should give up trying to construct a random list after set number of attempts" do
+      unreachable_limit = SetMemberSubject.count + 1
+      allow_any_instance_of(subject.class).to receive(:available_count).and_return(unreachable_limit + 1)
+      allow_any_instance_of(subject.class).to receive(:limit).and_return(unreachable_limit)
+      results = subject.select
+      expect(results).to eq(results)
+    end
+  end
+end

--- a/spec/lib/subjects/postgresql_random_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_random_selection_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Subjects::PostgresqlRandomSelection do
   let(:available) { SetMemberSubject.all }
-  let(:opts) { {} }
   subject { Subjects::PostgresqlRandomSelection.new(available, 10) }
 
   before do

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -8,81 +8,6 @@ RSpec.describe Subjects::PostgresqlSelection do
     end
   end
 
-  shared_examples "select for incomplete_project" do
-    let(:args) { opts }
-    subject { Subjects::PostgresqlSelection.new(workflow, user, args) }
-
-    let(:sms_scope) do
-      if ss_id = args[:subject_set_id]
-        SetMemberSubject.where(subject_set_id: ss_id)
-      else
-        SetMemberSubject.all
-      end
-    end
-
-    let(:unseen_count) do
-      _seen_count = if ss_id = args[:subject_set_id]
-        group_sms = SetMemberSubject.where(subject_set_id: ss_id)
-        group_sms.where(subject_id: uss.subject_ids).count
-      else
-        seen_count
-      end
-      sms_scope.count - _seen_count
-    end
-
-    context "when a user has only seen a few subjects" do
-      let(:seen_count) { 5 }
-      let(:limit) { nil }
-      let(:args) { opts.merge(limit: limit) }
-      let!(:uss) do
-        subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
-        create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
-      end
-
-      context "with a limit of 1" do
-        let(:limit) { 1 }
-
-        it 'should return an unseen subject' do
-          expect(uss.subject_ids).to_not include(subject.select.first)
-        end
-      end
-
-      context "with a limit of 10" do
-        let(:limit) { 10 }
-
-        it 'should no have duplicates' do
-          result = subject.select
-          expect(result).to match_array(result.to_a.uniq)
-        end
-      end
-
-      #account for the loop cut off limit constructing the random sample
-      it 'should always return an approximate sample of subjects up to the unseen limit' do
-        unseen_count.times do |n|
-          limit = n+1
-          results_size = subject.select(limit).length
-          expect(results_size).to be_between(results_size, limit).inclusive
-        end
-      end
-    end
-
-    context "when a user has seen most of the subjects" do
-      let(:seen_count) { 20 }
-      let!(:uss) do
-        subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
-        create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
-      end
-
-      it 'should return as many subjects as possible' do
-        unseen_count.times do |n|
-          limit = n+unseen_count
-          results_size = subject.select(limit).length
-          expect(results_size).to be_between(results_size, limit).inclusive
-        end
-      end
-    end
-  end
-
   describe "selection" do
     let(:user) { User.first }
     let(:workflow) { Workflow.first }
@@ -103,9 +28,9 @@ RSpec.describe Subjects::PostgresqlSelection do
         it_behaves_like "select for incomplete_project"
 
         it "should reassign the random attribute after selection" do
-          allow(subject).to receive(:reassign_random?).and_return(true)
+          allow(Panoptes::SubjectSelection).to receive(:index_rebuild_rate).and_return(1)
           expect(RandomOrderShuffleWorker).to receive(:perform_async).once
-          results = subject.select
+          subject.select
         end
 
         it "should give up trying to construct a random list after set number of attempts" do

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -26,20 +26,6 @@ RSpec.describe Subjects::PostgresqlSelection do
     describe "#select" do
       describe "random selection" do
         it_behaves_like "select for incomplete_project"
-
-        it "should reassign the random attribute after selection" do
-          allow(Panoptes::SubjectSelection).to receive(:index_rebuild_rate).and_return(1)
-          expect(RandomOrderShuffleWorker).to receive(:perform_async).once
-          subject.select
-        end
-
-        it "should give up trying to construct a random list after set number of attempts" do
-          unreachable_limit = SetMemberSubject.count + 1
-          allow_any_instance_of(subject.class).to receive(:available_count).and_return(unreachable_limit + 1)
-          allow_any_instance_of(subject.class).to receive(:limit).and_return(unreachable_limit)
-          results = subject.select
-          expect(results).to eq(results)
-        end
       end
 
       context "grouped selection" do

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -90,15 +90,12 @@ RSpec.describe Subjects::PostgresqlSelection do
     let(:opts) { {} }
     subject { Subjects::PostgresqlSelection.new(workflow, user, opts) }
 
-    before(:all) do
+    before do
       uploader = create(:user)
       created_workflow = create(:workflow_with_subject_sets)
       create_list(:subject, 25, project: created_workflow.project, uploader: uploader).each do |subject|
         create(:set_member_subject, subject: subject, subject_set: created_workflow.subject_sets.first)
       end
-    end
-    after(:all) do
-      DatabaseCleaner.clean_with(:deletion)
     end
 
     describe "#select" do
@@ -123,7 +120,7 @@ RSpec.describe Subjects::PostgresqlSelection do
       context "grouped selection" do
         let(:subject_set_id) { workflow.subject_sets.first.id }
         let(:opts) { {subject_set_id: subject_set_id} }
-        before(:each) do
+        before do
           allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
         end
 
@@ -145,7 +142,7 @@ RSpec.describe Subjects::PostgresqlSelection do
         let(:limit) { ordered.size }
         let(:opts) { { limit: limit } }
 
-        before(:each) do
+        before do
           update_sms_priorities
           allow_any_instance_of(Workflow).to receive(:prioritized).and_return(true)
         end
@@ -184,13 +181,13 @@ RSpec.describe Subjects::PostgresqlSelection do
         let(:subject_set_id) { SubjectSet.first.id }
         let(:sms) { SetMemberSubject.where(subject_set_id: subject_set_id) }
 
-        before(:each) do
+        before do
           %i( prioritized grouped ).each do |method|
             allow_any_instance_of(Workflow).to receive(method).and_return(true)
           end
         end
 
-        before(:all) do
+        before do
           update_sms_priorities
           created_workflow = Workflow.first
           subject_set = created_workflow.subject_sets.last
@@ -225,7 +222,7 @@ RSpec.describe Subjects::PostgresqlSelection do
       context "grouped workflow" do
         let(:subject_set_id) { SubjectSet.first.id }
 
-        before(:each) do
+        before do
           allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
         end
 

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -73,32 +73,6 @@ RSpec.describe Subjects::PostgresqlSelection do
         end
 
         it_behaves_like "select for incomplete_project"
-
-        it 'should select subjects in asc order of the priority field' do
-          result = subject.select
-          expect(result).to eq(ordered)
-        end
-
-        context "with order by param" do
-          let(:opts) { { limit: ordered.size, order: :desc } }
-
-          it 'should ignore any order param on the priority field' do
-            result = subject.select
-            expect(result).to eq(ordered)
-          end
-        end
-
-        context "with 1 limit for prepend test" do
-          let(:limit) { 1 }
-
-          it 'should allow negative numbers to prepend the sort list' do
-            sms_subject = create(:subject,project: workflow.project, uploader: user)
-            sms = create(:set_member_subject, subject: sms_subject,
-              subject_set: workflow.subject_sets.first, priority: -10.to_f)
-            first_id = subject.select.first
-            expect(first_id).to eq(sms.id)
-          end
-        end
       end
 
       describe "priority and grouped selection" do

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -131,40 +131,5 @@ RSpec.describe Subjects::PostgresqlSelection do
         end
       end
     end
-
-    describe "#any_workflow_data" do
-      let(:subject_set_id) { nil }
-      let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
-      let(:expected_ids) do
-        workflow.set_member_subjects.pluck("set_member_subjects.id")
-      end
-      let(:subject_ids) { subject.any_workflow_data }
-
-      it "should select some data from the workflow" do
-        expect(expected_ids).to include(*subject_ids)
-      end
-
-      context "grouped workflow" do
-        let(:subject_set_id) { SubjectSet.first.id }
-
-        before do
-          allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
-        end
-
-        it "should select some data from the group" do
-          expect(expected_ids).to include(*subject_ids)
-        end
-
-        context "without a subject_set_id param" do
-          let(:subject_set_id) { nil }
-
-          it "should raise an error" do
-            expect {
-              subject_ids
-            }.to raise_error(Subjects::Selector::MissingParameter)
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/support/shared_examples_for_postgresql_selection.rb
+++ b/spec/support/shared_examples_for_postgresql_selection.rb
@@ -26,6 +26,8 @@ shared_examples "select for incomplete_project" do
     let(:args) { opts.merge(limit: limit) }
     let!(:uss) do
       subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
+      puts "All: #{sms_scope.map(&:subject_id).inspect}"
+      puts "Seen: #{subject_ids.inspect}"
       create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
     end
 
@@ -33,7 +35,9 @@ shared_examples "select for incomplete_project" do
       let(:limit) { 1 }
 
       it 'should return an unseen subject' do
-        expect(uss.subject_ids).to_not include(selector.select.first)
+      	selected = selector.select.first
+      	puts "Selected: #{selected.inspect}"
+        expect(uss.subject_ids).to_not include(selected)
       end
     end
 

--- a/spec/support/shared_examples_for_postgresql_selection.rb
+++ b/spec/support/shared_examples_for_postgresql_selection.rb
@@ -1,6 +1,6 @@
 shared_examples "select for incomplete_project" do
   let(:args) { opts }
-  subject { Subjects::PostgresqlSelection.new(workflow, user, args) }
+  let(:selector) { Subjects::PostgresqlSelection.new(workflow, user, args) }
 
   let(:sms_scope) do
     if ss_id = args[:subject_set_id]
@@ -33,7 +33,7 @@ shared_examples "select for incomplete_project" do
       let(:limit) { 1 }
 
       it 'should return an unseen subject' do
-        expect(uss.subject_ids).to_not include(subject.select.first)
+        expect(uss.subject_ids).to_not include(selector.select.first)
       end
     end
 
@@ -41,7 +41,7 @@ shared_examples "select for incomplete_project" do
       let(:limit) { 10 }
 
       it 'should no have duplicates' do
-        result = subject.select
+        result = selector.select
         expect(result).to match_array(result.to_a.uniq)
       end
     end
@@ -50,7 +50,7 @@ shared_examples "select for incomplete_project" do
     it 'should always return an approximate sample of subjects up to the unseen limit' do
       unseen_count.times do |n|
         limit = n+1
-        results_size = subject.select(limit).length
+        results_size = Subjects::PostgresqlSelection.new(workflow, user, (args || {}).merge(limit: limit)).select.length
         expect(results_size).to be_between(results_size, limit).inclusive
       end
     end
@@ -66,7 +66,7 @@ shared_examples "select for incomplete_project" do
     it 'should return as many subjects as possible' do
       unseen_count.times do |n|
         limit = n+unseen_count
-        results_size = subject.select(limit).length
+        results_size = Subjects::PostgresqlSelection.new(workflow, user, (args || {}).merge(limit: limit)).select.length
         expect(results_size).to be_between(results_size, limit).inclusive
       end
     end

--- a/spec/support/shared_examples_for_postgresql_selection.rb
+++ b/spec/support/shared_examples_for_postgresql_selection.rb
@@ -11,13 +11,13 @@ shared_examples "select for incomplete_project" do
   end
 
   let(:unseen_count) do
-    _seen_count = if ss_id = args[:subject_set_id]
-      group_sms = SetMemberSubject.where(subject_set_id: ss_id)
-      group_sms.where(subject_id: uss.subject_ids).count
-    else
-      seen_count
-    end
-    sms_scope.count - _seen_count
+    scoped_seen_count = if ss_id = args[:subject_set_id]
+                          group_sms = SetMemberSubject.where(subject_set_id: ss_id)
+                          group_sms.where(subject_id: uss.subject_ids).count
+                        else
+                          seen_count
+                        end
+    sms_scope.count - scoped_seen_count
   end
 
   context "when a user has only seen a few subjects" do
@@ -47,7 +47,7 @@ shared_examples "select for incomplete_project" do
       end
     end
 
-    #account for the loop cut off limit constructing the random sample
+    # Account for the loop cut off limit constructing the random sample
     it 'should always return an approximate sample of subjects up to the unseen limit' do
       unseen_count.times do |n|
         limit = n+1
@@ -73,5 +73,3 @@ shared_examples "select for incomplete_project" do
     end
   end
 end
-
-

--- a/spec/support/shared_examples_for_postgresql_selection.rb
+++ b/spec/support/shared_examples_for_postgresql_selection.rb
@@ -1,0 +1,76 @@
+shared_examples "select for incomplete_project" do
+  let(:args) { opts }
+  subject { Subjects::PostgresqlSelection.new(workflow, user, args) }
+
+  let(:sms_scope) do
+    if ss_id = args[:subject_set_id]
+      SetMemberSubject.where(subject_set_id: ss_id)
+    else
+      SetMemberSubject.all
+    end
+  end
+
+  let(:unseen_count) do
+    _seen_count = if ss_id = args[:subject_set_id]
+      group_sms = SetMemberSubject.where(subject_set_id: ss_id)
+      group_sms.where(subject_id: uss.subject_ids).count
+    else
+      seen_count
+    end
+    sms_scope.count - _seen_count
+  end
+
+  context "when a user has only seen a few subjects" do
+    let(:seen_count) { 5 }
+    let(:limit) { nil }
+    let(:args) { opts.merge(limit: limit) }
+    let!(:uss) do
+      subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
+      create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
+    end
+
+    context "with a limit of 1" do
+      let(:limit) { 1 }
+
+      it 'should return an unseen subject' do
+        expect(uss.subject_ids).to_not include(subject.select.first)
+      end
+    end
+
+    context "with a limit of 10" do
+      let(:limit) { 10 }
+
+      it 'should no have duplicates' do
+        result = subject.select
+        expect(result).to match_array(result.to_a.uniq)
+      end
+    end
+
+    #account for the loop cut off limit constructing the random sample
+    it 'should always return an approximate sample of subjects up to the unseen limit' do
+      unseen_count.times do |n|
+        limit = n+1
+        results_size = subject.select(limit).length
+        expect(results_size).to be_between(results_size, limit).inclusive
+      end
+    end
+  end
+
+  context "when a user has seen most of the subjects" do
+    let(:seen_count) { 20 }
+    let!(:uss) do
+      subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
+      create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
+    end
+
+    it 'should return as many subjects as possible' do
+      unseen_count.times do |n|
+        limit = n+unseen_count
+        results_size = subject.select(limit).length
+        expect(results_size).to be_between(results_size, limit).inclusive
+      end
+    end
+  end
+end
+
+

--- a/spec/support/shared_examples_for_postgresql_selection.rb
+++ b/spec/support/shared_examples_for_postgresql_selection.rb
@@ -26,8 +26,6 @@ shared_examples "select for incomplete_project" do
     let(:args) { opts.merge(limit: limit) }
     let!(:uss) do
       subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
-      puts "All: #{sms_scope.map(&:subject_id).inspect}"
-      puts "Seen: #{subject_ids.inspect}"
       create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
     end
 
@@ -35,8 +33,7 @@ shared_examples "select for incomplete_project" do
       let(:limit) { 1 }
 
       it 'should return an unseen subject' do
-      	selected = selector.select.first
-      	puts "Selected: #{selected.inspect}"
+        selected = selector.select.first
         expect(uss.subject_ids).to_not include(selected)
       end
     end


### PR DESCRIPTION
Started with removal of those `before(:all)` statements, then to keep stuff at least somewhat speedy I'm splitting up some stuff so tests can be more focussed. Not perfect yet, but time to merge this before it gets out of hand :P

- [x] Figure out why this spec keeps randomly failing --> Doesn't want to fail locally :(

```
  1) Subjects::PostgresqlSelection selection #select grouped selection behaves like select for incomplete_project when a user has only seen a few subjects with a limit of 1 should return an unseen subject
     Failure/Error: expect(uss.subject_ids).to_not include(subject.select.first)
       expected [417, 430, 419, 427, 410] not to include 427
     Shared Example Group: "select for incomplete_project" called from ./spec/lib/subjects/postgresql_selection_spec.rb:52
     # ./spec/support/shared_examples_for_postgresql_selection.rb:36:in `block (4 levels) in <top (required)>'
```