### PR TITLE
split dequeue subject queue workers up

### DIFF
--- a/app/workers/dequeue_subject_queue_worker.rb
+++ b/app/workers/dequeue_subject_queue_worker.rb
@@ -1,13 +1,7 @@
 class DequeueSubjectQueueWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :data_medium
-  sidekiq_options congestion: {
-      interval: 30,
-      max_in_interval: 1,
-      min_delay: 0,
-      reject_with: :cancel
-    }.merge({key: -> (queue_id, sms_ids) { "queue_#{ queue_id }_dequeue" }})
+  sidekiq_options queue: :data_high
 
   def perform(queue_id, sms_ids)
     return if sms_ids.blank?

--- a/app/workers/non_logged_in_dequeue_subject_queue_worker.rb
+++ b/app/workers/non_logged_in_dequeue_subject_queue_worker.rb
@@ -1,0 +1,19 @@
+class NonLoggedInDequeueSubjectQueueWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_medium
+  sidekiq_options congestion: {
+      interval: 30,
+      max_in_interval: 1,
+      min_delay: 0,
+      reject_with: :cancel
+    }.merge({key: -> (queue_id, sms_ids) { "queue_#{ queue_id }_dequeue" }})
+
+  def perform(queue_id, sms_ids)
+    return if sms_ids.blank?
+    queue = SubjectQueue.find(queue_id)
+    queue.dequeue_update(sms_ids)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Subjects::Selector do
         # to the non-logged in queues, use the rate limiter in sidekiq to
         # control how often these happen
         it 'should schedule a dequeue for the non-logged in queue' do
-          expect(DequeueSubjectQueueWorker).to receive(:perform_async)
+          expect(NonLoggedInDequeueSubjectQueueWorker).to receive(:perform_async)
             .with(subject_queue.id, array_including(sms_ids))
           subject.get_subjects
         end

--- a/spec/support/dequeue_subject_queue.rb
+++ b/spec/support/dequeue_subject_queue.rb
@@ -1,0 +1,34 @@
+shared_examples "a dequeue subject queue worker" do
+  let(:workflow) { create(:workflow_with_subject_set) }
+  let(:subject_set) { workflow.subject_sets.first }
+  let(:user) { workflow.project.owner }
+  let(:sms_ids) { (1..10).to_a }
+  let(:queue) do
+    create(:subject_queue, user: user, workflow: workflow, set_member_subject_ids: sms_ids)
+  end
+
+  describe "#perform" do
+
+    it 'should call dequeue on subject queue' do
+      expect_any_instance_of(SubjectQueue)
+        .to receive(:dequeue_update)
+        .with(sms_ids)
+      subject.perform(queue.id, sms_ids)
+    end
+
+    context "with an empty set of sms_ids" do
+
+      it "should not call dequeue" do
+        expect_any_instance_of(SubjectQueue).not_to receive(:dequeue_update)
+        subject.perform(queue.id, [])
+      end
+    end
+
+    context "when the queue does not exist" do
+      it 'should not raise an error' do
+        expect { subject.perform(-1, sms_ids) }.to_not raise_error
+      end
+    end
+  end
+
+end

--- a/spec/workers/non_logged_in_dequeue_subject_queue_worker_spec.rb
+++ b/spec/workers/non_logged_in_dequeue_subject_queue_worker_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
-RSpec.describe DequeueSubjectQueueWorker do
+RSpec.describe NonLoggedInDequeueSubjectQueueWorker do
+
   subject { described_class.new }
 
   it_behaves_like "a dequeue subject queue worker"


### PR DESCRIPTION
linked to #1640

rate limit non-logged in ones (no user) but do not skip the non-logged in ones. Also bump the queue priority for the logged in dequeue operation as we need to get this data out of the queue asap for a user session.