### PR TITLE
CSV export to allow new tasks

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -10,23 +10,42 @@ module Formatter
       end
 
       def to_h
-        annotation.merge! "task_label" => task_label
-
-        case task["type"]
-        when "drawing"
-          value_with_tool = (annotation["value"] || []).map do |drawn_item|
-            drawn_item.merge "tool_label" => tool_label(drawn_item)
-          end
-          annotation.merge!("value" => value_with_tool)
-        when /single/i
-          annotation.merge!("value" => answer_label)
-        when /multiple/i
-          annotation.merge!("value" => answer_labels)
-        end
-        annotation
+        send(task["type"])
       end
 
       private
+
+      def drawing
+        # annotation.merge! "task_label" => task_label
+        # value_with_tool = (annotation["value"] || []).map do |drawn_item|
+        #  drawn_item.merge "tool_label" => tool_label(drawn_item)
+        # end
+        # annotation.merge!("value" => value_with_tool)
+      end
+
+      def simple
+        {}.tap do |new_annotation|
+          new_annotation['task'] = annotation['task']
+          new_annotation['task_label'] = task_label
+          new_annotation['value'] = task['type'] == 'multiple' ? answer_labels : answer_label
+        end
+      end
+
+      alias_method :single, :simple
+      alias_method :multiple, :simple
+
+      def combo
+        # {}.tap do |new_annotation|
+        #   annotation['value'].each do |subtask|
+        #     binding.pry
+
+            # anno = annotation_by_task(subtask).last
+            # answer_string = anno['answers'][subtask['value']]['label']
+            # new_annotation['value'] = translate(answer_string)
+            # new_annotation['task_label'] = translate(anno['question'])
+          # end
+        # end
+      end
 
       def task_label
         translate(task["question"] || task["instruction"])
@@ -69,10 +88,16 @@ module Formatter
         classification.workflow_version.split(".")[1].to_i
       end
 
+      def annotation_by_task(subtask)
+        workflow_at_version.tasks.find do |key, task|
+          key == subtask['task']
+        end
+      end
+
       def task
         return @task if @task
         task_annotation = workflow_at_version.tasks.find do |key, task|
-          key == annotation["task"]
+         key == annotation["task"]
         end
         @task = task_annotation.try(:last) || {}
       end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -29,10 +29,6 @@ module Formatter
 
       private
 
-      def valid_tasks
-        %w(single multiple text drawing combo dropdown)
-      end
-
       def drawing(task_info=task)
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -11,10 +11,18 @@ module Formatter
       end
 
       def to_h
-        send(task['type'])
+        if valid_tasks.include? task['type']
+          send(task['type'])
+        else
+         { error: "task cannot be exported" }
+        end
       end
 
       private
+
+      def valid_tasks
+        %w(single multiple text drawing combo dropdown)
+      end
 
       def drawing(task_info=task)
         {}.tap do |new_anno|

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -64,16 +64,29 @@ module Formatter
           annotation['value'].each do |subtask|
             @current = subtask
             task_info = get_task_info(subtask)
-            new_anno['value'].push send(task_info['type'], task_info)
+            new_anno['value'].push case task_info['type']
+              when "drawing"
+                drawing(task_info)
+              when "single", "multiple"
+                simple(task_info)
+              when "text"
+                text(task_info)
+              when "combo"
+                { error: "combo tasks cannot be nested" }
+              when "dropdown"
+                dropdown(task_info)
+              else
+                { error: "task cannot be exported" }
+              end
           end
         end
       end
 
-      def dropdown
+      def dropdown(task_info=task)
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
           new_anno['value'] = []
-          task['selects'].each_with_index do |selects, index|
+          task_info['selects'].each_with_index do |selects, index|
             new_anno['value'].push dropdown_process_selects(selects, index)
           end
         end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -58,6 +58,16 @@ module Formatter
         end
       end
 
+      def dropdown
+        binding.pry
+        {}.tap do |new_anno|
+          new_anno['task'] = annotation['task']
+          annotationp['value'].each do
+
+          end
+        end
+      end
+
       def task_label(task_info)
         translate(task_info["question"] || task_info["instruction"])
       end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -48,9 +48,6 @@ module Formatter
         end
       end
 
-      alias_method :single, :simple
-      alias_method :multiple, :simple
-
       def text(task_info=task)
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
@@ -76,23 +73,34 @@ module Formatter
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
           new_anno['value'] = []
-          task['selects'].each_with_index do |sel, idx|
-            {}.tap do |tmp|
-              tmp['select_label'] = sel['title']
-              tmp['option'] = sel['allowCreate']
-              sel['options'].each do |key, arr|
-                arr.each do |ans|
-                  if ans['value'] == @current['value'][idx]['value']
-                    tmp['value'] = ans['value']
-                    tmp['label'] = translate(ans['label'])
-                  end
-                end
-              end
-              new_anno['value'].push tmp
-            end
+          task['selects'].each_with_index do |selects, index|
+            new_anno['value'].push dropdown_process_selects(selects, index)
           end
         end
       end
+
+      def dropdown_process_selects(selects, index)
+        {}.tap do |drop_anno|
+          drop_anno['select_label'] = selects['title']
+          drop_anno['option'] = selects['allowCreate']
+          selects['options'].each do |key, options|
+            dropdown_process_options(options, index, drop_anno)
+          end
+        end
+      end
+
+      def dropdown_process_options(options, index, drop_anno)
+        options.each do |opt|
+          if opt['value'] == @current['value'][index]['value']
+            drop_anno['value'], drop_anno['label'] = dropdown_label(opt, index)
+          end
+        end
+      end
+
+      def dropdown_label(option, index)
+        [option['value'], translate(option['label'])]
+      end
+
 
       def task_label(task_info)
         translate(task_info["question"] || task_info["instruction"])

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -11,8 +11,17 @@ module Formatter
       end
 
       def to_h
-        if valid_tasks.include? task['type']
-          send(task['type'])
+        case task['type']
+        when "drawing"
+          drawing
+        when "single", "multiple"
+          simple
+        when "text"
+          text
+        when "combo"
+          combo
+        when "dropdown"
+          dropdown
         else
          { error: "task cannot be exported" }
         end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -11,7 +11,7 @@ module Formatter
       end
 
       def to_h
-        send(task["type"])
+        send(task['type'])
       end
 
       private
@@ -49,6 +49,7 @@ module Formatter
       def combo
         {}.tap do |new_anno|
           new_anno['task'] = annotation['task']
+          new_anno['task_label'] = nil
           new_anno['value'] ||= []
           annotation['value'].each do |subtask|
             @current = subtask
@@ -59,11 +60,23 @@ module Formatter
       end
 
       def dropdown
-        binding.pry
         {}.tap do |new_anno|
-          new_anno['task'] = annotation['task']
-          annotationp['value'].each do
-
+          new_anno['task'] = @current['task']
+          new_anno['value'] = []
+          task['selects'].each_with_index do |sel, idx|
+            {}.tap do |tmp|
+              tmp['select_label'] = sel['title']
+              tmp['option'] = sel['allowCreate']
+              sel['options'].each do |key, arr|
+                arr.each do |ans|
+                  if ans['value'] == @current['value'][idx]['value']
+                    tmp['value'] = ans['value']
+                    tmp['label'] = translate(ans['label'])
+                  end
+                end
+              end
+              new_anno['value'].push tmp
+            end
           end
         end
       end
@@ -83,7 +96,6 @@ module Formatter
 
       def answer_labels
         Array.wrap(@current["value"]).map do |answer_idx|
-          # answer_string = task["answers"][answer_idx]["label"]
           answer_string = workflow_at_version.tasks[@current['task']]['answers'][answer_idx]['label']
           translate(answer_string)
         end

--- a/spec/factories/workflow_contents.rb
+++ b/spec/factories/workflow_contents.rb
@@ -3,16 +3,31 @@ FactoryGirl.define do
     workflow
     language "en"
     strings({
-             "interest.question" => "Draw a circle",
-             "interest.help" => "Duh?",
-             "interest.tools.0.label" => "Red",
-             "interest.tools.1.label" => "Green",
-             "interest.tools.2.label" => "Blue",
-             "shape.question" => "What shape is this galaxy",
-             "shape.help" => "Duh?",
-             "shape.answers.0.label" => "Smooth",
-             "shape.answers.1.label" => "Features",
-             "shape.answers.2.label" => "Star or artifact",
+            "interest.question" => "Draw a circle",
+            "interest.help" => "Duh?",
+            "interest.tools.0.label" => "Red",
+            "interest.tools.1.label" => "Green",
+            "interest.tools.2.label" => "Blue",
+            "shape.question" => "What shape is this galaxy",
+            "shape.help" => "Duh?",
+            "shape.answers.0.label" => "Smooth",
+            "shape.answers.1.label" => "Features",
+            "shape.answers.2.label" => "Star or artifact",
             })
+
+    factory :combo_workflow_content do
+      strings({
+            "T2.help"=>"Just pick a fruit already",
+            "T2.answers.0.label"=>"Pineapple",
+            "T2.answers.1.label"=>"Tomato?!",
+            "T2.answers.2.label"=>"An Old Peach",
+            "T2.question"=>"FRUITS?!?! (MULTIPLE)",
+            "init.answers.0.label"=>"I'm positive.",
+            "init.answers.1.label"=>"Well now I'm second guessing myself",
+            "init.question"=>"Are you sure? (SINGLE)",
+            "T6.instruction"=>"Tell me a secret.",
+            "T6.help"=>"A really good one, pls"
+            })
+    end
   end
 end

--- a/spec/factories/workflow_contents.rb
+++ b/spec/factories/workflow_contents.rb
@@ -29,5 +29,33 @@ FactoryGirl.define do
             "T6.help"=>"A really good one, pls"
             })
     end
+
+    factory :dd_workflow_content do
+      strings({
+        "T7.help"=>"it drops down",
+        "T7.selects.0.options.*.0.label"=>"Oceania",
+        "T7.selects.0.options.*.1.label"=>"Eurasia",
+        "T7.selects.0.options.*.2.label"=>"US",
+        "T7.selects.1.options.3844fc24a3df7.0.label"=>"Arizona",
+        "T7.selects.1.options.3844fc24a3df7.1.label"=>"Illinois",
+        "T7.selects.1.options.c6e0d98477ec8.0.label"=>"Left Oceania",
+        "T7.selects.1.options.c6e0d98477ec8.1.label"=>"Right Oceania",
+        "T7.selects.1.options.3a9b7c7d53d6f.0.label"=>"Left Eurasia",
+        "T7.selects.1.options.3a9b7c7d53d6f.1.label"=>"Right Eurasia",
+        "T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.0.label"=>"Townsville",
+        "T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.1.label"=>"Cityton",
+        "T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.0.label"=>"Green Acres",
+        "T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.1.label"=>"Palm Springs",
+        "T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.0.label"=>"Best City",
+        "T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.1.label"=>"Tryhard Junction",
+        "T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.0.label"=>"Independant New South Bummersville",
+        "T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.1.label"=>"Cowton",
+        "T7.selects.2.options.3844fc24a3df7;2619efdf9012.0.label"=>"Phoenix",
+        "T7.selects.2.options.3844fc24a3df7;2619efdf9012.1.label"=>"Tucson",
+        "T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.0.label"=>"Chicago",
+        "T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.1.label"=>"Everywhere Else",
+        "T7.instruction"=>"DROPPIN' DOWN"
+      })
+    end
   end
 end

--- a/spec/factories/workflow_contents.rb
+++ b/spec/factories/workflow_contents.rb
@@ -15,7 +15,7 @@ FactoryGirl.define do
             "shape.answers.2.label" => "Star or artifact",
             })
 
-    factory :combo_workflow_content do
+    trait :combo_task do
       strings({
             "T2.help"=>"Just pick a fruit already",
             "T2.answers.0.label"=>"Pineapple",
@@ -30,7 +30,7 @@ FactoryGirl.define do
             })
     end
 
-    factory :dd_workflow_content do
+    trait :dropdown_task do
       strings({
         "T7.help"=>"it drops down",
         "T7.selects.0.options.*.0.label"=>"Oceania",

--- a/spec/factories/workflow_contents.rb
+++ b/spec/factories/workflow_contents.rb
@@ -15,7 +15,7 @@ FactoryGirl.define do
             "shape.answers.2.label" => "Star or artifact",
             })
 
-    trait :combo_task do
+    trait :complex_task do
       strings({
             "T2.help"=>"Just pick a fruit already",
             "T2.answers.0.label"=>"Pineapple",
@@ -26,35 +26,30 @@ FactoryGirl.define do
             "init.answers.1.label"=>"Well now I'm second guessing myself",
             "init.question"=>"Are you sure? (SINGLE)",
             "T6.instruction"=>"Tell me a secret.",
-            "T6.help"=>"A really good one, pls"
-            })
-    end
-
-    trait :dropdown_task do
-      strings({
-        "T7.help"=>"it drops down",
-        "T7.selects.0.options.*.0.label"=>"Oceania",
-        "T7.selects.0.options.*.1.label"=>"Eurasia",
-        "T7.selects.0.options.*.2.label"=>"US",
-        "T7.selects.1.options.3844fc24a3df7.0.label"=>"Arizona",
-        "T7.selects.1.options.3844fc24a3df7.1.label"=>"Illinois",
-        "T7.selects.1.options.c6e0d98477ec8.0.label"=>"Left Oceania",
-        "T7.selects.1.options.c6e0d98477ec8.1.label"=>"Right Oceania",
-        "T7.selects.1.options.3a9b7c7d53d6f.0.label"=>"Left Eurasia",
-        "T7.selects.1.options.3a9b7c7d53d6f.1.label"=>"Right Eurasia",
-        "T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.0.label"=>"Townsville",
-        "T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.1.label"=>"Cityton",
-        "T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.0.label"=>"Green Acres",
-        "T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.1.label"=>"Palm Springs",
-        "T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.0.label"=>"Best City",
-        "T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.1.label"=>"Tryhard Junction",
-        "T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.0.label"=>"Independant New South Bummersville",
-        "T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.1.label"=>"Cowton",
-        "T7.selects.2.options.3844fc24a3df7;2619efdf9012.0.label"=>"Phoenix",
-        "T7.selects.2.options.3844fc24a3df7;2619efdf9012.1.label"=>"Tucson",
-        "T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.0.label"=>"Chicago",
-        "T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.1.label"=>"Everywhere Else",
-        "T7.instruction"=>"DROPPIN' DOWN"
+            "T6.help"=>"A really good one, pls",
+            "T7.help"=>"it drops down",
+            "T7.selects.0.options.*.0.label"=>"Oceania",
+            "T7.selects.0.options.*.1.label"=>"Eurasia",
+            "T7.selects.0.options.*.2.label"=>"US",
+            "T7.selects.1.options.3844fc24a3df7.0.label"=>"Arizona",
+            "T7.selects.1.options.3844fc24a3df7.1.label"=>"Illinois",
+            "T7.selects.1.options.c6e0d98477ec8.0.label"=>"Left Oceania",
+            "T7.selects.1.options.c6e0d98477ec8.1.label"=>"Right Oceania",
+            "T7.selects.1.options.3a9b7c7d53d6f.0.label"=>"Left Eurasia",
+            "T7.selects.1.options.3a9b7c7d53d6f.1.label"=>"Right Eurasia",
+            "T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.0.label"=>"Townsville",
+            "T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.1.label"=>"Cityton",
+            "T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.0.label"=>"Green Acres",
+            "T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.1.label"=>"Palm Springs",
+            "T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.0.label"=>"Best City",
+            "T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.1.label"=>"Tryhard Junction",
+            "T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.0.label"=>"Independant New South Bummersville",
+            "T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.1.label"=>"Cowton",
+            "T7.selects.2.options.3844fc24a3df7;2619efdf9012.0.label"=>"Phoenix",
+            "T7.selects.2.options.3844fc24a3df7;2619efdf9012.1.label"=>"Tucson",
+            "T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.0.label"=>"Chicago",
+            "T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.1.label"=>"Everywhere Else",
+            "T7.instruction"=>"DROPPIN' DOWN"
       })
     end
   end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -132,5 +132,86 @@ FactoryGirl.define do
         }
       )
     end
+
+    factory :dd_task_workflow do
+      display_name "Combo Workflow"
+      tasks (
+      {
+        "T7"=>
+          {"help"=>"T7.help",
+           "type"=>"dropdown",
+           "selects"=>
+            [{"id"=>"c99e5ef444475",
+              "title"=>"Country",
+              "options"=>
+               {"*"=>
+                 [{"label"=>"T7.selects.0.options.*.0.label",
+                   "value"=>"c6e0d98477ec8"},
+                  {"label"=>"T7.selects.0.options.*.1.label",
+                   "value"=>"3a9b7c7d53d6f"},
+                  {"label"=>"T7.selects.0.options.*.2.label",
+                   "value"=>"3844fc24a3df7"}]},
+              "required"=>true,
+              "allowCreate"=>false},
+             {"id"=>"e7e963e06159e",
+              "title"=>"State",
+              "options"=>
+               {"3844fc24a3df7"=>
+                 [{"label"=>"T7.selects.1.options.3844fc24a3df7.0.label",
+                   "value"=>"2619efdf9012"},
+                  {"label"=>"T7.selects.1.options.3844fc24a3df7.1.label",
+                   "value"=>"2f003e4bac96b"}],
+                "3a9b7c7d53d6f"=>
+                 [{"label"=>"T7.selects.1.options.3a9b7c7d53d6f.0.label",
+                   "value"=>"5243f2462e8b7"},
+                  {"label"=>"T7.selects.1.options.3a9b7c7d53d6f.1.label",
+                   "value"=>"ddb28c5f936ac"}],
+                "c6e0d98477ec8"=>
+                 [{"label"=>"T7.selects.1.options.c6e0d98477ec8.0.label",
+                   "value"=>"fb39ba165bfd4"},
+                  {"label"=>"T7.selects.1.options.c6e0d98477ec8.1.label",
+                   "value"=>"74ad7005baad5"}]},
+              "required"=>false,
+              "condition"=>"c99e5ef444475",
+              "allowCreate"=>true},
+             {"id"=>"2f54a93bb2804",
+              "title"=>"City",
+              "options"=>
+               {"3844fc24a3df7;2619efdf9012"=>
+                 [{"label"=>"T7.selects.2.options.3844fc24a3df7;2619efdf9012.0.label",
+                   "value"=>"24f09ef4d999c"},
+                  {"label"=>"T7.selects.2.options.3844fc24a3df7;2619efdf9012.1.label",
+                   "value"=>"515e2031a9f2"}],
+                "3844fc24a3df7;2f003e4bac96b"=>
+                 [{"label"=>"T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.0.label",
+                   "value"=>"908c3c68e1f36"},
+                  {"label"=>"T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.1.label",
+                   "value"=>"48b9769fe7556"}],
+                "3a9b7c7d53d6f;5243f2462e8b7"=>
+                 [{"label"=>"T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.0.label",
+                   "value"=>"be506b6d9e42e"},
+                  {"label"=>"T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.1.label",
+                   "value"=>"11a1c32d3a6ca"}],
+                "3a9b7c7d53d6f;ddb28c5f936ac"=>
+                 [{"label"=>"T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.0.label",
+                   "value"=>"7c9fe6fb69c1d"},
+                  {"label"=>"T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.1.label",
+                   "value"=>"d8fb8a1489c3c"}],
+                "c6e0d98477ec8;74ad7005baad5"=>
+                 [{"label"=>"T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.0.label",
+                   "value"=>"3935249042d33"},
+                  {"label"=>"T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.1.label",
+                   "value"=>"bf2ac1dff4aee"}],
+                "c6e0d98477ec8;fb39ba165bfd4"=>
+                 [{"label"=>"T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.0.label",
+                   "value"=>"81a10debaa648"},
+                  {"label"=>"T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.1.label",
+                   "value"=>"acef6073251e2"}]},
+              "required"=>false,
+              "condition"=>"e7e963e06159e",
+              "allowCreate"=>true}],
+           "instruction"=>"T7.instruction"}
+        })
+    end
   end
 end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -71,7 +71,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :question_task_workflow do
+    trait :question_task do
       tasks (
         {
           "init" => {
@@ -98,7 +98,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :combo_task_workflow do
+    trait :combo_task do
       display_name "Combo Workflow"
       tasks (
         {
@@ -133,7 +133,7 @@ FactoryGirl.define do
       )
     end
 
-    factory :dd_task_workflow do
+    trait :dropdown_task do
       display_name "Combo Workflow"
       tasks (
       {

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -97,5 +97,40 @@ FactoryGirl.define do
         end
       end
     end
+
+    factory :combo_task_workflow do
+      display_name "Combo Workflow"
+      tasks (
+        {
+          "T2"=>{
+          "help"=>"T2.help",
+          "type"=>"multiple",
+          "answers"=>[
+            {"label"=>"T2.answers.0.label"},
+            {"label"=>"T2.answers.1.label"},
+            {"label"=>"T2.answers.2.label"}
+          ],
+          "question"=>"T2.question"
+        },
+          "T3"=>{
+            "type"=>"combo",
+            "tasks"=>["init", "T2", "T6"]
+        },
+          "T6"=>{
+            "help"=>"T6.help",
+            "type"=>"text",
+            "instruction"=>"T6.instruction"
+        },
+          "init"=> {
+            "type"=>"single",
+            "answers"=>[
+              {"next"=>"T2", "label"=>"init.answers.0.label"},
+              {"label"=>"init.answers.1.label"}
+            ],
+            "question"=>"init.question"
+          }
+        }
+      )
+    end
   end
 end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -98,8 +98,8 @@ FactoryGirl.define do
       end
     end
 
-    trait :combo_task do
-      display_name "Combo Workflow"
+    trait :complex_task do
+      display_name "Complex Workflow"
       tasks (
         {
           "T2"=>{
@@ -128,89 +128,82 @@ FactoryGirl.define do
               {"label"=>"init.answers.1.label"}
             ],
             "question"=>"init.question"
+        },
+          "T7"=>{
+            "help"=>"T7.help",
+            "type"=>"dropdown",
+            "selects"=>
+              [{"id"=>"c99e5ef444475",
+                "title"=>"Country",
+                "options"=>
+                 {"*"=>
+                   [{"label"=>"T7.selects.0.options.*.0.label",
+                     "value"=>"c6e0d98477ec8"},
+                    {"label"=>"T7.selects.0.options.*.1.label",
+                     "value"=>"3a9b7c7d53d6f"},
+                    {"label"=>"T7.selects.0.options.*.2.label",
+                     "value"=>"3844fc24a3df7"}]},
+                "required"=>true,
+                "allowCreate"=>false},
+               {"id"=>"e7e963e06159e",
+                "title"=>"State",
+                "options"=>
+                 {"3844fc24a3df7"=>
+                   [{"label"=>"T7.selects.1.options.3844fc24a3df7.0.label",
+                     "value"=>"2619efdf9012"},
+                    {"label"=>"T7.selects.1.options.3844fc24a3df7.1.label",
+                     "value"=>"2f003e4bac96b"}],
+                  "3a9b7c7d53d6f"=>
+                   [{"label"=>"T7.selects.1.options.3a9b7c7d53d6f.0.label",
+                     "value"=>"5243f2462e8b7"},
+                    {"label"=>"T7.selects.1.options.3a9b7c7d53d6f.1.label",
+                     "value"=>"ddb28c5f936ac"}],
+                  "c6e0d98477ec8"=>
+                   [{"label"=>"T7.selects.1.options.c6e0d98477ec8.0.label",
+                     "value"=>"fb39ba165bfd4"},
+                    {"label"=>"T7.selects.1.options.c6e0d98477ec8.1.label",
+                     "value"=>"74ad7005baad5"}]},
+                "required"=>false,
+                "condition"=>"c99e5ef444475",
+                "allowCreate"=>true},
+               {"id"=>"2f54a93bb2804",
+                "title"=>"City",
+                "options"=>
+                 {"3844fc24a3df7;2619efdf9012"=>
+                   [{"label"=>"T7.selects.2.options.3844fc24a3df7;2619efdf9012.0.label",
+                     "value"=>"24f09ef4d999c"},
+                    {"label"=>"T7.selects.2.options.3844fc24a3df7;2619efdf9012.1.label",
+                     "value"=>"515e2031a9f2"}],
+                  "3844fc24a3df7;2f003e4bac96b"=>
+                   [{"label"=>"T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.0.label",
+                     "value"=>"908c3c68e1f36"},
+                    {"label"=>"T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.1.label",
+                     "value"=>"48b9769fe7556"}],
+                  "3a9b7c7d53d6f;5243f2462e8b7"=>
+                   [{"label"=>"T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.0.label",
+                     "value"=>"be506b6d9e42e"},
+                    {"label"=>"T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.1.label",
+                     "value"=>"11a1c32d3a6ca"}],
+                  "3a9b7c7d53d6f;ddb28c5f936ac"=>
+                   [{"label"=>"T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.0.label",
+                     "value"=>"7c9fe6fb69c1d"},
+                    {"label"=>"T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.1.label",
+                     "value"=>"d8fb8a1489c3c"}],
+                  "c6e0d98477ec8;74ad7005baad5"=>
+                   [{"label"=>"T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.0.label",
+                     "value"=>"3935249042d33"},
+                    {"label"=>"T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.1.label",
+                     "value"=>"bf2ac1dff4aee"}],
+                  "c6e0d98477ec8;fb39ba165bfd4"=>
+                   [{"label"=>"T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.0.label",
+                     "value"=>"81a10debaa648"},
+                    {"label"=>"T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.1.label",
+                     "value"=>"acef6073251e2"}]},
+                "required"=>false,
+                "condition"=>"e7e963e06159e",
+                "allowCreate"=>true}],
+             "instruction"=>"T7.instruction"
           }
-        }
-      )
-    end
-
-    trait :dropdown_task do
-      display_name "Combo Workflow"
-      tasks (
-      {
-        "T7"=>
-          {"help"=>"T7.help",
-           "type"=>"dropdown",
-           "selects"=>
-            [{"id"=>"c99e5ef444475",
-              "title"=>"Country",
-              "options"=>
-               {"*"=>
-                 [{"label"=>"T7.selects.0.options.*.0.label",
-                   "value"=>"c6e0d98477ec8"},
-                  {"label"=>"T7.selects.0.options.*.1.label",
-                   "value"=>"3a9b7c7d53d6f"},
-                  {"label"=>"T7.selects.0.options.*.2.label",
-                   "value"=>"3844fc24a3df7"}]},
-              "required"=>true,
-              "allowCreate"=>false},
-             {"id"=>"e7e963e06159e",
-              "title"=>"State",
-              "options"=>
-               {"3844fc24a3df7"=>
-                 [{"label"=>"T7.selects.1.options.3844fc24a3df7.0.label",
-                   "value"=>"2619efdf9012"},
-                  {"label"=>"T7.selects.1.options.3844fc24a3df7.1.label",
-                   "value"=>"2f003e4bac96b"}],
-                "3a9b7c7d53d6f"=>
-                 [{"label"=>"T7.selects.1.options.3a9b7c7d53d6f.0.label",
-                   "value"=>"5243f2462e8b7"},
-                  {"label"=>"T7.selects.1.options.3a9b7c7d53d6f.1.label",
-                   "value"=>"ddb28c5f936ac"}],
-                "c6e0d98477ec8"=>
-                 [{"label"=>"T7.selects.1.options.c6e0d98477ec8.0.label",
-                   "value"=>"fb39ba165bfd4"},
-                  {"label"=>"T7.selects.1.options.c6e0d98477ec8.1.label",
-                   "value"=>"74ad7005baad5"}]},
-              "required"=>false,
-              "condition"=>"c99e5ef444475",
-              "allowCreate"=>true},
-             {"id"=>"2f54a93bb2804",
-              "title"=>"City",
-              "options"=>
-               {"3844fc24a3df7;2619efdf9012"=>
-                 [{"label"=>"T7.selects.2.options.3844fc24a3df7;2619efdf9012.0.label",
-                   "value"=>"24f09ef4d999c"},
-                  {"label"=>"T7.selects.2.options.3844fc24a3df7;2619efdf9012.1.label",
-                   "value"=>"515e2031a9f2"}],
-                "3844fc24a3df7;2f003e4bac96b"=>
-                 [{"label"=>"T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.0.label",
-                   "value"=>"908c3c68e1f36"},
-                  {"label"=>"T7.selects.2.options.3844fc24a3df7;2f003e4bac96b.1.label",
-                   "value"=>"48b9769fe7556"}],
-                "3a9b7c7d53d6f;5243f2462e8b7"=>
-                 [{"label"=>"T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.0.label",
-                   "value"=>"be506b6d9e42e"},
-                  {"label"=>"T7.selects.2.options.3a9b7c7d53d6f;5243f2462e8b7.1.label",
-                   "value"=>"11a1c32d3a6ca"}],
-                "3a9b7c7d53d6f;ddb28c5f936ac"=>
-                 [{"label"=>"T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.0.label",
-                   "value"=>"7c9fe6fb69c1d"},
-                  {"label"=>"T7.selects.2.options.3a9b7c7d53d6f;ddb28c5f936ac.1.label",
-                   "value"=>"d8fb8a1489c3c"}],
-                "c6e0d98477ec8;74ad7005baad5"=>
-                 [{"label"=>"T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.0.label",
-                   "value"=>"3935249042d33"},
-                  {"label"=>"T7.selects.2.options.c6e0d98477ec8;74ad7005baad5.1.label",
-                   "value"=>"bf2ac1dff4aee"}],
-                "c6e0d98477ec8;fb39ba165bfd4"=>
-                 [{"label"=>"T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.0.label",
-                   "value"=>"81a10debaa648"},
-                  {"label"=>"T7.selects.2.options.c6e0d98477ec8;fb39ba165bfd4.1.label",
-                   "value"=>"acef6073251e2"}]},
-              "required"=>false,
-              "condition"=>"e7e963e06159e",
-              "allowCreate"=>true}],
-           "instruction"=>"T7.instruction"}
         })
     end
   end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -100,14 +100,20 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
       end
 
       context "with a combo task" do
-        let(:combo_workflow) { build(:workflow, :combo_task) }
+        let(:combo_workflow) { build(:workflow, :complex_task) }
         let(:annotation) do
           {
             "task"=>"T3",
             "value"=>[
               {"task"=>"init", "value"=>1},
               {"task"=>"T2", "value"=>[1]},
-              {"task"=>"T6", "value"=>"no secrets between us, panoptes. you see all."}
+              {"task"=>"T6", "value"=>"no secrets between us, panoptes. you see all."},
+              {"task"=>"T7", "value"=>[
+                  {"value"=>"c6e0d98477ec8", "option"=>true},
+                  {"value"=>"fb39ba165bfd4", "option"=>true},
+                  {"value"=>"81a10debaa648", "option"=>true}
+                ]
+              }
             ]
           }
         end
@@ -115,7 +121,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         let(:new_classification) do
           build_stubbed(:classification, subjects: [], workflow: combo_workflow, annotations: [annotation])
         end
-        let(:combo_contents) { create(:workflow_content, :combo_task, workflow: combo_workflow) }
+        let(:combo_contents) { create(:workflow_content, :complex_task, workflow: combo_workflow) }
         let(:combo_cache) { double(workflow_at_version: combo_workflow, workflow_content_at_version: combo_contents)}
 
         let(:codex) do
@@ -137,6 +143,14 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
                 "task"=>"T6",
                 "value"=>"no secrets between us, panoptes. you see all.",
                 "task_label"=>"Tell me a secret."
+              },
+              {
+                "task"=>"T7",
+                "value"=> [
+                  {"select_label"=>"Country", "option"=>false, "value"=>"c6e0d98477ec8", "label"=>"Oceania"},
+                  {"select_label"=>"State", "option"=>true, "value"=>"fb39ba165bfd4", "label"=>"Left Oceania"},
+                  {"select_label"=>"City", "option"=>true, "value"=>"81a10debaa648", "label"=>"Townsville"}
+                ]
               }
             ]
           }
@@ -150,7 +164,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
       end
 
       context "with a dropdown task" do
-        let(:dd_workflow) { build(:workflow, :dropdown_task) }
+        let(:dd_workflow) { build(:workflow, :complex_task) }
         let(:annotation) do
           {
             "task"=>"T7",
@@ -165,7 +179,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         let(:dd_classification) do
           build_stubbed(:classification, subjects: [], workflow: dd_workflow, annotations: [annotation])
         end
-        let(:dd_contents) { create(:workflow_content, :dropdown_task, workflow: dd_workflow) }
+        let(:dd_contents) { create(:workflow_content, :complex_task, workflow: dd_workflow) }
         let(:dd_cache) { double(workflow_at_version: dd_workflow, workflow_content_at_version: dd_contents)}
 
         let(:codex) do

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -102,8 +102,9 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
       context "with a combo task" do
         let(:combo_workflow) { build(:combo_task_workflow) }
         let(:annotation) do
-          { "task"=>"T3", "value"=>
-            [
+          {
+            "task"=>"T3",
+            "value"=>[
               {"task"=>"init", "value"=>1},
               {"task"=>"T2", "value"=>[1]},
               {"task"=>"T6", "value"=>"no secrets between us, panoptes. you see all."}
@@ -118,28 +119,69 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         let(:combo_cache) { double(workflow_at_version: combo_workflow, workflow_content_at_version: combo_contents)}
 
         let(:codex) do
-          [
-            {
-              "task"=>"init",
-              "task_label"=>"Are you sure? (SINGLE)",
-              "value"=>"Positive"
-            },
-            {
-              "task"=>"T2",
-              "task_label"=>"FRUITS?!?! (MULTIPLE)",
-              "value"=>"Tomato?!"
-            },
-            {
-              "task"=>"T6",
-              "value"=>"no secrets between us, panoptes. you see all.",
-              "task_label"=>"Tell me a secret."
-            }
-          ]
+          {
+            "task"=>"T3",
+            "task_label"=>nil,
+            "value"=>[
+              {
+                "task"=>"init",
+                "task_label"=>"Are you sure? (SINGLE)",
+                "value"=>"Well now I'm second guessing myself"
+              },
+              {
+                "task"=>"T2",
+                "task_label"=>"FRUITS?!?! (MULTIPLE)",
+                "value"=>"Tomato?!"
+              },
+              {
+                "task"=>"T6",
+                "value"=>"no secrets between us, panoptes. you see all.",
+                "task_label"=>"Tell me a secret."
+              }
+            ]
+          }
         end
 
         it 'should add the correct answer labels' do
           formatted = described_class.new(new_classification, new_classification.annotations[0], combo_cache).to_h
-          expect(formatted["value"]).to eq(codex)
+          expect(formatted).to eq(codex)
+        end
+
+      end
+
+      context "with a dropdown task" do
+        let(:dd_workflow) { build(:dd_task_workflow) }
+        let(:annotation) do
+          {
+            "task"=>"T7",
+            "value"=>[
+              {"value"=>"c6e0d98477ec8", "option"=>true},
+              {"value"=>"fb39ba165bfd4", "option"=>true},
+              {"value"=>"81a10debaa648", "option"=>true}
+            ]
+           }
+        end
+
+        let(:dd_classification) do
+          build_stubbed(:classification, subjects: [], workflow: dd_workflow, annotations: [annotation])
+        end
+        let(:dd_contents) { create(:dd_workflow_content, workflow: dd_workflow) }
+        let(:dd_cache) { double(workflow_at_version: dd_workflow, workflow_content_at_version: dd_contents)}
+
+        let(:codex) do
+          {
+            "task"=>"T7",
+            "value"=> [
+              {"select_label"=>"Country", "option"=>false, "value"=>"c6e0d98477ec8", "label"=>"Oceania"},
+              {"select_label"=>"State", "option"=>true, "value"=>"fb39ba165bfd4", "label"=>"Left Oceania"},
+              {"select_label"=>"City", "option"=>true, "value"=>"81a10debaa648", "label"=>"Townsville"}
+            ]
+          }
+        end
+
+        it 'should add the correct answer labels' do
+          formatted = described_class.new(dd_classification, dd_classification.annotations[0], dd_cache).to_h
+          expect(formatted).to eq(codex)
         end
 
       end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -99,6 +99,51 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         end
       end
 
+      context "with a combo task" do
+        let(:combo_workflow) { build(:combo_task_workflow) }
+        let(:annotation) do
+          { "task"=>"T3", "value"=>
+            [
+              {"task"=>"init", "value"=>1},
+              {"task"=>"T2", "value"=>[1]},
+              {"task"=>"T6", "value"=>"no secrets between us, panoptes. you see all."}
+            ]
+          }
+        end
+
+        let(:new_classification) do
+          build_stubbed(:classification, subjects: [], workflow: combo_workflow, annotations: [annotation])
+        end
+        let(:combo_contents) { create(:combo_workflow_content, workflow: combo_workflow) }
+        let(:combo_cache) { double(workflow_at_version: combo_workflow, workflow_content_at_version: combo_contents)}
+
+        let(:codex) do
+          [
+            {
+              "task"=>"init",
+              "task_label"=>"Are you sure? (SINGLE)",
+              "value"=>"Positive"
+            },
+            {
+              "task"=>"T2",
+              "task_label"=>"FRUITS?!?! (MULTIPLE)",
+              "value"=>"Tomato?!"
+            },
+            {
+              "task"=>"T6",
+              "value"=>"no secrets between us, panoptes. you see all.",
+              "task_label"=>"Tell me a secret."
+            }
+          ]
+        end
+
+        it 'should add the correct answer labels' do
+          formatted = described_class.new(new_classification, new_classification.annotations[0], combo_cache).to_h
+          expect(formatted["value"]).to eq(codex)
+        end
+
+      end
+
       context "when the classification refers to the workflow and contents at a prev version" do
         let(:classification) do
           vers = "#{workflow.versions.first.index + 1}.#{contents.versions.first.index + 1}"

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
       let(:classification) do
         build_stubbed(:classification, subjects: [], workflow: workflow)
       end
-      let(:q_workflow) { build(:question_task_workflow) }
+      let(:q_workflow) { build(:workflow, :question_task) }
       let(:tasks) { q_workflow.tasks }
       let(:strings) { q_workflow.workflow_contents.first.strings }
 
@@ -100,7 +100,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
       end
 
       context "with a combo task" do
-        let(:combo_workflow) { build(:combo_task_workflow) }
+        let(:combo_workflow) { build(:workflow, :combo_task) }
         let(:annotation) do
           {
             "task"=>"T3",
@@ -115,7 +115,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         let(:new_classification) do
           build_stubbed(:classification, subjects: [], workflow: combo_workflow, annotations: [annotation])
         end
-        let(:combo_contents) { create(:combo_workflow_content, workflow: combo_workflow) }
+        let(:combo_contents) { create(:workflow_content, :combo_task, workflow: combo_workflow) }
         let(:combo_cache) { double(workflow_at_version: combo_workflow, workflow_content_at_version: combo_contents)}
 
         let(:codex) do
@@ -150,7 +150,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
       end
 
       context "with a dropdown task" do
-        let(:dd_workflow) { build(:dd_task_workflow) }
+        let(:dd_workflow) { build(:workflow, :dropdown_task) }
         let(:annotation) do
           {
             "task"=>"T7",
@@ -165,7 +165,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         let(:dd_classification) do
           build_stubbed(:classification, subjects: [], workflow: dd_workflow, annotations: [annotation])
         end
-        let(:dd_contents) { create(:dd_workflow_content, workflow: dd_workflow) }
+        let(:dd_contents) { create(:workflow_content, :dropdown_task, workflow: dd_workflow) }
         let(:dd_cache) { double(workflow_at_version: dd_workflow, workflow_content_at_version: dd_contents)}
 
         let(:codex) do

--- a/spec/lib/formatter/csv/workflow_content_spec.rb
+++ b/spec/lib/formatter/csv/workflow_content_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Formatter::Csv::WorkflowContent do
   context "with a versioned workflow content" do
 
     with_versioning do
-      let(:q_workflow) { build(:question_task_workflow) }
+      let(:q_workflow) { build(:workflow, :question_task) }
       let(:strings) { q_workflow.workflow_contents.first.strings }
 
       before(:each) do

--- a/spec/lib/formatter/csv/workflow_spec.rb
+++ b/spec/lib/formatter/csv/workflow_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Formatter::Csv::Workflow do
   context "with a versioned workflow" do
 
     with_versioning do
-      let(:q_workflow) { build(:question_task_workflow) }
+      let(:q_workflow) { build(:workflow, :question_task) }
       let(:tasks) { q_workflow.tasks }
 
       before(:each) do

--- a/spec/workers/workflow_contents_dump_worker_spec.rb
+++ b/spec/workers/workflow_contents_dump_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WorkflowContentsDumpWorker do
   context "with a versioned workflow content" do
 
     with_versioning do
-      let(:q_workflow) { build(:question_task_workflow) }
+      let(:q_workflow) { build(:workflow, :question_task) }
       let(:strings) { q_workflow.workflow_contents.first.strings }
       let(:workflow_content) { workflow.workflow_contents.first }
 

--- a/spec/workers/workflows_dump_worker_spec.rb
+++ b/spec/workers/workflows_dump_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WorkflowsDumpWorker do
   context "with a versioned workflow" do
 
     with_versioning do
-      let(:q_workflow) { build(:question_task_workflow) }
+      let(:q_workflow) { build(:workflow, :question_task) }
       let(:tasks) { q_workflow.tasks }
 
       before(:each) do


### PR DESCRIPTION
In order to allow the more complex Combo and Dropdown tasks to be correctly exported, I did some refactoring of Formatter::Csv::AnnotationForCsv. Hopefully this will make it easier to add new tasks in the future. 

~~This is a Work In Progress PR, and while it should all currently be working, not all the upstream specs are passing, it could be prettier/DRYer, and Hound is going to throw a fit. Please let me know, @marten or @camallen, about changes that you'd like to see. I anticipate there will be many, but I wanted to get this into your hands ASAP.~~

Update: ready to be reviewed.

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [x] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [x] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
