### PR TITLE
speed up and fix some csv annotation errors

### DIFF
--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -8,33 +8,49 @@ class ClassificationsDumpWorker
 
   sidekiq_options queue: :data_high
 
+  attr_accessor :cache
+
   def perform_dump
     CSV.open(csv_file_path, 'wb') do |csv|
-      cache = ClassificationDumpCache.new
+      @cache = ClassificationDumpCache.new
       formatter = Formatter::Csv::Classification.new(project, cache)
-
-      csv <<  formatter.class.headers
-
-      completed_project_classifications.find_in_batches do |group|
-        subject_ids = group.flat_map(&:subject_ids).uniq
-        workflow_ids = group.map(&:workflow_id).uniq
-
-        cache.reset_subjects(Subject.where(id: subject_ids).load)
-        retired_counts = SubjectWorkflowStatus.retired.where(
-          subject_id: subject_ids,
-          workflow_id: workflow_ids
-        ).load
-        cache.reset_subject_workflow_statuses(retired_counts)
-
-        group.each { |classification| csv << formatter.to_array(classification) }
+      csv << formatter.class.headers
+      completed_project_classifications.find_in_batches do |batch|
+        subject_ids = setup_subjects_cache(batch)
+        setup_retirement_cache(batch, subject_ids)
+        batch.each do |classification|
+          csv << formatter.to_array(classification)
+        end
       end
     end
   end
 
   def completed_project_classifications
-    project.classifications
-    .complete
-    .joins(:workflow)
-    .includes(:user, workflow: [:workflow_contents])
+    project
+      .classifications
+      .complete
+      .joins(:workflow)
+      .includes(:user, workflow: [:workflow_contents])
+  end
+
+  private
+
+  def setup_subjects_cache(classifications)
+    classification_ids = classifications.map(&:id).join(",")
+    sql = "SELECT classification_id, subject_id FROM classification_subjects where classification_id IN (#{classification_ids})"
+    c_s_ids = ActiveRecord::Base.connection.select_rows(sql)
+    cache.reset_classification_subjects(c_s_ids)
+    subject_ids = c_s_ids.map { |cs| cs.last }
+    cache.reset_subjects(Subject.unscoped.where(id: subject_ids).load)
+    subject_ids
+  end
+
+  def setup_retirement_cache(classifications, subject_ids)
+    workflow_ids = classifications.map(&:workflow_id).uniq
+    retired_counts = SubjectWorkflowStatus.retired.where(
+      subject_id: subject_ids,
+      workflow_id: workflow_ids
+    ).load
+    cache.reset_subject_workflow_statuses(retired_counts)
   end
 end

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -8,11 +8,8 @@ class ClassificationsDumpWorker
 
   sidekiq_options queue: :data_high
 
-  attr_accessor :cache
-
   def perform_dump
     CSV.open(csv_file_path, 'wb') do |csv|
-      @cache = ClassificationDumpCache.new
       formatter = Formatter::Csv::Classification.new(project, cache)
       csv << formatter.class.headers
       completed_project_classifications.find_in_batches do |batch|
@@ -34,6 +31,10 @@ class ClassificationsDumpWorker
   end
 
   private
+
+  def cache
+    @cache ||= ClassificationDumpCache.new
+  end
 
   def setup_subjects_cache(classifications)
     classification_ids = classifications.map(&:id).join(",")

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -41,7 +41,7 @@ class ClassificationsDumpWorker
     sql = "SELECT classification_id, subject_id FROM classification_subjects where classification_id IN (#{classification_ids})"
     c_s_ids = ActiveRecord::Base.connection.select_rows(sql)
     cache.reset_classification_subjects(c_s_ids)
-    subject_ids = c_s_ids.map { |cs| cs.last }
+    subject_ids = c_s_ids.map { |_, subject_id| subject_id }
     cache.reset_subjects(Subject.unscoped.where(id: subject_ids).load)
     subject_ids
   end

--- a/lib/classification_dump_cache.rb
+++ b/lib/classification_dump_cache.rb
@@ -17,8 +17,9 @@ class ClassificationDumpCache
   end
 
   def reset_classification_subjects(classification_subjects)
-    @classification_to_subjects = classification_subjects.map do |cs|
-      [ cs.first.to_i, [cs.last.to_i] ]
+    classification_groups = classification_subjects.group_by(&:first)
+    @classification_to_subjects = classification_groups.map do |classification_id, groups|
+      [ classification_id.to_i, groups.map { |ids| ids.last.to_i } ]
     end.to_h
   end
 

--- a/lib/classification_dump_cache.rb
+++ b/lib/classification_dump_cache.rb
@@ -4,6 +4,7 @@ class ClassificationDumpCache
     @workflow_contents = {}
     @subjects = {}
     @subject_workflow_statuses = {}
+    @classification_to_subjects = {}
     @secure_ip_lookup = {}
   end
 
@@ -15,8 +16,18 @@ class ClassificationDumpCache
     @subject_workflow_statuses = subject_workflow_statuses.group_by(&:subject_id)
   end
 
+  def reset_classification_subjects(classification_subjects)
+    @classification_to_subjects = classification_subjects.map do |cs|
+      [ cs.first.to_i, [cs.last.to_i] ]
+    end.to_h
+  end
+
   def subject(subject_id)
     @subjects[subject_id]
+  end
+
+  def subject_ids_from_classification(classification_id)
+    @classification_to_subjects[classification_id]
   end
 
   def retired?(subject_id, workflow_id)

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -151,8 +151,8 @@ module Formatter
               error_class:   "Task export error",
               error_message: "The task cannot be exported",
               context: {
-                classification: @classification.inspect,
-                annotation: @annotation.inspect,
+                classification: @classification.id,
+                annotation: @annotation.id,
                 workflow_at_version: workflow_at_version,
                 workflow_version: workflow_version,
                 content_version: content_version,

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -128,11 +128,7 @@ module Formatter
       def tool_label(task_info, tool_index)
         have_tool_lookup_info = !!(task_info["tools"] && tool_index)
         known_tool = have_tool_lookup_info && task_info["tools"][tool_index]
-        if known_tool
-          translate(known_tool["label"])
-        else
-          "unknown tool"
-        end
+        translate(known_tool["label"]) if known_tool
       end
 
       def answer_label

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -34,7 +34,7 @@ module Formatter
           new_anno['task'] = @current['task']
           new_anno['task_label'] = task_label(task_info)
           value_with_tool = (@current["value"] || []).map do |drawn_item|
-           drawn_item.merge "tool_label" => tool_label(task_info, drawn_item)
+            drawn_item.merge "tool_label" => tool_label(task_info, drawn_item)
           end
           new_anno["value"] = value_with_tool
         end
@@ -125,7 +125,7 @@ module Formatter
       end
 
       def tool_label(task_info, drawn_item)
-        tool = task_info["tools"] && task_info["tools"][drawn_item["tool"]]
+        tool = task_info["tools"] && task_info["tools"][drawn_item.fetch("tool", 0)]
         translate(tool["label"]) if tool
       end
 
@@ -145,8 +145,8 @@ module Formatter
               error_class:   "Task export error",
               error_message: "The task cannot be exported",
               context: {
-                classification: @classification,
-                annotation: @annotation,
+                classification: @classification.inspect,
+                annotation: @annotation.inspect,
                 workflow_at_version: workflow_at_version,
                 workflow_version: workflow_version,
                 content_version: content_version,

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -143,19 +143,7 @@ module Formatter
           rescue TypeError
             "unknown answer label"
           rescue NoMethodError => e
-            Honeybadger.notify(
-              error_class:   "Task export error",
-              error_message: "The task cannot be exported",
-              context: {
-                classification: @classification.id,
-                annotation: @annotation.id,
-                workflow_at_version: workflow_at_version,
-                workflow_version: workflow_version,
-                content_version: content_version,
-                current_task: @current['task'],
-                answer_idx: answer_idx
-              }
-            )
+            report_to_honey_badger(answer_idx)
             raise e
           end
         end
@@ -200,6 +188,22 @@ module Formatter
          key == annotation["task"]
         end
         @task = task_annotation.try(:last) || {}
+      end
+
+      def report_to_honey_badger(answer_idx)
+        Honeybadger.notify(
+          error_class:   "Task export error",
+          error_message: "The task cannot be exported",
+          context: {
+            classification: @classification.id,
+            annotation: @annotation,
+            workflow_at_version: workflow_at_version.id,
+            workflow_version: workflow_version,
+            content_version: content_version,
+            current_task: @current['task'],
+            answer_idx: answer_idx
+          }
+        )
       end
     end
   end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -34,7 +34,8 @@ module Formatter
           new_anno['task'] = @current['task']
           new_anno['task_label'] = task_label(task_info)
           value_with_tool = (@current["value"] || []).map do |drawn_item|
-            drawn_item.merge "tool_label" => tool_label(task_info, drawn_item)
+            tool_label = tool_label(task_info, drawn_item["tool"])
+            drawn_item.merge("tool_label" => tool_label)
           end
           new_anno["value"] = value_with_tool
         end
@@ -124,9 +125,14 @@ module Formatter
         translate(task_info["question"] || task_info["instruction"])
       end
 
-      def tool_label(task_info, drawn_item)
-        tool = task_info["tools"] && task_info["tools"][drawn_item.fetch("tool", 0)]
-        translate(tool["label"]) if tool
+      def tool_label(task_info, tool_index)
+        have_tool_lookup_info = !!(task_info["tools"] && tool_index)
+        known_tool = have_tool_lookup_info && task_info["tools"][tool_index]
+        if known_tool
+          translate(known_tool["label"])
+        else
+          "unknown tool"
+        end
       end
 
       def answer_label

--- a/lib/formatter/csv/classification.rb
+++ b/lib/formatter/csv/classification.rb
@@ -44,7 +44,7 @@ module Formatter
 
       def subject_data
         {}.tap do |subjects_and_metadata|
-          classification.subject_ids.map {|id| cache.subject(id) }.each do |subject|
+          classification_subject_ids.map {|id| cache.subject(id) }.each do |subject|
             retired_data = { retired: cache.retired?(subject.id, workflow.id) }
             subjects_and_metadata[subject.id] = retired_data.reverse_merge!(subject.metadata)
           end
@@ -52,7 +52,7 @@ module Formatter
       end
 
       def subject_ids
-          classification.subject_ids.join(";")
+        classification_subject_ids.join(";")
       end
 
       def metadata
@@ -71,6 +71,10 @@ module Formatter
 
       def workflow_name
         workflow.display_name
+      end
+
+      def classification_subject_ids
+        cache.subject_ids_from_classification(classification.id)
       end
     end
   end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -26,14 +26,9 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
     }
   end
 
-  it 'adds the task label', :focus do
+  it 'adds the task label' do
     formatted = described_class.new(classification, annotation, cache).to_h
     expect(formatted["task_label"]).to eq("Draw a circle")
-  end
-
-  it 'adds an unknown tool label if the tool index is missing' do
-    formatted = described_class.new(classification, weird_annotation, cache).to_h
-    expect(formatted["value"][0]["tool_label"]).to eq("unknown tool")
   end
 
   it 'adds the tool labels for drawing tasks', :aggregate_failures do
@@ -41,6 +36,11 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
     expect(formatted["value"][0]["tool_label"]).to eq("Green")
     expect(formatted["value"][1]["tool_label"]).to eq("Blue")
     expect(formatted["value"][2]["tool_label"]).to eq("Green")
+  end
+
+  it 'adds an unknown tool label if the tool index is missing' do
+    formatted = described_class.new(classification, weird_annotation, cache).to_h
+    expect(formatted["value"][0]["tool_label"]).to be_nil
   end
 
   it 'has a nil label when the tool is not found in the workflow' do

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -4,13 +4,11 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
   let(:contents) { build_stubbed(:workflow_content, workflow: nil) }
   let(:workflow) { build_stubbed(:workflow, workflow_contents: [contents], build_contents: false) }
   let(:cache)    { double(workflow_at_version: workflow, workflow_content_at_version: contents)}
-
   let(:classification) do
     build_stubbed(:classification, subjects: []).tap do |c|
       allow(c.workflow).to receive(:primary_content).and_return(contents)
     end
   end
-
   let(:annotation) do
     {
       "task" => "interest",
@@ -24,6 +22,14 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
       "task" => "interest",
       "value" => [{"x"=>1, "y"=>2}]
     }
+  end
+
+  describe '#report_to_honey_badger' do
+    it 'reports the correct details' do
+      annotator = described_class.new(classification, annotation, cache)
+      expect(Honeybadger).to receive(:notify)
+      annotator.send(:report_to_honey_badger, 1)
+    end
   end
 
   it 'adds the task label' do

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -19,9 +19,20 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
                   {"x"=>5, "y"=>6, "tool"=>1}]
     }
   end
+  let(:weird_annotation) do
+    {
+      "task" => "interest",
+      "value" => [{"x"=>1, "y"=>2}]
+    }
+  end
 
   it 'adds the task label' do
     formatted = described_class.new(classification, annotation, cache).to_h
+    expect(formatted["task_label"]).to eq("Draw a circle")
+  end
+
+  it 'adds the first task label if the tool index is missing' do
+    formatted = described_class.new(classification, weird_annotation, cache).to_h
     expect(formatted["task_label"]).to eq("Draw a circle")
   end
 

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
     }
   end
 
-  it 'adds the task label' do
+  it 'adds the task label', :focus do
     formatted = described_class.new(classification, annotation, cache).to_h
     expect(formatted["task_label"]).to eq("Draw a circle")
   end
 
-  it 'adds the first task label if the tool index is missing' do
+  it 'adds an unknown tool label if the tool index is missing' do
     formatted = described_class.new(classification, weird_annotation, cache).to_h
-    expect(formatted["task_label"]).to eq("Draw a circle")
+    expect(formatted["value"][0]["tool_label"]).to eq("unknown tool")
   end
 
   it 'adds the tool labels for drawing tasks', :aggregate_failures do

--- a/spec/lib/formatter/csv/classification_spec.rb
+++ b/spec/lib/formatter/csv/classification_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Formatter::Csv::Classification do
       retired?: false,
       workflow_at_version: workflow,
       workflow_content_at_version: double("WorkflowContent", strings: {}),
-      secure_user_ip: secure_user_ip
+      secure_user_ip: secure_user_ip,
+      subject_ids_from_classification: [subject.id]
     )
   end
 

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ClassificationsDumpWorker do
   let(:workflow) { create(:workflow) }
   let(:project) { workflow.project }
   let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
-  let!(:classifications) do
+  let(:classifications) do
     create_list(:classification, 5, project: project, workflow: workflow, subjects: [subject])
   end
 

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -6,12 +6,23 @@ RSpec.describe ClassificationsDumpWorker do
   let(:project) { workflow.project }
   let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
   let(:classifications) do
-    create_list(:classification, 5, project: project, workflow: workflow, subjects: [subject])
+    create_list(:classification, 2, project: project, workflow: workflow, subjects: [subject])
   end
 
   describe "#perform" do
     it_behaves_like "dump worker", ClassificationDataMailerWorker, "project_classifications_export" do
       let(:num_entries) { classifications.size + 1 }
+    end
+
+    context "with multi subject classification" do
+      let(:second_subject) { create(:subject, project: project, subject_sets: subject.subject_sets) }
+      let(:classifications) do
+        [ create(:classification, project: project, workflow: workflow, subjects: [subject, second_subject]) ]
+      end
+
+      it_behaves_like "dump worker", ClassificationDataMailerWorker, "project_classifications_export" do
+        let(:num_entries) { classifications.size + 1 }
+      end
     end
   end
 


### PR DESCRIPTION
add cache for classification -> subjects lookup (massive speed up here) and fixed some missing annotation tool label information in classifications. 

some classifications are missing the tool label index e.g. {"x"=>X, "y"=>Y} VS {"x"=>X, "y"=>Y, "tool"=>0, "frame"=>0, "details"=>[]} ~~most likely a borked PFE deploy that lost some frame info...~~ Seems to be the gold standard classification uploads after chatting to the researcher.

No will just return nil label as there is no information on the tool index that was being used.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
