### PR TITLE
set include subdomain hsts header

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,6 +41,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  config.ssl_options = { hsts: { subdomains: true } }
 
   # Set to :debug to see everything in the log.
   config.log_level = :info

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,6 +41,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  config.ssl_options = { hsts: { subdomains: true } }
 
   # Set to :debug to see everything in the log.
   config.log_level = :debug


### PR DESCRIPTION
avoid subdomains leaking cookies 

Note to future selves, rails 5 offers more options on this like preload so we should update to those when bumping rails see [here](https://github.com/rails/rails/blob/823915da2873f110ecbecfdfe57a30f64af46d23/actionpack/lib/action_dispatch/middleware/ssl.rb#L40)