### PR TITLE
SubjectSerializer includes seen_all_live_data for each subject

### DIFF
--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -5,7 +5,7 @@ class SubjectSerializer
   attributes :id, :metadata, :locations, :zooniverse_id,
     :created_at, :updated_at, :href
 
-  optional :retired, :already_seen
+  optional :retired, :already_seen, :seen_all_live_data
 
   can_include :project, :collections
 
@@ -25,6 +25,10 @@ class SubjectSerializer
     !!(user_seen && user_seen.subject_ids.include?(@model.id))
   end
 
+  def seen_all_live_data
+    !!(user_seen && (user_seen.workflow.subject_ids.uniq.sort == user_seen.subject_ids.uniq.sort))
+  end
+
   private
 
   def include_retired?
@@ -32,6 +36,10 @@ class SubjectSerializer
   end
 
   def include_already_seen?
+    selected?
+  end
+
+  def include_seen_all_live_data?
     selected?
   end
 

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -5,7 +5,7 @@ class SubjectSerializer
   attributes :id, :metadata, :locations, :zooniverse_id,
     :created_at, :updated_at, :href
 
-  optional :retired, :already_seen, :seen_all_live_data
+  optional :retired, :already_seen, :finished_workflow
 
   can_include :project, :collections
 
@@ -25,10 +25,6 @@ class SubjectSerializer
     !!(user_seen && user_seen.subject_ids.include?(@model.id))
   end
 
-  def seen_all_live_data
-    !!(user_seen && (user_seen.workflow.subject_ids.uniq.sort == user_seen.subject_ids.uniq.sort))
-  end
-
   private
 
   def include_retired?
@@ -39,7 +35,7 @@ class SubjectSerializer
     selected?
   end
 
-  def include_seen_all_live_data?
+  def include_finished_workflow?
     selected?
   end
 
@@ -53,5 +49,9 @@ class SubjectSerializer
 
   def user_seen
     @context[:user_seen].try(:first)
+  end
+
+  def finished_workflow
+    @context[:finished_workflow]
   end
 end

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -106,7 +106,8 @@ module Subjects
     def queue_context
       @queue_context ||= {
         workflow: workflow,
-        user_seen: UserSeenSubject.where(user: user, workflow: workflow)
+        user_seen: UserSeenSubject.where(user: user, workflow: workflow),
+        finished_workflow: user&.has_finished?(workflow)
       }
     end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -57,7 +57,7 @@ describe Api::V1::SubjectsController, type: :controller do
             json_response[api_resource_name].map { |s| s.has_key?(optional_attr) }.uniq
           end
 
-          %w( retired already_seen ).each do |attr|
+          %w( retired already_seen seen_all_live_data ).each do |attr|
             let(:optional_attr) { attr }
 
             it "should not serialize the #{attr} attribute" do
@@ -144,6 +144,7 @@ describe Api::V1::SubjectsController, type: :controller do
       context "a queued request" do
         let!(:sms) { create_list(:set_member_subject, 2, subject_set: subject_set) }
         let(:request_params) { { sort: 'queued', workflow_id: workflow.id.to_s } }
+
         context "with queued subjects" do
           let!(:queue) do
             create(:subject_queue,
@@ -170,6 +171,11 @@ describe Api::V1::SubjectsController, type: :controller do
             expect(already_seen).to all( be false )
           end
 
+          it 'should return seen_all_live_data as false' do
+            seen_all = json_response["subjects"].map{ |s| s['seen_all_live_data']}
+            expect(seen_all).to all( be false )
+          end
+
           it 'should return retired as false' do
             retired = json_response["subjects"].map{ |s| s['retired']}
             expect(retired).to all( be false )
@@ -190,6 +196,12 @@ describe Api::V1::SubjectsController, type: :controller do
             get :index, request_params
             already_seen = json_response["subjects"].map{ |s| s['already_seen']}
             expect(already_seen).to all( be true )
+          end
+
+          it 'should return seen_all_live_data as true' do
+            get :index, request_params
+            seen_all = json_response["subjects"].map{ |s| s['seen_all_live_data']}
+            expect(seen_all).to all( be true )
           end
         end
 
@@ -222,6 +234,11 @@ describe Api::V1::SubjectsController, type: :controller do
           it 'should return already_seen as true for seen subject' do
             already_seen = json_response["subjects"].map{ |s| s['already_seen']}
             expect(already_seen).to include(true)
+          end
+
+          it 'should return seen_all_live_data as false for each subject' do
+            seen_all = json_response["subjects"].map{ |s| s['seen_all_live_data']}
+            expect(seen_all).to include(false)
           end
 
           it 'should return all subjects as retired' do

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -57,7 +57,7 @@ describe Api::V1::SubjectsController, type: :controller do
             json_response[api_resource_name].map { |s| s.has_key?(optional_attr) }.uniq
           end
 
-          %w( retired already_seen seen_all_live_data ).each do |attr|
+          %w( retired already_seen finished_workflow ).each do |attr|
             let(:optional_attr) { attr }
 
             it "should not serialize the #{attr} attribute" do
@@ -171,8 +171,8 @@ describe Api::V1::SubjectsController, type: :controller do
             expect(already_seen).to all( be false )
           end
 
-          it 'should return seen_all_live_data as false' do
-            seen_all = json_response["subjects"].map{ |s| s['seen_all_live_data']}
+          it 'should return finished_workflow as false' do
+            seen_all = json_response["subjects"].map{ |s| s['finished_workflow']}
             expect(seen_all).to all( be false )
           end
 
@@ -198,9 +198,9 @@ describe Api::V1::SubjectsController, type: :controller do
             expect(already_seen).to all( be true )
           end
 
-          it 'should return seen_all_live_data as true' do
+          it 'should return finished_workflow as true' do
             get :index, request_params
-            seen_all = json_response["subjects"].map{ |s| s['seen_all_live_data']}
+            seen_all = json_response["subjects"].map{ |s| s['finished_workflow']}
             expect(seen_all).to all( be true )
           end
         end
@@ -236,9 +236,9 @@ describe Api::V1::SubjectsController, type: :controller do
             expect(already_seen).to include(true)
           end
 
-          it 'should return seen_all_live_data as false for each subject' do
-            seen_all = json_response["subjects"].map{ |s| s['seen_all_live_data']}
-            expect(seen_all).to include(false)
+          it 'should return finished_workflow as false for each subject' do
+            seen_all = json_response["subjects"].map{ |s| s['finished_workflow']}
+            expect(seen_all).to all be(false)
           end
 
           it 'should return all subjects as retired' do


### PR DESCRIPTION
SubjectSerializer includes seen_all_live_data for each subject. Relevant line is 

`!!(user_seen && (user_seen.workflow.subject_ids.uniq.sort == user_seen.subject_ids.uniq.sort))`

If a user has seen all the subjects in the workflow, it'll be true and be included with each sample. If not, then the value will be false for all subjects (including those which have been seen).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

