### PR TITLE
Fix Workflow#finished_at assignment

### DIFF
--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -12,10 +12,6 @@ class RetirementWorker
       WorkflowRetiredCountWorker.perform_async(workflow.id)
       PublishRetirementEventWorker.perform_async(workflow.id)
 
-      if workflow.finished?
-        Workflow.where(id: workflow.id).update_all(finished_at: Time.now)
-      end
-
       if Panoptes.use_cellect?(workflow)
         RetireCellectWorker.perform_async(count.subject_id, workflow.id)
       end

--- a/app/workers/workflow_retired_count_worker.rb
+++ b/app/workers/workflow_retired_count_worker.rb
@@ -18,5 +18,9 @@ class WorkflowRetiredCountWorker
       :retired_set_member_subjects_count,
       counter.retired_subjects
     )
+
+    if workflow.finished?
+      Workflow.where(id: workflow.id).update_all(finished_at: Time.now)
+    end
   end
 end

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -76,40 +76,4 @@ RSpec.describe RetirementWorker do
       end
     end
   end
-
-  describe "finishing workflows" do
-    before do
-      allow_any_instance_of(SubjectWorkflowStatus)
-        .to receive(:retire?)
-        .and_return(true)
-    end
-
-    it 'should not mark the workflow as finished when it is not' do
-      allow(workflow).to receive(:finished?).and_return(false)
-      expect do
-        worker.perform(count.id)
-      end.to_not change{ Workflow.find(workflow.id).finished_at }
-    end
-
-    context "workflow is finished" do
-      before do
-        allow_any_instance_of(Workflow)
-          .to receive(:finished?)
-          .and_return(true)
-      end
-
-      it 'should set workflow.finished_at to the current time' do
-        expect do
-          worker.perform(count.id)
-        end.to change{ Workflow.find(workflow.id).finished_at }.from(nil)
-      end
-
-      context "when the workflow optimistic lock is updated" do
-        it 'should save the changes and not raise an error' do
-          Workflow.find(workflow.id).touch
-          expect { worker.perform(count.id) }.to_not raise_error
-        end
-      end
-    end
-  end
 end

--- a/spec/workers/workflow_retired_count_worker_spec.rb
+++ b/spec/workers/workflow_retired_count_worker_spec.rb
@@ -20,4 +20,40 @@ RSpec.describe WorkflowRetiredCountWorker do
       worker.perform(workflow.id)
     end
   end
+
+  describe "finishing workflows" do
+    before do
+      allow_any_instance_of(SubjectWorkflowStatus)
+        .to receive(:retire?)
+        .and_return(true)
+    end
+
+    it 'should not mark the workflow as finished when it is not' do
+      allow(workflow).to receive(:finished?).and_return(false)
+      expect do
+        worker.perform(workflow.id)
+      end.to_not change{ Workflow.find(workflow.id).finished_at }
+    end
+
+    context "workflow is finished" do
+      before do
+        allow_any_instance_of(Workflow)
+          .to receive(:finished?)
+          .and_return(true)
+      end
+
+      it 'should set workflow.finished_at to the current time' do
+        expect do
+          worker.perform(workflow.id)
+        end.to change{ Workflow.find(workflow.id).finished_at }.from(nil)
+      end
+
+      context "when the workflow optimistic lock is updated" do
+        it 'should save the changes and not raise an error' do
+          Workflow.find(workflow.id).touch
+          expect { worker.perform(workflow.id) }.to_not raise_error
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #1571 

Basically, the `finished?` check is called before `WorkflowRetiredCountWorker` can update the retired counters used by `finished?`.  This just moves the `finished?` call to `WorkflowRetiredCountWorker`.