### PR TITLE
Oauth fix

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,7 +5,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     sign_in @user, event: :authentication
     redirect_to sign_in_redirect
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
-    # TODO Redirect to a page to edit user options
+    flash[:alert] = "Sorry, an account with your email address already exists. Please log in normally or attempt a password reset if you've forgotten your password."
+    redirect_to new_user_session_path
   end
 
   alias_method :facebook, :callback

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,7 +5,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     sign_in @user, event: :authentication
     redirect_to sign_in_redirect
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
-    flash[:alert] = "Sorry, an account with your email address already exists. Please log in normally or attempt a password reset if you've forgotten your password."
+    flash[:alert] = "Sorry, an account with your email address already exists. Please log in with your Zooniverse account, or attempt a password reset if you've forgotten your password."
     redirect_to new_user_session_path
   end
 

--- a/config/social.yml.hudson
+++ b/config/social.yml.hudson
@@ -3,7 +3,7 @@ development:
     app_id: <%= ENV['FACEBOOK_APP_ID'] %>
     app_secret: <%= ENV['FACEBOOK_APP_SECRET'] %>
     scope: email, public_profile
-  gplus:
+  google_oauth2:
     app_id: <%= ENV['GPLUS_APP_ID'] %>
     app_secret: <%= ENV['GPLUS_APP_SECRET'] %>
     scope: userinfo.email, userinfo.profile, plus.login
@@ -14,7 +14,7 @@ test:
     app_id: Not a real id
     app_secret: Not a real secret
     scope: email, public_profile
-  gplus:
+  google_oauth2:
     app_id: Not real
     app_secret: all_fake
     scope: userinfo.email, userinfo.profile, plus.login

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -31,8 +31,11 @@ shared_examples "an omniauth callback" do
     expect(response).to redirect_to 'https://zooniverse.org/'
   end
 
-  it 'should redirect to a user editor if the created user is not valid'
-  it 'should redirect to a user editor if the created user is not unique'
+  it 'should show an error when created user is invalid' do
+    user = create(:user)
+    request.env['omniauth.auth']['info']['email'] = user.email
+    req
+  end
 end
 
 describe OmniauthCallbacksController, type: :controller do

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -54,7 +54,7 @@ describe OmniauthCallbacksController, type: :controller do
 
   describe '#google_oauth2' do
     before(:each) do
-      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:gplus]
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
     end
 
     let(:provider) { 'google_oauth2' }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,14 +67,6 @@ describe User, type: :model do
       end
     end
 
-    context 'an invalid user' do
-      it 'should raise an exception' do
-        create(:user, email: 'examplar@example.com')
-        auth_hash = OmniAuth.config.mock_auth[:google_oauth2]
-        expect{ User.from_omniauth(auth_hash) }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
     context 'a user who already had a normal account' do
       it 'should raise an exception when email is used' do
         user = create(:user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,7 +25,7 @@ describe User, type: :model do
 
     shared_examples 'new user from omniauth' do
       let(:user_from_auth_hash) do
-        user = User.from_omniauth(auth_hash)
+        User.from_omniauth(auth_hash)
       end
 
       it 'should create a new valid user' do
@@ -70,8 +70,27 @@ describe User, type: :model do
     context 'an invalid user' do
       it 'should raise an exception' do
         create(:user, email: 'examplar@example.com')
-        auth_hash = OmniAuth.config.mock_auth[:gplus]
+        auth_hash = OmniAuth.config.mock_auth[:google_oauth2]
         expect{ User.from_omniauth(auth_hash) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context 'a user who already had a normal account' do
+      it 'should raise an exception when email is used' do
+        user = create(:user)
+        auth_hash = OmniAuth.config.mock_auth[:facebook]
+        auth_hash[:info][:email] = user.email
+        expect { User.from_omniauth(auth_hash) }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(Authorization.count).to eq(0)
+      end
+
+      it 'should create multiple users if email is different' do
+        user = create(:user, display_name: 'Same Thing', login: User.sanitize_login('Same Thing'))
+
+        auth_hash = OmniAuth.config.mock_auth[:facebook]
+        auth_hash[:info][:name] = user.display_name
+        auth_hash[:info][:email] = "somethingelse@example.com"
+        expect(User.from_omniauth(auth_hash)).to be_persisted
       end
     end
   end

--- a/spec/support/omniauth_hash.rb
+++ b/spec/support/omniauth_hash.rb
@@ -27,7 +27,8 @@ google_oauth2 = {
 }
 
 facebook_no_email = facebook.dup
-facebook_no_email[:info] = facebook[:info].dup.delete(:email)
+facebook_no_email[:info] = facebook[:info].dup
+facebook_no_email[:info].delete(:email)
 
 OmniAuth.config.add_mock(:facebook, facebook)
 OmniAuth.config.add_mock(:facebook_no_email, facebook_no_email)

--- a/spec/support/omniauth_hash.rb
+++ b/spec/support/omniauth_hash.rb
@@ -27,7 +27,7 @@ google_oauth2 = {
 }
 
 facebook_no_email = facebook.dup
-facebook_no_email[:info].delete(:email)
+facebook_no_email[:info] = facebook[:info].dup.delete(:email)
 
 OmniAuth.config.add_mock(:facebook, facebook)
 OmniAuth.config.add_mock(:facebook_no_email, facebook_no_email)

--- a/spec/support/omniauth_hash.rb
+++ b/spec/support/omniauth_hash.rb
@@ -12,8 +12,8 @@ facebook = {
   }
 }
 
-gplus = {
-  provider: 'gplus',
+google_oauth2 = {
+  provider: 'google_oauth2',
   uid: '12345',
   info: {
     email: 'examplar@example.com',
@@ -31,4 +31,4 @@ facebook_no_email[:info].delete(:email)
 
 OmniAuth.config.add_mock(:facebook, facebook)
 OmniAuth.config.add_mock(:facebook_no_email, facebook_no_email)
-OmniAuth.config.add_mock(:gplus, gplus)
+OmniAuth.config.add_mock(:google_oauth2, google_oauth2)


### PR DESCRIPTION
In case logging in with OAuth tries to generate a conflicting user account, try to generate a unique value for the login field.

We can't deduplicate emails, and we definitely can't be sure that foo@bar.com on our site is the same person as foo@bar.com on Facebook, so that duplication is still a failure. But now we're telling the user about it and chance are it is the same person who just forgot they already had a normal account.