### PR TITLE
All non-standard tasks should pass unaltered annotations

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -22,10 +22,8 @@ module Formatter
           combo
         when "dropdown"
           dropdown
-        when "survey"
-          @annotation
         else
-         { error: "task cannot be exported" }
+          @annotation
         end
       end
 


### PR DESCRIPTION
Tasks are more varied than I thought. If the task isn't of a recognized type, instead of yielding an error, it will just pass the unaltered annotation through. Surveys now fall into this category, as well as whatever Old Weather uses. This was the previous behavior and I figured it was better to be specific, but turns out there's more out there than I thought. 

The exception is if an unsupported task (i.e. *not* drawing/single/multiple/text/dropdown) is inside of a combo task, it will still yield a "task cannot be exported" for the annotation.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

