### PR TITLE
serialize the subject_limit attribute name

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -6,7 +6,7 @@ class UserSerializer
   attributes :id, :login, :display_name, :credited_name, :email, :languages,
     :created_at, :updated_at, :type, :global_email_communication,
     :project_email_communication, :beta_email_communication,
-    :max_subjects, :uploaded_subjects_count, :admin, :href, :login_prompt,
+    :subject_limit, :uploaded_subjects_count, :admin, :href, :login_prompt,
     :private_profile, :zooniverse_id, :upload_whitelist
 
   can_include :classifications, :project_preferences, :collection_preferences,
@@ -14,10 +14,6 @@ class UserSerializer
     collections: { param: "owner", value: "login" }
 
   media_include :avatar, :profile_header
-
-  def max_subjects
-    @model.subject_limit
-  end
 
   def admin
     !!@model.admin
@@ -38,7 +34,7 @@ class UserSerializer
   end
 
   %w(credited_name email languages global_email_communication project_email_communication
-     beta_email_communication uploaded_subjects_count max_subjects admin
+     beta_email_communication uploaded_subjects_count subject_limit admin
      login_prompt zooniverse_id, upload_whitelist).each do |me_only_attribute|
     alias_method :"include_#{me_only_attribute}?", :permitted_requester?
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -66,8 +66,8 @@ describe Api::V1::UsersController, type: :controller do
           expect(requester).to include("uploaded_subjects_count")
         end
 
-        it "should have a max_subjects" do
-          expect(requester).to include("max_subjects")
+        it "should have a subject_limit" do
+          expect(requester).to include("subject_limit")
         end
 
         it "should have a upload_whitelist" do
@@ -102,8 +102,8 @@ describe Api::V1::UsersController, type: :controller do
           expect(not_requester).to_not include("uploaded_subjects_count")
         end
 
-        it "should not have a max_subjects" do
-          expect(not_requester).to_not include("max_subjects")
+        it "should not have a subject_limit" do
+          expect(not_requester).to_not include("subject_limit")
         end
 
         it "should not have a upload_whitelist" do
@@ -149,8 +149,8 @@ describe Api::V1::UsersController, type: :controller do
         expect(json_response[api_resource_name][0]).to_not include("uploaded_subjects_count")
       end
 
-      it "should not have a max_subjects" do
-        expect(json_response[api_resource_name][0]).to_not include("max_subjects")
+      it "should not have a subject_limit" do
+        expect(json_response[api_resource_name][0]).to_not include("subject_limit")
       end
 
       it "should not have a upload_whitelist" do
@@ -408,9 +408,9 @@ describe Api::V1::UsersController, type: :controller do
       expect(uploaded_subjects).to eq(user.uploaded_subjects_count)
     end
 
-    it "should have the user's max_subjects" do
-      max_subjects = user_response["max_subjects"]
-      expect(max_subjects).to eq(Panoptes.max_subjects)
+    it "should have the user's subject_limit" do
+      subject_limit = user_response["subject_limit"]
+      expect(subject_limit).to eq(Panoptes.max_subjects)
     end
 
     it "should have the languages for the user" do


### PR DESCRIPTION
Linked to https://github.com/zooniverse/Panoptes-Front-End/pull/2379

Serialise the attribute name for use in the client. 

# Review checklist

* First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
* If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
* If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
* Are all the changes covered by tests? Think about any possible edge cases that might be left untested.