### PR TITLE
Do not track inactive memberships

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -5,10 +5,8 @@ class Membership < ActiveRecord::Base
   belongs_to :user
   enum state: [:active, :invited, :inactive]
 
-  scope :identity, -> { where(identity: true,
-                              state: states[:active],
-                              roles: ["group_admin"]) }
-
+  scope :active, -> { where(state: states[:active]) }
+  scope :identity, -> { active.where(identity: true, roles: ["group_admin"]) }
   scope :not_identity, -> { where(identity: false) }
 
   validates_presence_of :user, unless: :identity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,7 +257,7 @@ class User < ActiveRecord::Base
   end
 
   def non_identity_user_group_ids
-    memberships.where(identity: false).pluck(:user_group_id)
+    memberships.active.not_identity.pluck(:user_group_id)
   end
 
   def panoptes_zoo_id

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -595,11 +595,18 @@ describe ClassificationLifecycle do
     it "should add all other groups a user is currently in" do
       group1 = create :user_group
       group2 = create :user_group
-      classification.user.memberships.create! user_group: group1
-      classification.user.memberships.create! user_group: group2
+      classification.user.memberships.create! user_group: group1, state: 'active'
+      classification.user.memberships.create! user_group: group2, state: 'active'
 
       subject.add_user_groups
       expect(classification.metadata[:user_group_ids]).to match_array([group1.id, group2.id])
+    end
+
+    it 'should not add groups with inactive memberships' do
+      classification.user.memberships.create! user_group: create(:user_group), state: 'inactive'
+
+      subject.add_user_groups
+      expect(classification.metadata[:user_group_ids]).to be_empty
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -750,6 +750,26 @@ describe User, type: :model do
     end
   end
 
+  describe '#non_identity_user_group_ids' do
+    let(:user) { create :user }
+    let(:user_group) { create :user_group }
+
+    it 'returns an empty array when not a member of any groups apart from the identity group' do
+      expect(user.identity_group).to be_present
+      expect(user.non_identity_user_group_ids).to be_empty
+    end
+
+    it 'returns user group ids for memberships' do
+      user.memberships.create! user_group: user_group, state: 'active'
+      expect(user.non_identity_user_group_ids).to match_array([user_group.id])
+    end
+
+    it 'does not return ids from inactive memberships' do
+      user.memberships.create! user_group: user_group, state: 'inactive'
+      expect(user.non_identity_user_group_ids).to be_empty
+    end
+  end
+
   describe '#set_zooniverse_id' do
     let(:user){ create :user }
     subject{ user.zooniverse_id }


### PR DESCRIPTION
Classification lifecycle was not taking into account membership state when adding user groups to classification metadata. This PR ensures that only active memberships are recorded.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

