### PR TITLE
feature flag testing of inband subject selection

### DIFF
--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -262,29 +262,15 @@ RSpec.describe Subjects::Selector do
       expect(subject.selected_subjects(subject_queue).size).to be > 0
     end
 
-    context "testing straight selection over queues" do
-      let(:config) do
-        CodeExperimentConfig.create!(
-          name: 'skip_queue_selection',
-          enabled_rate: 0.0,
-          always_enabled_for_admins: true
-        )
-      end
-
-      before do
-        allow(CodeExperiment.reporter).to receive(:publish)
-        allow(user).to receive(:is_admin?).and_return(true)
-        config
-      end
-
-      it 'should not run the experiment' do
+    context "feature flip straight selection over queues" do
+      it 'should use queue selection when feature is off' do
+        expect(subject).to receive(:sms_ids_from_queue).and_call_original
         subject.selected_subjects(subject_queue)
-        expect(subject).not_to receive(:run_strategy_selection)
       end
 
-      it 'should run the experiment when feature is on' do
+      it 'should skip queue selection when feature is on' do
         Panoptes.flipper[:skip_queue_selection].enable
-        expect(subject).to receive(:run_strategy_selection)
+        expect(subject).to receive(:run_strategy_selection).and_call_original
         subject.selected_subjects(subject_queue)
       end
     end


### PR DESCRIPTION
Use feature flags for testing inband selection during a media event. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

