### PR TITLE
call unsubscribe worker regardless of email correctness

### DIFF
--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -101,10 +101,19 @@ describe EmailsController, type: :controller do
       end
 
       context "when supplying an invalid email" do
+        let(:unknown_email) { "not@my.email" }
+        let(:unsubscribe) do
+          post :unsubscribe_via_email, email: unknown_email
+        end
 
         it "should be successful" do
-          post :unsubscribe_via_email, email: "not@my.email"
+          unsubscribe
           expect(response).to have_http_status(:ok)
+        end
+
+        it 'should queue an unsubscribe maillist worker' do
+          expect(UnsubscribeWorker).to receive(:perform_async).with(unknown_email)
+          unsubscribe
         end
       end
 


### PR DESCRIPTION
let the list server decide if they user is to be unsubscribed regardless of if the user has put in the correct email

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.