### PR TITLE
respect active linked workflow state for counting at project level

### DIFF
--- a/app/counters/project_counter.rb
+++ b/app/counters/project_counter.rb
@@ -14,6 +14,6 @@ class ProjectCounter
   end
 
   def classifications
-    project.workflows.sum(:classifications_count)
+    project.workflows.where(active: true).sum(:classifications_count)
   end
 end

--- a/spec/counters/project_counter_spec.rb
+++ b/spec/counters/project_counter_spec.rb
@@ -25,11 +25,21 @@ describe ProjectCounter do
       expect(counter.classifications).to eq(0)
     end
 
-    it "should return 2" do
-      project.workflows.each do |w|
-        w.update_column(:classifications_count, 1)
+    context "with classifications counts" do
+      before do
+        project.workflows.each do |w|
+          w.update_column(:classifications_count, 1)
+        end
       end
-      expect(counter.classifications).to eq(2)
+
+      it "should return 2" do
+        expect(counter.classifications).to eq(2)
+      end
+
+      it "should only count the active workflows" do
+        project.workflows.last.update_column(:active, false)
+        expect(counter.classifications).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
Don't count testing / inactive workflow classifications. 

I did notice that the active field here clashes with the activatable enum scope active? which we should look at too, basically `workflow.active = false` => `workflow.active? == true` which threw me a bit. i'm wondering if / what to rename the active field to since i like the name active and people are used to it on the front end.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

