### PR TITLE
summate the counters from the lowest level

### DIFF
--- a/app/counters/project_counter.rb
+++ b/app/counters/project_counter.rb
@@ -14,14 +14,6 @@ class ProjectCounter
   end
 
   def classifications
-    classifications = project.classifications
-    if launch_date
-      classifications = classifications.where("created_at >= ?", launch_date)
-    end
-    classifications.count
-  end
-
-  def launch_date
-    @launch_date ||= project.launch_date
+    project.workflows.sum(:classifications_count)
   end
 end

--- a/app/counters/workflow_counter.rb
+++ b/app/counters/workflow_counter.rb
@@ -7,10 +7,6 @@ class WorkflowCounter
   end
 
   def classifications
-    scope = workflow.classifications
-    if launch_date = workflow.project.launch_date
-      scope = workflow.classifications.where("created_at >= ?", launch_date)
-    end
-    scope.count
+    SubjectWorkflowStatus.where(workflow: workflow).sum(:classifications_count)
   end
 end

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -14,9 +14,6 @@ class ProjectClassificationsCountWorker
   }
 
   def perform(project_id)
-    #temp fix to clear the counters
-    return nil
-
     project = Project.find(project_id)
     project.workflows.map do |workflow|
       counter = WorkflowCounter.new(workflow)

--- a/app/workers/reset_project_counters_worker.rb
+++ b/app/workers/reset_project_counters_worker.rb
@@ -11,18 +11,17 @@ class ResetProjectCountersWorker
 
   def perform(project_id, rate_limit=true)
     project = Project.find(project_id)
-    counter = ProjectCounter.new(project)
+    project.workflows.each do |workflow|
+      reset_subject_workflow_classification_counters!(workflow)
+      counter = WorkflowCounter.new(workflow)
+      workflow.update_columns classifications_count: counter.classifications
+    end
 
+    counter = ProjectCounter.new(project)
     project.update_columns(
       classifications_count: counter.classifications,
       classifiers_count: counter.volunteers
     )
-
-    project.workflows.find_each do |workflow|
-      counter = WorkflowCounter.new(workflow)
-      workflow.update_columns classifications_count: counter.classifications
-      reset_subject_workflow_classification_counters!(workflow)
-    end
   end
 
   private

--- a/spec/counters/project_counter_spec.rb
+++ b/spec/counters/project_counter_spec.rb
@@ -1,38 +1,14 @@
 require 'spec_helper'
 
 describe ProjectCounter do
-  let(:project) { create(:project) }
+  let(:project) { create(:project_with_workflows) }
   let(:counter) { ProjectCounter.new(project) }
 
-  shared_examples 'a project counter' do |counter_name|
-    let(:now) { DateTime.now.utc }
+  describe 'volunteers' do
 
     it "should return 0 if there are none" do
-      expect(counter.send(counter_name)).to eq(0)
+      expect(counter.volunteers).to eq(0)
     end
-
-    context "with classifications" do
-      before do
-        2.times do
-          c = create(:classification, project: project)
-          create(:user_project_preference, project: project, user: c.user)
-        end
-      end
-
-      it "should return 2" do
-        expect(counter.send(counter_name)).to eq(2)
-      end
-
-      it "should respect the project launch date" do
-        allow(counter).to receive(:launch_date).and_return(now)
-        expect(counter.send(counter_name)).to eq(0)
-        allow(counter).to receive(:launch_date).and_return(now-1.day)
-        expect(counter.send(counter_name)).to eq(2)
-      end
-    end
-  end
-
-  describe 'volunteers' do
 
     it "should return 2" do
       2.times do
@@ -44,6 +20,16 @@ describe ProjectCounter do
   end
 
   describe 'classifications' do
-    it_should_behave_like 'a project counter', :classifications
+
+    it "should return 0 if there are none" do
+      expect(counter.classifications).to eq(0)
+    end
+
+    it "should return 2" do
+      project.workflows.each do |w|
+        w.update_column(:classifications_count, 1)
+      end
+      expect(counter.classifications).to eq(2)
+    end
   end
 end

--- a/spec/counters/workflow_counter_spec.rb
+++ b/spec/counters/workflow_counter_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe WorkflowCounter do
-  let(:workflow) { create(:workflow) }
-  let(:project) { workflow.project }
+  let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
   let(:counter) { WorkflowCounter.new(workflow) }
 
   describe 'classifications' do
@@ -14,20 +13,12 @@ describe WorkflowCounter do
 
     context "with classifications" do
       before do
-        2.times do
-          c = create(:classification, project: project, workflow: workflow)
-          create(:user_project_preference, project: project, user: c.user)
+        workflow.subjects.each do |subject|
+          create(:subject_workflow_status, workflow: workflow, subject: subject, classifications_count: 1)
         end
       end
 
       it "should return 2" do
-        expect(counter.classifications).to eq(2)
-      end
-
-      it "should respect the project launch date" do
-        allow(project).to receive(:launch_date).and_return(now)
-        expect(counter.classifications).to eq(0)
-        allow(project).to receive(:launch_date).and_return(now-1.day)
         expect(counter.classifications).to eq(2)
       end
     end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -66,8 +66,12 @@ FactoryGirl.define do
     end
 
     factory :workflow_with_subjects do
-      after(:create) do |w|
-        create_list(:subject_set_with_subjects, 2, workflows: [w], project: w.project)
+      ignore do
+        num_sets 2
+      end
+
+      after(:create) do |w, evaluator|
+        create_list(:subject_set_with_subjects, evaluator.num_sets, workflows: [w], project: w.project)
       end
     end
 

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -6,28 +6,23 @@ RSpec.describe ProjectClassificationsCountWorker do
   let!(:project) { workflow.project }
 
   describe "#perform" do
-    # temp fix - remove this once we've cleared the jam
-    # and figured out how to do the counting for certain projects
-    it "should return nil" do
-      expect(worker.perform(project.id)).to be_nil
+
+    it 'calls the workflow counter to update the workflow counts' do
+      expect_any_instance_of(WorkflowCounter)
+        .to receive(:classifications)
+      expect_any_instance_of(Workflow)
+        .to receive(:update_column)
+        .with(:classifications_count, anything)
+      worker.perform(project.id)
     end
 
-    # it 'calls the workflow counter to update the workflow counts' do
-    #   expect_any_instance_of(WorkflowCounter)
-    #     .to receive(:classifications)
-    #   expect_any_instance_of(Workflow)
-    #     .to receive(:update_column)
-    #     .with(:classifications_count, anything)
-    #   worker.perform(project.id)
-    # end
-    #
-    # it 'calls the project counter to update the project counts' do
-    #   expect_any_instance_of(ProjectCounter)
-    #     .to receive(:classifications)
-    #   expect_any_instance_of(Project)
-    #     .to receive(:update_column)
-    #     .with(:classifications_count, anything)
-    #   worker.perform(project.id)
-    # end
+    it 'calls the project counter to update the project counts' do
+      expect_any_instance_of(ProjectCounter)
+        .to receive(:classifications)
+      expect_any_instance_of(Project)
+        .to receive(:update_column)
+        .with(:classifications_count, anything)
+      worker.perform(project.id)
+    end
   end
 end


### PR DESCRIPTION
Rely on the subject workflow status counts being the authoritative source of classification counts that respect the launch dates, just aggregate these up the chain via simple sum queries to avoid counting these again.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
