### PR TITLE
add method to easily update the selection strategy configuration

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -85,6 +85,12 @@ class Workflow < ActiveRecord::Base
     configuration.with_indifferent_access[:selection_strategy].try(:to_sym)
   end
 
+  def set_selection_strategy(strategy)
+    new_config = configuration
+    new_config[:selection_strategy] = strategy
+    self.update_column(:configuration, new_config)
+  end
+
   def cellect_size_subject_space?
     set_member_subjects.count >= Panoptes.cellect_min_pool_size
   end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -341,6 +341,29 @@ describe Workflow, type: :model do
     end
   end
 
+  describe "#set_selection_strategy" do
+    let(:workflow) { create(:workflow, configuration: config) }
+    let(:config) { {} }
+    let(:strategy) { "cellect" }
+
+    it "should set the param config" do
+      expect(workflow.selection_strategy).to be_nil
+      workflow.set_selection_strategy(strategy)
+      expect(workflow.selection_strategy.to_s).to eq(strategy)
+    end
+
+    context "with existing configuration directives" do
+      let(:config) { { directive: "set this up", another_setting: true } }
+
+      it "should respect the existing directives" do
+        workflow.set_selection_strategy(strategy)
+        config = workflow.configuration.with_indifferent_access
+        expected = config.merge(selection_strategy: strategy)
+        expect(config).to eq(expected)
+      end
+    end
+  end
+
   describe "#using_cellect?" do
     it "should return false if the config set to someting not cellect" do
       config = { selection_strategy: :database }


### PR DESCRIPTION
simple worfklow method to safely add the selection configuration instead respecting existing configuration directives.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

