### PR TITLE
do not double render in the experiement and add a user context

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -16,14 +16,15 @@ class Api::V1::WorkflowsController < Api::ApiController
     experiment_name = :eager_load_workflows
     sms_ids = CodeExperiment.run "#{experiment_name}" do |e|
       e.run_if { Panoptes.flipper[experiment_name].enabled? }
-      e.use { super }
+      e.context user: api_user
+      e.use { }
       e.try do
         @controlled_resources = @controlled_resources
           .eager_load(:subject_sets, :expert_subject_sets, :attached_images)
-        super
       end
       #skip the mismatch reporting...we just want perf metrics
       e.ignore { true }
+      super
     end
   end
 


### PR DESCRIPTION
Just call the render method once - i'm not sure exactly how this will be testable since the experiment being recorded will just be adding eager loading to the AR relation object. Though we can use this to ramp up the rate and check response times via new relic.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.