### PR TITLE
allow short old hash_func passwords to still log in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -255,6 +255,8 @@ class User < ActiveRecord::Base
         self.password = plain_password
         self.hash_func = 'bcrypt'
         setup_unsubscribe_token
+        #unset the attribute to skip devise length validation
+        self.password = nil
         self.save!
         break
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -36,8 +36,8 @@ FactoryGirl.define do
     end
 
     factory :insecure_user do
-      hash_func 'sha1'
-      password 'tajikistan'
+      # hash_func 'sha1' # hash func is not set via build / create
+      # password 'tajikistan' # password will set the hash_func to bcrypt
       encrypted_password 'zKUhbXyjCsgmcv6Fh5rQiHTzJWI='
       password_salt 'nK5bXjD2YS7LSYndVJNGGdY='
     end


### PR DESCRIPTION
skip devise password length validation when updating / signing in old sha1 account passwords.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.