### PR TITLE
add updated_at attribute to project cards response

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -18,13 +18,21 @@ class Api::V1::ProjectsController < Api::ApiController
   CONTENT_PARAMS = [:description,
                     :title,
                     :workflow_description,
-                    :introduction]
+                    :introduction].freeze
 
   CONTENT_FIELDS = [:title,
                     :description,
                     :workflow_description,
                     :introduction,
-                    :url_labels]
+                    :url_labels].freeze
+
+  CARD_FIELDS = [:id,
+                 :display_name,
+                 :description,
+                 :slug,
+                 :redirect,
+                 :avatar_src,
+                 :updated_at].freeze
 
   before_action :eager_load_relations, only: :index
   before_action :filter_by_tags, only: :index
@@ -219,15 +227,17 @@ class Api::V1::ProjectsController < Api::ApiController
 
   def context
     if action_name == "index" && !!params[:cards]
-      exclude_keys = ProjectSerializer.serializable_attributes
-        .except(:id, :display_name, :description, :slug, :redirect, :avatar_src).keys
       {cards: true, include_avatar_src?: true}.tap do |context|
-        exclude_keys.map do |k|
+        cards_exclude_keys.map do |k|
           context["include_#{k}?".to_sym] = false
         end
       end
     else
       super
     end
+  end
+
+  def cards_exclude_keys
+    ProjectSerializer.serializable_attributes.except(*CARD_FIELDS).keys
   end
 end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -100,7 +100,7 @@ describe Api::V1::ProjectsController, type: :controller do
         describe "cards only" do
           let(:index_options) { { cards: true } }
           let(:card_attrs) do
-            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links"]
+            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at"]
           end
 
           it "should return only serialise the card data" do


### PR DESCRIPTION
Adds the project updated_at attribute to the cards response object per project. This will be used by https://github.com/zooniverse/Panoptes-Front-End/pull/2979

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

