### PR TITLE
cascade delete of subject set to subject queues

### DIFF
--- a/db/migrate/20160628165038_modify_subject_set_queues_fk_constraint.rb
+++ b/db/migrate/20160628165038_modify_subject_set_queues_fk_constraint.rb
@@ -1,0 +1,6 @@
+class ModifySubjectSetQueuesFkConstraint < ActiveRecord::Migration
+  def change
+    remove_foreign_key :subject_queues, :subject_sets
+    add_foreign_key :subject_queues, :subject_sets, on_update: :cascade, on_delete: :cascade
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2930,7 +2930,7 @@ ALTER TABLE ONLY classification_subjects
 --
 
 ALTER TABLE ONLY subject_queues
-    ADD CONSTRAINT fk_rails_81596e7851 FOREIGN KEY (subject_set_id) REFERENCES subject_sets(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+    ADD CONSTRAINT fk_rails_81596e7851 FOREIGN KEY (subject_set_id) REFERENCES subject_sets(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -3438,4 +3438,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160613074924');
 INSERT INTO schema_migrations (version) VALUES ('20160613074934');
 
 INSERT INTO schema_migrations (version) VALUES ('20160613075003');
+
+INSERT INTO schema_migrations (version) VALUES ('20160628165038');
 


### PR DESCRIPTION
Delete subject queues with a subject_set_id when the subject_set is deleted.

@saschaishikawa once this is deployed you'll be able to remove subject sets for grouped workflows. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

