### PR TITLE
fix intermittent flipper spec failure

### DIFF
--- a/spec/lib/flipper_spec.rb
+++ b/spec/lib/flipper_spec.rb
@@ -3,15 +3,22 @@ require 'spec_helper'
 describe Flipper do
 
   describe 'feature flippin' do
-    let(:feature) { :test_feature }
+    let(:feature_name) { :test_feature }
+
+    before do
+      # Panoptes.flipper.remove(feature_name) once
+      # https://github.com/jnunemaker/flipper/pull/126 is released
+      feature = Panoptes.flipper[feature_name]
+      feature.adapter.remove(feature)
+    end
 
     it "should not be enabled by default" do
-      expect(Panoptes.flipper[feature].enabled?).to be_falsey
+      expect(Panoptes.flipper[feature_name].enabled?).to be_falsey
     end
 
     it "should enable features being turned on" do
-      Panoptes.flipper[feature].enable
-      expect(Panoptes.flipper[feature].enabled?).to be_truthy
+      Panoptes.flipper[feature_name].enable
+      expect(Panoptes.flipper[feature_name].enabled?).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Panoptes.flipper uses cached DSL instance that internally memoizes the features for re-use. DSL in master has a remove method but not released as a gem yet.

Fixes intermittent bug failures in travis.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.