### PR TITLE
add api routes for cellect

### DIFF
--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -1,0 +1,10 @@
+class CellectController < ApplicationController
+  def workflows
+    respond_to do |format|
+      format.json do
+        cellect_workflows = Workflow.all
+        render json: { workflow_ids: cellect_workflows.pluck(:id).as_json }
+      end
+    end
+  end
+end

--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -1,6 +1,8 @@
 class CellectController < ApplicationController
   before_filter :html_to_json_override
 
+  EXPIRY = 10.minutes.freeze
+
   def workflows
     respond_to do |format|
       format.json do
@@ -25,7 +27,11 @@ class CellectController < ApplicationController
   end
 
   def all_cellect_workflow_ids
-     workflow_ids_using_cellect | Workflow.using_cellect.pluck(:id)
+    cache_key = "#{Rails.env}#all_cellect_workflow_ids"
+    Rails.cache.fetch(cache_key, expires_in: EXPIRY) do
+      workflow_ids_using_cellect | Workflow.using_cellect.pluck(:id)
+    end
+  end
 
   def html_to_json_override
     request.format = :json if request.format == :html

--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -43,7 +43,7 @@ class CellectController < ApplicationController
 
   def cellect_workflow_subject_ids
     if workflow = cellect_workflow_from_param
-      workflow.set_member_subjects.pluck(:subject_id)
+      SetMemberSubject.non_retired_for_workflow(workflow).pluck(:subject_id)
     else
       []
     end

--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -1,4 +1,6 @@
 class CellectController < ApplicationController
+  before_filter :html_to_json_override
+
   def workflows
     respond_to do |format|
       format.json do
@@ -24,5 +26,8 @@ class CellectController < ApplicationController
 
   def all_cellect_workflow_ids
      workflow_ids_using_cellect | Workflow.using_cellect.pluck(:id)
+
+  def html_to_json_override
+    request.format = :json if request.format == :html
   end
 end

--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -11,6 +11,14 @@ class CellectController < ApplicationController
     end
   end
 
+  def subjects
+    respond_to do |format|
+      format.json do
+        render json: { subject_ids: cellect_workflow_subject_ids.as_json }
+      end
+    end
+  end
+
   private
 
   def launched_workflows
@@ -31,6 +39,19 @@ class CellectController < ApplicationController
     Rails.cache.fetch(cache_key, expires_in: EXPIRY) do
       workflow_ids_using_cellect | Workflow.using_cellect.pluck(:id)
     end
+  end
+
+  def cellect_workflow_subject_ids
+    if workflow = cellect_workflow_from_param
+      workflow.set_member_subjects.pluck(:subject_id)
+    else
+      []
+    end
+  end
+
+  def cellect_workflow_from_param
+    w_id = all_cellect_workflow_ids.find { |id| id.to_s == params[:workflow_id] }
+    Workflow.where(id: w_id).select(:id).first if w_id
   end
 
   def html_to_json_override

--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -2,9 +2,27 @@ class CellectController < ApplicationController
   def workflows
     respond_to do |format|
       format.json do
-        cellect_workflows = Workflow.all
-        render json: { workflow_ids: cellect_workflows.pluck(:id).as_json }
+        render json: { workflow_ids: all_cellect_workflow_ids.as_json }
       end
     end
+  end
+
+  private
+
+  def launched_workflows
+    Workflow
+      .joins(:project)
+      .where("projects.launch_approved IS TRUE")
+      .select(:id, :use_cellect)
+  end
+
+  def workflow_ids_using_cellect
+    launched_workflows.collect do |w|
+      w.using_cellect? ? w.id : nil
+    end.compact
+  end
+
+  def all_cellect_workflow_ids
+     workflow_ids_using_cellect | Workflow.using_cellect.pluck(:id)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,6 +58,8 @@ class Project < ActiveRecord::Base
 
   after_update :send_notifications
 
+  scope :launched, -> { where("launch_approved IS TRUE") }
+
   can_by_role :destroy, :update, :update_links, :destroy_links, :create_classifications_export,
     :create_subjects_export, :create_aggregations_export, :create_workflows_export,
     :create_workflow_contents_export, :retire_subjects, roles: [ :owner, :collaborator ]

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -29,6 +29,8 @@ class Workflow < ActiveRecord::Base
   cache_by_association :workflow_contents
   cache_by_resource_method :subjects_count, :finished?
 
+  scope :using_cellect, -> { where("use_cellect IS TRUE") }
+
   DEFAULT_RETIREMENT_OPTIONS = {
     'criteria' => 'classification_count',
     'options' => {'count' => 15}

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -81,29 +81,12 @@ class Workflow < ActiveRecord::Base
     self.retirement.presence || DEFAULT_RETIREMENT_OPTIONS
   end
 
-  def selection_strategy
-    configuration.with_indifferent_access[:selection_strategy].try(:to_sym)
-  end
-
-  def set_selection_strategy(strategy)
-    new_config = configuration
-    new_config[:selection_strategy] = strategy
-    self.update_column(:configuration, new_config)
-  end
-
   def cellect_size_subject_space?
     set_member_subjects.count >= Panoptes.cellect_min_pool_size
   end
 
   def using_cellect?
-    case
-    when selection_strategy == :cellect
-      true
-    when selection_strategy
-      false
-    else
-      cellect_size_subject_space?
-    end
+    use_cellect || cellect_size_subject_space?
   end
 
   def subjects_count

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  #turn off the rails cache store
+  config.cache_store = :null_store
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace "cellect", constraints: { format: 'json' } do
+    get  "workflows"
+  end
+
   get "health_check", to: "home#index"
   root to: "home#index"
   match "*path", to: "application#unknown_route", via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,8 @@ Rails.application.routes.draw do
   end
 
   namespace "cellect", constraints: { format: 'json' } do
-    get  "workflows"
+    get "workflows"
+    get "subjects"
   end
 
   get "health_check", to: "home#index"

--- a/db/migrate/20160810140805_workflow_promote_cellect_to_own_attribute.rb
+++ b/db/migrate/20160810140805_workflow_promote_cellect_to_own_attribute.rb
@@ -7,7 +7,7 @@ class WorkflowPromoteCellectToOwnAttribute < ActiveRecord::Migration
       strategy = config[:selection_strategy].try(:to_sym)
       if strategy == :cellect
         new_config = config.except(:selection_strategy)
-        w.update_columns(configuration: new_config, cellect: true)
+        w.update_columns(configuration: new_config, use_cellect: true)
       end
     end
   end

--- a/db/migrate/20160810140805_workflow_promote_cellect_to_own_attribute.rb
+++ b/db/migrate/20160810140805_workflow_promote_cellect_to_own_attribute.rb
@@ -1,0 +1,18 @@
+class WorkflowPromoteCellectToOwnAttribute < ActiveRecord::Migration
+  def up
+    add_column :workflows, :use_cellect, :boolean, index: true, default: false, null: false
+    launched_workflows = Workflow.joins(:project).where("projects.launch_approved = true")
+    launched_workflows.select do |w|
+      config = w.configuration.with_indifferent_access
+      strategy = config[:selection_strategy].try(:to_sym)
+      if strategy == :cellect
+        new_config = config.except(:selection_strategy)
+        w.update_columns(configuration: new_config, cellect: true)
+      end
+    end
+  end
+
+  def down
+    remove_column :workflows, :use_cellect
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2749,16 +2749,12 @@ CREATE INDEX users_idx_trgm_login ON users USING gin ((COALESCE((login)::text, '
 
 CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'display_name');
 
-ALTER TABLE projects DISABLE TRIGGER tsvectorupdate;
-
 
 --
 -- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'login');
-
-ALTER TABLE users DISABLE TRIGGER tsvectorupdate;
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1401,7 +1401,8 @@ CREATE TABLE workflows (
     completeness double precision DEFAULT 0.0 NOT NULL,
     activity integer DEFAULT 0 NOT NULL,
     current_version_number character varying,
-    activated_state integer DEFAULT 0 NOT NULL
+    activated_state integer DEFAULT 0 NOT NULL,
+    use_cellect boolean DEFAULT false NOT NULL
 );
 
 
@@ -2722,6 +2723,13 @@ CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tu
 
 
 --
+-- Name: index_workflows_on_use_cellect; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_workflows_on_use_cellect ON workflows USING btree (use_cellect);
+
+
+--
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2741,12 +2749,16 @@ CREATE INDEX users_idx_trgm_login ON users USING gin ((COALESCE((login)::text, '
 
 CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'display_name');
 
+ALTER TABLE projects DISABLE TRIGGER tsvectorupdate;
+
 
 --
 -- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'login');
+
+ALTER TABLE users DISABLE TRIGGER tsvectorupdate;
 
 
 --
@@ -3442,4 +3454,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160613075003');
 INSERT INTO schema_migrations (version) VALUES ('20160628165038');
 
 INSERT INTO schema_migrations (version) VALUES ('20160630150419');
+
+INSERT INTO schema_migrations (version) VALUES ('20160810140805');
 

--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -19,7 +19,7 @@ module Subjects
       if sms_ids.empty?
         []
       else
-        Subjects::SeenRemover.new(user_seen_subject, sms_ids).unseen_ids
+        strip_seen_ids(sms_ids)
       end
     rescue Subjects::CellectClient::ConnectionError
       default_strategy_sms_ids
@@ -57,10 +57,12 @@ module Subjects
       Subjects::PostgresqlSelection.new(workflow, user, opts).select
     end
 
-
-    def user_seen_subject
+    def strip_seen_ids(sms_ids)
       if user
-        UserSeenSubject.find_by(user: user, workflow: workflow)
+        uss = UserSeenSubject.find_by(user: user, workflow: workflow)
+        Subjects::SeenRemover.new(uss, sms_ids).unseen_ids
+      else
+        sms_ids
       end
     end
   end

--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -29,14 +29,16 @@ module Subjects
       @strategy ||= case
       when !Panoptes.cellect_on
         nil
-      when strategy_param == :cellect
-        strategy_param
-      else
-        workflow_strategy
+      when cellect_strategy?
+        :cellect
       end
     end
 
     private
+
+    def cellect_strategy?
+      strategy_param == :cellect || workflow.using_cellect?
+    end
 
     def strategy_sms_ids
       case strategy
@@ -55,13 +57,6 @@ module Subjects
       Subjects::PostgresqlSelection.new(workflow, user, opts).select
     end
 
-    def workflow_strategy
-      if set_strategy = workflow.selection_strategy
-        set_strategy
-      elsif workflow.using_cellect?
-        :cellect
-      end
-    end
 
     def user_seen_subject
       if user

--- a/spec/controllers/cellect_controller_spec.rb
+++ b/spec/controllers/cellect_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe CellectController, type: :controller, focus: true do
+  let(:cellect_workflow) do
+    create(:workflow, configuration: { selection_strategy: :cellect})
+  end
+  let(:non_cellect_workflow) { create(:workflow) }
+
+  describe "GET 'workflows'" do
+    context "as json" do
+      before(:each) do
+        cellect_workflow
+        non_cellect_workflow
+        get 'workflows', format: :json
+      end
+
+      it "returns success" do
+        expect(response).to be_success
+      end
+
+      it "returns the expected json header" do
+        expect(response.content_type).to eq("application/json")
+      end
+
+      it "should respond with only the cellect workflow" do
+        expect(json_response).to eq({"workflow_ids"=>[cellect_workflow.id]})
+      end
+
+      context "with a workflow that satifies the cellect subjects critera" do
+        before do
+          allow_any_instance_of(Workflow)
+            .to receive(:cellect_size_subject_space?)
+            .and_return(true)
+        end
+
+        it "should respond with all the workflows" do
+          expect(json_response).to eq({"workflow_ids"=>[Workflow.all.pluck(:id)]})
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/cellect_controller_spec.rb
+++ b/spec/controllers/cellect_controller_spec.rb
@@ -27,7 +27,8 @@ describe CellectController, type: :controller do
 
       it "should respond with only the cellect workflow" do
         run_get
-        expect(json_response).to eq({"workflow_ids"=>[cellect_workflow.id]})
+        expected = { workflow_ids: [cellect_workflow.id] }.as_json
+        expect(json_response).to eq(expected)
       end
 
       context "with a workflow that satifies the cellect subjects critera" do
@@ -39,7 +40,43 @@ describe CellectController, type: :controller do
 
         it "should respond with all the workflows" do
           run_get
-          expect(json_response).to eq({"workflow_ids"=>Workflow.all.pluck(:id)})
+          expected = { workflow_ids: Workflow.all.pluck(:id) }.as_json
+          expect(json_response).to eq(expected)
+        end
+      end
+    end
+  end
+
+  describe "GET 'subjects'" do
+    let(:cellect_workflow) do
+      create(:workflow_with_subjects, use_cellect: true)
+    end
+    let(:another_cellect_workflow) do
+      create(:workflow_with_subjects, use_cellect: true)
+    end
+    let(:run_get) do
+      get 'subjects', workflow_id: cellect_workflow.id.to_s, format: :json
+    end
+
+    context "as json" do
+      before do
+        cellect_workflow
+        another_cellect_workflow
+      end
+
+      it "should respond with only the subject ids of the params workflow" do
+        subject_ids = cellect_workflow.subjects.map(&:id)
+        expect(subject_ids.count > 0).to be_truthy
+        run_get
+        expect(json_response["subject_ids"]).to match_array(subject_ids)
+      end
+
+      context "when the worklfow is not set to use cellect" do
+        let(:cellect_workflow) { create(:workflow_with_subjects) }
+
+        it "should respond with an empty array" do
+          run_get
+          expect(json_response).to eq({ subject_ids: [] }.as_json)
         end
       end
     end

--- a/spec/controllers/cellect_controller_spec.rb
+++ b/spec/controllers/cellect_controller_spec.rb
@@ -1,28 +1,32 @@
 require 'spec_helper'
 
-describe CellectController, type: :controller, focus: true do
+describe CellectController, type: :controller do
   let(:cellect_workflow) do
-    create(:workflow, configuration: { selection_strategy: :cellect})
+    create(:workflow, use_cellect: true)
   end
   let(:non_cellect_workflow) { create(:workflow) }
 
   describe "GET 'workflows'" do
+    let(:run_get) { get 'workflows', format: :json }
+
     context "as json" do
       before(:each) do
         cellect_workflow
         non_cellect_workflow
-        get 'workflows', format: :json
       end
 
       it "returns success" do
+        run_get
         expect(response).to be_success
       end
 
       it "returns the expected json header" do
+        run_get
         expect(response.content_type).to eq("application/json")
       end
 
       it "should respond with only the cellect workflow" do
+        run_get
         expect(json_response).to eq({"workflow_ids"=>[cellect_workflow.id]})
       end
 
@@ -34,7 +38,8 @@ describe CellectController, type: :controller, focus: true do
         end
 
         it "should respond with all the workflows" do
-          expect(json_response).to eq({"workflow_ids"=>[Workflow.all.pluck(:id)]})
+          run_get
+          expect(json_response).to eq({"workflow_ids"=>Workflow.all.pluck(:id)})
         end
       end
     end

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe Subjects::StrategySelection do
   end
 
   describe "#strategy" do
-    let(:config) { { selection_strategy: :cellect } }
     let(:cellect_size) { Panoptes.cellect_min_pool_size }
 
     before do
@@ -113,9 +112,9 @@ RSpec.describe Subjects::StrategySelection do
         end
       end
 
-      context "when the workflow config has a selection strategy" do
+      context "when the workflow is set to use cellect" do
         it "should use the workflow config strategy" do
-          allow(workflow).to receive(:configuration).and_return(config)
+          allow(workflow).to receive(:use_cellect).and_return(true)
           expect(subject.strategy).to eq(:cellect)
         end
       end
@@ -129,12 +128,13 @@ RSpec.describe Subjects::StrategySelection do
         end
       end
 
-      context "with a workflow config and large subject set size" do
+      context "worfklow set to use_cellect and large subject set size" do
         it "should only use the worfklow strategy", :aggregate_failures do
-          allow(workflow).to receive(:configuration).and_return(config)
-          allow(workflow).to receive_message_chain("set_member_subjects.count") do
-            cellect_size
-          end
+          allow(workflow).to receive(:use_cellect).and_return(true)
+          allow(workflow)
+            .to receive(:cellect_size_subject_space?)
+            .and_return(true)
+            .and_call_original
           expect(workflow).not_to receive(:set_member_subjects)
           expect(subject.strategy).to eq(:cellect)
         end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -329,55 +329,13 @@ describe Workflow, type: :model do
     end
   end
 
-  describe "#selection_strategy" do
-    it "should return the configuration directive" do
-      expect(workflow.selection_strategy).to be_nil
-    end
-
-    it "should return the configuration directive when it's set" do
-      config = { selection_strategy: :cellect }
-      allow(workflow).to receive(:configuration).and_return(config)
-      expect(workflow.selection_strategy).to eq(:cellect)
-    end
-  end
-
-  describe "#set_selection_strategy" do
-    let(:workflow) { create(:workflow, configuration: config) }
-    let(:config) { {} }
-    let(:strategy) { "cellect" }
-
-    it "should set the param config" do
-      expect(workflow.selection_strategy).to be_nil
-      workflow.set_selection_strategy(strategy)
-      expect(workflow.selection_strategy.to_s).to eq(strategy)
-    end
-
-    context "with existing configuration directives" do
-      let(:config) { { directive: "set this up", another_setting: true } }
-
-      it "should respect the existing directives" do
-        workflow.set_selection_strategy(strategy)
-        config = workflow.configuration.with_indifferent_access
-        expected = config.merge(selection_strategy: strategy)
-        expect(config).to eq(expected)
-      end
-    end
-  end
-
   describe "#using_cellect?" do
-    it "should return false if the config set to someting not cellect" do
-      config = { selection_strategy: :database }
-      allow(workflow).to receive(:configuration).and_return(config)
-      expect(workflow.using_cellect?).to be_falsey
-    end
-
     it "should return false if the config is missing and small subject space" do
       expect(workflow.using_cellect?).to be_falsey
     end
 
     it "should return true if the config is set" do
-      config = { selection_strategy: :cellect }
-      allow(workflow).to receive(:configuration).and_return(config)
+      allow(workflow).to receive(:use_cellect).and_return(true)
       expect(workflow.using_cellect?).to be_truthy
     end
 


### PR DESCRIPTION
Provide cellect panoptes with api endpoints to enum the workflow to preload. Long term we can look to decouple the db connector and try api end points.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
