### PR TITLE
raise connection error when no cellect hosts available

### DIFF
--- a/lib/subjects/cellect_client.rb
+++ b/lib/subjects/cellect_client.rb
@@ -81,7 +81,7 @@ module Subjects
         super(action, params) do
           params[:host] = @session.reset_host
         end
-      rescue Redis::CannotConnectError => e
+      rescue Redis::CannotConnectError, Subjects::CellectSession::NoHostError
         raise ConnectionError, "Cellect can't find a server host"
       end
     end

--- a/lib/subjects/cellect_session.rb
+++ b/lib/subjects/cellect_session.rb
@@ -3,6 +3,8 @@ require 'cellect/client'
 module Subjects
   class CellectSession
     NilWorkflowError = Class.new(StandardError)
+    NoHostError = Class.new(StandardError)
+
     attr_reader :user_id, :workflow_id
 
     def initialize(user_id, workflow_id)
@@ -24,11 +26,14 @@ module Subjects
     end
 
     def reset_host(ttl=ttl_secs)
-      host = cellect_host
-      Sidekiq.redis do |redis_conn|
-        redis_conn.setex(user_workflow_key, ttl, host)
+      if host = cellect_host
+        Sidekiq.redis do |redis_conn|
+          redis_conn.setex(user_workflow_key, ttl, host)
+        end
+        host
+      else
+        raise NoHostError.new("No cellect host available")
       end
-      host
     end
 
     private

--- a/spec/lib/subjects/cellect_client_spec.rb
+++ b/spec/lib/subjects/cellect_client_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe Subjects::CellectClient do
         )
       end
     end
+
+    #applies to all RequestToHost methods
+    context "when cellect session raises no host error" do
+      it 'should raise a connection error' do
+        allow_any_instance_of(Subjects::CellectSession)
+          .to receive(:host)
+          .and_raise(Subjects::CellectSession::NoHostError)
+        expect do
+          Subjects::CellectClient.get_subjects(1, 2, nil, 4)
+        end.to raise_error(
+          Subjects::CellectClient::ConnectionError,
+         "Cellect can't find a server host"
+        )
+      end
+    end
   end
 
   describe "::reload_workflow" do


### PR DESCRIPTION
handle the case where the cellect node_set is empty and thus the returned host will be nil.