### PR TITLE
Save user project_id attr on first UPP save

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -40,7 +40,10 @@ module Api
         was_new = upp.new_record?
         upp.legacy_count[create_params[:workflow]] = create_params[:count]
         if upp.save
-          ProjectClassifiersCountWorker.perform_async(upp.project_id) if was_new
+          if was_new
+            ProjectClassifiersCountWorker.perform_async(upp.project_id)
+            upp.user.update( {project_id: upp.project.id} )
+          end
           :ok
         else
           :unprocessable_entity

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -42,7 +42,7 @@ module Api
         if upp.save
           if was_new
             ProjectClassifiersCountWorker.perform_async(upp.project_id)
-            upp.user.update( {project_id: upp.project.id} )
+            upp.user.update_column(:project_id, upp.project.id)
           end
           :ok
         else

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -37,7 +37,7 @@ class ClassificationLifecycle
       if first_classifcation = upp.email_communication.nil?
         ProjectClassificationsCountWorker.perform_async(project.id)
         upp.email_communication = user.project_email_communication
-        upp.user.update( {project_id: project.id} )
+        upp.user.update_column(:project_id, project.id)
       end
       upp.changed? ? upp.save! : upp.touch
     end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -37,6 +37,7 @@ class ClassificationLifecycle
       if first_classifcation = upp.email_communication.nil?
         ProjectClassificationsCountWorker.perform_async(project.id)
         upp.email_communication = user.project_email_communication
+        upp.user.update( {project_id: project.id} )
       end
       upp.changed? ? upp.save! : upp.touch
     end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -18,7 +18,7 @@ describe Api::EventsController, type: :controller do
       let(:workflow) { create(:workflow) }
       let(:project) do
         p = workflow.project
-        p.update_columns(migrated: true, id: zoo_home_project_id, configuration: { zoo_home_project_id: zoo_home_project_id })
+        p.update_columns(migrated: true, configuration: { zoo_home_project_id: zoo_home_project_id })
         p
       end
       let(:user) do
@@ -179,7 +179,6 @@ describe Api::EventsController, type: :controller do
         end
 
         it "sets the project_id" do
-          first_visit_event_params[:event][:project_id] = project.id
           post :create, first_visit_event_params
           user.reload
           expect(user.project_id).to eq(project.id)

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -18,7 +18,7 @@ describe Api::EventsController, type: :controller do
       let(:workflow) { create(:workflow) }
       let(:project) do
         p = workflow.project
-        p.update_columns(migrated: true, configuration: { zoo_home_project_id: zoo_home_project_id })
+        p.update_columns(migrated: true, id: zoo_home_project_id, configuration: { zoo_home_project_id: zoo_home_project_id })
         p
       end
       let(:user) do
@@ -144,7 +144,7 @@ describe Api::EventsController, type: :controller do
 
       context "when the project id refers to a non-legacy migrated project" do
         let(:unknown_legacy_project) do
-          overridden_params(project_id: project.id)
+          overridden_params(project_id: 9999)
         end
 
         it "should respond with a 422" do
@@ -176,6 +176,13 @@ describe Api::EventsController, type: :controller do
             .to receive(:perform_async)
             .with(project.id)
           post :create, first_visit_event_params
+        end
+
+        it "sets the project_id" do
+          first_visit_event_params[:event][:project_id] = project.id
+          post :create, first_visit_event_params
+          user.reload
+          expect(user.project_id).to eq(project.id)
         end
 
         context "with an unknown user zooniverse_id" do

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -315,6 +315,12 @@ describe ClassificationLifecycle do
           expect_any_instance_of(UserProjectPreference).to receive(:save!)
           subject.process_project_preference
         end
+
+        it "saves the project id" do
+          subject.process_project_preference
+          user.reload
+          expect(user.project_id).to eq(project.id)
+        end
       end
 
       context "when a preference exists" do


### PR DESCRIPTION
Closes #1794. Saves a user's project_id when the UPP is created for the first time so that we know which project was the first that a user contributed to.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

