### PR TITLE
Do not verify self-signed SSL certs used by CellectEx

### DIFF
--- a/app/services/cellect_ex_client.rb
+++ b/app/services/cellect_ex_client.rb
@@ -13,7 +13,7 @@ class CellectExClient
   end
 
   def connect!(adapter)
-    Faraday.new host do |faraday|
+    Faraday.new(host, ssl: {verify: false}) do |faraday|
       faraday.response :json, content_type: /\bjson$/
       faraday.adapter(*adapter)
     end


### PR DESCRIPTION
Tiny snag: those self-signed certs I added at the last minute don't pass verification, and Faraday apparently enforces verification by default (which is great!).