### PR TITLE
correct user projet preference activity counts

### DIFF
--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -20,25 +20,11 @@ class UserSeenSubject < ActiveRecord::Base
 
   def self.activity_by_workflow(user_id, workflow_ids=[])
     workflow_ids = Array.wrap(workflow_ids)
-
-    CodeExperiment.run "activity_by_workflow" do |e|
-      e.use do
-        scope = self.where(user_id: user_id)
-        unless workflow_ids.empty?
-          scope = scope.where(workflow_id: workflow_ids)
-        end
-
-        scope.group(:workflow_id).sum("cardinality(subject_ids)").as_json
-      end
-
-      e.try do
-        scope = Classification.joins_classification_subjects
-        scope = scope.where(user_id: user_id)
-        scope = scope.where(workflow_id: workflow_ids) if workflow_ids.present?
-        scope = scope.select("workflow_id, subject_id").group(:workflow_id).count("DISTINCT subject_id")
-        scope.stringify_keys
-      end
+    scope = self.where(user_id: user_id)
+    unless workflow_ids.empty?
+      scope = scope.where(workflow_id: workflow_ids)
     end
+    scope.group(:workflow_id).sum("cardinality(subject_ids)").as_json
   end
 
   def self.seen_for_user_by_workflow(user, workflow)

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -17,11 +17,15 @@ class UserProjectPreferenceSerializer
   end
 
   def activity_count_by_workflow
-    UserSeenSubject.activity_by_workflow(@model.user_id, project_workflows_ids)
+    unless project_workflows_ids.empty?
+      UserSeenSubject.activity_by_workflow(@model.user_id, project_workflows_ids)
+    end
   end
 
   def user_project_activity
-    UserSeenSubject.count_user_activity(@model.user_id, project_workflows_ids)
+    unless project_workflows_ids.empty?
+      UserSeenSubject.count_user_activity(@model.user_id, project_workflows_ids)
+    end
   end
 
   def project_workflows_ids


### PR DESCRIPTION
when the project has no workflows ensure we dont' return all the workflow counts (across projects).

Also removed an old experiment while i was there...

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
