### PR TITLE
Correctly configure the panoptes client

### DIFF
--- a/app/workers/subject_removal_worker.rb
+++ b/app/workers/subject_removal_worker.rb
@@ -3,7 +3,7 @@ require 'subjects/remover'
 class SubjectRemovalWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :data_medium
+  sidekiq_options queue: :data_low
 
   def perform(subject_id)
     Subjects::Remover.new(subject_id).cleanup

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -45,7 +45,7 @@ module Subjects
     end
 
     def talk_client
-      @client ||= Panoptes::Client.new
+      @client ||= Panoptes::Client.new(env: Rails.env)
     end
 
     def notify_cellect(workflow_ids)

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -30,8 +30,7 @@ module Subjects
     end
 
     def orphan
-     @orphan ||=
-       Subject
+      @orphan ||= Subject
        .where(id: subject_id)
        .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
        .where("classification_subjects.subject_id IS NULL")

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -41,10 +41,10 @@ module Subjects
     end
 
     def no_talk_discussions?
-      talk_client.discussions(focus_id: subject_id, focus_type: 'Subject').empty?
+      panoptes_client.discussions(focus_id: subject_id, focus_type: 'Subject').empty?
     end
 
-    def talk_client
+    def panoptes_client
       @client ||= Panoptes::Client.new(env: Rails.env)
     end
 

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -8,16 +8,24 @@ RSpec.describe Subjects::Remover do
   let(:subjects) { subject_set.subjects }
   let(:subject) { subjects.sample }
   let(:remover) { Subjects::Remover.new(subject.id) }
-  let(:talk_client) { instance_double(Panoptes::Client) }
+  let(:panoptes_client) { instance_double(Panoptes::Client) }
   let(:discussions) { [] }
 
   describe "#cleanup" do
     before do
-      allow(talk_client)
+      allow(panoptes_client)
         .to receive(:discussions)
         .with(focus_id: subject.id, focus_type: "Subject")
         .and_return(discussions)
-      allow(remover).to receive(:talk_client).and_return(talk_client)
+      allow(remover).to receive(:panoptes_client).and_return(panoptes_client)
+    end
+
+    it "should setup the panoptes client with the correct env" do
+      expect(Panoptes::Client)
+        .to receive(:new)
+        .with(env: Rails.env)
+        .and_call_original
+      remover.cleanup
     end
 
     context "without a real subject" do

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -8,75 +8,82 @@ RSpec.describe Subjects::Remover do
   let(:subjects) { subject_set.subjects }
   let(:subject) { subjects.sample }
   let(:remover) { Subjects::Remover.new(subject.id) }
-  let(:panoptes_client) { instance_double(Panoptes::Client) }
-  let(:discussions) { [] }
 
   describe "#cleanup" do
-    before do
-      allow(panoptes_client)
-        .to receive(:discussions)
-        .with(focus_id: subject.id, focus_type: "Subject")
-        .and_return(discussions)
-      allow(remover).to receive(:panoptes_client).and_return(panoptes_client)
-    end
 
-    it "should setup the panoptes client with the correct env" do
-      expect(Panoptes::Client)
-        .to receive(:new)
-        .with(env: Rails.env)
-        .and_call_original
-      remover.cleanup
-    end
+    describe "testing the client configuration" do
 
-    context "without a real subject" do
-      let(:subject) { double(id: 100) }
-
-      it "should ignore non existant subject ids" do
-        expect(remover.cleanup).to be_falsey
+      it "should setup the panoptes client with the correct env" do
+        expect(Panoptes::Client)
+          .to receive(:new)
+          .with(env: Rails.env)
+          .and_call_original
+        remover.cleanup
       end
     end
 
-    it "should not remove a subject that has been classified" do
-      create(:classification, subjects: [subject])
-      expect(remover.cleanup).to be_falsey
-    end
+    context "with a client test double testing the client configuration" do
+      let(:panoptes_client) { instance_double(Panoptes::Client) }
+      let(:discussions) { [] }
 
-    it "should not remove a subject that has been collected" do
-      create(:collection, subjects: [subject])
-      expect(remover.cleanup).to be_falsey
-    end
+      before do
+        allow(panoptes_client)
+          .to receive(:discussions)
+          .with(focus_id: subject.id, focus_type: "Subject")
+          .and_return(discussions)
+        allow(remover).to receive(:panoptes_client).and_return(panoptes_client)
+      end
 
-    context "with a talk discussions" do
-      let(:discussions) { [{"dummy" => "discussion"}] }
+      context "without a real subject" do
+        let(:subject) { double(id: 100) }
 
-      it "should not remove a subject that has been in a talk discussion" do
+        it "should ignore non existant subject ids" do
+          expect(remover.cleanup).to be_falsey
+        end
+      end
+
+      it "should not remove a subject that has been classified" do
+        create(:classification, subjects: [subject])
         expect(remover.cleanup).to be_falsey
       end
-    end
 
-    it "should remove a subject that has not been used" do
-      remover.cleanup
-      expect { Subject.find(subject.id) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
+      it "should not remove a subject that has been collected" do
+        create(:collection, subjects: [subject])
+        expect(remover.cleanup).to be_falsey
+      end
 
-    it "should remove the associated set_member_subjects" do
-      sms_ids = subject.set_member_subjects.map(&:id)
-      remover.cleanup
-      expect { SetMemberSubject.find(sms_ids) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
+      context "with a talk discussions" do
+        let(:discussions) { [{"dummy" => "discussion"}] }
 
-    it "should remove the associated media resources" do
-      locations = subjects.map { |s| create(:medium, linked: s) }
-      media_ids = subject.reload.locations.map(&:id)
-      remover.cleanup
-      expect { Medium.find(media_ids) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
+        it "should not remove a subject that has been in a talk discussion" do
+          expect(remover.cleanup).to be_falsey
+        end
+      end
 
-    it "notify cellect about the subject removal" do
-      expect(RetireCellectWorker)
-        .to receive(:perform_async)
-        .with(subject.id, workflow.id)
-      remover.cleanup
+      it "should remove a subject that has not been used" do
+        remover.cleanup
+        expect { Subject.find(subject.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "should remove the associated set_member_subjects" do
+        sms_ids = subject.set_member_subjects.map(&:id)
+        remover.cleanup
+        expect { SetMemberSubject.find(sms_ids) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "should remove the associated media resources" do
+        locations = subjects.map { |s| create(:medium, linked: s) }
+        media_ids = subject.reload.locations.map(&:id)
+        remover.cleanup
+        expect { Medium.find(media_ids) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "notify cellect about the subject removal" do
+        expect(RetireCellectWorker)
+          .to receive(:perform_async)
+          .with(subject.id, workflow.id)
+        remover.cleanup
+      end
     end
   end
 end


### PR DESCRIPTION
Make sure the panoptes client is using the correct operating env. Also lowered the subject removal worker queue priority.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
