### PR TITLE
eager load the recents required models for serialization

### DIFF
--- a/app/controllers/concerns/recents.rb
+++ b/app/controllers/concerns/recents.rb
@@ -6,10 +6,14 @@ module Recents
   end
 
   def recent_scope
-    classification_query = { :"#{resource_name}_id" => resource_ids }
-    classification_query['project_id'] = params[:project_id] if params.has_key?(:project_id)
-    classification_query['workflow_id'] = params[:workflow_id] if params.has_key?(:workflow_id)
-    Recent.eager_load(:locations, :classification)
+    Recent.eager_load(:classification, :subject, :locations, :workflow, :project)
       .where(classifications: classification_query)
+  end
+
+  def classification_query
+    query = { :"#{resource_name}_id" => resource_ids }
+    query['project_id'] = params[:project_id] if params.has_key?(:project_id)
+    query['workflow_id'] = params[:workflow_id] if params.has_key?(:workflow_id)
+    query
   end
 end

--- a/spec/support/recents.rb
+++ b/spec/support/recents.rb
@@ -3,70 +3,79 @@ RSpec.shared_examples "has recents" do
     [create(:classification_with_recents, created_at: 1.hour.ago, resource_key => resource ),
       create(:classification_with_recents, resource_key => resource )]
   end
-
+  let(:filter_params) { {} }
   let(:links) { recent_json.map{|r| r['links']} }
   let(:recent_json) { json_response['recents'] }
 
-  describe "#recents"
-  before(:each) do
+  before do
     default_request(scopes: scopes, user_id: authorized_user.id)
-    get :recents, filter_params.merge(resource_key_id => resource.id)
   end
 
-  context "no filters" do
-    let(:filter_params) { {} }
-    it 'should respond ok' do
-      expect(response).to have_http_status(:ok)
-    end
-
-    it 'should have recently classified subjects' do
-      expect(recent_json.length).to eq(4)
-    end
-
-    it 'should have a link to the project and workflow' do
-      expect(links).to all( include('project', 'workflow') )
-    end
-
-    it 'should have a locations hash' do
-      expect(recent_json).to all( include('locations') )
-    end
+  it "should call the correct eager_loads join queries" do
+    eager_loads = %i(classification subject locations workflow project)
+    expect(Recent).to receive(:eager_load).with(*eager_loads).and_call_original
+    get :recents, { resource_key_id => resource.id }
   end
 
-  context "sorted by created_at asc" do
-    let(:filter_params) { {sort: "+created_at" } }
-
-    it 'should be sorted by created_at in ascending order' do
-      expect(recent_json.map{ |r| r['id'].to_i }).to match_array(Recent.order(created_at: :asc).pluck(:id))
-    end
-  end
-
-  context "sorted by created_at desc" do
-    let(:filter_params) { {sort: "-created_at" } }
-
-    it 'should be sorted by created_at in descending order' do
-      expect(recent_json.map{ |r| r['id'].to_i }).to match_array(Recent.order(created_at: :desc).pluck(:id))
-    end
-  end
-
-  context "filtered by project" do
-    let(:filter_params) { {project_id: classifications.first.project.id.to_s} }
-    it 'should be filterable' do
-      expect(recent_json.length).to eq(2)
+  context "with the controller action run" do
+    before do
+      get :recents, filter_params.merge(resource_key_id => resource.id)
     end
 
-    it 'should all have the same project_id' do
-      expect(links.map{ |l| l['project'] }).to all( eq(classifications.first.project.id.to_s))
-    end
-  end
+    context "no filters" do
+      it 'should respond ok' do
+        expect(response).to have_http_status(:ok)
+      end
 
-  context "filtered by workflow" do
-    let(:filter_params) { {workflow_id: classifications.first.workflow.id.to_s} }
-    it 'should be filterable' do
-      expect(recent_json.length).to eq(2)
+      it 'should have recently classified subjects' do
+        expect(recent_json.length).to eq(4)
+      end
+
+      it 'should have a link to the project and workflow' do
+        expect(links).to all( include('project', 'workflow') )
+      end
+
+      it 'should have a locations hash' do
+        expect(recent_json).to all( include('locations') )
+      end
     end
 
-    it 'should all have the same workflow_id' do
-      expect(links.map{ |l| l['workflow'] }).to all( eq(classifications.first.workflow.id.to_s))
+    context "sorted by created_at asc" do
+      let(:filter_params) { {sort: "+created_at" } }
+
+      it 'should be sorted by created_at in ascending order' do
+        expect(recent_json.map{ |r| r['id'].to_i }).to match_array(Recent.order(created_at: :asc).pluck(:id))
+      end
+    end
+
+    context "sorted by created_at desc" do
+      let(:filter_params) { {sort: "-created_at" } }
+
+      it 'should be sorted by created_at in descending order' do
+        expect(recent_json.map{ |r| r['id'].to_i }).to match_array(Recent.order(created_at: :desc).pluck(:id))
+      end
+    end
+
+    context "filtered by project" do
+      let(:filter_params) { {project_id: classifications.first.project.id.to_s} }
+      it 'should be filterable' do
+        expect(recent_json.length).to eq(2)
+      end
+
+      it 'should all have the same project_id' do
+        expect(links.map{ |l| l['project'] }).to all( eq(classifications.first.project.id.to_s))
+      end
+    end
+
+    context "filtered by workflow" do
+      let(:filter_params) { {workflow_id: classifications.first.workflow.id.to_s} }
+      it 'should be filterable' do
+        expect(recent_json.length).to eq(2)
+      end
+
+      it 'should all have the same workflow_id' do
+        expect(links.map{ |l| l['workflow'] }).to all( eq(classifications.first.workflow.id.to_s))
+      end
     end
   end
 end


### PR DESCRIPTION
avoid N+1 queries when serialising the link objects

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.