### PR TITLE
lock sidekiq at 3.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'logstasher', '~> 0.6'
 gem 'honeybadger', '~> 2.0'
 gem 'jquery-rails', '~> 4.0'
 gem 'uglifier', '~> 2.0'
-gem 'sidekiq', '~> 3.0'
+gem 'sidekiq', '= 3.4.2'
 gem 'sinatra', '>= 1.3.0', require: nil
 gem 'aws-sdk-v1', '~> 1.0'
 gem 'json-schema', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,23 +78,8 @@ GEM
       attention (~> 0.0.4)
       http (~> 0.9)
       multi_json (~> 1.11)
-    celluloid (0.17.3)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.5)
-      timers (>= 4.1.1)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     coderay (1.1.1)
     concurrent-ruby (1.0.1)
     congestion (0.0.3)
@@ -337,8 +322,8 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     shellany (0.0.1)
-    sidekiq (3.5.4)
-      celluloid (~> 0.17.2)
+    sidekiq (3.4.2)
+      celluloid (~> 0.16.0)
       connection_pool (~> 2.2, >= 2.2.0)
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
@@ -372,7 +357,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
-    timers (4.1.1)
+    timers (4.0.4)
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -437,7 +422,7 @@ DEPENDENCIES
   rspec-rails
   schema_plus_pg_indexes (~> 0.1)
   sdoc (~> 0.4.0)
-  sidekiq (~> 3.0)
+  sidekiq (= 3.4.2)
   sidekiq-congestion (~> 0.1.0)
   sidetiq (~> 0.6.3)
   sinatra (>= 1.3.0)


### PR DESCRIPTION
sidekiq 3.5+ bumps celluloid but sidetiq fails with this on 0.6.3 as it needs 0.7+ and that requires sidekiq 4+. Eventually we should just bump to sidekiq 4 and fix the deps.