### PR TITLE
Avoid multiple classifcation counts on classification receipt

### DIFF
--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -9,8 +9,8 @@ class ClassificationCountWorker
     if workflow.project.live
       count = SubjectWorkflowStatus.find_or_create_by!(subject_id: subject_id, workflow_id: workflow_id)
 
-      counter = SubjectWorkflowCounter.new(count)
-      count.update_column(:classifications_count, counter.classifications)
+      count.class.increment_counter(:classifications_count, count.id)
+      SubjectWorkflowStatusCountWorker.perform_async(count.id)
 
       ProjectClassificationsCountWorker.perform_async(workflow.project.id)
       RetirementWorker.perform_async(count.id)

--- a/app/workers/subject_workflow_status_count_worker.rb
+++ b/app/workers/subject_workflow_status_count_worker.rb
@@ -1,7 +1,7 @@
 class SubjectWorkflowStatusCountWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :data_low
+  sidekiq_options queue: :really_high
 
   sidekiq_options congestion: {
     interval: ENV.fetch("sws_count_worker_interval", 30),

--- a/app/workers/subject_workflow_status_count_worker.rb
+++ b/app/workers/subject_workflow_status_count_worker.rb
@@ -1,0 +1,21 @@
+class SubjectWorkflowStatusCountWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_low
+
+  sidekiq_options congestion: {
+    interval: ENV.fetch("sws_count_worker_interval", 30),
+    max_in_interval: ENV.fetch("sws_count_worker_max_in_interval", 1),
+    min_delay: 0,
+    reject_with: ENV.fetch("sws_count_worker_reject_with", :cancel),
+    key: ->(count_id) {
+      "sws_#{count_id}_count_worker"
+    }
+  }
+
+  def perform(count_id)
+    sws = SubjectWorkflowStatus.find(count_id)
+    counter = SubjectWorkflowCounter.new(sws)
+    sws.update_column(:classifications_count, counter.classifications)
+  end
+end

--- a/spec/workers/classification_count_worker_spec.rb
+++ b/spec/workers/classification_count_worker_spec.rb
@@ -15,12 +15,17 @@ RSpec.describe ClassificationCountWorker do
           create(:subject_workflow_status, subject: sms.subject, workflow_id: workflow_id)
         end
 
-        it 'should call the counter to update the classifications_count' do
-          expect_any_instance_of(SubjectWorkflowCounter)
-            .to receive(:classifications)
-          expect_any_instance_of(SubjectWorkflowStatus)
-            .to receive(:update_column)
-            .with(:classifications_count, anything)
+        it 'should incremement the classifications_count counter' do
+          expect(SubjectWorkflowStatus)
+            .to receive(:increment_counter)
+            .with(:classifications_count, count.id)
+          worker.perform(sms.subject_id, workflow_id)
+        end
+
+        it 'should call a worker to accurately count the classifications' do
+          expect(SubjectWorkflowStatusCountWorker)
+            .to receive(:perform_async)
+            .with(count.id)
           worker.perform(sms.subject_id, workflow_id)
         end
       end

--- a/spec/workers/subject_workflow_status_count_worker_spec.rb
+++ b/spec/workers/subject_workflow_status_count_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe SubjectWorkflowStatusCountWorker do
+  let(:worker) { described_class.new }
+  let(:sws) { create(:subject_workflow_status) }
+
+  it "should be rate limited with defaults" do
+    opts = worker.class.get_sidekiq_options['congestion']
+    expect(opts[:interval]).to eq(30)
+    expect(opts[:max_in_interval]).to eq(1)
+    expect(opts[:min_delay]).to eq(0)
+    expect(opts[:reject_with]).to eq(:cancel)
+  end
+
+  describe "#perform" do
+
+    it 'should call the counter to update the classifications_count' do
+      expect_any_instance_of(SubjectWorkflowCounter)
+        .to receive(:classifications)
+      expect_any_instance_of(SubjectWorkflowStatus)
+        .to receive(:update_column)
+        .with(:classifications_count, anything)
+      worker.perform(sws.id)
+    end
+  end
+end


### PR DESCRIPTION
Try and not spam the db, instead use a increment counter on hopefully? non-deadlocking subject workflow status records and a rate limited worker to resolve the correct count.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
