### PR TITLE
reset the retired_subject_count on the worklfow too

### DIFF
--- a/app/workers/reset_project_counters_worker.rb
+++ b/app/workers/reset_project_counters_worker.rb
@@ -15,6 +15,7 @@ class ResetProjectCountersWorker
       reset_subject_workflow_classification_counters!(workflow)
       counter = WorkflowCounter.new(workflow)
       workflow.update_columns classifications_count: counter.classifications
+      workflow.update_columns retired_set_member_subjects_count: counter.retired_subjects
     end
 
     counter = ProjectCounter.new(project)

--- a/spec/workers/reset_project_counters_worker_spec.rb
+++ b/spec/workers/reset_project_counters_worker_spec.rb
@@ -23,7 +23,7 @@ describe ResetProjectCountersWorker do
     create(:classification, classification_attrs.merge(user: user2, created_at: project.launch_date + 1.week))
 
     project.update_columns classifications_count: 3, classifiers_count: 3
-    workflow.update_columns classifications_count: 3
+    workflow.update_columns classifications_count: 3, retired_set_member_subjects_count: 2
 
     create :user_project_preference, user: user1, project: project
     create :user_project_preference, user: user2, project: project
@@ -45,6 +45,11 @@ describe ResetProjectCountersWorker do
   it 'resets workflow classifications count' do
     described_class.new.perform(project.id)
     expect { workflow.reload }.to change { workflow.classifications_count }.from(3).to(1)
+  end
+
+  it 'resets retired subjects count' do
+    described_class.new.perform(project.id)
+    expect { workflow.reload }.to change { workflow.retired_subjects_count }.from(2).to(0)
   end
 
   it 'resets subject workflow counters' do


### PR DESCRIPTION
make sure the reset count worker resets the retired subjects count for finished at calcs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

