### PR TITLE
fix evaluation order of class / instance methods

### DIFF
--- a/app/models/concerns/extended_cache_key.rb
+++ b/app/models/concerns/extended_cache_key.rb
@@ -2,24 +2,20 @@ module ExtendedCacheKey
   extend ActiveSupport::Concern
 
   included do
-    @included_associations = []
-    @included_resource_methods = []
+    @included_associations = Set.new
+    @included_resource_methods = Set.new
   end
 
   module ClassMethods
     def cache_by_association(*associations)
       associations.each do |association|
-        if self.reflect_on_association(association) && !@included_associations.include?(association)
-          @included_associations << association
-        end
+        @included_associations << association
       end
     end
 
     def cache_by_resource_method(*resource_methods)
       resource_methods.each do |method|
-        if self.method_defined?(method) && !@included_resource_methods.include?(method)
-          @included_resource_methods << method
-        end
+        @included_resource_methods << method
       end
     end
 

--- a/spec/support/extended_cache_key.rb
+++ b/spec/support/extended_cache_key.rb
@@ -33,7 +33,28 @@ shared_examples "has an extended cache key" do |associations, resource_methods|
   end
 
   describe "#cache_key" do
+    shared_examples "it should raise an error" do |method, result|
+      it "should raise an error" do
+        allow(cached_resource.class).to receive(method).and_return([result])
+        expect {
+          cache_key_result
+        }.to raise_error(NoMethodError)
+      end
+    end
+
     let(:cache_key_result) { cached_resource.cache_key }
+
+    context "when the class method name is invalid" do
+      it_behaves_like "it should raise an error",
+        :included_associations,
+        :unknown_class_method
+    end
+
+    context "when the instance method name is invalid" do
+      it_behaves_like "it should raise an error",
+        :included_resource_methods,
+        :unknown_instance_method
+    end
 
     context "when no extra cache key directives are set" do
 

--- a/spec/support/extended_cache_key.rb
+++ b/spec/support/extended_cache_key.rb
@@ -27,7 +27,8 @@ shared_examples "has an extended cache key" do |associations, resource_methods|
 
     it "should store the resource methods" do
       resource_class.cache_by_resource_method(*resource_methods)
-      expect(resource_class.included_resource_methods).to match_array(resource_methods)
+      expect(resource_class.included_resource_methods)
+        .to match_array(resource_methods)
     end
   end
 
@@ -36,7 +37,7 @@ shared_examples "has an extended cache key" do |associations, resource_methods|
 
     context "when no extra cache key directives are set" do
 
-      before(:each) do
+      before do
         %i(included_associations included_resource_methods).each do |cache_key|
           allow(cached_resource.class).to receive(cache_key).and_return([])
         end
@@ -51,15 +52,18 @@ shared_examples "has an extended cache key" do |associations, resource_methods|
     # by default or else the model spec won't need the shared helpers
     context "when extra cache key directives are set" do
 
-      before(:each) do
+      before do
         resource_association_instances.each do |instance|
           stubbed_cache_key = resource_cache_key(instance)
-          allow_any_instance_of(instance.class).to receive(:cache_key).and_return(stubbed_cache_key)
+          allow_any_instance_of(instance.class)
+            .to receive(:cache_key)
+            .and_return(stubbed_cache_key)
         end
       end
 
       it "should include the resource key" do
-        expect(cache_key_result).to match(/#{cached_resource.model_name.cache_key}\/\w+/)
+        expect(cache_key_result)
+          .to match(/#{cached_resource.model_name.cache_key}\/\w+/)
       end
 
       it "should include the resource method key" do
@@ -71,7 +75,8 @@ shared_examples "has an extended cache key" do |associations, resource_methods|
 
       it "should include all the association keys" do
         cached_resource.send(*associations).map do |relation|
-          expect(cache_key_result).to match(/#{relation.model_name.cache_key}\/\w+/)
+          expect(cache_key_result)
+            .to match(/#{relation.model_name.cache_key}\/\w+/)
         end
       end
     end


### PR DESCRIPTION
Testing existence of instance methods before they were defined was stupid. Do not silently allow invalid method definitions in the cache key DSL, instead raise an error if the method doesn’t exist so it can be fixed.

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [x] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [x] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [x] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.