### PR TITLE
Doorkeeper access tokens can be JWT tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # Ignore all config files
 /config/*.yml
 /config/aws_ips.json
+/config/doorkeeper-jwt.*
 
 .vagrant/
 *.swp

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,16 @@ gem 'postgres_ext', '~> 2.4.0'
 gem 'active_record_union', '~> 1.1.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'doorkeeper', '~> 3.0'
+gem 'doorkeeper-jwt', '~> 0.1.6'
 gem 'devise', '~> 3.0'
 gem 'versionist', '~> 1.0'
 gem 'rack-cors', '~> 0.3', require: 'rack/cors'
 gem 'restpack_serializer', github: "edpaget/restpack_serializer", branch: "dev" # REST API
 gem 'active_model_serializers', '0.10.0.rc2' # Event stream
 gem 'paper_trail', '~> 3.0'
+# Needed because version 1.1.0 locks JWT at an older version than doorkeeper-jwt requires.
+# Not a lot of commits between 1.1.0 and this ref. Remove this once the next version is released.
+gem 'oauth2', github: 'intridea/oauth2', ref: 'e0006cb5099bf392f011eb5c49cbec4f893bbdba'
 gem 'omniauth', '~> 1.0'
 gem 'omniauth-facebook', '~> 3.0'
 gem 'omniauth-gplus', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,18 @@ GIT
       activesupport (>= 4.0.3, < 5.0)
       kaminari (~> 0.16.1)
 
+GIT
+  remote: git://github.com/intridea/oauth2.git
+  revision: e0006cb5099bf392f011eb5c49cbec4f893bbdba
+  ref: e0006cb5099bf392f011eb5c49cbec4f893bbdba
+  specs:
+    oauth2 (1.1.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -116,6 +128,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (3.1.0)
       railties (>= 3.2)
+    doorkeeper-jwt (0.1.6)
+      jwt (~> 1.5.2, >= 1.5.2)
     erubis (2.7.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
@@ -182,7 +196,7 @@ GEM
     json (1.8.3)
     json-schema (2.6.1)
       addressable (~> 2.3.8)
-    jwt (1.5.1)
+    jwt (1.5.4)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -223,12 +237,6 @@ GEM
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oauth2 (1.1.0)
-      faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0, < 1.5.2)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
@@ -418,6 +426,7 @@ DEPENDENCIES
   database_cleaner (~> 1.3.0)
   devise (~> 3.0)
   doorkeeper (~> 3.0)
+  doorkeeper-jwt (~> 0.1.6)
   factory_girl_rails
   faraday (~> 0.9)
   faraday-http-cache (~> 1.0)
@@ -434,6 +443,7 @@ DEPENDENCIES
   librato-metrics (~> 1.6.1)
   logstasher (~> 0.6)
   newrelic_rpm (~> 3.0)
+  oauth2!
   omniauth (~> 1.0)
   omniauth-facebook (~> 3.0)
   omniauth-gplus (~> 2.0)
@@ -468,4 +478,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0.1)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -59,8 +59,13 @@ Doorkeeper::JWT.configure do
         scope: opts[:scopes].to_a,
         admin: user.is_admin?
       },
-      # allows consumers to check expiry
-      exp: Time.now.to_i + opts[:expires_in]
+      exp: Time.now.to_i + opts[:expires_in],
+
+      # RNG is not an official JWT claim.
+      # Needed so that JWT token is unique even when making multiple requests at the same time.
+      # Shorter than using the standard 'jti' claim with a UUID in it (saves about 40 chars in
+      # the resulting Base64-string).
+      rng: SecureRandom.hex(2)
     }
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -55,9 +55,9 @@ Doorkeeper::JWT.configure do
       user: {
         id: user.id,
         login: user.login,
-        display_name: user.display_name,
-        is_admin: user.is_admin?
-      }
+        dname: user.display_name,
+        admin: user.is_admin?
+      },
     }
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -52,7 +52,7 @@ Doorkeeper::JWT.configure do
     user = User.find(opts[:resource_owner_id])
 
     {
-      user: {
+      data: {
         id: user.id,
         login: user.login,
         dname: user.display_name,

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -59,6 +59,8 @@ Doorkeeper::JWT.configure do
         scope: opts[:scopes].to_a,
         admin: user.is_admin?
       },
+      # allows consumers to check expiry
+      exp: Time.now.to_i + opts[:expires_in]
     }
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -56,6 +56,7 @@ Doorkeeper::JWT.configure do
         id: user.id,
         login: user.login,
         dname: user.display_name,
+        scope: opts[:scopes].to_a,
         admin: user.is_admin?
       },
     }

--- a/db/migrate/20160630150419_enlarge_access_token_column.rb
+++ b/db/migrate/20160630150419_enlarge_access_token_column.rb
@@ -1,0 +1,5 @@
+class EnlargeAccessTokenColumn < ActiveRecord::Migration
+  def change
+    change_column :oauth_access_tokens, :token, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -528,7 +528,7 @@ CREATE TABLE oauth_access_tokens (
     id integer NOT NULL,
     resource_owner_id integer,
     application_id integer,
-    token character varying NOT NULL,
+    token text NOT NULL,
     refresh_token character varying,
     expires_in integer,
     revoked_at timestamp without time zone,
@@ -3440,4 +3440,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160613074934');
 INSERT INTO schema_migrations (version) VALUES ('20160613075003');
 
 INSERT INTO schema_migrations (version) VALUES ('20160628165038');
+
+INSERT INTO schema_migrations (version) VALUES ('20160630150419');
 

--- a/lib/tasks/configure.rake
+++ b/lib/tasks/configure.rake
@@ -8,6 +8,11 @@ namespace :configure do
       new_name = file[0..-8]
       sh "cp #{file} #{new_name}"
     end
+
+    rsa_private = OpenSSL::PKey::RSA.generate 4096
+    rsa_public = rsa_private.public_key
+    File.open('config/doorkeeper-jwt.pem', 'w') { |f| f.puts rsa_private.to_s }
+    File.open('config/doorkeeper-jwt.pub', 'w') { |f| f.puts rsa_public.to_s }
   end
 
   task travis: :local do

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -42,7 +42,11 @@ module APIRequestHelpers
   end
 
   def stub_token(scopes: [], user_id: nil)
-    allow(controller).to receive(:doorkeeper_token).and_return(token(scopes, user_id))
+    if user_id
+      allow(controller).to receive(:doorkeeper_token).and_return(token(scopes, user_id))
+    else
+      allow(controller).to receive(:doorkeeper_token).and_return(nil)
+    end
   end
 
   def token(scopes, user_id)


### PR DESCRIPTION
This allows auxiliary services (Nero, EducationAPI, ZooEventStats, ...) to independently verify the validity of OAuth tokens sent to them by clients. Right now they have to make an API call to Panoptes to verify any tokens given to them (`GET /api/me`).

Currently issued tokens will expire at some point (a few hours) and get replaced with JWT-based ones.

