### PR TITLE
respect workflow for retired filtering in selection

### DIFF
--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -58,6 +58,7 @@ module Subjects
       retired_ids = SetMemberSubject
         .joins("INNER JOIN subject_workflow_counts ON subject_workflow_counts.subject_id = set_member_subjects.subject_id")
         .where("subject_workflow_counts.retired_at IS NOT NULL")
+        .where("subject_workflow_counts.workflow_id = ?", workflow.id)
         .where(set_member_subjects: {id: sms_ids})
         .pluck(:id)
       return sms_ids if retired_ids.blank?

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -262,6 +262,14 @@ RSpec.describe Subjects::Selector do
       expect(subject.selected_subjects(subject_queue).size).to be > 0
     end
 
+    it "should respect the order of the sms selection", :focus do
+      ordered_sms = smses.sample(5)
+      sms_ids = ordered_sms.map(&:id)
+      expect(subject).to receive(:run_strategy_selection).and_return(sms_ids)
+      subjects = subject.selected_subjects(double(stale?: true, update_ids: nil))
+      expect(ordered_sms.map(&:subject_id)).to eq(subjects.map(&:id))
+    end
+
     context "feature flip straight selection over queues" do
       it 'should use queue selection when feature is off' do
         expect(subject).to receive(:sms_ids_from_queue).and_call_original

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -245,14 +245,36 @@ RSpec.describe Subjects::Selector do
   end
 
   describe '#selected_subjects' do
-    it 'should not return retired subjects' do
-      sms = smses[0]
-      swc = create(:subject_workflow_count, subject: sms.subject, workflow: workflow, retired_at: Time.zone.now)
-      expected = subject_queue.set_member_subject_ids[1..-1].sort
-      result = subject.selected_subjects(subject_queue).map do |subj|
-        subj.set_member_subjects.first.id
-      end.sort
-      expect(result).to eq(expected)
+
+    context "with retired subjects" do
+      let(:retired_workflow) { workflow }
+      let(:sms) { smses[0] }
+      let!(:swc) do
+        create(:subject_workflow_count,
+          subject: sms.subject,
+          workflow: retired_workflow,
+          retired_at: Time.zone.now
+        )
+      end
+      let(:result) do
+        subject.selected_subjects(subject_queue).map do |s|
+          s.set_member_subjects.first.id
+        end
+      end
+
+      it 'should not return retired subjects' do
+        expected = subject_queue.set_member_subject_ids[1..-1]
+        expect(result).to match_array(expected)
+      end
+
+      context "when the sms is retired for a different workflow" do
+        let(:retired_workflow) { create(:workflow, project: workflow.project) }
+
+        it 'should return all the subjects' do
+          expected = subject_queue.set_member_subject_ids
+          expect(result).to match_array(expected)
+        end
+      end
     end
 
     it 'should return something when everything in the queue is retired' do
@@ -262,7 +284,7 @@ RSpec.describe Subjects::Selector do
       expect(subject.selected_subjects(subject_queue).size).to be > 0
     end
 
-    it "should respect the order of the sms selection", :focus do
+    it "should respect the order of the sms selection" do
       ordered_sms = smses.sample(5)
       sms_ids = ordered_sms.map(&:id)
       expect(subject).to receive(:run_strategy_selection).and_return(sms_ids)


### PR DESCRIPTION
Closes #1891 - Do not filter out subjects that have been retired for another workflow. 

Also added in an explicit spec to ensure the subjects are returned in the order the selector chooses them. used mostly for priority selection but will preserve ordering for random too.

Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
