### PR TITLE
add always on scienceing for admin users

### DIFF
--- a/spec/services/code_experiment_spec.rb
+++ b/spec/services/code_experiment_spec.rb
@@ -3,25 +3,89 @@ require 'spec_helper'
 describe CodeExperiment do
   describe 'running experiments' do
     include Scientist
+    let(:admin_enabled) { false }
+    let(:config) do
+      CodeExperimentConfig.create!(
+        name: 'test',
+        enabled_rate: enabled_rate,
+        always_enabled_for_admins: admin_enabled
+      )
+    end
 
-    it 'runs multiple times' do
+    before do
       allow(CodeExperiment.reporter).to receive(:publish)
+      config
+      CodeExperimentConfig.reset_cache!
+    end
 
-      CodeExperimentConfig.create! name: 'test', enabled_rate: 1.0
+    context "always enabled" do
+      let(:enabled_rate) { 1.0 }
 
-      result1 = CodeExperiment.run "test" do |e|
-        e.use { 1 }
-        e.try { 1 }
+      it 'runs multiple times' do
+        result1 = CodeExperiment.run "test" do |e|
+          e.use { 1 }
+          e.try { 1 }
+        end
+
+        result2 = CodeExperiment.run "test" do |e|
+          e.use { 1 }
+          e.try { 2 }
+        end
+
+        expect(result1).to eq(1)
+        expect(result2).to eq(1)
+        expect(CodeExperiment.reporter).to have_received(:publish).twice
+      end
+    end
+
+    context "zero enabled rate" do
+      let(:enabled_rate) { 0.0 }
+      let(:run_experiment) do
+        CodeExperiment.run "test" do |e|
+          e.use { 1 }
+          e.try { 2 }
+        end
       end
 
-      result2 = CodeExperiment.run "test" do |e|
-        e.use { 1 }
-        e.try { 2 }
+      it 'should not run' do
+        run_experiment
+        expect(CodeExperiment.reporter).not_to have_received(:publish)
       end
 
-      expect(result1).to eq(1)
-      expect(result2).to eq(1)
-      expect(CodeExperiment.reporter).to have_received(:publish).twice
+      context "enabled for admin users" do
+        let(:admin_enabled) { true }
+        let(:user) { nil }
+        let(:run_experiment) do
+          CodeExperiment.run "test" do |e|
+            e.context user: user
+            e.use { 1 }
+            e.try { 2 }
+          end
+        end
+
+        it 'should not run without a user context' do
+          run_experiment
+          expect(CodeExperiment.reporter).not_to have_received(:publish)
+        end
+
+        context "with a normal user context" do
+          let(:user) { double("User", is_admin?: false) }
+
+          it 'should not run' do
+            run_experiment
+            expect(CodeExperiment.reporter).not_to have_received(:publish)
+          end
+        end
+
+        context "with an admin user context" do
+          let(:user) { double("User", is_admin?: true) }
+
+          it 'should run' do
+            run_experiment
+            expect(CodeExperiment.reporter).to have_received(:publish)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
always run science experiments for admin users when passing in the user context.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

