### PR TITLE
Project state

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,6 +42,8 @@ class Project < ActiveRecord::Base
 
   has_paper_trail only: [:private, :live, :beta_requested, :beta_approved, :launch_requested, :launch_approved]
 
+  enum state: [:paused, :finished]
+
   cache_by_association :project_contents, :tags
   cache_by_resource_method :subjects_count, :retired_subjects_count, :finished?
 
@@ -137,6 +139,14 @@ class Project < ActiveRecord::Base
   end
 
   def finished?
-    @finished ||= workflows.all?(&:finished?)
+    super ? super : workflows.all?(&:finished?)
+  end
+
+  def state
+    if self[:state]
+      super
+    else
+      live ? "live" : "development"
+    end
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -11,7 +11,7 @@ class ProjectSerializer
     :configuration, :live, :urls, :migrated, :classifiers_count, :slug, :redirect,
     :beta_requested, :beta_approved, :launch_requested, :launch_approved, :launch_date,
     :href, :workflow_description, :primary_language, :tags, :experimental_tools,
-    :completeness, :activity
+    :completeness, :activity, :state
 
   optional :avatar_src
   can_include :workflows, :subject_sets, :owners, :project_contents,
@@ -21,9 +21,14 @@ class ProjectSerializer
     subjects_export: { include: false },
     aggregations_export: { include: false }
   can_filter_by :display_name, :slug, :beta_requested, :beta_approved,
-    :launch_requested, :launch_approved, :private
+    :launch_requested, :launch_approved, :private, :state
   can_sort_by :launch_date, :activity, :completeness, :classifiers_count,
     :updated_at, :display_name
+
+  def self.page(params = {}, scope = nil, context = {})
+    params["state"] = Project.states[params["state"]] if params.key?("state")
+    super(params, scope, context)
+  end
 
   def self.links
     links = super

--- a/db/migrate/20160427150421_add_project_state.rb
+++ b/db/migrate/20160427150421_add_project_state.rb
@@ -1,0 +1,6 @@
+class AddProjectState < ActiveRecord::Migration
+  def change
+    add_column :projects, :state, :integer
+    add_index :projects, :state
+  end
+end

--- a/db/migrate/20160427150421_add_project_state.rb
+++ b/db/migrate/20160427150421_add_project_state.rb
@@ -1,6 +1,5 @@
 class AddProjectState < ActiveRecord::Migration
   def change
     add_column :projects, :state, :integer
-    add_index :projects, :state, where: "(state IS NOT NULL)", algorithm: :concurrently
   end
 end

--- a/db/migrate/20160427150421_add_project_state.rb
+++ b/db/migrate/20160427150421_add_project_state.rb
@@ -1,6 +1,6 @@
 class AddProjectState < ActiveRecord::Migration
   def change
     add_column :projects, :state, :integer
-    add_index :projects, :state
+    add_index :projects, :state, where: "(state IS NOT NULL)", algorithm: :concurrently
   end
 end

--- a/db/migrate/20160506182308_add_project_state_index.rb
+++ b/db/migrate/20160506182308_add_project_state_index.rb
@@ -1,0 +1,10 @@
+class AddProjectStateIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :projects,
+    :state,
+    where: "(state IS NOT NULL)",
+    algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -636,7 +636,8 @@ CREATE TABLE projects (
     launch_date timestamp without time zone,
     completeness double precision DEFAULT 0.0 NOT NULL,
     activity integer DEFAULT 0 NOT NULL,
-    tsv tsvector
+    tsv tsvector,
+    state integer
 );
 
 
@@ -2213,6 +2214,13 @@ CREATE INDEX index_projects_on_slug ON projects USING btree (slug);
 
 
 --
+-- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_projects_on_state ON projects USING btree (state);
+
+
+--
 -- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2989,4 +2997,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160412125332');
 INSERT INTO schema_migrations (version) VALUES ('20160414151041');
 
 INSERT INTO schema_migrations (version) VALUES ('20160425190129');
+
+INSERT INTO schema_migrations (version) VALUES ('20160427150421');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2217,7 +2217,7 @@ CREATE INDEX index_projects_on_slug ON projects USING btree (slug);
 -- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_projects_on_state ON projects USING btree (state);
+CREATE INDEX index_projects_on_state ON projects USING btree (state) WHERE (state IS NOT NULL);
 
 
 --
@@ -2999,4 +2999,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160414151041');
 INSERT INTO schema_migrations (version) VALUES ('20160425190129');
 
 INSERT INTO schema_migrations (version) VALUES ('20160427150421');
+
+INSERT INTO schema_migrations (version) VALUES ('20160506182308');
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -331,7 +331,7 @@ describe Api::V1::ProjectsController, type: :controller do
           end
         end
 
-        describe "filter by state", :focus  do
+        describe "filter by state"  do
           let(:projects) do
             create_list(:project_with_contents, 2, owner: user).tap do |list|
               list[0].paused!

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -5,7 +5,7 @@ describe Api::V1::ProjectsController, type: :controller do
   let(:projects) do
     create_list(:project_with_contents, 2, owner: user)
   end
-  let(:project) { create(:project_with_contents, owner: user) }
+  let(:project) { create(:project_with_contents, owner: user, state: "paused") }
   let(:authorized_user) { user }
 
   let(:api_resource_name) { "projects" }
@@ -15,7 +15,7 @@ describe Api::V1::ProjectsController, type: :controller do
      "description", "introduction", "migrated","private", "live",
      "retired_subjects_count", "urls", "classifiers_count", "redirect",
      "workflow_description", "tags", "experimental_tools",
-     "completeness", "activity" ]
+     "completeness", "activity", "state" ]
   end
   let(:api_resource_links) do
     [ "projects.workflows",
@@ -328,6 +328,29 @@ describe Api::V1::ProjectsController, type: :controller do
           it "should respond with the correct item" do
             project_slug = json_response[api_resource_name][0]['slug']
             expect(project_slug).to eq(new_project.slug)
+          end
+        end
+
+        describe "filter by state", :focus  do
+          let(:projects) do
+            create_list(:project_with_contents, 2, owner: user).tap do |list|
+              list[0].paused!
+            end
+          end
+
+          let(:filtered_project) do
+            projects.first
+          end
+
+          let(:index_options) { { state: "paused" } }
+
+          it "should respond with 1 item" do
+            expect(json_response[api_resource_name].length).to eq(1)
+          end
+
+          it "should respond with the correct item" do
+            project_state = json_response[api_resource_name][0]['state']
+            expect(project_state).to eq(filtered_project.state)
           end
         end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ProjectSerializer do
-  let(:project) { create(:full_project) }
+  let(:project) { create(:full_project, :state => "finished") }
   let(:context) { {languages: ['en'], fields: [:title, :url_labels]} }
 
   let(:serializer) do
@@ -25,6 +25,18 @@ describe ProjectSerializer do
               {"label" => "Twitter",
                "url" => "http://twitter.com/example"}]
       expect(serializer.urls).to eq(urls)
+    end
+  end
+
+  describe "#state" do
+    it "includes the state" do
+      expect(serializer.state).to eq project.state
+    end
+
+    it 'can filter by state' do
+      project.finished!
+      serializer = described_class.page({"state" => "finished"})
+      expect(serializer[:projects][0][:id]).to eq(project.id.to_s)
     end
   end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -28,7 +28,7 @@ describe ProjectSerializer do
     end
   end
 
-  describe "#state", :focus do
+  describe "#state" do
     it "includes the state" do
       expect(serializer.state).to eq project.state
     end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ProjectSerializer do
-  let(:project) { create(:full_project, :state => "finished") }
+  let(:project) { create(:full_project, state: "finished") }
   let(:context) { {languages: ['en'], fields: [:title, :url_labels]} }
 
   let(:serializer) do
@@ -28,15 +28,17 @@ describe ProjectSerializer do
     end
   end
 
-  describe "#state" do
+  describe "#state", :focus do
     it "includes the state" do
       expect(serializer.state).to eq project.state
     end
 
+    let!(:paused_project) { create(:full_project, state: "paused") }
     it 'can filter by state' do
-      project.finished!
-      serializer = described_class.page({"state" => "finished"})
-      expect(serializer[:projects][0][:id]).to eq(project.id.to_s)
+      project.touch
+      results = described_class.page({"state" => "finished"})
+      expect(results[:projects][0][:id]).to eq(project.id.to_s)
+      expect(results[:projects].count).to eq(1)
     end
   end
 


### PR DESCRIPTION
Adds "state" as a project attribute and to its serializer. Project#state will, in the case of a nil value, return either "live" or "development" depending on launch_approved?. @marten assisted with the serializer portion on account of Restpack's confusion about the enum and my confusion about Restpack.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
