### PR TITLE
Fix project classifiers counter and subject set subjects counter not updating

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -37,13 +37,9 @@ module Api
 
     def process_incoming_event
       if upp = user_project_preference
-        was_new = upp.new_record?
         upp.legacy_count[create_params[:workflow]] = create_params[:count]
+
         if upp.save
-          if was_new
-            ProjectClassifiersCountWorker.perform_async(upp.project_id)
-            upp.user.update_column(:project_id, upp.project.id) if upp.user.project_id.blank?
-          end
           :ok
         else
           :unprocessable_entity
@@ -81,9 +77,11 @@ module Api
 
     def user_project_preference
       user_zoo_id = create_params[:zooniverse_user_id]
-      if user_zoo_id && user_id = User.find_by(zooniverse_id: user_zoo_id).try(:id)
-        UserProjectPreference.find_or_initialize_by(project_id: legacy_zoo_project.id,
-                                                    user_id: user_id)
+      project = legacy_zoo_project
+      user = User.find_by(zooniverse_id: user_zoo_id) if user_zoo_id
+
+      if user
+        UserProjectPreferences::FindOrCreate.run! project: project, user: user
       end
     end
 

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -8,15 +8,24 @@ class Api::V1::SubjectSetsController < Api::ApiController
   IMPORT_COLUMNS = %w(subject_set_id subject_id random)
 
   def create
-    super { |subject_set| refresh_queue(subject_set) }
+    super do |subject_set|
+      refresh_queue(subject_set)
+      reset_subject_counts(subject_set.id)
+    end
   end
 
   def update
-    super { |subject_set| refresh_queue(subject_set) }
+    super do |subject_set|
+      refresh_queue(subject_set)
+      reset_subject_counts(subject_set.id)
+    end
   end
 
   def update_links
-    super { |subject_set| refresh_queue(subject_set) }
+    super do |subject_set|
+      refresh_queue(subject_set)
+      reset_subject_counts(subject_set.id)
+    end
   end
 
   def destroy
@@ -39,7 +48,10 @@ class Api::V1::SubjectSetsController < Api::ApiController
   end
 
   def destroy_links
-    super { |subject_set| refresh_queue(subject_set) }
+    super do |subject_set|
+      refresh_queue(subject_set)
+      reset_subject_counts(subject_set.id)
+    end
   end
 
   protected
@@ -78,7 +90,6 @@ class Api::V1::SubjectSetsController < Api::ApiController
         [ resource.id, subject_id, rand ]
       end
       SetMemberSubject.import IMPORT_COLUMNS, new_sms_values, validate: false
-      reset_subject_counts(resource.id)
     else
       super
     end
@@ -90,7 +101,6 @@ class Api::V1::SubjectSetsController < Api::ApiController
       set_member_subjects = resource.set_member_subjects.where(subject_id: linked_sms_ids)
       remove_linked_set_member_subjects(set_member_subjects)
       reset_subject_set_workflow_counts(controlled_resource.id)
-      reset_subject_counts(resource.id)
     else
       super
     end

--- a/app/operations/user_project_preferences/find_or_create.rb
+++ b/app/operations/user_project_preferences/find_or_create.rb
@@ -1,0 +1,26 @@
+module UserProjectPreferences
+  class FindOrCreate < Operation
+    object :api_user, default: nil
+    object :user
+    object :project
+
+    def execute
+      upp = UserProjectPreference.find_or_initialize_by(project_id: project.id, user_id: user.id)
+
+      if upp.email_communication.nil?
+        upp.email_communication = user.project_email_communication
+      end
+
+      if upp.new_record? || upp.changed?
+        upp.save!
+        ProjectClassifiersCountWorker.perform_async(upp.project_id)
+      else
+        upp.touch
+      end
+
+      user.update_column(:project_id, project.id) unless user.project_id
+
+      upp
+    end
+  end
+end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -58,15 +58,7 @@ class ClassificationLifecycle
 
   def process_project_preference
     return unless should_create_project_preference?
-
-    upp = UserProjectPreference.where(user: user, project: project).first_or_initialize { |up| up.preferences = {} }
-
-    if upp.email_communication.nil?
-      upp.email_communication = user.project_email_communication
-      upp.user.update_column(:project_id, project.id) if upp.user.project_id.blank?
-    end
-
-    upp.changed? ? upp.save! : upp.touch
+    UserProjectPreferences::FindOrCreate.run! user: user, project: project
   end
 
   def create_recent

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -116,6 +116,25 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
     it_behaves_like "supports update_links"
 
+    describe 'update' do
+      let(:workflows) { [create(:workflow, project: project)] }
+      let(:resource) do
+        create(:subject_set,project: project, subjects: []) do |sset|
+          sset.workflows = workflows
+        end
+      end
+
+      it "should queue the counter worker" do
+        expect(SubjectSetSubjectCounterWorker)
+          .to receive(:perform_async)
+          .with(resource.id)
+        default_request scopes: scopes, user_id: authorized_user.id
+        update_params[:subject_sets][:links][:subjects] = subjects.map(&:id)
+        put :update, update_params.merge(id: resource.id)
+        expect(resource.subjects.count).to eq(subjects.size)
+      end
+    end
+
     describe "update_links" do
       let(:sms_count) { resource.reload.set_member_subjects_count }
       let(:run_update_links) do
@@ -287,6 +306,20 @@ describe Api::V1::SubjectSetsController, type: :controller do
                              }
                      }
       }
+    end
+
+    describe 'after create' do
+      let(:subjects) { create_list(:subject, 4, project: project) }
+
+      it "should queue the counter worker" do
+        allow(SubjectSetSubjectCounterWorker).to receive(:perform_async)
+        default_request scopes: scopes, user_id: authorized_user.id
+        create_params[:subject_sets][:links][:subjects] = subjects.map(&:id)
+        post(:create, create_params)
+        resource = JSON.parse(response.body)["subject_sets"].first
+        expect(SubjectSetSubjectCounterWorker).to have_received(:perform_async).with(resource["id"].to_i)
+        expect(SubjectSet.last.subjects.count).to eq(subjects.size)
+      end
     end
 
     context "with illegal link properties" do

--- a/spec/operations/user_project_preferences/find_or_create_spec.rb
+++ b/spec/operations/user_project_preferences/find_or_create_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe UserProjectPreferences::FindOrCreate do
+  let(:user) { create :user }
+  let(:project) { create :project }
+  let(:operation) { described_class.with(user: user, project: project) }
+
+  context 'when UPP already exists' do
+    it 'returns the UPP' do
+      user_project_preference = create :user_project_preference, user: user, project: project
+      result = operation.run
+      expect(result.result).to eq(user_project_preference)
+    end
+  end
+
+  context 'when UPP does not exist' do
+    it 'creates a UPP record' do
+      result = operation.run
+      expect(result).to be_valid
+      expect(UserProjectPreference.count).to eq(1)
+    end
+
+    it 'triggers a classifiers count' do
+      expect(ProjectClassifiersCountWorker).to receive(:perform_async).with(project.id)
+      operation.run
+    end
+
+    it 'sets the user project_id if not set' do
+      operation.run
+      expect(user.reload.project_id).to eq(project.id)
+    end
+
+    it 'does not change the project_id if the user has one' do
+      other_project = create :project
+      user.update! project_id: other_project.id
+      expect { operation.run }.not_to change { user.reload.project_id }
+    end
+  end
+end


### PR DESCRIPTION
UPPs were created in multiple places, code for which is now consolidated into an operation. I'm not actually sure this will fix the counter, since it seemed to trigger recounts in both places.

SubjectSets would only recount if using the `update_links` action, creating a new set with subjects from the start, or updating with the normal update action wouldn't trigger a recount. To simplify this, let's just always recount. Even if maybe the subjects relation didn't actually change. There's not a lot of other attributes on a set, so most requests will probably update the subjects association anyways.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
