### PR TITLE
Re add default activated_state value to subjects table

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -24,11 +24,6 @@ class Api::V1::SubjectsController < Api::ApiController
     super { |subject| SubjectRemovalWorker.perform_async(subject.id) }
   end
 
-  #REMOVE THIS AFTER THE RUNNING THE RAKE TASK TO UPDATE ALL THE ACTIVATED_STATES
-  def add_active_resources_scope
-    false
-  end
-
   private
 
   def check_subject_limit

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -26,9 +26,6 @@ class Subject < ActiveRecord::Base
   can_through_parent :project, :update, :index, :show, :destroy, :update_links,
                      :destroy_links, :versions, :version
 
-  #temp fix to ensure we're creating default values
-  before_create :set_activated_state
-
   def migrated_subject?
     !!migrated
   end
@@ -43,10 +40,5 @@ class Subject < ActiveRecord::Base
     else
       false
     end
-  end
-
-  #remove with the temp fix before_create callback
-  def set_activated_state
-    self.activated_state = 0
   end
 end

--- a/db/migrate/20160819134413_subject_activated_state_default.rb
+++ b/db/migrate/20160819134413_subject_activated_state_default.rb
@@ -1,0 +1,5 @@
+class SubjectActivatedStateDefault < ActiveRecord::Migration
+  def change
+    change_column_default(:subjects, :activated_state, false)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -950,7 +950,7 @@ CREATE TABLE subjects (
     migrated boolean,
     lock_version integer DEFAULT 0,
     upload_user_id integer,
-    activated_state integer
+    activated_state integer DEFAULT 0
 );
 
 
@@ -3458,4 +3458,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160630170502');
 INSERT INTO schema_migrations (version) VALUES ('20160810140805');
 
 INSERT INTO schema_migrations (version) VALUES ('20160810195152');
+
+INSERT INTO schema_migrations (version) VALUES ('20160819134413');
 

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -38,9 +38,7 @@ module Subjects
     private
 
     def active_subjects_in_selection_order(sms_ids)
-      #TODO: Rever to just active scope once the activated_state defaults / rake task has run
-      # @scope.active
-      @scope.where(activated_state: [nil, 0])
+      @scope.active
       .eager_load(:set_member_subjects)
       .where(set_member_subjects: {id: sms_ids})
       .order("idx(array[#{sms_ids.join(',')}], set_member_subjects.id)")

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -160,8 +160,10 @@ namespace :migrate do
   namespace :subjects do
     desc "Set default value for subject activated_state"
     task :activated_state_default => :environment do
-      Subject.unscoped.select("id").find_in_batches do |batch|
-        Subject.unscoped.where(id: batch.map(&:id)).update_all(activated_state: 0)
+      scope = Subject.unscoped
+      subjects = scope.where(activated_state: nil).select(:id)
+      subjects.find_in_batches do |batch|
+        scope.where(id: batch.map(&:id)).update_all(activated_state: 0)
         print '.'
       end
       puts ' done'

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -11,10 +11,7 @@ describe Subject, :type => :model do
     expect(subject).to be_valid
   end
 
-  #TODO: remove this once the activated_state defaults are in place
-  it "should set the activated_state on create" do
-    expect(subject.activated_state).to be_nil
-    subject.save
+  it "should by default be active" do
     expect(subject.active?).to be_truthy
   end
 


### PR DESCRIPTION
Merge / deploy only after #1915 has been deployed and the default values filled in by the rake task.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
