### PR TITLE
Optimize role control

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -30,10 +30,9 @@ class Membership < ActiveRecord::Base
   def self.scope_for(action, user, opts={})
     return all if user.is_admin?
     roles, _ = parent_class.roles(action)
-    accessible_groups = user.user_groups.where.overlap(memberships: {roles: roles})
-    query = not_identity.where(user_group_id: accessible_groups)
+    accessible_group_ids = user.user_groups.where.overlap(memberships: {roles: roles}).pluck(:id)
+    query = not_identity.where(user_group_id: accessible_group_ids)
             .or(not_identity.where(user_id: user.id))
-
 
     case action
     when :show, :index

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -63,6 +63,12 @@ class UserGroup < ActiveRecord::Base
       .where(memberships: { identity: false })
   end
 
+  def self.public_query(private_query, public_flag)
+    query = where(id: private_query.pluck(:id))
+    query = query.or(public_scope) if public_flag
+    query
+  end
+
   def self.roles_allowed_to_access(action, klass=nil)
     roles = case action
             when :show, :index

--- a/db/migrate/20160412125332_add_index_on_user_group_private.rb
+++ b/db/migrate/20160412125332_add_index_on_user_group_private.rb
@@ -1,0 +1,7 @@
+class AddIndexOnUserGroupPrivate < ActiveRecord::Migration
+  disable_ddl_transaction!
+  
+  def change
+    add_index :user_groups, :private, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2369,6 +2369,13 @@ CREATE UNIQUE INDEX index_user_groups_on_name ON user_groups USING btree (lower(
 
 
 --
+-- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_user_groups_on_private ON user_groups USING btree (private);
+
+
+--
 -- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2922,4 +2929,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160330142609');
 INSERT INTO schema_migrations (version) VALUES ('20160406151657');
 
 INSERT INTO schema_migrations (version) VALUES ('20160408104326');
+
+INSERT INTO schema_migrations (version) VALUES ('20160412125332');
 

--- a/lib/role_control/actor.rb
+++ b/lib/role_control/actor.rb
@@ -4,8 +4,8 @@ module RoleControl
       attr_reader :scope, :action, :actor
 
       def initialize(actor, action)
-        @action = action
         @actor = actor
+        @action = action
       end
 
       def to(klass, context={}, add_active_scope: true)

--- a/lib/role_control/controlled.rb
+++ b/lib/role_control/controlled.rb
@@ -33,7 +33,7 @@ module RoleControl
       end
 
       def public_query(private_query, public_flag)
-        query = where(id: private_query)
+        query = where(id: private_query.pluck(:resource_id))
         query = query.or(public_scope) if public_flag
         query
       end


### PR DESCRIPTION
Investigating why `/api/v1/user_groups` and `/api/v1/memberships` were so slow to load, I found that the issue could be solved by splitting the query up in two, rather than doing a subquery. PostgreSQL seems to be able to leverage indexes rather than doing seq scans this way.

I'd love to roll this out under Scientist, but we'd have to set that up first and since `scope_for` just returns a scope rather than records, I'm not too sure where I'd start measuring the difference and timing.

# Review checklist

* First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
* If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
* If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
* Are all the changes covered by tests? Think about any possible edge cases that might be left untested.