### PR TITLE
skip subject limit checks for whitelisted users

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::UsersController < Api::ApiController
 
   allowed_params :update, :login, :display_name, :email, :credited_name,
    :global_email_communication, :project_email_communication,
-   :beta_email_communication, :subject_limit
+   :beta_email_communication, :subject_limit, :upload_whitelist
 
   alias_method :user, :controlled_resource
 
@@ -73,7 +73,7 @@ class Api::V1::UsersController < Api::ApiController
   end
 
   def build_update_hash(update_params, id)
-    admin_allowed(update_params, :subject_limit)
+    admin_allowed(update_params, :subject_limit, :upload_whitelist)
     super
   end
 

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -5,7 +5,8 @@ class ApiUser
 
   delegate :memberships_for, :owns?, :id, :languages, :user_groups,
     :project_preferences, :collection_preferences, :classifications,
-    :user_groups, :has_finished?, :memberships, to: :user, allow_nil: true
+    :user_groups, :has_finished?, :memberships, :upload_whitelist,
+    to: :user, allow_nil: true
 
   def initialize(user, admin: false)
     @user, @admin_flag = user, admin
@@ -28,7 +29,7 @@ class ApiUser
   end
 
   def above_subject_limit?
-    return false if is_admin?
+    return false if is_admin? || upload_whitelist
     current, max = subject_limits
     current >= max
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -7,7 +7,7 @@ class UserSerializer
     :updated_at, :type, :global_email_communication,
     :project_email_communication, :beta_email_communication,
     :max_subjects, :uploaded_subjects_count, :admin, :href, :login_prompt,
-    :private_profile, :zooniverse_id
+    :private_profile, :zooniverse_id, :upload_whitelist
 
   can_include :classifications, :project_preferences, :collection_preferences,
     projects: { param: "owner", value: "login" },
@@ -39,7 +39,7 @@ class UserSerializer
 
   %w(credited_name email global_email_communication project_email_communication
      beta_email_communication uploaded_subjects_count max_subjects admin
-     login_prompt zooniverse_id).each do |me_only_attribute|
+     login_prompt zooniverse_id, upload_whitelist).each do |me_only_attribute|
     alias_method :"include_#{me_only_attribute}?", :permitted_requester?
   end
 

--- a/db/migrate/20160323101942_user_upload_whitelist.rb
+++ b/db/migrate/20160323101942_user_upload_whitelist.rb
@@ -1,0 +1,5 @@
+class UserUploadWhitelist < ActiveRecord::Migration
+  def change
+    add_column :users, :upload_whitelist, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1150,7 +1150,8 @@ CREATE TABLE users (
     ouroboros_created boolean DEFAULT false,
     subject_limit integer,
     private_profile boolean DEFAULT true,
-    tsv tsvector
+    tsv tsvector,
+    upload_whitelist boolean DEFAULT false NOT NULL
 );
 
 
@@ -2821,4 +2822,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160114141909');
 INSERT INTO schema_migrations (version) VALUES ('20160202155708');
 
 INSERT INTO schema_migrations (version) VALUES ('20160303163658');
+
+INSERT INTO schema_migrations (version) VALUES ('20160323101942');
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -407,9 +407,8 @@ describe Api::V1::SubjectsController, type: :controller do
     end
 
     context "when the user has exceeded the allowed number of subjects" do
-      let(:authorised_user) { create(:user) }
       let(:upload_subjects) do
-        default_request scopes: scopes, user_id: authorised_user.id
+        default_request scopes: scopes, user_id: authorized_user.id
         post :create, create_params
       end
 
@@ -432,6 +431,15 @@ describe Api::V1::SubjectsController, type: :controller do
 
         it 'should return the created status' do
           allow_any_instance_of(ApiUser).to receive(:is_admin?).and_return(true)
+          upload_subjects
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      context "when the user is whitelisted to upload" do
+
+        it 'should return the created status' do
+          allow_any_instance_of(User).to receive(:upload_whitelist).and_return(true)
           upload_subjects
           expect(response).to have_http_status(:created)
         end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -69,6 +69,10 @@ describe Api::V1::UsersController, type: :controller do
         it "should have a max_subjects" do
           expect(requester).to include("max_subjects")
         end
+
+        it "should have a upload_whitelist" do
+          expect(requester).to include("upload_whitelist")
+        end
       end
 
       context "a record for a different user" do
@@ -100,6 +104,10 @@ describe Api::V1::UsersController, type: :controller do
 
         it "should not have a max_subjects" do
           expect(not_requester).to_not include("max_subjects")
+        end
+
+        it "should not have a upload_whitelist" do
+          expect(not_requester).to_not include("upload_whitelist")
         end
       end
 
@@ -139,6 +147,10 @@ describe Api::V1::UsersController, type: :controller do
 
       it "should not have a max_subjects" do
         expect(json_response[api_resource_name][0]).to_not include("max_subjects")
+      end
+
+      it "should not have a upload_whitelist" do
+        expect(json_response[api_resource_name][0]).to_not include("upload_whitelist")
       end
     end
 
@@ -412,6 +424,11 @@ describe Api::V1::UsersController, type: :controller do
     it "should have the zooniverse_id for the user" do
       result = user_response["zooniverse_id"]
       expect(result).to eq(user.zooniverse_id)
+    end
+
+    it "should have the upload_whitelist for the user" do
+      result = user_response["upload_whitelist"]
+      expect(result).to eq(user.upload_whitelist)
     end
 
     it_behaves_like "an api response"

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -49,13 +49,6 @@ RSpec.describe ApiUser do
 
     subject { api_user.above_subject_limit? }
 
-    context "user is admin" do
-      let(:flag) { true }
-      let(:user) { create(:user, admin: true) }
-
-      it { is_expected.to be false }
-    end
-
     context "user is above limit" do
       let(:limit) { 9 }
 
@@ -66,6 +59,31 @@ RSpec.describe ApiUser do
       let(:limit) { 11 }
 
       it { is_expected.to be false }
+    end
+
+    context "user is admin" do
+      let(:flag) { true }
+      let(:user) { create(:user, admin: true) }
+
+      it { is_expected.to be false }
+    end
+
+    context "user is whitelisted for upload" do
+      before do
+        allow_any_instance_of(User).to receive(:upload_whitelist).and_return(true)
+      end
+
+      context "user is above limit" do
+        let(:limit) { 9 }
+
+        it { is_expected.to be false }
+      end
+
+      context "user is below limit" do
+        let(:limit) { 11 }
+
+        it { is_expected.to be false }
+      end
     end
   end
 


### PR DESCRIPTION
closes #1716 - skip subject limit checks when uploading for whitelisted users.