### PR TITLE
allow virtual field attributes to be specified for serializer response

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -54,11 +54,10 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   def field_context
     if params[:fields].present?
-      included_keys = params[:fields].split ','
-      included_fields = included_keys.select{ |key| Workflow.columns_hash.has_key? key }
-      all_fields = WorkflowSerializer.serializable_attributes.keys.map &:to_s
-      excluded_fields = all_fields - included_fields - ['id'] # always include id
-
+      included_keys = params[:fields].split(',')
+      attrs = WorkflowSerializer.serializable_attributes.with_indifferent_access
+      allowed_keys = attrs.slice(*included_keys).keys | ['id']
+      excluded_fields = attrs.keys - allowed_keys
       { }.tap do |attributes|
         excluded_fields.each do |field|
           attributes[:"include_#{ field }?"] = false

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -72,9 +72,9 @@ describe Api::V1::WorkflowsController, type: :controller do
       end
 
       it 'should return only serialize the specified fields' do
-        get :index, fields: 'display_name,does_not_exist'
+        get :index, fields: 'display_name,subjects_count,does_not_exist'
         response_keys = json_response['workflows'].map(&:keys).uniq.flatten
-        expect(response_keys).to match_array ['id', 'links', 'display_name']
+        expect(response_keys).to match_array ['id', 'links', 'display_name', 'subjects_count']
       end
     end
   end


### PR DESCRIPTION
fixes #1881 - allows virtual attributes to be serialized via fields param.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

