### PR TITLE
Adds 'activity_count_by_workflow' to /project_preferences

### DIFF
--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -14,16 +14,16 @@ class UserSeenSubject < ActiveRecord::Base
   end
 
   def self.count_user_activity(user_id, workflow_ids=[])
+    workflow_counts = activity_by_workflow(user_id, workflow_ids)
+    workflow_counts.values.sum
+  end
+
+  def self.activity_by_workflow(user_id, workflow_ids=[])
     workflow_ids = Array.wrap(workflow_ids)
     scope = self.where(user_id: user_id)
     unless workflow_ids.empty?
       scope = scope.where(workflow_id: workflow_ids)
     end
-    scope.sum("cardinality(subject_ids)")
-  end
-
-  def self.activity_by_workflow(user_id)
-    scope = self.where(user_id: user_id)
     scope.group(:workflow_id).sum("cardinality(subject_ids)").as_json
   end
 

--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -14,13 +14,17 @@ class UserSeenSubject < ActiveRecord::Base
   end
 
   def self.count_user_activity(user_id, workflow_ids=[])
-
     workflow_ids = Array.wrap(workflow_ids)
     scope = self.where(user_id: user_id)
     unless workflow_ids.empty?
       scope = scope.where(workflow_id: workflow_ids)
     end
     scope.sum("cardinality(subject_ids)")
+  end
+
+  def self.activity_by_workflow(user_id)
+    scope = self.where(user_id: user_id)
+    scope.group(:workflow_id).sum("cardinality(subject_ids)").as_json
   end
 
   def subjects_seen?(ids)

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -1,6 +1,6 @@
 class UserProjectPreferenceSerializer
   include RestPack::Serializer
-  attributes :id, :email_communication, :preferences, :href, :activity_count
+  attributes :id, :email_communication, :preferences, :href, :activity_count, :activity_count_by_workflow
   can_include :user, :project
   can_sort_by :updated_at
 
@@ -14,6 +14,10 @@ class UserProjectPreferenceSerializer
     else
       user_project_activity
     end
+  end
+
+  def activity_count_by_workflow
+    UserSeenSubject.activity_by_workflow(@model.user_id)
   end
 
   def user_project_activity

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -17,11 +17,14 @@ class UserProjectPreferenceSerializer
   end
 
   def activity_count_by_workflow
-    UserSeenSubject.activity_by_workflow(@model.user_id)
+    UserSeenSubject.activity_by_workflow(@model.user_id, project_workflows_ids)
   end
 
   def user_project_activity
-    project_workflows_ids = Workflow.where(project_id: @model.project_id).pluck(:id)
     UserSeenSubject.count_user_activity(@model.user_id, project_workflows_ids)
+  end
+
+  def project_workflows_ids
+    Workflow.where(project_id: @model.project_id).pluck(:id)
   end
 end

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -25,6 +25,6 @@ class UserProjectPreferenceSerializer
   end
 
   def project_workflows_ids
-    Workflow.where(project_id: @model.project_id).pluck(:id)
+    @project_workflow_ids ||= Workflow.where(project_id: @model.project_id).pluck(:id)
   end
 end

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
       it "returns the workflow's seen subject count" do
         run_get
         expected_hash = created_instance(api_resource_name)["activity_count_by_workflow"]
-        expect(expected_hash[workflow.id.to_s]).to eq(user_seens.subject_ids.size.to_s)
+        expect(expected_hash[workflow.id.to_s]).to eq(user_seens.subject_ids.size)
       end
 
       context "when the user has classified on more than 1 project" do

--- a/spec/models/user_seen_subject_spec.rb
+++ b/spec/models/user_seen_subject_spec.rb
@@ -62,32 +62,52 @@ RSpec.describe UserSeenSubject, :type => :model do
     end
   end
 
-  describe "::count_user_activity" do
+  context "counting user activity" do
     let(:user_seen_subject) { create(:user_seen_subject, build_real_subjects: false) }
     let!(:another_uss) { create(:user_seen_subject, user: user_seen_subject.user, build_real_subjects: false) }
-    let(:workflow_ids) { [user_seen_subject, another_uss].map(&:workflow_id) }
+    let(:workflow_ids) { [user_seen_subject, another_uss].map(&:workflow_id).map(&:to_s) }
     let(:all_seen_counts) { [user_seen_subject, another_uss].map(&:subject_ids).flatten.size }
 
-    it "should sum all the seen subjects across all workflows" do
-      count = UserSeenSubject.count_user_activity(user_seen_subject.user_id)
-      expect(count).to eq(all_seen_counts)
+    describe "::count_user_activity" do
+
+      it "should sum all the seen subjects across all workflows" do
+        count = UserSeenSubject.count_user_activity(user_seen_subject.user_id)
+        expect(count).to eq(all_seen_counts)
+      end
+
+      it "should sum all the seen subjects across specific workflow ids" do
+        count = UserSeenSubject.count_user_activity(user_seen_subject.user_id, workflow_ids)
+        expect(count).to eq(all_seen_counts)
+      end
+
+      it "should sum all the seen subjects across a specific workflow" do
+        count = UserSeenSubject.count_user_activity(user_seen_subject.user_id, user_seen_subject.workflow_id)
+        expect(count).to eq(user_seen_subject.subject_ids.size)
+      end
+
+      context "when no counts exist for the user" do
+
+        it "should return 0" do
+          count = UserSeenSubject.count_user_activity(user_seen_subject.user_id+1)
+          expect(count).to eq(0)
+        end
+      end
     end
 
-    it "should sum all the seen subjects across specific workflow ids" do
-      count = UserSeenSubject.count_user_activity(user_seen_subject.user_id, workflow_ids)
-      expect(count).to eq(all_seen_counts)
-    end
+    describe '::activity_by_workflow' do
+      it 'should return number of elements equal to UserSeenSubjects for that user' do
+        expect( UserSeenSubject.activity_by_workflow(user_seen_subject.user_id).size).to eq(
+          UserSeenSubject.where(user_id: user_seen_subject.user_id).size
+        )
+      end
 
-    it "should sum all the seen subjects across a specific workflow" do
-      count = UserSeenSubject.count_user_activity(user_seen_subject.user_id, user_seen_subject.workflow_id)
-      expect(count).to eq(user_seen_subject.subject_ids.size)
-    end
+      it 'should include keys for each workflow' do
+        expect(UserSeenSubject.activity_by_workflow(user_seen_subject.user_id).keys).to match_array(workflow_ids)
+      end
 
-    context "when no counts exist for the user" do
-
-      it "should return 0" do
-        count = UserSeenSubject.count_user_activity(user_seen_subject.user_id+1)
-        expect(count).to eq(0)
+      it 'sums to the same value as ::count_user_activity' do
+        count = UserSeenSubject.count_user_activity(user_seen_subject.user_id)
+        expect(UserSeenSubject.activity_by_workflow(user_seen_subject.user_id).values.map(&:to_i).reduce(:+)).to eq(count)
       end
     end
   end


### PR DESCRIPTION
Activity counts via UserSeenSubjects are included per workflow to calls made to /project_preferences. There could be the potential for performance issues related to these queries, but the association is already indexed and the non-legacy counts are being generated on the fly already, so this isn't much heavier.

Will close #1796.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

