### PR TITLE
allow show of incomplete classifications

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -353,9 +353,7 @@ classification including:
             }
 
 ### Retrieve a single Classification [GET]
-A User may only retrieve a single classification if it not completed
-in order to finish it. Otherwise they may retrieve a list of
-classifications from the Classification Collection resource.
+A User may retrieve any classification, irrespective of the complete status.
 
 + Request
 

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -20,15 +20,17 @@ class Classification < ActiveRecord::Base
   validate :validate_gold_standard
 
   scope :incomplete, -> { where("completed IS FALSE") }
-  scope :created_by, -> (user) { where(user: user) }
+  scope :created_by, -> (user) { where(user_id: user.id) }
   scope :complete, -> { where(completed: true) }
   scope :gold_standard, -> { where("gold_standard IS TRUE") }
 
   def self.scope_for(action, user, opts={})
     return all if user.is_admin? && action != :gold_standard
     case action
-    when :show, :index
-      complete.merge(created_by(user.user)).includes(:subjects)
+    when :index
+      complete.merge(created_by(user)).includes(:subjects)
+    when :show
+      created_by(user).includes(:subjects)
     when :update, :destroy
       incomplete_for_user(user)
     when :incomplete
@@ -47,7 +49,7 @@ class Classification < ActiveRecord::Base
   end
 
   def self.incomplete_for_user(user)
-    incomplete.merge(created_by(user.user))
+    incomplete.merge(created_by(user))
   end
 
   def self.gold_standard_for_user(user)

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -243,6 +243,11 @@ describe Api::V1::ClassificationsController, type: :controller do
 
     let(:resource) { create(:classification, user: user) }
     it_behaves_like "is showable"
+
+    context "when incomplete" do
+      let(:resource) { create(:classification, user: user, completed: false) }
+      it_behaves_like "is showable"
+    end
   end
 
   describe "#create" do

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -156,9 +156,25 @@ describe Classification, :type => :model do
         expect(Classification.scope_for(:index, other_user)).to match_array(expected)
       end
 
-      it 'should not return incomplete classifications for a project' do
-        create(:classification, user: user.owner, completed: false)
-        expect(Classification.scope_for(:show, user)).to be_empty
+      describe "#index" do
+        it 'should not return incomplete classifications for a project' do
+          create(:classification, user: user.owner, completed: false)
+          expect(Classification.scope_for(:index, user)).to be_empty
+        end
+      end
+
+      describe "#show" do
+        let(:result) { Classification.scope_for(:show, user) }
+
+        it 'should return incomplete classifications for a project' do
+          expected = create(:classification, user: user.owner, completed: false)
+          expect(result).to match_array([expected])
+        end
+
+        it 'should return complete classifications for a project' do
+          expected = create(:classification, user: user.owner)
+          expect(result).to match_array(expected)
+        end
       end
     end
 


### PR DESCRIPTION
closes #1874 

Allow the api client to save incomplete classifications, todo this the etag (via get by id route) is called before running the PUT update method.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.