### PR TITLE
Build from official ruby image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,10 @@
-FROM zooniverse/ruby:2.3.0
+FROM ruby:2.3
 
 WORKDIR /rails_app
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/postgresql.list && \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" > /etc/apt/sources.list.d/postgresql.list && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update && apt-get -y upgrade && \

--- a/Dockerfile.official-ruby
+++ b/Dockerfile.official-ruby
@@ -1,0 +1,23 @@
+FROM ruby:2.3
+
+WORKDIR /rails_app
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y git curl supervisor libpq-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir config && curl "https://ip-ranges.amazonaws.com/ip-ranges.json" > config/aws_ips.json
+
+ADD ./Gemfile /rails_app/
+ADD ./Gemfile.lock /rails_app/
+
+RUN bundle install --without development test
+
+ADD supervisord.conf /etc/supervisor/conf.d/panoptes.conf
+ADD ./ /rails_app
+
+RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt && rm -rf .git)
+
+EXPOSE 81
+
+ENTRYPOINT /rails_app/scripts/docker/start.sh


### PR DESCRIPTION
There's basically no point in us maintaining our own docker builds of Ruby since the official images are almost identical to ours. They're built on Debian rather than Ubuntu, but that shouldn't make any difference.

This also makes the resulting image about 100 MB larger, but that shouldn't be a problem and I think it's worth it to not have to maintain our own builds.

I've confirmed this starts as expected with `docker-compose`, but we'll want to thoroughly test this on staging too.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
