### PR TITLE
Break up subjects default add_column migration

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -24,6 +24,11 @@ class Api::V1::SubjectsController < Api::ApiController
     super { |subject| SubjectRemovalWorker.perform_async(subject.id) }
   end
 
+  #REMOVE THIS AFTER THE RUNNING THE RAKE TASK TO UPDATE ALL THE ACTIVATED_STATES
+  def add_active_resources_scope
+    false
+  end
+
   private
 
   def check_subject_limit

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -26,6 +26,9 @@ class Subject < ActiveRecord::Base
   can_through_parent :project, :update, :index, :show, :destroy, :update_links,
                      :destroy_links, :versions, :version
 
+  #temp fix to ensure we're creating default values
+  before_create :set_activated_state
+
   def migrated_subject?
     !!migrated
   end
@@ -40,5 +43,10 @@ class Subject < ActiveRecord::Base
     else
       false
     end
+  end
+
+  #remove with the temp fix before_create callback
+  def set_activated_state
+    self.activated_state = 0
   end
 end

--- a/db/migrate/20160630170502_add_subjects_activated_state.rb
+++ b/db/migrate/20160630170502_add_subjects_activated_state.rb
@@ -1,5 +1,5 @@
 class AddSubjectsActivatedState < ActiveRecord::Migration
   def change
-    add_column :subjects, :activated_state, :integer, default: 0, null: false
+    add_column :subjects, :activated_state, :integer
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -950,7 +950,7 @@ CREATE TABLE subjects (
     migrated boolean,
     lock_version integer DEFAULT 0,
     upload_user_id integer,
-    activated_state integer DEFAULT 0 NOT NULL
+    activated_state integer
 );
 
 

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -38,8 +38,9 @@ module Subjects
     private
 
     def active_subjects_in_selection_order(sms_ids)
-      @scope
-      .active
+      #TODO: Rever to just active scope once the activated_state defaults / rake task has run
+      # @scope.active
+      @scope.where(activated_state: [nil, 0])
       .eager_load(:set_member_subjects)
       .where(set_member_subjects: {id: sms_ids})
       .order("idx(array[#{sms_ids.join(',')}], set_member_subjects.id)")

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -156,4 +156,15 @@ namespace :migrate do
       result_pages.update_all(url_key: 'results', title: 'Results')
     end
   end
+
+  namespace :subjects do
+    desc "Set default value for subject activated_state"
+    task :activated_state_default => :environment do
+      Subject.unscoped.select("id").find_in_batches do |batch|
+        Subject.unscoped.where(id: batch.map(&:id)).update_all(activated_state: 0)
+        print '.'
+      end
+      puts ' done'
+    end
+  end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -11,6 +11,13 @@ describe Subject, :type => :model do
     expect(subject).to be_valid
   end
 
+  #TODO: remove this once the activated_state defaults are in place
+  it "should set the activated_state on create" do
+    expect(subject.activated_state).to be_nil
+    subject.save
+    expect(subject.active?).to be_truthy
+  end
+
   describe "versioning" do
     let(:subject) { create(:subject) }
 


### PR DESCRIPTION
Let's try and avoid locking the large table so this will remove the addtional non-null constraint with the default value. On Staging - I'm going to undo the prev migration so this can run correctly this time.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
