### PR TITLE
speed up doorkeeper lookups

### DIFF
--- a/db/migrate/20160901141903_add_oauth_tokens_index.rb
+++ b/db/migrate/20160901141903_add_oauth_tokens_index.rb
@@ -2,6 +2,8 @@ class AddOauthTokensIndex < ActiveRecord::Migration
   disable_ddl_transaction!
 
   def change
+    Doorkeeper::AccessCleanup.new.cleanup!
+
     unless index_exists?(:oauth_access_tokens, [:application_id, :resource_owner_id])
       add_index :oauth_access_tokens, [:application_id, :resource_owner_id],
         name: 'index_oauth_access_tokens_on_app_id_and_owner_id',

--- a/db/migrate/20160901141903_add_oauth_tokens_index.rb
+++ b/db/migrate/20160901141903_add_oauth_tokens_index.rb
@@ -1,0 +1,11 @@
+class AddOauthTokensIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    unless index_exists?(:oauth_access_tokens, [:application_id, :resource_owner_id])
+      add_index :oauth_access_tokens, [:application_id, :resource_owner_id],
+        name: 'index_oauth_access_tokens_on_app_id_and_owner_id',
+        algorithm: :concurrently
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2215,6 +2215,13 @@ CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON oauth_access_grants US
 
 
 --
+-- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_oauth_access_tokens_on_app_id_and_owner_id ON oauth_access_tokens USING btree (application_id, resource_owner_id);
+
+
+--
 -- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3472,4 +3479,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160819134413');
 INSERT INTO schema_migrations (version) VALUES ('20160824101413');
 
 INSERT INTO schema_migrations (version) VALUES ('20160901100944');
+
+INSERT INTO schema_migrations (version) VALUES ('20160901141903');
 

--- a/lib/gem_ext/doorkeeper/access_cleanup.rb
+++ b/lib/gem_ext/doorkeeper/access_cleanup.rb
@@ -1,0 +1,34 @@
+module Doorkeeper
+  class AccessCleanup
+    attr_reader :keep_for_days
+
+    def initialize(keep_for_days: 30)
+      @keep_for_days = keep_for_days
+    end
+
+    def cleanup!
+      Doorkeeper::AccessGrant.transaction {
+        expired_grants.delete_all
+        expired_tokens.delete_all
+      }
+    end
+
+    def expired_grants
+      Doorkeeper::AccessGrant.where(expiry_params)
+    end
+
+    def expired_tokens
+      Doorkeeper::AccessToken.where(expiry_params)
+    end
+
+    def delete_before
+      DateTime.now - keep_for_days.days
+    end
+
+    protected
+
+    def expiry_params
+      ["created_at < ? OR revoked_at IS NOT NULL", delete_before]
+    end
+  end
+end

--- a/spec/lib/gem_ext/doorkeeper/access_cleanup_spec.rb
+++ b/spec/lib/gem_ext/doorkeeper/access_cleanup_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Doorkeeper::AccessCleanup do
+
+  shared_examples 'it cleans up after doorkeeper' do
+
+    it "should not cleanup expired" do
+      cleaner.cleanup!
+      expect{ instance.reload }.not_to raise_error
+    end
+
+    it "should not cleanup revoked" do
+      cleaner.cleanup!
+      expect{ instance.reload }.not_to raise_error
+    end
+
+    it "should cleanup a revoked" do
+      instance.revoke
+      cleaner.cleanup!
+      expect{ instance.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "should cleanup an old expired" do
+      instance.update_column(:created_at, DateTime.now - 31.day)
+      cleaner.cleanup!
+      expect{ instance.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe 'cleanup!' do
+    let(:cleaner) { described_class.new }
+    let(:owner) { create(:user) }
+    let(:app) { create(:application, owner: owner)}
+
+    it_should_behave_like "it cleans up after doorkeeper" do
+      let!(:instance) do
+        Doorkeeper::AccessToken.create! do |ac|
+          ac.resource_owner_id = owner.id
+          ac.application_id = app.id
+          ac.expires_in = 7200
+          ac.scopes = "public test"
+        end
+      end
+    end
+
+    it_should_behave_like "it cleans up after doorkeeper" do
+      let!(:instance) do
+        Doorkeeper::AccessGrant.create! do |ag|
+          ag.resource_owner_id = owner.id
+          ag.application_id = app.id
+          ag.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
+          ag.expires_in = 7200
+          ag.scopes = "public test"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
add index for doorkeeper authorisation lookup now with cleanup code that will remove old tokens / grants before running the migration. We should add (happy to do for this PR but can come in future) a rake task / scheduled worker for the cleanup

Also once these get cleanup up it'll help with the issue of the video showing on the home page for PFE. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
