### PR TITLE
Combo dropdown export

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -85,35 +85,40 @@ module Formatter
       def dropdown(task_info=task)
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
-          new_anno['value'] = []
-          task_info['selects'].each_with_index do |selects, index|
-            new_anno['value'].push dropdown_process_selects(selects, index)
+          new_anno['value'] = task_info['selects'].map.with_index do |selects, index|
+            dropdown_process_selects(selects, index)
           end
         end
       end
 
       def dropdown_process_selects(selects, index)
+        answer = @current['value'][index]
+
         {}.tap do |drop_anno|
           drop_anno['select_label'] = selects['title']
-          drop_anno['option'] = selects['allowCreate']
-          selects['options'].each do |key, options|
-            dropdown_process_options(options, index, drop_anno)
+
+          if selects['allowCreate']
+            drop_anno['option'] = false
+            drop_anno['value'] = @current['value'][index]['value']
+          end
+
+          selected_option = dropdown_find_selected_option(selects, answer)
+          if selected_option
+            drop_anno['option'] = true
+            drop_anno['value'] = selected_option['value']
+            drop_anno['label'] = translate(selected_option['label'])
           end
         end
       end
 
-      def dropdown_process_options(options, index, drop_anno)
-        options.each do |opt|
-          if opt['value'] == @current['value'][index]['value']
-            drop_anno['value'], drop_anno['label'] = dropdown_label(opt, index)
+      def dropdown_find_selected_option(selects, answer)
+        selects['options'].each do |key, options|
+          options.each do |option|
+            return option if option['value'] == answer['value']
           end
         end
+        nil
       end
-
-      def dropdown_label(option, index)
-        [option['value'], translate(option['label'])]
-      end
-
 
       def task_label(task_info)
         translate(task_info["question"] || task_info["instruction"])

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -44,7 +44,7 @@ module Formatter
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
           new_anno['task_label'] = task_label(task_info)
-          new_anno['value'] = task['type'] == 'multiple' ? answer_labels : answer_label
+          new_anno['value'] = task_info['type'] == 'multiple' ? answer_labels : answer_label
         end
       end
 

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
               {
                 "task"=>"T2",
                 "task_label"=>"FRUITS?!?! (MULTIPLE)",
-                "value"=>"Tomato?!"
+                "value"=>["Tomato?!"]
               },
               {
                 "task"=>"T6",

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
               {
                 "task"=>"T7",
                 "value"=> [
-                  {"select_label"=>"Country", "option"=>false, "value"=>"c6e0d98477ec8", "label"=>"Oceania"},
+                  {"select_label"=>"Country", "option"=>true, "value"=>"c6e0d98477ec8", "label"=>"Oceania"},
                   {"select_label"=>"State", "option"=>true, "value"=>"fb39ba165bfd4", "label"=>"Left Oceania"},
                   {"select_label"=>"City", "option"=>true, "value"=>"81a10debaa648", "label"=>"Townsville"}
                 ]
@@ -171,7 +171,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
             "value"=>[
               {"value"=>"c6e0d98477ec8", "option"=>true},
               {"value"=>"fb39ba165bfd4", "option"=>true},
-              {"value"=>"81a10debaa648", "option"=>true}
+              {"value"=>"something unlisted", "option"=>false}
             ]
            }
         end
@@ -186,9 +186,9 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
           {
             "task"=>"T7",
             "value"=> [
-              {"select_label"=>"Country", "option"=>false, "value"=>"c6e0d98477ec8", "label"=>"Oceania"},
+              {"select_label"=>"Country", "option"=>true, "value"=>"c6e0d98477ec8", "label"=>"Oceania"},
               {"select_label"=>"State", "option"=>true, "value"=>"fb39ba165bfd4", "label"=>"Left Oceania"},
-              {"select_label"=>"City", "option"=>true, "value"=>"81a10debaa648", "label"=>"Townsville"}
+              {"select_label"=>"City", "option"=>false, "value"=>"something unlisted"}
             ]
           }
         end
@@ -197,7 +197,6 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
           formatted = described_class.new(dd_classification, dd_classification.annotations[0], dd_cache).to_h
           expect(formatted).to eq(codex)
         end
-
       end
 
       context "when the classification refers to the workflow and contents at a prev version" do


### PR DESCRIPTION
@mcbouslog found a couple of issues with the current export formatter, relating to combo and dropdown tasks, specifically:

* if a combo task contains a `multiple` task, only one selected value was exported instead of all
* if a dropdown task was answered with a custom string value, `option` and `value` were exported incorrectly.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.