### PR TITLE
clean up postgresql selection specs

### DIFF
--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -26,12 +26,11 @@ module Subjects
     end
 
     def available
-      return @available if @available
       query = SetMemberSubject.available(workflow, user)
       if workflow.grouped
         query = query.where(subject_set_id: opts[:subject_set_id])
       end
-      @available = query
+      query
     end
 
     def limit

--- a/spec/support/shared_examples_for_postgresql_selection.rb
+++ b/spec/support/shared_examples_for_postgresql_selection.rb
@@ -1,21 +1,8 @@
 shared_examples "select for incomplete_project" do
   let(:args) { opts }
   let(:selector) { Subjects::PostgresqlSelection.new(workflow, user, args) }
-  let(:sms_scope) do
-    if ss_id = args[:subject_set_id]
-      SetMemberSubject.where(subject_set_id: ss_id)
-    else
-      SetMemberSubject.all
-    end
-  end
   let(:unseen_count) do
-    scoped_seen_count = if ss_id = args[:subject_set_id]
-                          group_sms = SetMemberSubject.where(subject_set_id: ss_id)
-                          group_sms.where(subject_id: uss.subject_ids).count
-                        else
-                          seen_count
-                        end
-    sms_scope.count - scoped_seen_count
+    sms_count - seen_count
   end
 
   def run_limit_selection(limit)
@@ -31,7 +18,6 @@ shared_examples "select for incomplete_project" do
     let(:args) { opts.merge(limit: limit) }
     let(:uss) do
       subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
-      create(:classification, user: user, workflow: workflow, subject_ids: subject_ids)
       create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
     end
 
@@ -48,7 +34,7 @@ shared_examples "select for incomplete_project" do
     context "with a limit of 10" do
       let(:limit) { 10 }
 
-      it 'should no have duplicates' do
+      it 'should not have duplicates' do
         result = selector.select
         expect(result).to match_array(result.to_a.uniq)
       end
@@ -67,7 +53,6 @@ shared_examples "select for incomplete_project" do
     let(:seen_count) { 20 }
     let!(:uss) do
       subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
-      create(:classification, user: user, workflow: workflow, subject_ids: subject_ids)
       create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
     end
 

--- a/spec/support/shared_examples_for_postgresql_selection.rb
+++ b/spec/support/shared_examples_for_postgresql_selection.rb
@@ -24,7 +24,7 @@ shared_examples "select for incomplete_project" do
     let(:seen_count) { 5 }
     let(:limit) { nil }
     let(:args) { opts.merge(limit: limit) }
-    let!(:uss) do
+    let(:uss) do
       subject_ids = sms_scope.sample(seen_count).map(&:subject_id)
       create(:classification, user: user, workflow: workflow, subject_ids: subject_ids)
       create(:user_seen_subject, user: user, subject_ids: subject_ids, workflow: workflow)
@@ -34,8 +34,9 @@ shared_examples "select for incomplete_project" do
       let(:limit) { 1 }
 
       it 'should return an unseen subject' do
+        seen_ids = uss.subject_ids
         selected = selector.select.first
-        expect(uss.subject_ids).to_not include(selected)
+        expect(seen_ids).to_not include(selected)
       end
     end
 


### PR DESCRIPTION
This is an attempt to fix the intermittent subject selection spec failure, e.g. https://travis-ci.org/zooniverse/Panoptes/jobs/157673258 and clean up the limit selection specs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
