### PR TITLE
skip dead queue for cellect seen workers

### DIFF
--- a/app/workers/seen_cellect_worker.rb
+++ b/app/workers/seen_cellect_worker.rb
@@ -5,7 +5,7 @@ class SeenCellectWorker
 
   # SGL-PRIORITY
   # sidekiq_options retry: 3, queue: :data_high
-  sidekiq_options retry: 3, queue: :high
+  sidekiq_options retry: 3, queue: :high, dead: false
 
   def perform(workflow_id, user_id, subject_id)
     return if user_id.nil?


### PR DESCRIPTION
these are pretty noisy and we don't need them to sit around in the dead queue