### PR TITLE
Record a reason when a subject is retired

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -41,7 +41,8 @@ module Api
       Api::UnpermittedParameter,
       RestPack::Serializer::InvalidInclude,
       ActiveRecord::RecordNotUnique,
-      Operation::Error,                                    with: :unprocessable_entity
+      Operation::Error,
+      ActiveInteraction::InvalidInteractionError,          with: :unprocessable_entity
 
     prepend_before_action :require_login, only: [:create, :update, :destroy]
     prepend_before_action :ban_user, only: [:create, :update, :destroy]

--- a/app/models/subject_workflow_count.rb
+++ b/app/models/subject_workflow_count.rb
@@ -31,7 +31,7 @@ class SubjectWorkflowCount < ActiveRecord::Base
     return if retired?
 
     ActiveRecord::Base.transaction(requires_new: true) do
-      update!(retirement_reason: reason, retired_at: Time.now.utc)
+      update!(retirement_reason: reason, retired_at: Time.zone.now)
       Workflow.increment_counter(:retired_set_member_subjects_count, workflow.id)
       yield if block_given?
     end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -62,10 +62,10 @@ class Workflow < ActiveRecord::Base
     subject_workflow_counts.retired.includes(:subject).map(&:subject)
   end
 
-  def retire_subject(subject_id)
+  def retire_subject(subject_id, reason=nil)
     if set_member_subjects.where(subject_id: subject_id).any?
       count = subject_workflow_counts.where(subject_id: subject_id, workflow_id: id).first_or_create!
-      count.retire!
+      count.retire!(reason)
     end
   end
 

--- a/app/operations/workflows/retire_subjects.rb
+++ b/app/operations/workflows/retire_subjects.rb
@@ -1,5 +1,7 @@
 module Workflows
   class RetireSubjects < Operation
+    validates :retirement_reason, inclusion: { in: SubjectWorkflowCount.retirement_reasons.keys, allow_nil: true }
+
     object :workflow
 
     integer :subject_id, default: nil

--- a/app/operations/workflows/retire_subjects.rb
+++ b/app/operations/workflows/retire_subjects.rb
@@ -6,11 +6,12 @@ module Workflows
     array :subject_ids, default: [] do
       integer
     end
+    string :retirement_reason, default: nil
 
     def execute
       Workflow.transaction do
         subject_ids.each do |subject_id|
-          workflow.retire_subject(subject_id)
+          workflow.retire_subject(subject_id, retirement_reason)
         end
 
         # This needs to be the last step in the transaction. If the transaction

--- a/db/migrate/20160425190129_add_retirement_reason.rb
+++ b/db/migrate/20160425190129_add_retirement_reason.rb
@@ -1,0 +1,5 @@
+class AddRetirementReason < ActiveRecord::Migration
+  def change
+    add_column :subject_workflow_counts, :retirement_reason, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -847,7 +847,8 @@ CREATE TABLE subject_workflow_counts (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     retired_at timestamp without time zone,
-    subject_id integer NOT NULL
+    subject_id integer NOT NULL,
+    retirement_reason integer
 );
 
 
@@ -2986,4 +2987,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160408104326');
 INSERT INTO schema_migrations (version) VALUES ('20160412125332');
 
 INSERT INTO schema_migrations (version) VALUES ('20160414151041');
+
+INSERT INTO schema_migrations (version) VALUES ('20160425190129');
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -535,16 +535,11 @@ describe Api::V1::WorkflowsController, type: :controller do
       expect(subject.retired_for_workflow?(workflow)).to be_truthy
     end
 
-    context "when the retirement_reason param is invalid" do
-      it 'throws an API error' do
-        post :retire_subjects, workflow_id: workflow.id, subject_id: subject.id, retirement_reason: "notreal" 
-        expect(json_response['errors'][0]['message']).to eq("Retirement reason is not included in the list")
-      end
-
-      it 'responds with a 422' do
-        post :retire_subjects, workflow_id: workflow.id, subject_id: subject.id, retirement_reason: "notreal" 
-        expect(response.status).to eq(422)
-      end
+    it 'throws an unpermitted params error when retired_reason is invalid', :aggregate_failures do
+      post :retire_subjects, workflow_id: workflow.id, subject_id: subject.id, retirement_reason: "notreal"
+      expect(json_response['errors'][0]['message'])
+        .to eq("Retirement reason is not included in the list")
+      expect(response.status).to eq(422)
     end
 
     it 'queues a cellect retirement if the workflow uses cellect' do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -535,6 +535,18 @@ describe Api::V1::WorkflowsController, type: :controller do
       expect(subject.retired_for_workflow?(workflow)).to be_truthy
     end
 
+    context "when the retirement_reason param is invalid" do
+      it 'throws an API error' do
+        post :retire_subjects, workflow_id: workflow.id, subject_id: subject.id, retirement_reason: "notreal" 
+        expect(json_response['errors'][0]['message']).to eq("Retirement reason is not included in the list")
+      end
+
+      it 'responds with a 422' do
+        post :retire_subjects, workflow_id: workflow.id, subject_id: subject.id, retirement_reason: "notreal" 
+        expect(response.status).to eq(422)
+      end
+    end
+
     it 'queues a cellect retirement if the workflow uses cellect' do
       allow(Panoptes).to receive(:use_cellect?).and_return(true)
       expect(RetireCellectWorker).to receive(:perform_async).with(subject.id, workflow.id)

--- a/spec/models/subject_workflow_count_spec.rb
+++ b/spec/models/subject_workflow_count_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe SubjectWorkflowCount, type: :model do
       count.retire!("blank")
       expect(count.retirement_reason).to match("blank")
     end
+
+    it 'does not record an invalid retirement reason' do
+      count.retire!("not-a-reason")
+      expect(count.retirement_reason).not_to match("not-a-reason")
+    end
   end
 
   describe "#retire?" do

--- a/spec/models/subject_workflow_count_spec.rb
+++ b/spec/models/subject_workflow_count_spec.rb
@@ -66,11 +66,6 @@ RSpec.describe SubjectWorkflowCount, type: :model do
       count.retire!("blank")
       expect(count.retirement_reason).to match("blank")
     end
-
-    it 'does not record an invalid retirement reason' do
-      count.retire!("not-a-reason")
-      expect(count.retirement_reason).not_to match("not-a-reason")
-    end
   end
 
   describe "#retire?" do

--- a/spec/models/subject_workflow_count_spec.rb
+++ b/spec/models/subject_workflow_count_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe SubjectWorkflowCount, type: :model do
       count.retired_at = 5.days.ago
       expect { count.retire! }.not_to change { count.retired_at }
     end
+
+    it 'records the retirement reason' do
+      count.retire!("blank")
+      expect(count.retirement_reason).to match("blank")
+    end
   end
 
   describe "#retire?" do

--- a/spec/operations/workflows/retire_subjects_spec.rb
+++ b/spec/operations/workflows/retire_subjects_spec.rb
@@ -11,6 +11,12 @@ describe Workflows::RetireSubjects do
 
   let(:operation) { described_class.with(api_user: api_user) }
 
+  it 'sets the retirement reason' do
+    operation.run! workflow: workflow, subject_id: subject1.id, retirement_reason: "blank"
+    expect(SubjectWorkflowCount.by_subject_workflow(subject1.id, workflow.id).retirement_reason)
+      .to match("blank")
+  end
+
   context 'with a single subject_id' do
     it 'retires the subject' do
       operation.run! workflow: workflow, subject_id: subject1.id

--- a/spec/operations/workflows/retire_subjects_spec.rb
+++ b/spec/operations/workflows/retire_subjects_spec.rb
@@ -19,8 +19,12 @@ describe Workflows::RetireSubjects do
 
   it 'is invalid with an invalid retirement reason' do
     result = operation.run workflow: workflow, subject_id: subject1.id, retirement_reason: "nope"
-    expect(result)
-      .not_to be_valid
+    expect(result).not_to be_valid
+  end
+
+  it 'is valid with a missing parameter' do
+    result = operation.run workflow: workflow, subject_id: subject1.id
+    expect(result).to be_valid
   end
 
   context 'with a single subject_id' do


### PR DESCRIPTION
Reasons for retirement are stored in an enum on the SubjectWorkflowCount model. The current list of possible reasons looks like this:

[ :classification_count, :flagged, :blank, :consensus, :other ]

Nil is also still fine. Nero can set this value when it retires a subject after it detects it in a classification.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

