### PR TITLE
correctly serialize the retired status of subjects

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -45,10 +45,7 @@ class Subject < ActiveRecord::Base
 
   def retired_for_workflow?(workflow)
     if workflow&.persisted?
-      SubjectWorkflowStatus
-        .retired
-        .by_subject_workflow(self.id, workflow.id)
-        .present?
+      SubjectWorkflowStatus.retired.by_subject_workflow(self.id, workflow.id).present?
     else
       false
     end

--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -7,7 +7,7 @@ class SubjectWorkflowStatus < ActiveRecord::Base
   belongs_to :workflow
 
   enum retirement_reason:
-    [ :classification_count, :flagged, :blank, :consensus, :other ]
+    [ :classification_count, :flagged, :nothing_here, :consensus, :other ]
 
   scope :retired, -> { where.not(retired_at: nil) }
 

--- a/app/operations/workflows/retire_subjects.rb
+++ b/app/operations/workflows/retire_subjects.rb
@@ -1,5 +1,7 @@
 module Workflows
   class RetireSubjects < Operation
+    set_callback :validate, :before, :rewrite_blank_reason
+
     validates :retirement_reason, inclusion: {
       in: SubjectWorkflowStatus.retirement_reasons.keys,
       allow_nil: true
@@ -34,6 +36,14 @@ module Workflows
 
     def subject_ids
       Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+    end
+
+    private
+
+    def rewrite_blank_reason
+      if @retirement_reason == "blank"
+        @retirement_reason = "nothing_here"
+      end
     end
   end
 end

--- a/app/operations/workflows/retire_subjects.rb
+++ b/app/operations/workflows/retire_subjects.rb
@@ -1,6 +1,9 @@
 module Workflows
   class RetireSubjects < Operation
-    validates :retirement_reason, inclusion: { in: SubjectWorkflowStatus.retirement_reasons.keys, allow_nil: true }
+    validates :retirement_reason, inclusion: {
+      in: SubjectWorkflowStatus.retirement_reasons.keys,
+      allow_nil: true
+    }
 
     object :workflow
 

--- a/spec/models/subject_workflow_status_spec.rb
+++ b/spec/models/subject_workflow_status_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe SubjectWorkflowStatus, type: :model do
     end
 
     it 'records the retirement reason' do
-      count.retire!("blank")
-      expect(count.retirement_reason).to match("blank")
+      count.retire!("nothing_here")
+      expect(count.retirement_reason).to match("nothing_here")
     end
   end
 

--- a/spec/operations/workflows/retire_subjects_spec.rb
+++ b/spec/operations/workflows/retire_subjects_spec.rb
@@ -17,6 +17,12 @@ describe Workflows::RetireSubjects do
       .to match("nothing_here")
   end
 
+  it 'rewrites the reason blank to nothing here' do
+    operation.run! workflow: workflow, subject_id: subject1.id, retirement_reason: "blank"
+    expect(SubjectWorkflowStatus.by_subject_workflow(subject1.id, workflow.id).retirement_reason)
+      .to match("nothing_here")
+  end
+
   it 'is invalid with an invalid retirement reason' do
     result = operation.run workflow: workflow, subject_id: subject1.id, retirement_reason: "nope"
     expect(result).not_to be_valid

--- a/spec/operations/workflows/retire_subjects_spec.rb
+++ b/spec/operations/workflows/retire_subjects_spec.rb
@@ -12,9 +12,9 @@ describe Workflows::RetireSubjects do
   let(:operation) { described_class.with(api_user: api_user) }
 
   it 'sets a valid retirement reason' do
-    operation.run! workflow: workflow, subject_id: subject1.id, retirement_reason: "blank"
+    operation.run! workflow: workflow, subject_id: subject1.id, retirement_reason: "nothing_here"
     expect(SubjectWorkflowStatus.by_subject_workflow(subject1.id, workflow.id).retirement_reason)
-      .to match("blank")
+      .to match("nothing_here")
   end
 
   it 'is invalid with an invalid retirement reason' do


### PR DESCRIPTION
Closes: https://github.com/zooniverse/Panoptes-Front-End/issues/3077

Rename the enum field to not override the instance `blank?` method.
``` ruby 
irb(main):041:0> SubjectWorkflowStatus.retired.by_subject_workflow(subject.id, workflow.id).present?
=> false
irb(main):042:0> SubjectWorkflowStatus.retired.by_subject_workflow(subject.id, workflow.id)         
=> #<SubjectWorkflowStatus id: .....>
irb(main):053:0> SubjectWorkflowStatus.retired.by_subject_workflow(subject.id, workflow.id).blank?  
=> true
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

this was returning false even though an AR instance was returned.