### PR TITLE
[WIP] use post to update user_preference settings

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
 
       json_api_resources :project_preferences do
         collection do
-          put :update_settings
+          post :update_settings
         end
       end
 

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -150,24 +150,25 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
         }
       }
     end
+    let(:run_update) { post :update_settings, settings_params }
 
     before(:each) do
       default_request user_id: authorized_user.id, scopes: scopes
     end
 
     it "responds with a 200" do
-      put :update_settings, settings_params
+      run_update
       expect(response.status).to eq(200)
     end
 
     it "updates the UPP settings attribute" do
-      put :update_settings, settings_params
+      run_update
       found = UserProjectPreference.where(project: project, user: upp.user).first
       expect(found.settings["workflow_id"]).to eq(settings_params[:project_preferences][:settings][:workflow_id].to_s)
     end
 
-    it "cannot update preferences" do
-      sneaky_params =
+    context "with sneaky params" do
+      let(:settings_params) do
         {
           project_preferences: {
             user_id: upp.user_id,
@@ -175,15 +176,20 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
             preferences: { mail_me_all_the_time: true }
           }
         }
-      put :update_settings, sneaky_params
-      expect(response.status).to eq(422)
+      end
+
+      it "cannot update preferences" do
+        run_update
+        expect(response.status).to eq(422)
+      end
     end
 
-    it "only updates settings of owned project" do
-      unowned_project = create(:project)
-      new_upp = create(:user_project_preference, project: unowned_project)
-
-      nefarious_params =
+    context "with nefarious params" do
+      let(:unowned_project) { create(:project) }
+      let(:new_upp) do
+        create(:user_project_preference, project: unowned_project)
+      end
+      let(:settings_params) do
         {
           project_preferences: {
             user_id: new_upp.user_id,
@@ -191,13 +197,17 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
             settings: { workflow_id: 1234 }
           }
         }
-      put :update_settings, nefarious_params
-      expect(response.status).to eq(403)
+      end
+
+      it "only updates settings of owned project" do
+        run_update
+        expect(response.status).to eq(403)
+      end
     end
 
-    it "responds with a 404 if UPP not found" do
-      unused_project = create(:project)
-      silly_params =
+    context "with silly params" do
+      let(:unused_project) { create(:project) }
+      let(:settings_params) do
         {
           project_preferences: {
             user_id: unused_project.owner.id,
@@ -205,8 +215,12 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
             settings: { workflow_id: 1234 }
           }
         }
-      put :update_settings, silly_params
-      expect(response.status).to eq(404)
+      end
+
+      it "responds with a 404 if UPP not found" do
+        run_update
+        expect(response.status).to eq(404)
+      end
     end
   end
 end


### PR DESCRIPTION
since we don't know the resource URI we should not use PUT, instead we should use POST with the user_id & project_id params to update the resource. Not sure how well this will play with the json api client as i couldn't figure out if it'll work via a resource create. If it does then it'll require the resource to be serialized in full and not just return nothing.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.