### PR TITLE
[WIP] Orphan subject removal worker 

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -13,7 +13,7 @@ class Subject < ActiveRecord::Base
   has_many :set_member_subjects, dependent: :destroy
   has_many :subject_workflow_counts, dependent: :destroy
   has_many :locations, -> { where(type: 'subject_location') },
-    class_name: "Medium", as: :linked
+    class_name: "Medium", as: :linked, dependent: :destroy
   has_many :recents, dependent: :destroy
   has_many :aggregations, dependent: :destroy
   has_many :tutorial_workflows, class_name: 'Workflow', foreign_key: 'tutorial_subject_id', dependent: :restrict_with_exception

--- a/app/workers/orphan_subject_removal_worker.rb
+++ b/app/workers/orphan_subject_removal_worker.rb
@@ -1,0 +1,19 @@
+class OrphanSubjectRemovalWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_medium
+
+  def perform
+    orphans.map(&:destroy)
+  end
+
+  private
+
+  def orphans
+    Subject
+    .joins("LEFT OUTER JOIN set_member_subjects ON set_member_subjects.subject_id = subjects.id")
+    .where("subjects.id IS NOT NULL AND set_member_subjects.id IS NULL")
+    .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
+    .where("subjects.id IS NOT NULL AND classification_subjects.subject_id IS NULL")
+  end
+end

--- a/spec/workers/orphan_subject_removal_worker_spec.rb
+++ b/spec/workers/orphan_subject_removal_worker_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe OrphanSubjectRemovalWorker do
+  let!(:orphan) { create(:subject, :with_mediums) }
+  let!(:non_orphan_ids) { create(:classification).subject_ids }
+
+  it 'should remove the orphaned subjects' do
+    orphan_id = orphan.id
+    expect { subject.perform }.to change { Subject.count }.by(-1)
+    expect { Subject.find(orphan_id) }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it 'should remove the orphaned subjects media resources' do
+    medium_ids = orphan.locations.map(&:id)
+    subject.perform
+    expect(Medium.where(id: medium_ids).count).to eq(0)
+  end
+
+  it 'should leave the non-orphan subject in place' do
+    subject.perform
+    expect { Subject.find(non_orphan_ids) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Create a background worker to cleanup orphaned subjects.. I've defined an orphan here as one without any classifications and is not linked to a subject set. I couldn't think of a case where a subject could be collected / talked about without a classification but if we can then i'll add something in for these. 

Note: I've cascaded the destroy from subject -> subject media resources too. Happy to remove this if need be.

@parrish thoughts on how a subject can be talked about without any classifications (URL hacking) and not be in a subject set?

TODO:
- [ ] Add talk api client with auth to determine if there are any discussions on an orphaned subject from URL hacking without classifications (https://github.com/zooniverse/panoptes-client.rb/pull/4)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
