### PR TITLE
Count classifying workflow classifications not all of them

### DIFF
--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -14,8 +14,8 @@ class ClassificationCountWorker
         count.class.increment_counter(:classifications_count, count.id) unless was_update
       end
 
-      ProjectClassificationsCountWorker.perform_async(workflow.project.id)
       SubjectWorkflowStatusCountWorker.perform_async(count.id)
+      WorkflowClassificationsCountWorker.perform_in(5.seconds, workflow.id)
       RetirementWorker.perform_async(count.id)
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -6,7 +6,7 @@ class ProjectClassificationsCountWorker
   sidekiq_options congestion: {
     interval: 60,
     max_in_interval: 1,
-    min_delay: 0,
+    min_delay: 10,
     reject_with: :cancel,
     key: ->(project_id) {
       "project_#{project_id}_classifications_count_worker"
@@ -15,10 +15,6 @@ class ProjectClassificationsCountWorker
 
   def perform(project_id)
     project = Project.find(project_id)
-    project.workflows.map do |workflow|
-      counter = WorkflowCounter.new(workflow)
-      workflow.update_column(:classifications_count, counter.classifications)
-    end
     counter = ProjectCounter.new(project)
     project.update_column(:classifications_count, counter.classifications)
   end

--- a/app/workers/subject_workflow_status_count_worker.rb
+++ b/app/workers/subject_workflow_status_count_worker.rb
@@ -4,10 +4,10 @@ class SubjectWorkflowStatusCountWorker
   sidekiq_options queue: :really_high
 
   sidekiq_options congestion: {
-    interval: ENV.fetch("sws_count_worker_interval", 30),
-    max_in_interval: ENV.fetch("sws_count_worker_max_in_interval", 1),
-    min_delay: 0,
-    reject_with: ENV.fetch("sws_count_worker_reject_with", :cancel),
+    interval: 30,
+    max_in_interval: 1,
+    min_delay: 5,
+    reject_with: :cancel,
     key: ->(count_id) {
       "sws_#{count_id}_count_worker"
     }

--- a/app/workers/workflow_classifications_count_worker.rb
+++ b/app/workers/workflow_classifications_count_worker.rb
@@ -1,0 +1,23 @@
+class WorkflowClassificationsCountWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_low
+
+  sidekiq_options congestion: {
+    interval: 60,
+    max_in_interval: 1,
+    min_delay: 10,
+    reject_with: :cancel,
+    key: ->(workflow_id) {
+      "workflow_#{workflow_id}_classifications_count_worker"
+    }
+  }
+
+  def perform(workflow_id)
+    workflow = Workflow.find(workflow_id)
+    counter = WorkflowCounter.new(workflow)
+    workflow.update_column(:classifications_count, counter.classifications)
+
+    ProjectClassificationsCountWorker.perform_async(workflow.project.id)
+  end
+end

--- a/spec/workers/classification_count_worker_spec.rb
+++ b/spec/workers/classification_count_worker_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe ClassificationCountWorker do
       end
 
       it 'queues up a count update for project and workflow' do
-        expect(ProjectClassificationsCountWorker).to receive(:perform_async).with(project.id)
+        expect(WorkflowClassificationsCountWorker)
+          .to receive(:perform_in)
+          .with(5.seconds, workflow_id)
         worker.perform(sms.subject_id, workflow_id)
       end
 

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe ProjectClassificationsCountWorker do
   let(:worker) { described_class.new }
   let!(:project) { create(:project) }
 
+  it "should be rate limited with defaults" do
+    opts = worker.class.get_sidekiq_options['congestion']
+    expect(opts[:interval]).to eq(60)
+    expect(opts[:max_in_interval]).to eq(1)
+    expect(opts[:min_delay]).to eq(10)
+    expect(opts[:reject_with]).to eq(:cancel)
+  end
+
   describe "#perform" do
 
     it 'calls the project counter to update the project counts' do

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -2,26 +2,16 @@ require 'spec_helper'
 
 RSpec.describe ProjectClassificationsCountWorker do
   let(:worker) { described_class.new }
-  let(:workflow) { create(:workflow) }
-  let!(:project) { workflow.project }
+  let!(:project) { create(:project) }
 
   describe "#perform" do
 
-    it 'calls the workflow counter to update the workflow counts' do
-      expect_any_instance_of(WorkflowCounter)
-        .to receive(:classifications)
-      expect_any_instance_of(Workflow)
-        .to receive(:update_column)
-        .with(:classifications_count, anything)
-      worker.perform(project.id)
-    end
-
     it 'calls the project counter to update the project counts' do
-      expect_any_instance_of(ProjectCounter)
-        .to receive(:classifications)
+      expect_any_instance_of(ProjectCounter).to receive(:classifications)
       expect_any_instance_of(Project)
         .to receive(:update_column)
         .with(:classifications_count, anything)
+        .once
       worker.perform(project.id)
     end
   end

--- a/spec/workers/subject_workflow_status_count_worker_spec.rb
+++ b/spec/workers/subject_workflow_status_count_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SubjectWorkflowStatusCountWorker do
     opts = worker.class.get_sidekiq_options['congestion']
     expect(opts[:interval]).to eq(30)
     expect(opts[:max_in_interval]).to eq(1)
-    expect(opts[:min_delay]).to eq(0)
+    expect(opts[:min_delay]).to eq(5)
     expect(opts[:reject_with]).to eq(:cancel)
   end
 

--- a/spec/workers/workflow_classifications_count_worker_spec.rb
+++ b/spec/workers/workflow_classifications_count_worker_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe WorkflowClassificationsCountWorker do
   let(:workflow) { project.workflows.first }
   let(:count) { rand(10) }
 
+  it "should be rate limited with defaults" do
+    opts = worker.class.get_sidekiq_options['congestion']
+    expect(opts[:interval]).to eq(60)
+    expect(opts[:max_in_interval]).to eq(1)
+    expect(opts[:min_delay]).to eq(10)
+    expect(opts[:reject_with]).to eq(:cancel)
+  end
+
   describe "#perform" do
     before do
       expect_any_instance_of(WorkflowCounter)

--- a/spec/workers/workflow_classifications_count_worker_spec.rb
+++ b/spec/workers/workflow_classifications_count_worker_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe WorkflowClassificationsCountWorker do
+  let(:worker) { described_class.new }
+  let!(:project) { create(:project_with_workflows) }
+  let(:workflow) { project.workflows.first }
+  let(:count) { rand(10) }
+
+  describe "#perform" do
+    before do
+      expect_any_instance_of(WorkflowCounter)
+      .to receive(:classifications)
+      .and_return(count)
+    end
+
+    it 'calls the workflow counter to update the workflow counts' do
+      expect_any_instance_of(Workflow)
+        .to receive(:update_column)
+        .with(:classifications_count, count)
+        .once
+      worker.perform(workflow.id)
+    end
+
+    it 'chain calls project classification count worker' do
+      expect(ProjectClassificationsCountWorker)
+        .to receive(:perform_async)
+        .with(project.id)
+      worker.perform(workflow.id)
+    end
+  end
+end


### PR DESCRIPTION
I traced the deadlocking workflow update to the ProjectClassificationsCountWorker looping over all workflows and taking too long to finish. This allowed new jobs to pass the rate limiter (1 in 1 minute) and under certain circumstances try to update the same workflow at the same time (potential deadlock). 

I've split the count workers to now count the active classifying workflow (rate limited) and chain the project count update after a run that updates the workflow counts.

I've also introduced a freq backoff to ensure that we don't run these counters too often when lots of classifications are coming in short time frames. Note: I am happy to tweak these values. I based them testing counting large workflow counts (below) and guesstimated what i thought would be appropriate to avoid spamming the db with lots of counting as these counters will be eventually consistent over time.

``` ruby
irb(main):066:0> sws.classifications_count
=> 32
irb(main):067:0> sws.workflow_id          
=> 338
#time to count for a SWS baseline that all the counters derive off
irb(main):055:0> Benchmark.bm do |x|
irb(main):056:1*   10.times do 
irb(main):057:2*     x.report do
irb(main):058:3*       counter = SubjectWorkflowCounter.new(sws)
irb(main):059:3>       counter.classifications
irb(main):060:3>     end
irb(main):061:2>   end
irb(main):062:1> end
       user     system      total        real
   0.000000   0.000000   0.000000 (  0.005313)
   0.000000   0.000000   0.000000 (  0.003544)
   0.000000   0.000000   0.000000 (  0.003945)
   0.000000   0.000000   0.000000 (  0.003764)
   0.000000   0.000000   0.000000 (  0.004401)
   0.000000   0.000000   0.000000 (  0.004218)
   0.000000   0.000000   0.000000 (  0.003856)
   0.000000   0.000000   0.000000 (  0.005279)
   0.010000   0.000000   0.010000 (  0.004250)
   0.000000   0.000000   0.000000 (  0.003608)

irb(main):054:0> workflow.set_member_subjects.count
=> 223935
#time to count for the classifications for a workflow from the SWS base counts
irb(main):046:0* Benchmark.bm do |x|
irb(main):047:1*   10.times do 
irb(main):048:2*     x.report do
irb(main):049:3*       counter = WorkflowCounter.new(workflow) 
irb(main):050:3>       counter.classifications
irb(main):051:3>     end
irb(main):052:2>   end
irb(main):053:1> end
       user     system      total        real
   0.010000   0.000000   0.010000 (  0.145700)
   0.000000   0.000000   0.000000 (  0.133712)
   0.000000   0.000000   0.000000 (  0.182264)
   0.000000   0.000000   0.000000 (  0.149993)
   0.000000   0.000000   0.000000 (  0.153174)
   0.000000   0.000000   0.000000 (  0.148571)
   0.000000   0.000000   0.000000 (  0.128327)
   0.000000   0.000000   0.000000 (  0.098213)
   0.010000   0.000000   0.010000 (  0.119481)
   0.000000   0.000000   0.000000 (  0.104685)
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
