### PR TITLE
respect limits on small available counts

### DIFF
--- a/lib/subjects/postgresql_random_selection.rb
+++ b/lib/subjects/postgresql_random_selection.rb
@@ -43,7 +43,11 @@ module Subjects
 
     def limit_window
       half_available_count = (available_count * 0.5).ceil
-      (half_available_count..available_count).clamp(limit)
+      if half_available_count < limit
+        limit
+      else
+        half_available_count
+      end
     end
 
     def reassign_random?

--- a/spec/lib/subjects/postgresql_random_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_random_selection_spec.rb
@@ -2,12 +2,15 @@ require 'spec_helper'
 
 RSpec.describe Subjects::PostgresqlRandomSelection do
   let(:available) { SetMemberSubject.all }
-  subject { Subjects::PostgresqlRandomSelection.new(available, 10) }
+  let(:limit) { 10 }
+  let(:available_count) { 25 }
+  subject { Subjects::PostgresqlRandomSelection.new(available, limit) }
 
   before do
     uploader = create(:user)
     created_workflow = create(:workflow_with_subject_sets)
-    create_list(:subject, 25, project: created_workflow.project, uploader: uploader).each do |subject|
+    subjects = create_list(:subject, available_count, project: created_workflow.project, uploader: uploader)
+    subjects.each do |subject|
       create(:set_member_subject, subject: subject, subject_set: created_workflow.subject_sets.first)
     end
   end
@@ -25,6 +28,27 @@ RSpec.describe Subjects::PostgresqlRandomSelection do
       allow_any_instance_of(subject.class).to receive(:limit).and_return(unreachable_limit)
       results = subject.select
       expect(results).to eq(results)
+    end
+
+    describe "selection limits" do
+
+      context "larger than half available count" do
+        let(:limit) { 20 }
+
+        it 'should return limit size' do
+          results = subject.select
+          expect(results.length).to eq(limit)
+        end
+      end
+
+      context "smaller than half available count" do
+        let(:limit) { 10 }
+
+        it 'should return limit size' do
+          results = subject.select
+          expect(results.length).to eq(limit)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
when the limit is greater than half the available count, resect the limit size, otherwise keep larger focus windows to sample from.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

