### PR TITLE
respect the project launch_date for classification counts

### DIFF
--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -15,7 +15,9 @@ class ProjectClassificationsCountWorker
     project = Project.find(project_id)
 
     counts = project.workflows.map do |workflow|
-      count = workflow.subject_workflow_counts.sum(:classifications_count)
+      swcs = workflow.subject_workflow_counts
+      swcs = swcs.where("created_at >= ?", project.launch_date) if project.launch_date
+      count = swcs.sum(:classifications_count)
       workflow.update_column :classifications_count, count
       count
     end

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -4,8 +4,12 @@ RSpec.describe ProjectClassificationsCountWorker do
   let(:worker) { described_class.new }
   let(:workflow) { create(:workflow) }
   let(:project) { workflow.project }
-  let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
-
+  let(:subject) do
+    create(:subject,
+      project: project,
+      subject_sets: [create(:subject_set, workflows: [workflow])]
+    )
+  end
   let!(:swc) do
     create :subject_workflow_count, subject: subject, workflow: workflow, classifications_count: 5
   end
@@ -21,6 +25,30 @@ RSpec.describe ProjectClassificationsCountWorker do
       expect { worker.perform(project.id) }
         .to change { workflow.reload.classifications_count }
         .from(0).to(5)
+    end
+
+    context "when the project has launch date" do
+      let(:another_subject) do
+        create(:subject,
+          project: project,
+          subject_sets: [create(:subject_set, workflows: [workflow])]
+        )
+      end
+      let(:another_swc) do
+        create(:subject_workflow_count,
+          subject: another_subject,
+          workflow: workflow,
+          classifications_count: 2
+        )
+      end
+
+      it 'should respect the launch_date in the count' do
+        project.update_column(:launch_date, DateTime.now)
+        another_swc
+        expect { worker.perform(project.id) }
+          .to change { workflow.reload.classifications_count }
+          .from(0).to(2)
+      end
     end
   end
 end


### PR DESCRIPTION
after resetting the project counts using a launch date the classification counts were resetting to there prev totals after normal classification. this PR will respect the launch date setting for the classification count.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

