### PR TITLE
Users whiteload structure fix

### DIFF
--- a/db/migrate/20160406151657_add_user_upload_whitelist_defaults.rb
+++ b/db/migrate/20160406151657_add_user_upload_whitelist_defaults.rb
@@ -1,0 +1,5 @@
+class AddUserUploadWhitelistDefaults < ActiveRecord::Migration
+  def change
+    change_column_default(:users, :upload_whitelist, false)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1152,7 +1152,7 @@ CREATE TABLE users (
     subject_limit integer,
     private_profile boolean DEFAULT true,
     tsv tsvector,
-    upload_whitelist boolean DEFAULT false NOT NULL
+    upload_whitelist boolean DEFAULT false
 );
 
 
@@ -2918,4 +2918,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160323101942');
 INSERT INTO schema_migrations (version) VALUES ('20160329144922');
 
 INSERT INTO schema_migrations (version) VALUES ('20160330142609');
+
+INSERT INTO schema_migrations (version) VALUES ('20160406151657');
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -77,7 +77,7 @@ namespace :migrate do
 
     desc "Set default value for whitelist upload count"
     task :upload_whitelist_default => :environment do
-      User.select("id").find_in_batches do |batch|
+      User.where(upload_whitelist: nil).select("id").find_in_batches do |batch|
         User.where(id: batch.map(&:id)).update_all(upload_whitelist: false)
         print '.'
       end


### PR DESCRIPTION
add a default value to the users upload whitelist table and fix the out of sync structure.sql file. Not sure we need to have the `NOT NULL` clause anymore since it won't affect the code but happy to add another  migration PR if needed.

Need to rerun the rake task after this is deployed.