### PR TITLE
return 204 on workflows retire subjects

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   def retire_subjects
     operation.with(workflow: controlled_resource).run!(params)
-    render nothing: true
+    render nothing: true, status: 204
   end
 
   private

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -559,9 +559,9 @@ describe Api::V1::WorkflowsController, type: :controller do
     let(:subject_set_id) { subject_set.id }
     let(:subject) { create(:subject, subject_sets: [subject_set]) }
 
-    it 'returns a 200 status' do
+    it 'returns a 204 status' do
       post :retire_subjects, workflow_id: workflow.id, subject_id: subject.id
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(204)
     end
 
     it 'retires the subject' do


### PR DESCRIPTION
provide the correct status code for retire subjects with no content reponse.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

