### PR TITLE
[WIP] New emails to user

### DIFF
--- a/app/mailers/user_added_to_project_mailer.rb
+++ b/app/mailers/user_added_to_project_mailer.rb
@@ -1,0 +1,14 @@
+class UserAddedToProjectMailer < ApplicationMailer
+  layout false
+
+  SITE_NAME = "the Zooniverse"
+  DEFAULT_SUBJECT = "You've been added to a new Zooniverse project!"
+
+  def added_to_project(user, project, roles)
+    @user = user
+    @project = project
+    @roles = roles
+    @email_to = user.email
+    mail(to: @email_to, subject: DEFAULT_SUBJECT)
+  end
+end

--- a/app/mailers/user_info_changed_mailer.rb
+++ b/app/mailers/user_info_changed_mailer.rb
@@ -1,0 +1,21 @@
+class UserInfoChangedMailer < ApplicationMailer
+  layout false
+
+  SITE_NAME = "the Zooniverse"
+
+  def user_info_changed(user, info)
+    @user = user
+    @email_to = user.email
+
+    case info
+    when :email
+      subject = "Your Zooniverse email address has been changed"
+      template = "email_changed"
+    when :password
+      subject = "Your Zooniverse password has been changed"
+      template = "password_changed"
+    end
+
+    mail(to: @email_to, subject: subject, :template_name => template )
+  end
+end

--- a/app/models/access_control_list.rb
+++ b/app/models/access_control_list.rb
@@ -5,6 +5,19 @@ class AccessControlList < ActiveRecord::Base
   validates_presence_of :user_group
   validates_uniqueness_of :user_group, scope: [:resource_id, :resource_type], message: ". Roles have already been set for this user or group"
 
+  after_update :send_collaborator_email, if: :roles_changed?
+
+  def send_collaborator_email
+    if resource.class == Project && check_new_roles.present?
+      UserInfoChangedMailerWorker.perform_async(id, resource.id, check_new_roles)
+    end
+  end
+
+  def check_new_roles
+    diff = changes[:roles] ? changes[:roles][1].sort - changes[:roles][0].sort : []
+    ["collaborator", "expert"] & diff
+  end
+
   def self.scope_for(action, groups, resource_type: nil)
     case action
     when :show, :index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,9 @@ class User < ActiveRecord::Base
   after_create :send_welcome_email, unless: :migrated
   before_create :set_ouroboros_api_key
 
+  after_update :send_email_changed_email, if: :email_changed?
+  after_update :send_password_changed_email, if: :encrypted_password_changed?
+
   delegate :projects, to: :identity_group
   delegate :collections, to: :identity_group
   delegate :subjects, to: :identity_group
@@ -279,6 +282,14 @@ class User < ActiveRecord::Base
 
   def send_welcome_email
     UserWelcomeMailerWorker.perform_async(id, project_id)
+  end
+
+  def send_password_changed_email
+    UserInfoChangedMailerWorker.perform_async(id, :password)
+  end
+
+  def send_email_changed_email
+    UserInfoChangedMailerWorker.perform_async(id, :email)
   end
 
   def set_ouroboros_api_key

--- a/app/views/user_added_to_project_mailer/added_to_project.html.erb
+++ b/app/views/user_added_to_project_mailer/added_to_project.html.erb
@@ -1,0 +1,13 @@
+<p>You have been added to the Zooniverse project <%= @project.display_name %> in the following roles: <%= @roles.join(" and ") %></p>
+
+<p>Visit <a href="https://zooniverse.org/projects/<%= @project.slug %>"><%= @project.display_name %></a> to get started.</p>
+
+<% if @roles.include? "collaborator" %>
+  <p>To edit your project, go to <a href="https://zooniverse.org/lab/<%= @project.id %>">
+<% end %>
+
+<p>If you believe this to be in error, please contact support (contact@zooniverse.org).</p>
+
+<p>Thanks,</p>
+
+<p>The Zooniverse Team</p>

--- a/app/views/user_added_to_project_mailer/added_to_project.text.erb
+++ b/app/views/user_added_to_project_mailer/added_to_project.text.erb
@@ -1,0 +1,7 @@
+You have been added to the Zooniverse project <%= @project.display_name %> in the following roles: <%= @roles.join(" and ") %>
+
+Visit <a href="zooniverse.org/projects/<%= @project.slug %>"><% @project.display_name %></a> to get started.
+
+Thanks,
+
+The Zooniverse Team

--- a/app/views/user_added_to_project_mailer/added_to_project.text.erb
+++ b/app/views/user_added_to_project_mailer/added_to_project.text.erb
@@ -1,6 +1,12 @@
 You have been added to the Zooniverse project <%= @project.display_name %> in the following roles: <%= @roles.join(" and ") %>
 
-Visit <a href="zooniverse.org/projects/<%= @project.slug %>"><% @project.display_name %></a> to get started.
+Visit <a href="https://zooniverse.org/projects/<%= @project.slug %>"><%= @project.display_name %></a> to get started.
+
+<% if @roles.include? "collaborator" %>
+  To edit your project, go to <a href="https://zooniverse.org/lab/<%= @project.id %>">
+<% end %>
+
+If you believe this to be in error, please contact support (contact@zooniverse.org).
 
 Thanks,
 

--- a/app/views/user_info_changed_mailer/email_changed.html.erb
+++ b/app/views/user_info_changed_mailer/email_changed.html.erb
@@ -1,6 +1,6 @@
 <p>Your Zooniverse email address has been successfully changed.</p>
 
-<p>If you believe this to be in error, please contact [emailaddress].</p>
+<p>If you believe this to be in error, please email contact@zooniverse.org.</p>
 
 
 <p>Thanks,</p>

--- a/app/views/user_info_changed_mailer/email_changed.html.erb
+++ b/app/views/user_info_changed_mailer/email_changed.html.erb
@@ -1,0 +1,8 @@
+<p>Your Zooniverse email address has been successfully changed.</p>
+
+<p>If you believe this to be in error, please contact [emailaddress].</p>
+
+
+<p>Thanks,</p>
+
+<p>The Zooniverse Team </p>

--- a/app/views/user_info_changed_mailer/email_changed.text.erb
+++ b/app/views/user_info_changed_mailer/email_changed.text.erb
@@ -1,6 +1,6 @@
 Your Zooniverse email address has been successfully changed.
 
-If you believe this to be in error, please contact <emailaddress>.
+If you believe this to be in error, please email contact@zooniverse.org.
 
 Thanks,
 

--- a/app/views/user_info_changed_mailer/email_changed.text.erb
+++ b/app/views/user_info_changed_mailer/email_changed.text.erb
@@ -1,0 +1,7 @@
+Your Zooniverse email address has been successfully changed.
+
+If you believe this to be in error, please contact <emailaddress>.
+
+Thanks,
+
+The Zooniverse Team

--- a/app/views/user_info_changed_mailer/password_changed.html.erb
+++ b/app/views/user_info_changed_mailer/password_changed.html.erb
@@ -1,0 +1,8 @@
+<p>Your Zooniverse password has been successfully changed.</p>
+
+<p>If you believe this to be in error, please contact [emailaddress].</p>
+
+
+<p>Thanks,</p>
+
+<p>The Zooniverse Team </p>

--- a/app/views/user_info_changed_mailer/password_changed.html.erb
+++ b/app/views/user_info_changed_mailer/password_changed.html.erb
@@ -1,6 +1,6 @@
 <p>Your Zooniverse password has been successfully changed.</p>
 
-<p>If you believe this to be in error, please contact [emailaddress].</p>
+<p>If you believe this to be in error, please email contact@zooniverse.org.</p>
 
 
 <p>Thanks,</p>

--- a/app/views/user_info_changed_mailer/password_changed.text.erb
+++ b/app/views/user_info_changed_mailer/password_changed.text.erb
@@ -1,6 +1,6 @@
 Your Zooniverse password has been successfully changed.
 
-If you believe this to be in error, please contact <emailaddress>.
+If you believe this to be in error, please email contact@zooniverse.org.
 
 Thanks,
 

--- a/app/views/user_info_changed_mailer/password_changed.text.erb
+++ b/app/views/user_info_changed_mailer/password_changed.text.erb
@@ -1,0 +1,7 @@
+Your Zooniverse password has been successfully changed.
+
+If you believe this to be in error, please contact <emailaddress>.
+
+Thanks,
+
+The Zooniverse Team

--- a/app/workers/user_added_to_project_mailer_worker.rb
+++ b/app/workers/user_added_to_project_mailer_worker.rb
@@ -1,0 +1,19 @@
+class UserAddedToProjectMailerWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_high
+
+  attr_reader :user
+
+  def perform(user_id, project_id, roles)
+    @user = User.find(user_id)
+    if @user && !@user.email.blank? && roles
+      project = Project.find(project_id)
+      UserAddedToProjectMailer.added_to_project(user, project, roles).deliver
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
+  rescue Net::SMTPSyntaxError, Net::SMTPFatalError => e
+    @user.update_attribute(:valid_email, false)
+  end
+end

--- a/app/workers/user_info_changed_mailer_worker.rb
+++ b/app/workers/user_info_changed_mailer_worker.rb
@@ -1,0 +1,18 @@
+class UserInfoChangedMailerWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_high
+
+  attr_reader :user
+
+  def perform(user_id, info)
+    @user = User.find(user_id)
+    if @user && !@user.email.blank?
+      UserInfoChangedMailer.user_info_changed(user, info).deliver
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
+  rescue Net::SMTPSyntaxError, Net::SMTPFatalError => e
+    @user.update_attribute(:valid_email, false)
+  end
+end

--- a/spec/mailers/user_added_to_project_mailer_spec.rb
+++ b/spec/mailers/user_added_to_project_mailer_spec.rb
@@ -23,5 +23,14 @@ RSpec.describe UserAddedToProjectMailer, :type => :mailer do
     it 'has the project name in the body' do
       expect(mail.body.encoded).to match("#{project.display_name}")
     end
+
+    it 'includes the lab URL if the user is a collaborator' do
+      expect(mail.body.encoded).to match("https://zooniverse.org/lab/#{ project.id }")
+    end
+
+    it 'does not include the lab URL if the user is not a collaborator' do
+      newmail = UserAddedToProjectMailer.added_to_project(user, project, ['expert'])
+      expect(newmail.body.encoded).to_not match("https://zooniverse.org/lab/#{ project.id }")
+    end
   end
 end

--- a/spec/mailers/user_added_to_project_mailer_spec.rb
+++ b/spec/mailers/user_added_to_project_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe UserAddedToProjectMailer, :type => :mailer do
+  let(:project) { create(:project) }
+  let(:user) { project.owner }
+  let(:roles) { ["collaborator"] }
+  let(:mail) { UserAddedToProjectMailer.added_to_project(user, project, roles)}
+
+  describe "#added_to_project" do
+
+    it "mails the correct user" do
+      expect(mail.to).to include(user.email)
+    end
+
+    it 'comes from no-reply@zooniverse.org' do
+      expect(mail.from).to include('no-reply@zooniverse.org')
+    end
+
+    it 'has the correct subject' do
+      expect(mail.subject).to eq("You've been added to a new Zooniverse project!")
+    end
+
+    it 'has the project name in the body' do
+      expect(mail.body.encoded).to match("#{project.display_name}")
+    end
+  end
+end

--- a/spec/mailers/user_info_changed_mailer_spec.rb
+++ b/spec/mailers/user_info_changed_mailer_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+RSpec.describe UserInfoChangedMailer, :type => :mailer do
+  let(:user) { create(:user) }
+  let(:mail) { UserInfoChangedMailer.user_info_changed(user, :password)}
+
+  describe "#user_info_changed" do
+
+    it 'should mail the user' do
+      expect(mail.to).to include(user.email)
+    end
+
+    it 'should come from no-reply@zooniverse.org' do
+      expect(mail.from).to include('no-reply@zooniverse.org')
+    end
+
+    context "password was changed" do
+      it 'should have the correct subject' do
+        expect(mail.subject).to eq("Your Zooniverse password has been changed")
+      end
+    end
+
+    context "email address was changed" do
+      let(:mail) { UserInfoChangedMailer.user_info_changed(user, :email)}
+      it 'should have the correct subject' do
+        expect(mail.subject).to eq("Your Zooniverse email address has been changed")
+      end
+    end
+  end
+end

--- a/spec/models/access_control_list_spec.rb
+++ b/spec/models/access_control_list_spec.rb
@@ -1,5 +1,26 @@
 require 'spec_helper'
 
 RSpec.describe AccessControlList, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # pending "add some examples to (or delete) #{__FILE__}"
+
+  let(:project) { create(:project) }
+  let(:acl) { create(:access_control_list, resource: project) }
+
+  describe "callbacks" do
+    after(:each) { acl.update_attribute(:roles, ["expert"]) }
+    it 'calls the method' do
+      expect(acl).to receive(:send_collaborator_email)
+    end
+
+    it "calls the worker" do
+      expect(UserInfoChangedMailerWorker).to receive :perform_async
+    end
+  end
+
+  describe "#check_new_roles" do
+    it "returns the right values" do
+      acl.roles = ['expert']
+      expect(acl.check_new_roles).to eq(['expert'])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -830,6 +830,26 @@ describe User, type: :model do
     end
   end
 
+  describe "sends info changed emails after_update callback if info has changed" do
+    let!(:user) { create(:user) }
+
+    it "should send the info changed email if password has changed" do
+      expect(user).to receive(:send_password_changed_email)
+      user.update_attribute(:password, "totallychanged")
+    end
+
+    it "should send the info changed email if email address has changed" do
+      expect(user).to receive(:send_email_changed_email)
+      user.update_attribute(:email, "newemail@zoonverse.org")
+    end
+
+    it "should queue the worker with the user id" do
+      allow(UserInfoChangedMailerWorker).to receive :perform_async
+      user.update_attribute(:password, "totallychanged")
+      expect(UserInfoChangedMailerWorker).to have_received(:perform_async).with(user.id, :password).ordered
+    end
+  end
+
   describe "#set_ouroboros_api_key" do
     it 'should set the key on creation' do
       user = create(:user, api_key: nil)

--- a/spec/workers/user_added_to_project_mailer_worker_spec.rb
+++ b/spec/workers/user_added_to_project_mailer_worker_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe UserAddedToProjectMailerWorker do
+  let(:project) { create(:project) }
+  let(:user) { project.owner }
+  let(:roles) { ["collaborator"] }
+
+  it 'should deliver the mail' do
+    expect{ subject.perform(user.id, project.id, roles) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  context "missing attributes" do
+    it "is missing a user and doesn't send" do
+      expect{ subject.perform(nil, project, roles) }.to_not change{ ActionMailer::Base.deliveries.count }
+    end
+
+    it "is missing a project and doesn't send" do
+      expect{ subject.perform(user, nil, roles) }.to_not change{ ActionMailer::Base.deliveries.count }
+    end
+
+    it "is missing roles and doesn't send" do
+      expect{ subject.perform(user, project, nil) }.to_not change{ ActionMailer::Base.deliveries.count }
+    end
+  end
+
+  context "when an the user has been scrubbed of email address" do
+    it 'should not deliver the mail' do
+      UserInfoScrubber.scrub_personal_info!(user)
+      expect{ subject.perform(user.id, project.id, roles) }.to_not change{ ActionMailer::Base.deliveries.count }
+    end
+  end
+
+  context "when the user has an invalid email" do
+    [ Net::SMTPSyntaxError, Net::SMTPFatalError ].each do |error_klass|
+      before(:each) do
+        allow_any_instance_of(ActionMailer::MessageDelivery)
+          .to receive(:deliver)
+          .and_raise(error_klass.new)
+        allow(user).to receive(:email).and_return("test@example.com,ox")
+      end
+
+      it 'should attempt to send an email' do
+        expect_any_instance_of(ActionMailer::MessageDelivery).to receive(:deliver)
+        subject.perform(user.id, project.id, roles)
+      end
+
+      it 'should mark the user with invalid_email' do
+        subject.perform(user.id, project.id, roles)
+        expect(user.reload.valid_email).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/workers/user_info_changed_mailer_worker_spec.rb
+++ b/spec/workers/user_info_changed_mailer_worker_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe UserInfoChangedMailerWorker do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+
+  it 'should deliver the mail' do
+    expect{ subject.perform(user.id, :password) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  context "without a user" do
+    it 'should not deliver the mail' do
+      expect{ subject.perform(nil, :password) }.to_not change{ ActionMailer::Base.deliveries.count }
+    end
+  end
+
+  context "when an the user has been scrubbed of email address" do
+    it 'should not deliver the mail' do
+      UserInfoScrubber.scrub_personal_info!(user)
+      expect{ subject.perform(user.id, :password) }.to_not change{ ActionMailer::Base.deliveries.count }
+    end
+  end
+
+  context "when the user has an invalid email" do
+    [ Net::SMTPSyntaxError, Net::SMTPFatalError ].each do |error_klass|
+      before(:each) do
+        allow_any_instance_of(ActionMailer::MessageDelivery)
+          .to receive(:deliver)
+          .and_raise(error_klass.new)
+        allow(user).to receive(:email).and_return("test@example.com,ox")
+      end
+
+      it 'should attempt to send an email' do
+        expect_any_instance_of(ActionMailer::MessageDelivery).to receive(:deliver)
+        subject.perform(user.id, :password)
+      end
+
+      it 'should mark the user with invalid_email' do
+        subject.perform(user.id, :password)
+        expect(user.reload.valid_email).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
An email will be sent to a user when the following events occur:

* User's password is successfully changed
* User's email address is changed
* User is added to a project as a collaborator or expert 

This was done using model callbacks. I understand why this might not be ideal, so if whoever sees this would rather it were refactored using service objects, that's can be done. Might be nice for me to get in the habit.

Also: I thought about DRYing up the user mailer specs, but I got hung up on the fact that the list of arguments is different to each. Is there a simple way to deal with that?

Labelled WIP until copy is confirmed and refactoring question is answered. Resolves #1790.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
