### PR TITLE
POST not PUT for UPP updates, collabs allowed

### DIFF
--- a/app/controllers/api/v1/project_preferences_controller.rb
+++ b/app/controllers/api/v1/project_preferences_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::ProjectPreferencesController < Api::ApiController
       user_id: params_for[:user_id],
       project_id: params_for[:project_id]
     )
-    unless @upp.project.owner?(api_user.user)
+    unless @upp.project.owners_and_collaborators.include?(api_user.user)
       raise Api::Unauthorized.new("You must be the project owner")
     end
   end

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -175,6 +175,17 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
       expect(found.settings["workflow_id"]).to eq(settings_params[:project_preferences][:settings][:workflow_id].to_s)
     end
 
+    it "allows collaborators to update UPP" do
+      collab = create(:user)
+      create(:access_control_list,
+             resource: project,
+             user_group: collab.identity_group,
+             roles: ["collaborator"])
+      default_request user_id: collab.id, scopes: scopes
+      run_update
+      expect(response.status).to eq(200)
+    end
+
     describe "trying to update attribute we aren't allowed to" do
       let(:settings_params) do
         {


### PR DESCRIPTION
Combines @camallen's PR (#1914) and adds allowing collaborators to update UPPs for their projects.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
