### PR TITLE
add public cache control headers for non-changing cellect data

### DIFF
--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -6,6 +6,7 @@ class CellectController < ApplicationController
   def workflows
     respond_to do |format|
       format.json do
+        expires_in EXPIRY, public: true
         render json: { workflows: all_cellect_workflows.as_json }
       end
     end
@@ -14,6 +15,7 @@ class CellectController < ApplicationController
   def subjects
     respond_to do |format|
       format.json do
+        expires_in 1.minute, public: true
         render json: { subjects: cellect_workflow_subjects.as_json }
       end
     end

--- a/spec/controllers/cellect_controller_spec.rb
+++ b/spec/controllers/cellect_controller_spec.rb
@@ -25,6 +25,12 @@ describe CellectController, type: :controller do
         expect(response.content_type).to eq("application/json")
       end
 
+      it "returns a public cache header" do
+        run_get
+        cache_control = response.headers["Cache-Control"]
+        expect(cache_control).to eq("max-age=600, public")
+      end
+
       it "should respond with only the cellect workflow" do
         run_get
         expected = [cellect_workflow.slice(:id, :pairwise, :grouped, :prioritized)].as_json
@@ -69,6 +75,12 @@ describe CellectController, type: :controller do
       before do
         cellect_workflow
         another_cellect_workflow
+      end
+
+      it "returns a public cache header" do
+        run_get
+        cache_control = response.headers["Cache-Control"]
+        expect(cache_control).to eq("max-age=60, public")
       end
 
       it "should respond with only the subjects of the params workflow" do


### PR DESCRIPTION
Add caching into the cellect controllers

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

