### PR TITLE
Set text task answer label to default value

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -52,7 +52,7 @@ module Formatter
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
           new_anno['value'] = @current['value']
-          new_anno['task_label'] = task_label(task_info)
+          new_anno['task_label'] = "text"
         end
       end
 

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
               {
                 "task"=>"T6",
                 "value"=>"no secrets between us, panoptes. you see all.",
-                "task_label"=>"Tell me a secret."
+                "task_label"=>"text"
               },
               {
                 "task"=>"T7",


### PR DESCRIPTION
Instead of looking for a nonexistent answer label for a text task, just set it to "text". 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

