### PR TITLE
Disable Hound multiline method chains indentation warnings

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -204,3 +204,5 @@ Lint/LiteralInCondition:
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.
   Enabled: false
+Style/MultilineMethodCallIndentation:
+  Enabled: false


### PR DESCRIPTION
Stops hound complaints about:

```ruby
Foo.bar
  .baz
  .quux
```