### PR TITLE
Symbols to strings for sidekiq's sake

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::UsersController < Api::ApiController
           SubscribeWorker.perform_async(user.email)
           UnsubscribeWorker.perform_async(user.changes[:email].first)
         end
-        UserInfoChangedMailerWorker.perform_async(api_user.id, :email)
+        UserInfoChangedMailerWorker.perform_async(api_user.id, "email")
       end
     end
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -33,7 +33,7 @@ class RegistrationsController < Devise::RegistrationsController
   def update_from_json
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     if resource.update_with_password(account_update_params)
-      UserInfoChangedMailerWorker.perform_async(resource.id, :password)
+      UserInfoChangedMailerWorker.perform_async(resource.id, "password")
       render json: {}, status: :no_content
     else
       render json: {errors: [{message: "Current password was incorrect, or new passwords did not match"}]}, status: :unprocessable_entity

--- a/app/mailers/user_info_changed_mailer.rb
+++ b/app/mailers/user_info_changed_mailer.rb
@@ -6,10 +6,10 @@ class UserInfoChangedMailer < ApplicationMailer
     @email_to = user.email
 
     case info
-    when :email
+    when "email"
       subject = "Your Zooniverse email address has been changed"
       template = "email_changed"
-    when :password
+    when "password"
       subject = "Your Zooniverse password has been changed"
       template = "password_changed"
     end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -510,7 +510,7 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       it "sends an email to the new address" do
-        expect(UserInfoChangedMailerWorker).to receive(:perform_async).with(user.id, :email)
+        expect(UserInfoChangedMailerWorker).to receive(:perform_async).with(user.id, "email")
       end
 
       context 'when email preferences are true' do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -53,7 +53,7 @@ describe RegistrationsController, type: :controller do
         end
 
         it "should queue a mailer worker" do
-          expect(UserInfoChangedMailerWorker).to receive(:perform_async).with(user.id, :password)
+          expect(UserInfoChangedMailerWorker).to receive(:perform_async).with(user.id, "password")
           post_update
         end
       end

--- a/spec/mailers/user_info_changed_mailer_spec.rb
+++ b/spec/mailers/user_info_changed_mailer_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe UserInfoChangedMailer, :type => :mailer do
   let(:user) { create(:user) }
-  let(:mail) { UserInfoChangedMailer.user_info_changed(user, :password)}
+  let(:mail) { UserInfoChangedMailer.user_info_changed(user, "password")}
 
   describe "#user_info_changed" do
 
@@ -21,7 +21,7 @@ RSpec.describe UserInfoChangedMailer, :type => :mailer do
     end
 
     context "email address was changed" do
-      let(:mail) { UserInfoChangedMailer.user_info_changed(user, :email)}
+      let(:mail) { UserInfoChangedMailer.user_info_changed(user, "email")}
       it 'should have the correct subject' do
         expect(mail.subject).to eq("Your Zooniverse email address has been changed")
       end

--- a/spec/workers/user_info_changed_mailer_worker_spec.rb
+++ b/spec/workers/user_info_changed_mailer_worker_spec.rb
@@ -5,19 +5,19 @@ RSpec.describe UserInfoChangedMailerWorker do
   let(:user) { create(:user) }
 
   it 'should deliver the mail' do
-    expect{ subject.perform(user.id, :password) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    expect{ subject.perform(user.id, "password") }.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
 
   context "without a user" do
     it 'should not deliver the mail' do
-      expect{ subject.perform(nil, :password) }.to_not change{ ActionMailer::Base.deliveries.count }
+      expect{ subject.perform(nil, "password") }.to_not change{ ActionMailer::Base.deliveries.count }
     end
   end
 
   context "when an the user has been scrubbed of email address" do
     it 'should not deliver the mail' do
       UserInfoScrubber.scrub_personal_info!(user)
-      expect{ subject.perform(user.id, :password) }.to_not change{ ActionMailer::Base.deliveries.count }
+      expect{ subject.perform(user.id, "password") }.to_not change{ ActionMailer::Base.deliveries.count }
     end
   end
 
@@ -27,16 +27,16 @@ RSpec.describe UserInfoChangedMailerWorker do
         allow_any_instance_of(ActionMailer::MessageDelivery)
           .to receive(:deliver)
           .and_raise(error_klass.new)
-        allow(user).to receive(:email).and_return("test@example.com,ox")
+        allow(user).to receive("email").and_return("test@example.com,ox")
       end
 
       it 'should attempt to send an email' do
         expect_any_instance_of(ActionMailer::MessageDelivery).to receive(:deliver)
-        subject.perform(user.id, :password)
+        subject.perform(user.id, "password")
       end
 
       it 'should mark the user with invalid_email' do
-        subject.perform(user.id, :password)
+        subject.perform(user.id, "password")
         expect(user.reload.valid_email).to eq(false)
       end
     end


### PR DESCRIPTION
Switched from passing symbols to passing strings for sidekiq so that sidekiq knows what's up and correctly identifies which template to use.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

