### PR TITLE
skip the subject removal temporarily

### DIFF
--- a/app/workers/subject_removal_worker.rb
+++ b/app/workers/subject_removal_worker.rb
@@ -6,6 +6,8 @@ class SubjectRemovalWorker
   sidekiq_options queue: :data_low
 
   def perform(subject_id)
-    Subjects::Remover.new(subject_id).cleanup
+    #TODO: figure out why these subject deletes are maxing out the DB CPU
+    # in the meantime just move on and leave them as inactive
+    # Subjects::Remover.new(subject_id).cleanup
   end
 end

--- a/spec/workers/subject_removal_worker_spec.rb
+++ b/spec/workers/subject_removal_worker_spec.rb
@@ -3,10 +3,17 @@ require 'spec_helper'
 RSpec.describe SubjectRemovalWorker do
   let(:subject_id) { 1 }
 
-  it 'should call the orphan remover cleanup' do
-    remover = instance_double(Subjects::Remover)
-    expect(Subjects::Remover).to receive(:new).with(subject_id).and_return(remover)
-    expect(remover).to receive(:cleanup)
+  # TODO: reinstate this when the cleanup code is not killing the db
+  # it 'should call the orphan remover cleanup' do
+  #   remover = instance_double(Subjects::Remover)
+  #   expect(Subjects::Remover).to receive(:new).with(subject_id).and_return(remover)
+  #   expect(remover).to receive(:cleanup)
+  #   subject.perform(subject_id)
+  # end
+
+  # remove this when the above is fixed
+  it 'should not call the orphan remover cleanup', :focus do
+    expect(Subjects::Remover).not_to receive(:new)
     subject.perform(subject_id)
   end
 end


### PR DESCRIPTION
cleaning up subjects is causing really high cpu on the db, skipping the cleanup in the meantime instead just leaving them as inactive.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.