### PR TITLE
begin/rescue and spec

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -135,8 +135,12 @@ module Formatter
 
       def answer_labels
         Array.wrap(@current["value"]).map do |answer_idx|
-          answer_string = workflow_at_version.tasks[@current['task']]['answers'][answer_idx]['label']
-          translate(answer_string)
+          begin
+            answer_string = workflow_at_version.tasks[@current['task']]['answers'][answer_idx]['label']
+            translate(answer_string)
+          rescue TypeError
+            "unknown answer label"
+          end
         end
       end
 

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -60,10 +60,15 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         contents.update(strings: strings)
       end
 
-      context "with a single question workflow annotation" do
-        let(:annotation) { { task: "init", value: 1 } }
+      it 'notes in the value if the annotation is invalid' do
+        annotation = {"task" => "init", "value" => "YES" }
+        formatted = described_class.new(classification, annotation, cache).to_h
+        expect(formatted["value"]).to eq("unknown answer label")
+      end
 
+      context "with a single question workflow annotation" do
         it 'should add the correct answer label' do
+          annotation = {"task" => "init", "value" => 1 }
           formatted = described_class.new(classification, annotation, cache).to_h
           expect(formatted["value"]).to eq("No")
         end


### PR DESCRIPTION
Dump worker was throwing an error when Supernovae Hunters was exported. Error was caused by gold standard data uploaded with incorrect values ("Yes" vs 1). Annotation exporter now catches the TypeError and replaces replaces the untranslatable value with an error string.

These particular specs could really stand to be cleaned up, too. I got most of the way there but got stumped on the versioning-related specs failing simply by being moved. Will revisit.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

