### PR TITLE
extract scope concerns to seperate routes

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -524,20 +524,20 @@ key.
             }
 
 ### List all classifications [GET]
-Only lists a classifications the active user has made,
-classifications from other members of a user_group, or projects the
-user has edit permissions for.
+Only lists classifications the active user has made or projects the user has edit permissions for.
 
-Classifications have the special *for* parameter that indicates the
-scope of classifications you'd like to retrieve. Possible options are:
+Classifications have special collection routes that indicate the scope you would like to retrieve.
 
-+ 'user' will fetch the current user's past classifications.
-+ 'user_groups' will fetch classifications from groups a user is a member of
-+ 'projects' will fetch classifications from projects a user has 'edit' permissions for
+Possible options are:
 
-Any of the for scopes may be further filtered using the *project_id*
++ '/' default, will fetch the current user's past complete classifications.
++ 'incomplete' will fetch the current user's past incomplete classifications.
++ 'project' will fetch classifications from projects a user has 'edit' permissions for
++ 'gold_standard' will fetch gold standard classifications for all marked workflows
+
+
+Any of the scopes may be further filtered using the *project_id*, *workflow_id*
 and *user_group_id* parameters.
-
 + Parameters
     + page (optional, integer) ... index of the collection page, 1 is default
     + page_size (optional, integer) ... number of items on a page. 20 is default

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -2,13 +2,15 @@ require 'classification_lifecycle'
 
 class Api::V1::ClassificationsController < Api::ApiController
   skip_before_filter :require_login, only: :create
-  require_authentication :show, :index, :destroy, :update, scopes: [:classification]
+  require_authentication :show, :index, :destroy, :update, :incomplete, :project,
+    scopes: [:classification]
 
   resource_actions :default
 
   schema_type :json_schema
 
-  before_action :filter_by_subject_id, only: [ :index, :gold_standard ]
+  before_action :filter_by_subject_id,
+    only: [ :index, :gold_standard, :incomplete, :project ]
 
   rescue_from RoleControl::AccessDenied, with: :access_denied
 
@@ -21,8 +23,15 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def gold_standard
-    render json_api: serializer.page(params, controlled_resources, context),
-           generate_response_obj_etag: true
+    index
+  end
+
+  def incomplete
+    index
+  end
+
+  def project
+    index
   end
 
   private

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -28,14 +28,15 @@ class Classification < ActiveRecord::Base
     return all if user.is_admin? && action != :gold_standard
     case action
     when :show, :index
-      joins(:project).merge(Project.scope_for(:update, user))
-      .merge(complete)
-      .union_all(incomplete_for_user(user))
-      .includes(:subjects)
+      complete.merge(created_by(user.user)).includes(:subjects)
     when :update, :destroy
       incomplete_for_user(user)
+    when :incomplete
+      incomplete_for_user(user).includes(:subjects)
+    when :project
+      joins(:project).merge(Project.scope_for(:update, user)).includes(:subjects)
     when :gold_standard
-      gold_standard_for_user(user)
+      gold_standard_for_user(user).includes(:subjects)
     else
       none
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,11 @@ Rails.application.routes.draw do
       json_api_resources :project_preferences
 
       json_api_resources :classifications do
-        get :gold_standard, on: :collection
+        collection do
+          get :gold_standard
+          get :incomplete
+          get :project
+        end
       end
 
       json_api_resources :memberships


### PR DESCRIPTION
closes #1713 

extracting the overloading the show/index query scopes to route concerns. 

**NOTE:** this may break some existing functionality since by default show / index routes will now return just completed classification for the requesting user and not all classifications the user has access to from a project / that are incomplete.  I don't think it does but I'd like to make sure this api change doesn't break any existing functionality that PFE / custom projects rely on.

new routes:
GET      /api/classifications                         -> default, completed classfications for this user
GET      /api/classifications/incomplete       -> only incomplete for the user 
GET      /api/classifications/project             -> all classifications the user has project access to
GET      /api/classifications/gold_standard -> only gold standard for marked workflows

TODO:
- [x] Update the api docs...remove the cruft on special for params and outline the collection routes