### PR TITLE
Fix early retire workflows

### DIFF
--- a/app/counters/workflow_counter.rb
+++ b/app/counters/workflow_counter.rb
@@ -9,4 +9,18 @@ class WorkflowCounter
   def classifications
     SubjectWorkflowStatus.where(workflow: workflow).sum(:classifications_count)
   end
+
+  def retired_subjects
+    retired = SubjectWorkflowStatus.by_set(workflow.subject_sets.pluck(:id)).retired.where(workflow_id: workflow.id)
+    if launch_date
+      retired = retired.where("subject_workflow_counts.created_at >= ?", launch_date)
+    end
+    retired.count
+  end
+
+  private
+
+  def launch_date
+    workflow.project.launch_date
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -139,11 +139,11 @@ class Project < ActiveRecord::Base
   end
 
   def retired_subjects_count
-    @retired_subject_count ||= workflows.sum :retired_set_member_subjects_count
+    @retired_subject_count ||= active_workflows.sum :retired_set_member_subjects_count
   end
 
   def finished?
-    super ? super : workflows.all?(&:finished?)
+    super ? super : active_workflows.all?(&:finished?)
   end
 
   def state

--- a/spec/counters/workflow_counter_spec.rb
+++ b/spec/counters/workflow_counter_spec.rb
@@ -5,7 +5,6 @@ describe WorkflowCounter do
   let(:counter) { WorkflowCounter.new(workflow) }
 
   describe 'classifications' do
-    let(:now) { DateTime.now.utc }
 
     it "should return 0 if there are none" do
       expect(counter.classifications).to eq(0)
@@ -20,6 +19,35 @@ describe WorkflowCounter do
 
       it "should return 2" do
         expect(counter.classifications).to eq(2)
+      end
+    end
+  end
+
+  describe 'retired subjects' do
+
+    it "should return 0 if there are none" do
+      expect(counter.retired_subjects).to eq(0)
+    end
+
+    context "with workflow counts" do
+      before do
+        workflow.subjects.each do |subject|
+          create(:subject_workflow_status, workflow: workflow, subject: subject, retired_at: DateTime.now)
+        end
+      end
+
+      it "should return 2" do
+        expect(counter.retired_subjects).to eq(2)
+      end
+
+      it "should respect the project launch date" do
+        workflow.project.update_column(:launch_date, DateTime.now+1.day)
+        expect(counter.retired_subjects).to eq(0)
+      end
+
+      it "should return 0 when a subject set was unlinked" do
+        workflow.subject_sets = []
+        expect(counter.retired_subjects).to eq(0)
       end
     end
   end

--- a/spec/workers/workflow_retired_count_worker_spec.rb
+++ b/spec/workers/workflow_retired_count_worker_spec.rb
@@ -1,37 +1,23 @@
 require "spec_helper"
 
 RSpec.describe WorkflowRetiredCountWorker do
-  let(:workflows) { create_list(:workflow, 2, subject_sets: []) }
-  let(:subject_set) { create(:subject_set, workflows: workflows) }
-  let(:sms) { create_list(:set_member_subject, 4, subject_set: subject_set) }
-
   subject(:worker) { WorkflowRetiredCountWorker.new }
+  let(:workflow) { create(:workflow) }
 
   describe "#perform" do
-    let(:workflow) { workflows.first }
-    let(:non_retired_swc) do
-      create(:subject_workflow_status, subject: sms.last.subject, workflow: workflow, link_subject_sets: false)
-    end
-    before do
-      workflow.update! retired_set_member_subjects_count: 100
-      sms.take(2).each do |s|
-        opts = { subject: s.subject, workflow: workflow, retired_at: Time.now, link_subject_sets: false}
-        create(:subject_workflow_status, opts)
-      end
+
+    it 'should update the workflow retired count' do
+      allow(Workflow).to receive(:find).and_return(workflow)
+      expect(workflow)
+        .to receive(:update_column)
+        .with(:retired_set_member_subjects_count, anything)
+      worker.perform(workflow.id)
     end
 
-    it 'should reset the workflow retired count' do
-      non_retired_swc
-      expect do
-        worker.perform(workflow.id)
-      end.to change{Workflow.find(workflow.id).retired_set_member_subjects_count}.from(100).to(2)
-    end
-
-    it 'should respect the project launch date' do
-      workflow.project.update_column(:launch_date, DateTime.now)
-      expect do
-        worker.perform(workflow.id)
-      end.to change{Workflow.find(workflow.id).retired_set_member_subjects_count}.from(100).to(0)
+    it 'should use a workflow counter to do it' do
+      counter = instance_double(WorkflowCounter, retired_subjects: 0)
+      expect(WorkflowCounter).to receive(:new).with(workflow).and_return(counter)
+      worker.perform(workflow.id)
     end
   end
 end


### PR DESCRIPTION
Only count the current set of linked subjects to determine the retired subject count for the workflow and respect live workflows for the project counts.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
