### PR TITLE
fix param typo

### DIFF
--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -6,7 +6,7 @@ module Subjects
   class StrategySelection
     attr_reader :workflow, :user, :subject_set_id, :limit, :strategy_param
 
-    def initialize(workflow, user, set_id, limit=SubjectQueue::DEFAULT_LENGTH, strategy_param=nil)
+    def initialize(workflow, user, subject_set_id, limit=SubjectQueue::DEFAULT_LENGTH, strategy_param=nil)
       @workflow = workflow
       @user = user
       @subject_set_id = subject_set_id

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe Subjects::StrategySelection do
         end
 
         it "should use the cellect client" do
-          expect(Subjects::CellectClient).to receive(:get_subjects)
+          cellect_params = [ workflow.id, user.id, subject_set.id, limit ]
+          expect(Subjects::CellectClient)
+            .to receive(:get_subjects)
+            .with(*cellect_params)
             .and_return(result_ids)
           run_selection
         end


### PR DESCRIPTION
Linked to #https://github.com/zooniverse/old-weather/issues/94

ensure the strategy selector passes the correct selection information to the different strategy selectors.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.