### PR TITLE
Allow empty workflow tasks on create / update

### DIFF
--- a/app/controllers/api/v1/workflow_contents_controller.rb
+++ b/app/controllers/api/v1/workflow_contents_controller.rb
@@ -3,8 +3,5 @@ class Api::V1::WorkflowContentsController < Api::ApiController
 
   require_authentication :all, scopes: [:project]
   resource_actions :default
-  schema_type :strong_params
-
-  allowed_params :create, :language, strings: [], links: [:workflow]
-  allowed_params :update, strings: []
+  schema_type :json_schema
 end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -77,8 +77,10 @@ class Api::V1::WorkflowsController < Api::ApiController
     create_params[:tasks] = stripped_tasks
     create_params[:active] = false if project_live?
     workflow = super(create_params)
-    workflow.workflow_contents.build(strings: strings,
-                                     language: workflow.primary_language)
+    workflow.workflow_contents.build(
+      strings: strings,
+      language: workflow.primary_language
+    )
     workflow
   end
 

--- a/app/models/workflow_content.rb
+++ b/app/models/workflow_content.rb
@@ -2,5 +2,14 @@ class WorkflowContent < ActiveRecord::Base
   include TranslatedContent
   include CacheModelVersion
 
-  validates_presence_of :strings, :language
+  validates_presence_of :language
+  validate :validate_strings
+
+  private
+
+  def validate_strings
+    unless strings.is_a?(Hash)
+      errors.add(:strings, "must be present but can be empty")
+    end
+  end
 end

--- a/app/schemas/workflow_content_create_schema.rb
+++ b/app/schemas/workflow_content_create_schema.rb
@@ -1,0 +1,27 @@
+class WorkflowContentCreateSchema < JsonSchema
+  schema do
+    type "object"
+    description "Language contents for a workflow"
+    required "language", "strings", "links"
+
+    additional_properties false
+
+    property "language" do
+      type "string"
+    end
+
+    property "strings" do
+      type "object"
+    end
+
+    property "links" do
+      type "object"
+      required "workflow"
+      additional_properties false
+
+      property "workflow" do
+        type "string", "integer"
+      end
+    end
+  end
+end

--- a/app/schemas/workflow_content_update_schema.rb
+++ b/app/schemas/workflow_content_update_schema.rb
@@ -1,0 +1,13 @@
+class WorkflowContentUpdateSchema < JsonSchema
+  schema do
+    type "object"
+    description "Language contents for a workflow"
+    required "strings"
+
+    additional_properties false
+
+    property "strings" do
+      type "object"
+    end
+  end
+end

--- a/spec/controllers/api/v1/workflow_contents_controller_spec.rb
+++ b/spec/controllers/api/v1/workflow_contents_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Api::V1::WorkflowContentsController, type: :controller do
              roles: ["translator"])
     end
 
-
     let!(:private_resource) do
       project = create(:project, private: true)
       create(:workflow_with_contents, project: project)
@@ -58,7 +57,7 @@ RSpec.describe Api::V1::WorkflowContentsController, type: :controller do
     let(:create_params) do
       {
         workflow_contents: {
-          strings: %w(a bunch of strings),
+          strings: { "label" => "stuff", "question" => "is it interesting?" },
           language: 'en-CA',
           links: {
             workflow: resource.workflow
@@ -82,16 +81,12 @@ RSpec.describe Api::V1::WorkflowContentsController, type: :controller do
              roles: ["translator"])
     end
 
-
     let(:update_params) do
-      { workflow_contents: {
-          strings: %w(new strings)
-        }
-      }
+      { workflow_contents: { strings: test_attr_value } }
     end
 
     let(:test_attr) { :strings }
-    let(:test_attr_value) { %w(new strings) }
+    let(:test_attr_value) { { "label" => "new string" } }
 
     context "non-primary-language content" do
       it_behaves_like "is updatable"
@@ -146,10 +141,11 @@ RSpec.describe Api::V1::WorkflowContentsController, type: :controller do
              roles: ["translator"])
     end
 
-
     let(:num_times) { 11 }
     let!(:existing_versions) { resource.versions.length }
-    let(:update_proc) { Proc.new { |resource, n| resource.update!(strings: [n.to_s]) } }
+    let(:update_proc) do
+      Proc.new { |resource, n| resource.update!(strings: { n.to_s => n.to_s }) }
+    end
     let(:resource_param) { :workflow_content_id }
 
     it_behaves_like "a versioned resource"

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -386,46 +386,47 @@ describe Api::V1::WorkflowsController, type: :controller do
   describe '#create' do
     let(:test_attr) { :display_name }
     let(:test_attr_value) { 'Test workflow' }
+    let(:create_task_params) do
+      {
+        interest: {
+                   type: "draw",
+                   question: "Draw a Circle",
+                   next: "shape",
+                   tools: [
+                           {value: "red", label: "Red", type: 'point', color: 'red'},
+                           {value: "green", label: "Green", type: 'point', color: 'lime'},
+                           {value: "blue", label: "Blue", type: 'point', color: 'blue'},
+                          ]
+                  },
+        shape: {
+                type: 'multiple',
+                question: "What shape is this galaxy?",
+                answers: [
+                          {value: 'smooth', label: "Smooth"},
+                          {value: 'features', label: "Features"},
+                          {value: 'other', label: 'Star or artifact'}
+                         ],
+                next: nil
+               }
+       }
+    end
     let(:create_params) do
       {
-       workflows: {
-                   display_name: 'Test workflow',
-                   first_task: 'interest',
-                   active: true,
-                   retirement: { criteria: "classification_count" },
-                   aggregation: { public: true },
-                   configuration: { autoplay_subjects: true },
-                   public_gold_standard: true,
-                   tasks: {
-                           interest: {
-                                      type: "draw",
-                                      question: "Draw a Circle",
-                                      next: "shape",
-                                      tools: [
-                                              {value: "red", label: "Red", type: 'point', color: 'red'},
-                                              {value: "green", label: "Green", type: 'point', color: 'lime'},
-                                              {value: "blue", label: "Blue", type: 'point', color: 'blue'},
-                                             ]
-                                     },
-                           shape: {
-                                   type: 'multiple',
-                                   question: "What shape is this galaxy?",
-                                   answers: [
-                                             {value: 'smooth', label: "Smooth"},
-                                             {value: 'features', label: "Features"},
-                                             {value: 'other', label: 'Star or artifact'}
-                                            ],
-                                   next: nil
-                                  }
-                          },
-                   grouped: true,
-                   prioritized: true,
-                   primary_language: 'en',
-                   display_order_position: 1,
-                   links: {
-                           project: project.id.to_s
-                          }
-                  }
+         workflows: {
+                     display_name: 'Test workflow',
+                     first_task: 'interest',
+                     active: true,
+                     retirement: { criteria: "classification_count" },
+                     aggregation: { public: true },
+                     configuration: { autoplay_subjects: true },
+                     public_gold_standard: true,
+                     tasks: create_task_params,
+                     grouped: true,
+                     prioritized: true,
+                     primary_language: 'en',
+                     display_order_position: 1,
+                     links: { project: project.id.to_s }
+                    }
       }
     end
 
@@ -478,6 +479,12 @@ describe Api::V1::WorkflowsController, type: :controller do
       it 'sets the workflow active to false' do
         expect(Workflow.find(json_response["workflows"][0]["id"]).active).to be false
       end
+    end
+
+    context "with an empty task set" do
+      let(:create_task_params) { {} }
+
+      it_behaves_like "is creatable"
     end
   end
 

--- a/spec/models/workflow_content_spec.rb
+++ b/spec/models/workflow_content_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe WorkflowContent, :type => :model do
   end
 
   describe "versioning", versioning: true do
+    let(:new_strings) { { label: "some stuff" } }
     subject do
       create(:workflow_content)
     end
@@ -25,7 +26,6 @@ RSpec.describe WorkflowContent, :type => :model do
     it { is_expected.to be_versioned }
 
     it 'should track changes to strings' do
-      new_strings = %w(some stuff)
       subject.update!(strings: new_strings)
       expect(subject.previous_version.strings).to_not eq(new_strings)
     end
@@ -38,7 +38,7 @@ RSpec.describe WorkflowContent, :type => :model do
 
     it 'caches the new version number', :aggregate_failures do
       previous_number = subject.current_version_number
-      subject.update!(strings: %w(foo bar))
+      subject.update!(strings: new_strings)
       expect(subject.current_version_number).to eq(previous_number + 1)
       expect(subject.current_version_number).to eq(ModelVersion.version_number(subject))
     end

--- a/spec/models/workflow_content_spec.rb
+++ b/spec/models/workflow_content_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe WorkflowContent, :type => :model do
 
   it_behaves_like "is translated content"
 
+  describe "#strings" do
+
+    it "should not be valid with a missing strings object" do
+      expect(build(:workflow_content, strings: nil)).to be_invalid
+    end
+
+    it "should allow an empty hash of strings" do
+      expect(build(:workflow_content, strings: {})).to be_valid
+    end
+  end
+
   describe "versioning", versioning: true do
     subject do
       create(:workflow_content)


### PR DESCRIPTION
closes #1728 allow empty workflow tasks

When creating / updateing workflow tasks, allow the workflow_content strings to be empty but ensure they are a hash (by default in db and controller task strings extractor) to avoid the null db constraint. This should be fine client side as the task set and the contents don't get out of sync, i.e both are `{}` so the serialized tasks object (i.e. the translated strings re-inserted) is just an empty hash.