### PR TITLE
update docs for subject filtering by association

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -940,7 +940,7 @@ classify, usually for expert classifiers.
   + page (optional, integer) ... the index of the page to retrieve default is 1
   + page_size (optional, integer) ... number of items to include on a page default is 20
   + sort (optional, string) ... field to sort by 'queued' have special behaviour
-  + workflow_id (optional, integer) ... filter to subjects belonging to a specific workflow, it is only used and a required param when sort is 'queued'.
+  + workflow_id (optional, integer) ... filter to subjects belonging to a specific workflow, it is a required param when sort is 'queued'.
   + subject_set_id (optional, integer) ... return subjects belonging to the identified subject_set, it is required when sort is 'queued' and the workflow is grouped.
 
 + Request

--- a/apiary.apib
+++ b/apiary.apib
@@ -939,9 +939,9 @@ classify, usually for expert classifiers.
 + Parameters
   + page (optional, integer) ... the index of the page to retrieve default is 1
   + page_size (optional, integer) ... number of items to include on a page default is 20
-  + sort (optional, string) ... field to sort by 'cellect' and 'queued' have special behaviour
-  + workflow_id (optional, integer) ... filter to subjects belonging to a specific workflow. Required when sort is 'random'
-  + subject_set_id (optional, integer) ... return subjects belonging to the identified subject_set
+  + sort (optional, string) ... field to sort by 'queued' have special behaviour
+  + workflow_id (optional, integer) ... filter to subjects belonging to a specific workflow, it is only used and a required param when sort is 'queued'.
+  + subject_set_id (optional, integer) ... return subjects belonging to the identified subject_set, it is required when sort is 'queued' and the workflow is grouped.
 
 + Request
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -29,12 +29,27 @@ describe Api::V1::SubjectsController, type: :controller do
     context "logged out user" do
 
       describe "filtering" do
-        let(:filterable_resources) do
-          create_list(:collection_with_subjects, 2).first.subjects
-        end
         let(:expected_filtered_ids) { formated_string_ids(filterable_resources) }
 
-        it_behaves_like 'has many filterable', :collections
+        context "with collection has_many" do
+          let(:filterable_resources) do
+            create_list(:collection_with_subjects, 2).first.subjects
+          end
+
+          it_behaves_like 'has many filterable', :collections
+        end
+
+        context "with subject_sets has_many" do
+          before do
+            create(:subject_set_with_subjects)
+          end
+
+          let(:filterable_resources) do
+            subject_set.subjects
+          end
+
+          it_behaves_like 'has many filterable', :subject_sets
+        end
       end
 
       context "without any sort" do


### PR DESCRIPTION
make a note that workflow_id is only used for when the sort=queued param is set, i.e. via subject selection and subject_set_id is required for subject selection when the workflow is grouped. Also subject_set_id can be used on normal index routes to narrow the result set scope.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.