### PR TITLE
Move setting the default value to a rake task

### DIFF
--- a/db/migrate/20160323101942_user_upload_whitelist.rb
+++ b/db/migrate/20160323101942_user_upload_whitelist.rb
@@ -1,5 +1,5 @@
 class UserUploadWhitelist < ActiveRecord::Migration
   def change
-    add_column :users, :upload_whitelist, :boolean, default: false, null: false
+    add_column :users, :upload_whitelist, :boolean
   end
 end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -74,6 +74,15 @@ namespace :migrate do
         ig.save(validate: false)
       end
     end
+
+    desc "Set default value for whitelist upload count"
+    task :upload_whitelist_default => :environment do
+      User.select("id").find_in_batches do |batch|
+        User.where(id: batch.map(&:id)).update_all(upload_whitelist: false)
+        print '.'
+      end
+      puts ' done'
+    end
   end
 
   namespace :slug do


### PR DESCRIPTION
Moves the setting of the initial value to a rake task which we'll run out of band. A next PR will set the actual PSQL column default for whatever records are created after this, which we'll do in a second deploy.

# Review checklist

* First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
* If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
* If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
* Are all the changes covered by tests? Think about any possible edge cases that might be left untested.