### PR TITLE
do not destroy location relations with invalid location updates

### DIFF
--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -310,7 +310,9 @@ describe Api::V1::SubjectsController, type: :controller do
   end
 
   describe "#update" do
-    let(:resource) { create(:subject, project: create(:project, owner: user)) }
+    let(:resource) do
+      create(:subject, :with_mediums, num_media: 1, project: create(:project, owner: user))
+    end
     let(:test_attr) { :metadata }
     let(:test_attr_value) do
       {
@@ -318,6 +320,7 @@ describe Api::V1::SubjectsController, type: :controller do
        "an_interesting_array" => ["1", "2", "asdf", "99.99"]
       }
     end
+    let(:locations) { [ "image/jpeg" ] }
     let(:update_params) do
       {
        subjects: {
@@ -325,24 +328,58 @@ describe Api::V1::SubjectsController, type: :controller do
                              interesting_data: "Tested Collection",
                              an_interesting_array: ["1", "2", "asdf", "99.99"]
                             },
-                  locations: [ "image/jpeg" ]
+                  locations: locations
                  }
       }
     end
 
     it_behaves_like "is updatable"
 
+    context "with an authorized user" do
+      before do
+        default_request user_id: authorized_user.id, scopes: scopes
+      end
 
-    it 'should create externally linked media resources' do
-      default_request user_id: authorized_user.id, scopes: scopes
-      external_locs = [{"image/jpeg" => "http://example.com/1.jpg"}, {"image/jpeg" => "http://example.com/2.jpg"}]
-      external_src_urls = external_locs.map { |loc| loc.to_a.flatten[1] }
-      update_params[:subjects].merge!(locations: external_locs)
-      put :update, update_params.merge(id: resource.id)
-      locations = Subject.find(created_instance_id("subjects")).locations
-      aggregate_failures "external srcs" do
-        expect(locations.map(&:external_link)).to all( be true )
-        expect(locations.map(&:src)).to match_array(external_src_urls)
+      describe "using external urls" do
+        let(:external_locs) do
+          [
+            {"image/jpeg" => "http://example.com/1.jpg"},
+            {"image/jpeg" => "http://example.com/2.jpg"}
+          ]
+        end
+        let(:external_src_urls) do
+          external_locs.map { |loc| loc.to_a.flatten[1] }
+        end
+
+        it 'should create externally linked media resources' do
+          update_params[:subjects][:locations] = external_locs
+          put :update, update_params.merge(id: resource.id)
+          locations = Subject.find(created_instance_id("subjects")).locations
+          aggregate_failures "external srcs" do
+            expect(locations.map(&:external_link)).to all( be true )
+            expect(locations.map(&:src)).to match_array(external_src_urls)
+          end
+        end
+      end
+
+      context "when the mime type is not allowed" do
+        let(:locations) { [ "text/plain" ] }
+
+        it "should not overwrite existing locations" do
+          loc_ids = resource.locations.map(&:id)
+          put :update, update_params.merge(id: resource.id)
+          expect(loc_ids).to match_array(resource.reload.locations.map(&:id))
+        end
+      end
+
+      context "when the locations array is empty" do
+        let(:locations) { [] }
+
+        it "should not overwrite existing locations" do
+          loc_ids = resource.locations.map(&:id)
+          put :update, update_params.merge(id: resource.id)
+          expect(loc_ids).to match_array(resource.reload.locations.map(&:id))
+        end
       end
     end
   end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -9,8 +9,12 @@ FactoryGirl.define do
               loudness: 11})
 
     trait :with_mediums do
-      after(:create) do |s|
-        create_list(:medium, 2, linked: s)
+      ignore do
+        num_media 2
+      end
+
+      after :create do |s, evaluator|
+        create_list(:medium, evaluator.num_media, linked: s)
       end
     end
 


### PR DESCRIPTION
closes #1885 - avoid invalid location updates on the media resource. Make sure these validations pass before updating the relation to reflect the updated location resource.

Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.