### PR TITLE
Debug Honeybadger notify for annotation export

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -140,6 +140,21 @@ module Formatter
             translate(answer_string)
           rescue TypeError
             "unknown answer label"
+          rescue NoMethodError => e
+            Honeybadger.notify(
+              error_class:   "Task export error",
+              error_message: "The task cannot be exported",
+              context: {
+                classification: @classification,
+                annotation: @annotation,
+                workflow_at_version: workflow_at_version,
+                workflow_version: workflow_version,
+                content_version: content_version,
+                current_task: @current['task'],
+                answer_idx: answer_idx
+              }
+            )
+            raise e
           end
         end
       end


### PR DESCRIPTION
Added a debug notification to Honeybadger to provide more information on the project 2886's classification CSV export error.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

