### PR TITLE
Include display name when returning user as linked resource

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1117,6 +1117,7 @@ It has the following attributes:
                     "links": {
                         "owner": {
                             "id": "2",
+                            "display_name": "Owner 2",
                             "href": "/users/2",
                             "type": "user"
                         }
@@ -1316,6 +1317,7 @@ Projects are returned as an array under the _projects_ key.
                     "links": {
                         "owner": {
                             "id": "2",
+                            "display_name": "Owner 2",
                             "href": "/users/2",
                             "type": "users"
                         }
@@ -1347,6 +1349,7 @@ Projects are returned as an array under the _projects_ key.
                     "links": {
                         "owner": {
                             "id": "2",
+                            "display_name": "Owner 2",
                             "href": "/users/2",
                             "type": "users"
                         }
@@ -1398,6 +1401,7 @@ returned.
                         "workflows": ["1", "2"]
                         "owner": {
                             "id": 10,
+                            "display_name": "Owner 2",
                             "type": "user_groups",
                             "href": "user_groups/10"
                         }
@@ -2903,6 +2907,7 @@ It has the following attributes:
                     "links": {
                         "owner": {
                             "id": "10",
+                            "display_name": "Owner 10",
                             "href": "/users/10",
                             "type": "users"
                         }
@@ -3052,6 +3057,7 @@ Collections are returned as an array under *collections*.
                     "links": {
                         "owner": {
                             "id": "10",
+                            "display_name": "Owner 10",
                             "href": "/users/10",
                             "type": "users"
                         }
@@ -3065,6 +3071,7 @@ Collections are returned as an array under *collections*.
                     "links": {
                         "owner": {
                             "id": "11",
+                            "display_name": "Owner 11",
                             "type": "user_groups",
                             "href": "/user_groups/11"
                         }
@@ -3113,6 +3120,7 @@ owner, and links to subjects.
                     "links": {
                         "owner": {
                             "id" : "10",
+                            "display_name": "Owner 10",
                             "type": "user_groups",
                             "href": "/user_groups/10"
                         }
@@ -3426,6 +3434,7 @@ roles for a project may be:
                         "project": "11"
                         "owner": {
                             "id": "3",
+                            "display_name": "Owner 3",
                             "type": "users",
                             "href": "users/3"
                         }
@@ -3521,6 +3530,7 @@ ProjectRoles are returned as an array under *project_roles*.
                         "project": "11",
                         "owner": {
                             "id": "3",
+                            "display_name": "Owner 3",
                             "type": "users",
                             "href": "users/3"
                         }
@@ -3534,6 +3544,7 @@ ProjectRoles are returned as an array under *project_roles*.
                         "project": "81",
                         "owner": {
                             "id": "33",
+                            "display_name": "Owner 33",
                             "type": "users",
                             "href": "users/33"
                         }
@@ -4830,6 +4841,7 @@ Collection roles may be:
                         "collection": "11",
                         "owner": {
                             "id": "4",
+                            "display_name": "Owner 4",
                             "type": "user_groups",
                             "href"=>"user_groups/4"
                         }
@@ -4925,6 +4937,7 @@ CollectionRoles are returned as an array under *collection_roles*.
                         "collection": "11",
                         "owner": {
                             "id": "4",
+                            "display_name": "Owner 4",
                             "type": "user_groups",
                             "href"=>"user_groups/4"
                         }
@@ -4938,6 +4951,7 @@ CollectionRoles are returned as an array under *collection_roles*.
                         "collection": "81",
                         "owner": {
                             "id": "1",
+                            "display_name": "Owner 1",
                             "type": "users",
                             "href"=>"users/1"
                         }

--- a/app/serializers/concerns/owner_link_serializer.rb
+++ b/app/serializers/concerns/owner_link_serializer.rb
@@ -15,6 +15,7 @@ module OwnerLinkSerializer
     data = super
     model_name = @model.owner.class.model_name
     data[:links][:owner] = { id: @model.owner.id.to_s,
+                             display_name: @model.owner.display_name,
                              type: model_name.plural,
                              href: "/#{model_name.route_key}/#{@model.owner.id}" }
     data

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -29,7 +29,7 @@ describe Api::V1::CollectionsController, type: :controller do
     let(:deactivated_resource) { create(:collection, activated_state: :inactive) }
 
     it_behaves_like "is indexable"
-    it_behaves_like "it has custom owner links"
+    it_behaves_like "it has custom owner links", "display_name"
     it_behaves_like "it only lists active resources"
     it_behaves_like "filter by display_name"
     it_behaves_like 'has many filterable', :subjects

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -49,7 +49,7 @@ describe Api::V1::ProjectsController, type: :controller do
       end
 
       it_behaves_like "is indexable"
-      it_behaves_like "it has custom owner links"
+      it_behaves_like "it has custom owner links", "display_name"
       it_behaves_like "it only lists active resources"
     end
   end
@@ -66,7 +66,7 @@ describe Api::V1::ProjectsController, type: :controller do
           get :index
         end
 
-        it_behaves_like "it has custom owner links"
+        it_behaves_like "it has custom owner links", "display_name"
       end
 
       describe "params" do

--- a/spec/support/polymorphic_owner_links_serializer.rb
+++ b/spec/support/polymorphic_owner_links_serializer.rb
@@ -1,10 +1,14 @@
-shared_examples "it has custom owner links" do
+shared_examples "it has custom owner links" do |owner_attr|
   it "should have the custom owner resource links" do
     get :index
     resource_links = json_response[api_resource_name].map do |resource|
       resource["links"]["owner"].keys
     end
-    expect(resource_links.flatten.uniq).to eq %w(id type href)
+    attrs_to_test = %w(id type href)
+    if owner_attr
+      attrs_to_test << owner_attr
+    end
+    expect(resource_links.flatten.uniq).to match_array(attrs_to_test)
   end
 
   it "should have the formatted the custom owner href link" do


### PR DESCRIPTION
Fixes #1824.

Include display name when returning user as linked resource


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

