### PR TITLE
[WIP] add index to users valid_email column

### DIFF
--- a/db/migrate/20161011134340_add_valid_email_index_to_users.rb
+++ b/db/migrate/20161011134340_add_valid_email_index_to_users.rb
@@ -1,0 +1,7 @@
+class AddValidEmailIndexToUsers < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :valid_email, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2663,6 +2663,13 @@ CREATE UNIQUE INDEX index_users_on_unsubscribe_token ON users USING btree (unsub
 
 
 --
+-- Name: index_users_on_valid_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_users_on_valid_email ON users USING btree (valid_email);
+
+
+--
 -- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3481,4 +3488,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160824101413');
 INSERT INTO schema_migrations (version) VALUES ('20160901100944');
 
 INSERT INTO schema_migrations (version) VALUES ('20160901141903');
+
+INSERT INTO schema_migrations (version) VALUES ('20161011134340');
 


### PR DESCRIPTION
Closes #1967 

Concurrently adds an index to the boolean valid_email column on users table. I'm not sure this is going to avoid table scans as it depends on the query's where clause and the table scan cost used in the query planner.

Note: ~13K / ~1.5M have the value set to false and it's not null. I haven't actually tested this but I'm pretty sure a query like `select * from users where valid_email is true` will be a table scan even if we add this index. If that query is the only use case and it is slower than a table scan then we should not add the index. 

http://dba.stackexchange.com/questions/27681/unexpected-seq-scan-when-doing-query-against-boolean-with-value-null

Thoughts?
# Review checklist
- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
