### PR TITLE
unblock workers that counting changes introduced.

### DIFF
--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -1,6 +1,8 @@
 class ClassificationCountWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :data_medium
+
   def perform(subject_id, workflow_id)
     workflow = Workflow.find(workflow_id)
 

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -4,7 +4,7 @@ class ProjectClassificationsCountWorker
   sidekiq_options queue: :data_low
 
   sidekiq_options congestion: {
-    interval: 30,
+    interval: 60,
     max_in_interval: 1,
     min_delay: 0,
     reject_with: :cancel,

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -1,6 +1,8 @@
 class ProjectClassificationsCountWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :data_low
+
   sidekiq_options congestion: {
     interval: 15,
     max_in_interval: 1,

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -12,6 +12,9 @@ class ProjectClassificationsCountWorker
   }
 
   def perform(project_id)
+    #temp fix to clear the counters
+    return nil
+
     project = Project.find(project_id)
     project.workflows.map do |workflow|
       counter = WorkflowCounter.new(workflow)

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -4,10 +4,10 @@ class ProjectClassificationsCountWorker
   sidekiq_options queue: :data_low
 
   sidekiq_options congestion: {
-    interval: 15,
+    interval: 30,
     max_in_interval: 1,
     min_delay: 0,
-    reject_with: :reschedule,
+    reject_with: :cancel,
     key: ->(project_id) {
       "project_#{project_id}_classifications_count_worker"
     }

--- a/app/workers/project_classifiers_count_worker.rb
+++ b/app/workers/project_classifiers_count_worker.rb
@@ -2,10 +2,10 @@ class ProjectClassifiersCountWorker
   include Sidekiq::Worker
 
   sidekiq_options congestion: {
-    interval: 15,
+    interval: 60,
     max_in_interval: 1,
     min_delay: 0,
-    reject_with: :reschedule,
+    reject_with: :cancel,
     key: ->(project_id) { "project_#{project_id}_classifiers_count_worker" }
   }
 

--- a/app/workers/project_classifiers_count_worker.rb
+++ b/app/workers/project_classifiers_count_worker.rb
@@ -1,6 +1,8 @@
 class ProjectClassifiersCountWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :data_low
+
   sidekiq_options congestion: {
     interval: 60,
     max_in_interval: 1,

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProjectClassificationsCountWorker do
   let(:workflow) { create(:workflow) }
   let!(:project) { workflow.project }
 
-  describe "#perform", :focus do
+  describe "#perform" do
     # temp fix - remove this once we've cleared the jam
     # and figured out how to do the counting for certain projects
     it "should return nil" do

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -5,23 +5,29 @@ RSpec.describe ProjectClassificationsCountWorker do
   let(:workflow) { create(:workflow) }
   let!(:project) { workflow.project }
 
-  describe "#perform" do
-    it 'calls the workflow counter to update the workflow counts' do
-      expect_any_instance_of(WorkflowCounter)
-        .to receive(:classifications)
-      expect_any_instance_of(Workflow)
-        .to receive(:update_column)
-        .with(:classifications_count, anything)
-      worker.perform(project.id)
+  describe "#perform", :focus do
+    # temp fix - remove this once we've cleared the jam
+    # and figured out how to do the counting for certain projects
+    it "should return nil" do
+      expect(worker.perform(project.id)).to be_nil
     end
 
-    it 'calls the project counter to update the project counts' do
-      expect_any_instance_of(ProjectCounter)
-        .to receive(:classifications)
-      expect_any_instance_of(Project)
-        .to receive(:update_column)
-        .with(:classifications_count, anything)
-      worker.perform(project.id)
-    end
+    # it 'calls the workflow counter to update the workflow counts' do
+    #   expect_any_instance_of(WorkflowCounter)
+    #     .to receive(:classifications)
+    #   expect_any_instance_of(Workflow)
+    #     .to receive(:update_column)
+    #     .with(:classifications_count, anything)
+    #   worker.perform(project.id)
+    # end
+    #
+    # it 'calls the project counter to update the project counts' do
+    #   expect_any_instance_of(ProjectCounter)
+    #     .to receive(:classifications)
+    #   expect_any_instance_of(Project)
+    #     .to receive(:update_column)
+    #     .with(:classifications_count, anything)
+    #   worker.perform(project.id)
+    # end
   end
 end


### PR DESCRIPTION
Temp for to skip long project counts and modified the rate limiting and the queue priorities to ensure high priority jobs run before the counts.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
