### PR TITLE
Workflow is finished when there are no unseens

### DIFF
--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -52,39 +52,13 @@ class SetMemberSubject < ActiveRecord::Base
   end
 
   def self.seen_for_user_by_workflow(user, workflow)
-    CodeExperiment.run "seen_by_classifications_table" do |e|
-      e.use do
-        seen_subjects = for_user_by_workflow_scope(user, workflow)
-        by_workflow(workflow).where(seen_subjects.exists)
-      end
-
-      e.try do
-        seen_subjects = UserSeenSubject.seen_for_user_by_workflow(user, workflow)
-        by_workflow(workflow).where(subject_id: seen_subjects)
-      end
-
-      e.compare do |control, candidate|
-        control.pluck(:id).sort == candidate.pluck(:id).sort
-      end
-    end
+    seen_subjects = for_user_by_workflow_scope(user, workflow)
+    by_workflow(workflow).where(seen_subjects.exists)
   end
 
   def self.unseen_for_user_by_workflow(user, workflow)
-    CodeExperiment.run "unseen_by_classifications_table" do |e|
-      e.use do
-        seen_subjects = for_user_by_workflow_scope(user, workflow)
-        by_workflow(workflow).where(seen_subjects.exists.not)
-      end
-
-      e.try do
-        seen_subjects = UserSeenSubject.seen_for_user_by_workflow(user, workflow)
-        by_workflow(workflow).where.not(subject_id: seen_subjects)
-      end
-
-      e.compare do |control, candidate|
-        control.pluck(:id).sort == candidate.pluck(:id).sort
-      end
-    end
+    seen_subjects = UserSeenSubject.seen_for_user_by_workflow(user, workflow)
+    by_workflow(workflow).where.not(subject_id: seen_subjects)
   end
 
   def self.for_user_by_workflow_scope(user, workflow)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -215,10 +215,23 @@ class User < ActiveRecord::Base
   end
 
   def has_finished?(workflow)
-    current_seen_count = SetMemberSubject
-      .seen_for_user_by_workflow(self, workflow)
-      .count
-    !!(current_seen_count >= workflow.subjects_count)
+    CodeExperiment.run "has_finished_by_unseen" do |e|
+      e.use do
+        current_seen_count = SetMemberSubject
+          .seen_for_user_by_workflow(self, workflow)
+          .count
+        !!(current_seen_count >= workflow.subjects_count)
+      end
+
+      e.try do
+        SetMemberSubject.unseen_for_user_by_workflow(self, workflow).empty?
+      end
+
+      e.compare do |control, candidate|
+        control == candidate
+      end
+    end
+
   end
 
   def valid_sha1_password?(plain_password)


### PR DESCRIPTION
Rather than having both a `seen` and an `unseen`, we can consolidate and say that you've finished a workflow if we can't find any unseen subjects.

I'm removing the experiments from SetMemberSubject so that we don't have nested experiments running.

I'm choosing the candidate for `unseen_for_user_by_workflow`, but the control for `seen_for_user_by_workflow`. Candidate in that case seemed much slower hence this alternate approach.