### PR TITLE
Add feature flags and management tool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'zoo_stream', '~> 1.0.1'
 gem 'librato-metrics', '~> 1.6.1'
 gem 'scientist', '~> 1.0.0'
 gem 'flipper'
+gem 'flipper-active_record'
+gem 'flipper-ui'
 
 group :production do
   gem 'newrelic_rpm', '~> 3.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'pg', '~> 0.18'
 gem 'zoo_stream', '~> 1.0.1'
 gem 'librato-metrics', '~> 1.6.1'
 gem 'scientist', '~> 1.0.0'
+gem 'flipper'
 
 group :production do
   gem 'newrelic_rpm', '~> 3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.10)
     fig_rake (0.9.3)
+    flipper (0.7.5)
     foreman (0.78.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
@@ -414,6 +415,7 @@ DEPENDENCIES
   faraday-http-cache (~> 1.0)
   faraday_middleware (~> 0.9)
   fig_rake (~> 0.9.3)
+  flipper
   foreman
   guard-rspec
   honeybadger (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,14 @@ GEM
     ffi (1.9.10)
     fig_rake (0.9.3)
     flipper (0.7.5)
+    flipper-active_record (0.7.5)
+      activerecord (>= 3.2, < 5)
+      flipper (~> 0.7.5)
+    flipper-ui (0.7.5)
+      erubis (~> 2.7.0)
+      flipper (~> 0.7.5)
+      rack (>= 1.4, < 3)
+      rack-protection (~> 1.5.3)
     foreman (0.78.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
@@ -416,6 +424,8 @@ DEPENDENCIES
   faraday_middleware (~> 0.9)
   fig_rake (~> 0.9.3)
   flipper
+  flipper-active_record
+  flipper-ui
   foreman
   guard-rspec
   honeybadger (~> 2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,9 @@ module Panoptes
         end
       end
     end
+
+    config.middleware.use Flipper::Middleware::Memoizer, lambda {
+      Panoptes.flipper
+    }
   end
 end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,5 +1,9 @@
+require "flipper/instrumentation/log_subscriber"
+
 module Panoptes
   def self.flipper
-    @flipper ||= Flipper.new(Flipper::Adapters::ActiveRecord.new)
+    return @flipper if @flipper
+    adapter = Flipper::Adapters::ActiveRecord.new
+    @flipper = Flipper.new(adapter, instrumenter: ActiveSupport::Notifications)
   end
 end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,5 @@
+module Panoptes
+  def self.flipper
+    @flipper ||= Flipper.new(Flipper::Adapters::ActiveRecord.new)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
 
   authenticate :user, lambda { |u| u.admin? } do
     mount Sidekiq::Web => '/sidekiq'
+    flipper_block = lambda {
+      Panoptes.flipper
+    }
+    mount Flipper::UI.app(flipper_block) => '/flipper'
   end
 
   use_doorkeeper do

--- a/db/migrate/20160601162035_create_flipper_tables.rb
+++ b/db/migrate/20160601162035_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -344,6 +344,70 @@ ALTER SEQUENCE field_guides_id_seq OWNED BY field_guides.id;
 
 
 --
+-- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE flipper_features (
+    id integer NOT NULL,
+    key character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: flipper_features_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE flipper_features_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: flipper_features_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE flipper_features_id_seq OWNED BY flipper_features.id;
+
+
+--
+-- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE flipper_gates (
+    id integer NOT NULL,
+    feature_key character varying NOT NULL,
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: flipper_gates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE flipper_gates_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: flipper_gates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE flipper_gates_id_seq OWNED BY flipper_gates.id;
+
+
+--
 -- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1420,6 +1484,20 @@ ALTER TABLE ONLY field_guides ALTER COLUMN id SET DEFAULT nextval('field_guides_
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY flipper_features ALTER COLUMN id SET DEFAULT nextval('flipper_features_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY flipper_gates ALTER COLUMN id SET DEFAULT nextval('flipper_gates_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY media ALTER COLUMN id SET DEFAULT nextval('media_id_seq'::regclass);
 
 
@@ -1667,6 +1745,22 @@ ALTER TABLE ONLY collections_subjects
 
 ALTER TABLE ONLY field_guides
     ADD CONSTRAINT field_guides_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY flipper_features
+    ADD CONSTRAINT flipper_features_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY flipper_gates
+    ADD CONSTRAINT flipper_gates_pkey PRIMARY KEY (id);
 
 
 --
@@ -2051,6 +2145,20 @@ CREATE INDEX index_field_guides_on_language ON field_guides USING btree (languag
 --
 
 CREATE INDEX index_field_guides_on_project_id ON field_guides USING btree (project_id);
+
+
+--
+-- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_flipper_features_on_key ON flipper_features USING btree (key);
+
+
+--
+-- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON flipper_gates USING btree (feature_key, key, value);
 
 
 --
@@ -3320,4 +3428,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160525103520');
 INSERT INTO schema_migrations (version) VALUES ('20160527140046');
 
 INSERT INTO schema_migrations (version) VALUES ('20160527162831');
+
+INSERT INTO schema_migrations (version) VALUES ('20160601162035');
 

--- a/spec/lib/flipper_spec.rb
+++ b/spec/lib/flipper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Flipper do
+
+  describe 'feature flippin' do
+    let(:feature) { :test_feature }
+
+    it "should not be enabled by default" do
+      expect(Panoptes.flipper[feature].enabled?).to be_falsey
+    end
+
+    it "should enable features being turned on" do
+      Panoptes.flipper[feature].enable
+      expect(Panoptes.flipper[feature].enabled?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Provide the ability to turn on features in the API. This does not do per actor (user/groups) feature flipping at the moment but we can add if needed. 

The UI for this is located at `host/flipper`, add features and then code for them in the API..
```
if Panoptes.flipper[:science_things].enabled?
  #do all the science things
end
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
