### PR TITLE
Fix slow count queries

### DIFF
--- a/app/counters/project_counter.rb
+++ b/app/counters/project_counter.rb
@@ -7,13 +7,10 @@ class ProjectCounter
   end
 
   def volunteers
-    upps = UserProjectPreference
-      .joins("INNER JOIN classifications ON classifications.user_id = user_project_preferences.user_id")
+    UserProjectPreference
       .where(project_id: project.id)
-    if launch_date
-      upps = upps.where("classifications.created_at >= ?", launch_date)
-    end
-    upps.distinct.count
+      .where.not(email_communication: nil)
+      .count
   end
 
   def classifications

--- a/db/migrate/20160901100944_add_classification_subject_join_index.rb
+++ b/db/migrate/20160901100944_add_classification_subject_join_index.rb
@@ -1,0 +1,9 @@
+class AddClassificationSubjectJoinIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    unless index_exists?(:classification_subjects, :subject_id)
+      add_index :classification_subjects, :subject_id, algorithm: :concurrently
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2047,6 +2047,13 @@ CREATE INDEX index_classification_subjects_on_classification_id ON classificatio
 
 
 --
+-- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_classification_subjects_on_subject_id ON classification_subjects USING btree (subject_id);
+
+
+--
 -- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3463,4 +3470,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160810195152');
 INSERT INTO schema_migrations (version) VALUES ('20160819134413');
 
 INSERT INTO schema_migrations (version) VALUES ('20160824101413');
+
+INSERT INTO schema_migrations (version) VALUES ('20160901100944');
 

--- a/spec/counters/project_counter_spec.rb
+++ b/spec/counters/project_counter_spec.rb
@@ -33,14 +33,12 @@ describe ProjectCounter do
   end
 
   describe 'volunteers' do
-    it_should_behave_like 'a project counter', :volunteers
 
-    it "should only count the disctinct joins" do
-      c1 = create(:classification, project: project)
-      c2 = create(:classification, project: project)
-      create(:user_project_preference, project: project, user: c1.user)
-      create(:user_project_preference, project: project, user: c2.user)
-      create(:classification, user: c2.user, project: project)
+    it "should return 2" do
+      2.times do
+        c = create(:classification, project: project)
+        create(:user_project_preference, project: project, user: c.user)
+      end
       expect(counter.volunteers).to eq(2)
     end
   end

--- a/spec/workers/reset_project_counters_worker_spec.rb
+++ b/spec/workers/reset_project_counters_worker_spec.rb
@@ -13,7 +13,7 @@ describe ResetProjectCountersWorker do
     classification2 = create(:classification, user: user2, created_at: project.launch_date - 1.week, project: project, workflow: workflow, subjects: [subject])
     classification3 = create(:classification, user: user2, created_at: project.launch_date + 1.week, project: project, workflow: workflow, subjects: [subject])
 
-    project.update_columns classifications_count: 3, classifiers_count: 2
+    project.update_columns classifications_count: 3, classifiers_count: 3
     workflow.update_columns classifications_count: 3
 
     create :user_project_preference, user: user1, project: project
@@ -30,7 +30,7 @@ describe ResetProjectCountersWorker do
 
   it 'resets classifiers count' do
     described_class.new.perform(project.id)
-    expect { project.reload }.to change { project.classifiers_count }.from(2).to(1)
+    expect { project.reload }.to change { project.classifiers_count }.from(3).to(2)
   end
 
   it 'resets workflow classifications count' do


### PR DESCRIPTION
Make sure the counter queries aren't forcing table scans and use fast queries where we can. This PR is a start, i'll review the lot and update with subsequent PRs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

