### PR TITLE
Set src to nil for unknown mime types

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -29,7 +29,10 @@ class Medium < ActiveRecord::Base
   end
 
   def create_path
+    return unless errors.empty?
     self.src ||= MediaStorage.stored_path(content_type, type, *path_opts)
+  rescue MediaStorage::UnknownContentType
+    self.src ||= nil
   end
 
   def linked_resource_details

--- a/app/services/media_storage/abstract_adapter.rb
+++ b/app/services/media_storage/abstract_adapter.rb
@@ -1,8 +1,8 @@
 module MediaStorage
+  class EmptyPathError < StandardError; end
+  class UnknownContentType < StandardError; end
+
   class AbstractAdapter
-
-    class EmptyPathError < StandardError; end
-
     def initialize(opts={})
       @opts = opts
     end
@@ -37,6 +37,21 @@ module MediaStorage
       if path.blank?
         raise EmptyPathError.new("A storage path must be specified.")
       end
+    end
+
+    def get_extension(content_type)
+      case content_type
+      when "application/x-gzip"
+        "tar.gz"
+      else
+        get_mime_type(content_type).extensions.first
+      end
+    end
+
+    def get_mime_type(content_type)
+      known_types = MIME::Types[content_type]
+      raise UnknownContentType if known_types.blank?
+      known_types.first
     end
   end
 end

--- a/app/services/media_storage/aws_adapter.rb
+++ b/app/services/media_storage/aws_adapter.rb
@@ -1,6 +1,5 @@
 module MediaStorage
   class AwsAdapter < AbstractAdapter
-
     attr_accessor :prefix, :bucket
 
     def initialize(opts={})
@@ -22,12 +21,7 @@ module MediaStorage
     end
 
     def stored_path(content_type, medium_type, *path_prefix)
-      extension = case content_type
-                  when "application/x-gzip"
-                    "tar.gz"
-                  else
-                    MIME::Types[content_type].first.extensions.first
-                  end
+      extension = get_extension(content_type)
       path = "#{prefix}"
       path += "/" unless path[-1] == '/'
       path += "#{medium_type}/"

--- a/app/services/media_storage/test_adapter.rb
+++ b/app/services/media_storage/test_adapter.rb
@@ -1,7 +1,7 @@
 module MediaStorage
   class TestAdapter < AbstractAdapter
     def stored_path(content_type, medium_type, *path_prefix)
-      extension = MIME::Types[content_type].first.extensions.first
+      extension = get_extension(content_type)
       path = "#{medium_type}/"
       path += "#{path_prefix.join('/')}/" unless path_prefix.empty?
       path += "#{SecureRandom.uuid}.#{extension}"

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe Medium, :type => :model do
       expect(m).to_not be_valid
     end
 
+    it 'should not be valid with an empty content_type' do
+      m = build(:medium, content_type: "", src: nil)
+      expect(m).to_not be_valid
+    end
+
     it 'should be valid with a valid content_type' do
       m = build(:medium, content_type: "image/png")
       expect(m).to be_valid

--- a/spec/services/media_storage/aws_adapter_spec.rb
+++ b/spec/services/media_storage/aws_adapter_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe MediaStorage::AwsAdapter do
       error_message = "A storage path must be specified."
       expect do
         adapter.send(:object, nil)
-      end.to raise_error(MediaStorage::AbstractAdapter::EmptyPathError, error_message)
+      end.to raise_error(MediaStorage::EmptyPathError, error_message)
     end
   end
 end


### PR DESCRIPTION
This will no longer crash when people try to upload stuff with blank or weird filenames. Instead, it will get past the `before_validation` and then the validations on `src` and `mime_type` will fail, returning a correct error message back to API clients.

Resolves https://app.honeybadger.io/projects/40595/faults/30182593

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
