### PR TITLE
Deactivate subjects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'scientist', '~> 1.0.0'
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'
+gem 'panoptes-client', github: "zooniverse/panoptes-client.rb"
 
 group :production do
   gem 'newrelic_rpm', '~> 3.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'scientist', '~> 1.0.0'
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'
-gem 'panoptes-client', github: "zooniverse/panoptes-client.rb"
+gem 'panoptes-client'
 
 group :production do
   gem 'newrelic_rpm', '~> 3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,14 +20,6 @@ GIT
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
 
-GIT
-  remote: git://github.com/zooniverse/panoptes-client.rb.git
-  revision: 6ce3964660857702e6cd9d9f98ca4cefbe95e709
-  specs:
-    panoptes-client (0.2.6)
-      faraday
-      faraday-panoptes (~> 0.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -264,6 +256,9 @@ GEM
     orm_adapter (0.5.0)
     p3p (1.2.0)
       rack
+    panoptes-client (0.2.7)
+      faraday
+      faraday-panoptes (~> 0.2.0)
     paper_trail (3.0.9)
       activerecord (>= 3.0, < 5.0)
       activesupport (>= 3.0, < 5.0)
@@ -462,7 +457,7 @@ DEPENDENCIES
   omniauth-facebook (~> 3.0)
   omniauth-google-oauth2
   p3p (~> 1.0)
-  panoptes-client!
+  panoptes-client
   paper_trail (~> 3.0)
   pg (~> 0.18)
   pg_search

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,14 @@ GIT
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
 
+GIT
+  remote: git://github.com/zooniverse/panoptes-client.rb.git
+  revision: 6ce3964660857702e6cd9d9f98ca4cefbe95e709
+  specs:
+    panoptes-client (0.2.6)
+      faraday
+      faraday-panoptes (~> 0.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -141,6 +149,9 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.2.2)
       faraday (~> 0.8)
+    faraday-panoptes (0.2.0)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.10)
@@ -451,6 +462,7 @@ DEPENDENCIES
   omniauth-facebook (~> 3.0)
   omniauth-google-oauth2
   p3p (~> 1.0)
+  panoptes-client!
   paper_trail (~> 3.0)
   pg (~> 0.18)
   pg_search

--- a/app/controllers/api/v1/set_member_subjects_controller.rb
+++ b/app/controllers/api/v1/set_member_subjects_controller.rb
@@ -5,4 +5,26 @@ class Api::V1::SetMemberSubjectsController < Api::ApiController
 
   allowed_params :create, :priority, links: [:subject, :subject_set, retired_workflows: []]
   allowed_params :update, :priority, links: [retired_workflows: []]
+
+  def create
+    super do |set_member_subject|
+      update_set_counts(set_member_subject.subject_set_id)
+    end
+  end
+
+  def destroy
+    resource_class.transaction(requires_new: true) do
+      set_id = controlled_resource.subject_set_id
+      subject_id = controlled_resource.subject_id
+      super
+      update_set_counts(set_id)
+      SubjectRemovalWorker.perform_async(subject_id)
+    end
+  end
+
+  private
+
+  def update_set_counts(set_id)
+    SubjectSetSubjectCounterWorker.perform_async(set_id)
+  end
 end

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::SubjectsController < Api::ApiController
 
   require_authentication :update, :create, :destroy, :version, :versions,
     scopes: [:subject]
-  resource_actions :default
+  resource_actions :show, :index, :create, :update, :deactivate
   schema_type :json_schema
 
   alias_method :subject, :controlled_resource

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -20,6 +20,10 @@ class Api::V1::SubjectsController < Api::ApiController
     end
   end
 
+  def destroy
+    super { |subject| SubjectRemovalWorker.perform_async(subject.id) }
+  end
+
   private
 
   def check_subject_limit

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -18,12 +18,9 @@ class SetMemberSubject < ActiveRecord::Base
   can_through_parent :subject_set, :update, :show, :destroy, :index, :update_links,
     :destroy_links
 
-  before_create :set_random
-
   can_be_linked :subject_queue, :in_queue_workflow, :model
 
-  after_create :update_counter
-  before_destroy :update_counter
+  before_create :set_random
 
   def self.in_queue_workflow(queue)
     query = joins(subject_set: :workflows)
@@ -91,9 +88,5 @@ class SetMemberSubject < ActiveRecord::Base
 
   def set_random
     self.random = rand
-  end
-
-  def update_counter
-    SubjectSetSubjectCounterWorker.perform_in(3.minutes, subject_set_id)
   end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -13,6 +13,7 @@ class Subject < ActiveRecord::Base
   has_many :collections, through: :collections_subjects
   has_many :subject_sets, through: :set_member_subjects
   has_many :set_member_subjects, dependent: :destroy
+  has_many :workflows, through: :set_member_subjects
   has_many :subject_workflow_counts, dependent: :restrict_with_exception
   has_many :locations, -> { where(type: 'subject_location') },
     class_name: "Medium", as: :linked

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,6 +1,8 @@
 class Subject < ActiveRecord::Base
   include RoleControl::ParentalControlled
   include Linkable
+  include Activatable
+
   default_scope { eager_load(:locations) }
 
   has_paper_trail only: [:metadata, :locations]

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -13,7 +13,7 @@ class Subject < ActiveRecord::Base
   has_many :collections, through: :collections_subjects
   has_many :subject_sets, through: :set_member_subjects
   has_many :set_member_subjects, dependent: :destroy
-  has_many :subject_workflow_counts, dependent: :destroy
+  has_many :subject_workflow_counts, dependent: :restrict_with_exception
   has_many :locations, -> { where(type: 'subject_location') },
     class_name: "Medium", as: :linked
   has_many :recents, dependent: :destroy

--- a/app/workers/subject_removal_worker.rb
+++ b/app/workers/subject_removal_worker.rb
@@ -1,0 +1,12 @@
+require 'subjects/remover'
+
+class SubjectRemovalWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_medium
+
+  def perform(subject_id)
+    Subjects::Remover.new(subject_id).cleanup
+  rescue Subjects::Remover::NonOrphan
+  end
+end

--- a/app/workers/subject_removal_worker.rb
+++ b/app/workers/subject_removal_worker.rb
@@ -7,6 +7,5 @@ class SubjectRemovalWorker
 
   def perform(subject_id)
     Subjects::Remover.new(subject_id).cleanup
-  rescue Subjects::Remover::NonOrphan
   end
 end

--- a/db/migrate/20160630170502_add_subjects_activated_state.rb
+++ b/db/migrate/20160630170502_add_subjects_activated_state.rb
@@ -1,0 +1,5 @@
+class AddSubjectsActivatedState < ActiveRecord::Migration
+  def change
+    add_column :subjects, :activated_state, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -949,7 +949,8 @@ CREATE TABLE subjects (
     project_id integer,
     migrated boolean,
     lock_version integer DEFAULT 0,
-    upload_user_id integer
+    upload_user_id integer,
+    activated_state integer DEFAULT 0 NOT NULL
 );
 
 
@@ -1401,8 +1402,7 @@ CREATE TABLE workflows (
     completeness double precision DEFAULT 0.0 NOT NULL,
     activity integer DEFAULT 0 NOT NULL,
     current_version_number character varying,
-    activated_state integer DEFAULT 0 NOT NULL,
-    use_cellect boolean DEFAULT false NOT NULL
+    activated_state integer DEFAULT 0 NOT NULL
 );
 
 
@@ -2723,13 +2723,6 @@ CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tu
 
 
 --
--- Name: index_workflows_on_use_cellect; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_workflows_on_use_cellect ON workflows USING btree (use_cellect);
-
-
---
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3450,6 +3443,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160613075003');
 INSERT INTO schema_migrations (version) VALUES ('20160628165038');
 
 INSERT INTO schema_migrations (version) VALUES ('20160630150419');
+
+INSERT INTO schema_migrations (version) VALUES ('20160630170502');
 
 INSERT INTO schema_migrations (version) VALUES ('20160810140805');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1402,7 +1402,8 @@ CREATE TABLE workflows (
     completeness double precision DEFAULT 0.0 NOT NULL,
     activity integer DEFAULT 0 NOT NULL,
     current_version_number character varying,
-    activated_state integer DEFAULT 0 NOT NULL
+    activated_state integer DEFAULT 0 NOT NULL,
+    use_cellect boolean DEFAULT false NOT NULL
 );
 
 
@@ -2720,6 +2721,13 @@ CREATE INDEX index_workflows_on_public_gold_standard ON workflows USING btree (p
 --
 
 CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tutorial_subject_id);
+
+
+--
+-- Name: index_workflows_on_use_cellect; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_workflows_on_use_cellect ON workflows USING btree (use_cellect);
 
 
 --

--- a/lib/json_api_controller/deactivatable_resource.rb
+++ b/lib/json_api_controller/deactivatable_resource.rb
@@ -10,6 +10,11 @@ module JsonApiController
 
     def destroy
       Activation.disable_instances!(to_disable)
+
+      to_disable.each do |resource|
+        yield resource if block_given?
+      end
+
       deleted_resource_response
     end
 

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -12,11 +12,13 @@ module Subjects
       if can_be_removed?
         locations = orphan.locations
         set_member_subjects = orphan.set_member_subjects
+        workflow_ids = orphan.workflows.map(&:id)
         ActiveRecord::Base.transaction do
           orphan.delete
           locations.map(&:destroy)
           set_member_subjects.map(&:destroy)
         end
+        notify_cellect(workflow_ids)
       else
         raise_non_orphan_error
       end
@@ -49,6 +51,12 @@ module Subjects
 
     def talk_client
       @client ||= Panoptes::TalkClient.new(url: ENV["TALK_URL"])
+    end
+
+    def notify_cellect(workflow_ids)
+      workflow_ids.each do |workflow_id|
+        RetireCellectWorker.perform_async(orphan.id, workflow_id)
+      end
     end
   end
 end

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -1,7 +1,5 @@
 module Subjects
   class Remover
-    class NonOrphan < StandardError; end
-
     attr_reader :subject_id
 
     def initialize(subject_id)
@@ -19,8 +17,9 @@ module Subjects
           set_member_subjects.map(&:destroy)
         end
         notify_cellect(workflow_ids)
+        true
       else
-        raise_non_orphan_error
+        false
       end
     end
 
@@ -39,10 +38,6 @@ module Subjects
        .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
        .where("collections_subjects.subject_id IS NULL")
        .first
-    end
-
-    def raise_non_orphan_error
-      raise NonOrphan, "Subject with id: #{subject_id} has linked data and cannot be removed."
     end
 
     def no_talk_discussions?

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -35,9 +35,9 @@ module Subjects
        Subject
        .where(id: subject_id)
        .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
-       .where("subjects.id IS NOT NULL AND classification_subjects.subject_id IS NULL")
+       .where("classification_subjects.subject_id IS NULL")
        .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
-       .where("subjects.id IS NOT NULL AND collections_subjects.subject_id IS NULL")
+       .where("collections_subjects.subject_id IS NULL")
        .first
     end
 

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -25,7 +25,7 @@ module Subjects
     private
 
     def can_be_removed?
-      !!orphan
+      !!orphan && no_talk_discussions?
     end
 
     def orphan
@@ -41,6 +41,21 @@ module Subjects
 
     def raise_non_orphan_error
       raise NonOrphan, "Subject with id: #{subject_id} has linked data and cannot be removed."
+    end
+
+    def no_talk_discussions?
+      talk_client.discussions(focus_id: subject_id, focus_type: 'Subject').empty?
+    end
+
+    def talk_client
+      @client ||= Panoptes::TalkClient.new(
+        url: ENV["TALK_URL"],
+        auth_url: ENV["TALK_AUTH_URL"],
+        auth: {
+          client_id: ENV["TALK_CLIENT_ID"],
+          client_secret: ENV["TALK_CLIENT_SECRET"]
+        }
+      )
     end
   end
 end

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -48,14 +48,7 @@ module Subjects
     end
 
     def talk_client
-      @client ||= Panoptes::TalkClient.new(
-        url: ENV["TALK_URL"],
-        auth_url: ENV["TALK_AUTH_URL"],
-        auth: {
-          client_id: ENV["TALK_CLIENT_ID"],
-          client_secret: ENV["TALK_CLIENT_SECRET"]
-        }
-      )
+      @client ||= Panoptes::TalkClient.new(url: ENV["TALK_URL"])
     end
   end
 end

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -12,7 +12,7 @@ module Subjects
       if can_be_removed?
         locations = orphan.locations
         set_member_subjects = orphan.set_member_subjects
-        workflow_ids = orphan.workflows.map(&:id)
+        workflow_ids = orphan.workflows.pluck(:id)
         ActiveRecord::Base.transaction do
           orphan.delete
           locations.map(&:destroy)

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -1,0 +1,46 @@
+module Subjects
+  class Remover
+    class NonOrphan < StandardError; end
+
+    attr_reader :subject_id
+
+    def initialize(subject_id)
+      @subject_id = subject_id
+    end
+
+    def cleanup
+      if can_be_removed?
+        locations = orphan.locations
+        set_member_subjects = orphan.set_member_subjects
+        ActiveRecord::Base.transaction do
+          orphan.delete
+          locations.map(&:destroy)
+          set_member_subjects.map(&:destroy)
+        end
+      else
+        raise_non_orphan_error
+      end
+    end
+
+    private
+
+    def can_be_removed?
+      !!orphan
+    end
+
+    def orphan
+     @orphan ||=
+       Subject
+       .where(id: subject_id)
+       .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
+       .where("subjects.id IS NOT NULL AND classification_subjects.subject_id IS NULL")
+       .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
+       .where("subjects.id IS NOT NULL AND collections_subjects.subject_id IS NULL")
+       .first
+    end
+
+    def raise_non_orphan_error
+      raise NonOrphan, "Subject with id: #{subject_id} has linked data and cannot be removed."
+    end
+  end
+end

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -32,15 +32,17 @@ module Subjects
       if sms_ids.blank?
         sms_ids = fallback_selection
       end
-      subjects_in_selection_order(sms_ids)
+      active_subjects_in_selection_order(sms_ids)
     end
 
     private
 
-    def subjects_in_selection_order(sms_ids)
-      @scope.eager_load(:set_member_subjects)
-        .where(set_member_subjects: {id: sms_ids})
-        .order("idx(array[#{sms_ids.join(',')}], set_member_subjects.id)")
+    def active_subjects_in_selection_order(sms_ids)
+      @scope
+      .active
+      .eager_load(:set_member_subjects)
+      .where(set_member_subjects: {id: sms_ids})
+      .order("idx(array[#{sms_ids.join(',')}], set_member_subjects.id)")
     end
 
     def sms_ids_from_queue(queue)

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 shared_examples "cleans up the linked set member subjects" do
-
   it 'should remove the linked set_member_subjects' do
     delete_resources
     expect(SetMemberSubject.where(id: linked_sms_ids)).to be_empty
@@ -349,6 +348,15 @@ describe Api::V1::SubjectSetsController, type: :controller do
         result = SubjectSetsWorkflow.where(id: linked_subject_sets_workflows_ids)
         expect(result).to be_empty
       end
+    end
+
+    it 'should call the subject removal worker' do
+      subject_set.subjects.each do |s|
+        expect(SubjectRemovalWorker)
+          .to receive(:perform_async)
+          .with(s.id)
+      end
+      delete_resources
     end
   end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -499,6 +499,13 @@ describe Api::V1::SubjectsController, type: :controller do
     let(:instances_to_disable) { [resource] }
 
     it_behaves_like "is deactivatable"
+
+    it "should background a job to cleanup orphan subjects" do
+      stub_token(scopes: scopes, user_id: authorized_user.id)
+      set_preconditions
+      expect(SubjectRemovalWorker).to receive(:perform_async).with(resource.id)
+      delete :destroy, id: resource.id
+    end
   end
 
   describe "versioning" do

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -496,8 +496,9 @@ describe Api::V1::SubjectsController, type: :controller do
 
   describe "#destroy" do
     let(:resource) { create(:subject, project: create(:project, owner: user)) }
+    let(:instances_to_disable) { [resource] }
 
-    it_behaves_like "is destructable"
+    it_behaves_like "is deactivatable"
   end
 
   describe "versioning" do

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Subjects::Remover do
   let(:discussions) { [] }
 
   describe "#cleanup" do
-
     before do
       allow(talk_client)
         .to receive(:discussions)
@@ -25,25 +24,25 @@ RSpec.describe Subjects::Remover do
       let(:subject) { double(id: 100) }
 
       it "should ignore non existant subject ids" do
-        expect { remover.cleanup }.to raise_error(Subjects::Remover::NonOrphan)
+        expect(remover.cleanup).to be_falsey
       end
     end
 
     it "should not remove a subject that has been classified" do
       create(:classification, subjects: [subject])
-      expect { remover.cleanup }.to raise_error(Subjects::Remover::NonOrphan)
+      expect(remover.cleanup).to be_falsey
     end
 
     it "should not remove a subject that has been collected" do
       create(:collection, subjects: [subject])
-      expect { remover.cleanup }.to raise_error(Subjects::Remover::NonOrphan)
+      expect(remover.cleanup).to be_falsey
     end
 
     context "with a talk discussions" do
       let(:discussions) { [{"dummy" => "discussion"}] }
 
       it "should not remove a subject that has been in a talk discussion" do
-        expect { remover.cleanup }.to raise_error(Subjects::Remover::NonOrphan)
+        expect(remover.cleanup).to be_falsey
       end
     end
 

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Subjects::Remover do
+  let(:workflow) { create(:workflow_with_subjects) }
+  let(:user) { create(:user) }
+  let(:subject_set) { create(:subject_set_with_subjects) }
+  let(:subjects) { subject_set.subjects }
+  let(:subject) { subjects.sample }
+  let(:remover) { Subjects::Remover.new(subject.id) }
+
+  describe "::remove" do
+
+    it "should not remove a subject that has been classified" do
+      create(:classification, subjects: [subject])
+      expect { remover.cleanup }.to raise_error(Subjects::Remover::NonOrphan)
+    end
+
+    it "should not remove a subject that has been collected" do
+      create(:collection, subjects: [subject])
+      expect { remover.cleanup }.to raise_error(Subjects::Remover::NonOrphan)
+    end
+
+    it "should not remove a subject that has been in a talk discussion", :focus do
+      pending "add the talk api client discussion check here"
+    end
+
+    it "should remove a subject that has not been used" do
+      remover.cleanup
+      expect { Subject.find(subject.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "should remove the associated set_member_subjects" do
+      sms_ids = subject.set_member_subjects.map(&:id)
+      remover.cleanup
+      expect { SetMemberSubject.find(sms_ids) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "should remove the associated media resources" do
+      locations = subjects.map { |s| create(:medium, linked: s) }
+      media_ids = subject.reload.locations.map(&:id)
+      remover.cleanup
+      expect { Medium.find(media_ids) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -277,6 +277,13 @@ RSpec.describe Subjects::Selector do
       end
     end
 
+    it 'should not return deactivated subjects' do
+      deactivated_ids = smses[0..smses.length-2].map(&:subject_id)
+      Subject.where(id: deactivated_ids).update_all(activated_state: 1)
+      result = subject.selected_subjects(subject_queue).map(&:id)
+      expect(result).not_to include(*deactivated_ids)
+    end
+
     it 'should return something when everything in the queue is retired' do
       smses.each do |sms|
         swc = create(:subject_workflow_count, subject: sms.subject, workflow: workflow, retired_at: Time.zone.now)

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -63,10 +63,18 @@ describe Subject, :type => :model do
   end
 
   describe "#set_member_subjects" do
-    let(:set_member_subjects) { create(:subject, :with_subject_sets) }
+    let(:subject) { create(:subject, :with_subject_sets) }
 
     it "should have many set_member subjects" do
       expect(subject.set_member_subjects).to all( be_a(SetMemberSubject) )
+    end
+  end
+
+  describe "#workflows" do
+    let(:subject) { create(:subject, :with_subject_sets) }
+
+    it "should have many set_member subjects" do
+      expect(subject.workflows).to all( be_a(Workflow) )
     end
   end
 

--- a/spec/workers/subject_removal_worker_spec.rb
+++ b/spec/workers/subject_removal_worker_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe SubjectRemovalWorker do
+  let(:subject_id) { 1 }
+
+  it 'should call the orphan remover cleanup' do
+    remover = instance_double(Subjects::Remover)
+    expect(Subjects::Remover).to receive(:new).with(subject_id).and_return(remover)
+    expect(remover).to receive(:cleanup)
+    subject.perform(subject_id)
+  end
+end


### PR DESCRIPTION
closes #1193

Don't delete subjects via the API. Mark them as deleted and process the actual deletion in the background so we can check if they are in use / have classifications, etc. 

TODO
- [x] Tie into #1833 for removal OR actually kick off a proper deletion worker that the orphans worker can use as well.
- [x] Look at cellect remove notification (if the workflow is using cellect).
- [x] Ensure that the talk discussions don't need admin access via the client.
- [x] Release new panoptes client gem and use this gem version.
- [x] Update apiary docs showing the workflow_id can be used to filter the subjects end point.
- [x] Wire up to subject_set removal (and sms removal) or look at a timed job to cleanup all orphans.

Talk discussions are public by default but the actual subject data is private so we won't be leaking info and don't need to issue admin calls for the talk client. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
