### PR TITLE
add seperate route for health check

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get "health_check", to: "home#index"
   root to: "home#index"
   match "*path", to: "application#unknown_route", via: :all
 end


### PR DESCRIPTION
This route will be used for specialized nginx directive to allow force_ssl to work with ELB health checks over http.