### PR TITLE
ensure the resource is returned when updating classifications

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -81,4 +81,12 @@ class Api::V1::ClassificationsController < Api::ApiController
       "#{controller_name} with id='#{resource_ids}' is complete"
     end
   end
+
+  def update_response
+    serializer.resource(
+      {},
+      Classification.where(id: controlled_resources.first.id),
+      context
+    )
+  end
 end

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -23,8 +23,9 @@ shared_examples "is updatable" do
       end
     end
 
-    it 'should return 200' do
+    it 'should return 200 and return the updated resource', :aggregate_failures do
       expect(response).to have_http_status(:ok)
+      expect(json_response[api_resource_name].length).to eq(1)
     end
 
     it 'should include a Last-Modified header' do


### PR DESCRIPTION
The classification update caused the completed field to change and thus the controlled_scope didn't resolve in the serializer so this change will provide the seriailzer with a new scope ref to the updated resource.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.