### PR TITLE
add project and workflow names to retirement events

### DIFF
--- a/app/workers/publish_retirement_event_worker.rb
+++ b/app/workers/publish_retirement_event_worker.rb
@@ -4,10 +4,12 @@ class PublishRetirementEventWorker
   sidekiq_options queue: :data_high
 
   def perform(workflow_id)
-    workflow = Workflow.find(workflow_id)
+    workflow = Workflow.includes(:project).find(workflow_id)
     counters = {
       project_id: workflow.project_id,
+      project_name: workflow.project.display_name,
       workflow_id: workflow.id,
+      workflow_name: workflow.display_name,
       subjects_count: workflow.subjects_count,
       retired_subjects_count: workflow.retired_subjects_count,
       classifications_count: workflow.classifications_count

--- a/spec/workers/publish_retirement_event_worker_spec.rb
+++ b/spec/workers/publish_retirement_event_worker_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe PublishRetirementEventWorker do
   let(:payload_expectation) do
     a_hash_including(
       project_id: workflow.project_id,
+      project_name: workflow.project.display_name,
       workflow_id: workflow.id,
+      workflow_name: workflow.display_name,
       subjects_count: workflow.subjects_count,
       retired_subjects_count: workflow.retired_subjects_count,
       classifications_count: workflow.classifications_count


### PR DESCRIPTION
Add human readable names for published events. Classification stream has these by default from the serializer.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

for use in stats streams