### PR TITLE
add subject set ids for grouped workflow selection to cellect controller

### DIFF
--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -45,7 +45,7 @@ class CellectController < ApplicationController
     if workflow = cellect_workflow_from_param
       SetMemberSubject
         .non_retired_for_workflow(workflow)
-        .select('set_member_subjects.subject_id as id', :priority)
+        .select('set_member_subjects.subject_id as id', :priority, :subject_set_id)
     else
       []
     end

--- a/spec/controllers/cellect_controller_spec.rb
+++ b/spec/controllers/cellect_controller_spec.rb
@@ -62,7 +62,11 @@ describe CellectController, type: :controller do
     context "as json" do
       let(:subjects) do
         cellect_workflow.set_member_subjects.map do |s|
-          { 'id' => s.subject_id, 'priority' => s.priority }
+          {
+            'id' => s.subject_id,
+            'priority' => s.priority,
+            'subject_set_id' => s.subject_set_id
+          }
         end
       end
 


### PR DESCRIPTION
Add the subject's set infromation to the `/subjects` controller for use by cellect clients.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

