### PR TITLE
simplify the owner filter join and eager load the identity group users

### DIFF
--- a/app/controllers/concerns/filter_by_current_user_roles.rb
+++ b/app/controllers/concerns/filter_by_current_user_roles.rb
@@ -12,6 +12,7 @@ module FilterByCurrentUserRoles
         .joins(:access_control_lists)
         .where(access_control_lists: {user_group_id: api_user.user.identity_group.id})
         .where.overlap(access_control_lists: { roles: roles_filter })
+
       if owner_eager_load(roles_filter)
         @controlled_resources = @controlled_resources.preload(:owner)
       end

--- a/app/controllers/concerns/filter_by_owner.rb
+++ b/app/controllers/concerns/filter_by_owner.rb
@@ -10,11 +10,9 @@ module FilterByOwner
     unless owner_filter.blank?
       groups = UserGroup.where(UserGroup.arel_table[:name].lower.in(owner_filter.map(&:downcase)))
       @controlled_resources = controlled_resources
-        .eager_load(:owner)
-        .joins(:owner)
-        .joins(:access_control_lists)
-        .where(access_control_lists: {user_group: groups})
-        .where.overlap(access_control_lists: { roles: ["owner"] })
+      .eager_load(owner: [:users])
+      .joins(:owner)
+      .where(access_control_lists: { user_group: groups })
     end
   end
 end

--- a/app/controllers/concerns/filter_by_owner.rb
+++ b/app/controllers/concerns/filter_by_owner.rb
@@ -8,11 +8,11 @@ module FilterByOwner
   def add_owner_ids_to_filter_param!
     owner_filter = params.delete(:owner).try(:split, ',')
     unless owner_filter.blank?
-      groups = UserGroup.where(UserGroup.arel_table[:name].lower.in(owner_filter.map(&:downcase)))
-      @controlled_resources = controlled_resources
-      .eager_load(owner: [:users])
-      .joins(:owner)
-      .where(access_control_lists: { user_group: groups })
+      owner_group_scope = UserGroup.where(
+        UserGroup.arel_table[:name].lower.in(owner_filter.map(&:downcase))
+      )
+      owner_scope = resource_class.filter_by_owner(owner_group_scope)
+      @controlled_resources = controlled_resources.merge(owner_scope)
     end
   end
 end

--- a/lib/role_control/owned.rb
+++ b/lib/role_control/owned.rb
@@ -11,6 +11,12 @@ module RoleControl
 
       validates_presence_of :owner
 
+      def self.filter_by_owner(owner_groups)
+        eager_load(owner: [:users])
+        .joins(:owner)
+        .where(access_control_lists: { user_group: owner_groups })
+      end
+
       include OwnerOverrides
     end
 

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -34,9 +34,14 @@ describe Api::V1::CollectionsController, type: :controller do
     it_behaves_like "filter by display_name"
     it_behaves_like 'has many filterable', :subjects
 
-    describe "filtering", :focus do
+    describe "filtering" do
+      let(:owner_resources) { collections }
+      let(:collab_collection) { create(:collection) }
+      let(:collab_resource) { collab_collection }
+      let(:viewer_resource) { private_resource }
+
       it_behaves_like "filters by owner"
-      # it_behaves_like "filters by current user roles"
+      it_behaves_like "filters by current user roles"
 
       describe "project_ids" do
         let(:project_ids){ collections.map(&:project_ids).flatten }

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -34,38 +34,43 @@ describe Api::V1::CollectionsController, type: :controller do
     it_behaves_like "filter by display_name"
     it_behaves_like 'has many filterable', :subjects
 
-    describe "filtering on project_ids" do
-      let(:project_ids){ collections.map(&:project_ids).flatten }
-      let(:expected_filtered_ids) { collections.map(&:id).map(&:to_s) }
+    describe "filtering", :focus do
+      it_behaves_like "filters by owner"
+      # it_behaves_like "filters by current user roles"
 
-      it_behaves_like 'belongs to many filterable', :projects do
-        let(:filter_ids) { project_ids.join(",") }
-      end
-
-      context "single project_ids" do
-        let(:project_ids){ collections.first.project_ids }
-        let(:expected_filtered_ids) { [ collections.first.id.to_s ] }
+      describe "project_ids" do
+        let(:project_ids){ collections.map(&:project_ids).flatten }
+        let(:expected_filtered_ids) { collections.map(&:id).map(&:to_s) }
 
         it_behaves_like 'belongs to many filterable', :projects do
           let(:filter_ids) { project_ids.join(",") }
         end
-      end
 
-      context "filtering on singular resource" do
-        let(:expected_filtered_ids) { [ collections.first.id.to_s ] }
+        context "single project_ids" do
+          let(:project_ids){ collections.first.project_ids }
+          let(:expected_filtered_ids) { [ collections.first.id.to_s ] }
 
-        it_behaves_like 'has many filterable', :projects do
-          let(:filter_ids) { collections.first.project_ids.first }
+          it_behaves_like 'belongs to many filterable', :projects do
+            let(:filter_ids) { project_ids.join(",") }
+          end
+        end
+
+        context "on singular resource" do
+          let(:expected_filtered_ids) { [ collections.first.id.to_s ] }
+
+          it_behaves_like 'has many filterable', :projects do
+            let(:filter_ids) { collections.first.project_ids.first }
+          end
         end
       end
-    end
 
-    context "it is filterable by favorite" do
-      let!(:favorite_col) { create(:collection, favorite: true) }
+      describe "by favorite" do
+        let!(:favorite_col) { create(:collection, favorite: true) }
 
-      it 'should only return the favorite collection' do
-        get :index, favorite: true
-        expect(json_response[api_resource_name].map{ |r| r['id'] }).to match_array([favorite_col.id.to_s])
+        it 'should only return the favorite collection' do
+          get :index, favorite: true
+          expect(json_response[api_resource_name].map{ |r| r['id'] }).to match_array([favorite_col.id.to_s])
+        end
       end
     end
   end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -167,8 +167,10 @@ describe Api::V1::ProjectsController, type: :controller do
         end
 
         describe "filtering" do
-          let(:role_filter_resource) { beta_resource }
-          let(:role_filter_user) { user }
+          let(:owner_resources) { [ resource ] }
+          let(:collab_resource) { beta_resource }
+          let(:viewer_resource) { private_resource }
+          let(:authorized_user) { owner }
 
           it_behaves_like "filters by owner"
           it_behaves_like "filters by current user roles"
@@ -277,17 +279,13 @@ describe Api::V1::ProjectsController, type: :controller do
               end
             end
 
-            describe "filter by state"  do
+            describe "filter by state" do
               let(:projects) do
                 create_list(:project_with_contents, 2, owner: user).tap do |list|
                   list[0].paused!
                 end
               end
-
-              let(:filtered_project) do
-                projects.first
-              end
-
+              let(:filtered_project) { projects.first }
               let(:index_options) { { state: "paused" } }
 
               it "should respond with 1 item" do

--- a/spec/support/filter_by_current_user_roles.rb
+++ b/spec/support/filter_by_current_user_roles.rb
@@ -1,0 +1,41 @@
+RSpec.shared_examples "filters by current user roles" do
+  let(:index_options) do
+    { current_user_roles: 'owner,collaborator' }
+  end
+  let(:collab_acls) do
+    create(:access_control_list,
+           resource: role_filter_resource,
+           user_group: role_filter_user.identity_group,
+           roles: ["viewer"])
+    create(:access_control_list,
+           resource: resource,
+           user_group: role_filter_user.identity_group,
+           roles: ["collaborator"])
+  end
+  let(:response_ids) { json_response[api_resource_name].map{ |p| p['id'] } }
+
+  before(:each) do
+    collab_acls
+    get :index, index_options
+  end
+
+  it "should respond with 3 items" do
+    expect(json_response[api_resource_name].length).to eq(3)
+  end
+
+  it 'should not have a project where the user has a different role' do
+    expect(response_ids).to_not include(beta_resource.id.to_s)
+  end
+
+  it "should respond with the correct item" do
+    expect(response_ids).to include(new_project.id.to_s, *projects.map(&:id).map(&:to_s))
+  end
+
+  context "with just the owner role filter" do
+    let(:index_options) { { current_user_roles: 'owner' } }
+
+    it "should respond with 2 items" do
+      expect(json_response[api_resource_name].length).to eq(2)
+    end
+  end
+end

--- a/spec/support/filter_by_owner.rb
+++ b/spec/support/filter_by_owner.rb
@@ -2,14 +2,15 @@ RSpec.shared_examples "filters by owner" do
   let(:index_options) do
     { owner: owner.login }
   end
+  let(:expected_count) { owner_resources.count }
 
-  before(:each) do
+  before do
     resource
     get :index, index_options
   end
 
-  it "should respond with 1 item" do
-    expect(json_response[api_resource_name].length).to eq(1)
+  it "should respond with the correct number of items" do
+    expect(json_response[api_resource_name].length).to eq(expected_count)
   end
 
   it "should respond with the correct item" do
@@ -23,8 +24,8 @@ RSpec.shared_examples "filters by owner" do
       { owner: [owner.login.upcase, 'SOMETHING'].join(',') }
     end
 
-    it "should respond with 1 item" do
-      expect(json_response[api_resource_name].length).to eq(1)
+    it "should respond with the correct number of items" do
+      expect(json_response[api_resource_name].length).to eq(expected_count)
     end
 
     it "should respond with the correct item" do

--- a/spec/support/filter_by_owner.rb
+++ b/spec/support/filter_by_owner.rb
@@ -1,0 +1,35 @@
+RSpec.shared_examples "filters by owner" do
+  let(:index_options) do
+    { owner: owner.login }
+  end
+
+  before(:each) do
+    resource
+    get :index, index_options
+  end
+
+  it "should respond with 1 item" do
+    expect(json_response[api_resource_name].length).to eq(1)
+  end
+
+  it "should respond with the correct item" do
+    owner_id = json_response[api_resource_name][0]['links']['owner']['id']
+    expect(owner_id).to eq(resource.owner.id.to_s)
+  end
+
+  context "when the owner name has a different case to the identity group" do
+    let(:index_options) do
+      resource
+      { owner: [owner.login.upcase, 'SOMETHING'].join(',') }
+    end
+
+    it "should respond with 1 item" do
+      expect(json_response[api_resource_name].length).to eq(1)
+    end
+
+    it "should respond with the correct item" do
+      owner_id = json_response[api_resource_name][0]['links']['owner']['id']
+      expect(owner_id).to eq(resource.owner.id.to_s)
+    end
+  end
+end


### PR DESCRIPTION
closes #1774 

the previous query was creating 2 inner joins on the access_control_lists and creating duplicates on the join which was affecting the overal sql count queries, i.e. 1 result but count was 2. This is mostly creating shared helpers to test the filtering (which we weren't before).

TODO:
- [X] See about the N+1 on the owner preload for role filtering...(I failed on this one...)

# Review checklist

* First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
* If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
* If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
* Are all the changes covered by tests? Think about any possible edge cases that might be left untested.