### PR TITLE
build users index concurrently

### DIFF
--- a/db/migrate/20160512181921_add_users_lower_names_index.rb
+++ b/db/migrate/20160512181921_add_users_lower_names_index.rb
@@ -1,8 +1,11 @@
 class AddUsersLowerNamesIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
   def change
     add_index :users, [:login, :display_name],
       case_sensitive: false,
       operator_class: 'text_pattern_ops',
-      name: 'index_users_on_lower_names'
+      name: 'index_users_on_lower_names',
+      algorithm: :concurrently
   end
 end


### PR DESCRIPTION
don't lock the users table from writes while this is building (staging took ~20s) - this won't run on staging but it hasn't run on prod.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.