### PR TITLE
Add simplified completeness calculation for never_retire

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -27,14 +27,17 @@ class CalculateProjectCompletenessWorker
     return 0.0 if workflow.subjects.count == 0
 
     case workflow.retirement_scheme
+      when RetirementSchemes::NeverRetire
+        total_subjects = workflow.subjects.count
+        retired_subjects = workflow.retired_subjects_count
+
+        (0.0..1.0).clamp(retired_subjects / total_subjects.to_f)
     when RetirementSchemes::ClassificationCount
       total_subjects = workflow.subjects.count
-      retired_subjects = workflow.retired_subjects_count
       classifications_needed = total_subjects * workflow.retirement_scheme.count
       classifications_made = workflow.classifications_count
-      max = (retired_subjects >= total_subjects) ? 1.0 : 0.9
 
-      (0.0..max).clamp(classifications_made / classifications_needed.to_f)
+      (0.0..1.0).clamp(classifications_made / classifications_needed.to_f)
     else
       0.0
     end

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -31,29 +31,45 @@ describe CalculateProjectCompletenessWorker do
       expect(worker.workflow_completeness(workflow)).to eq(0.0)
     end
 
-    it 'returns 0 when not using a supported retirement scheme' do
-      workflow.update! retirement: {'criteria' => 'never_retire', 'options' => {}}
-      expect(worker.workflow_completeness(workflow)).to eq(0.0)
+    context 'no panoptes retirement' do
+      before do
+        workflow.retirement = {'criteria' => 'never_retire', 'options' => {}}
+      end
+
+      it 'returns 1 when all the subjects of a workflow have been retired' do
+        workflow.classifications_count = 20
+        workflow.retired_set_member_subjects_count = 2
+        expect(worker.workflow_completeness(workflow)).to eq(1.0)
+      end
+
+      it 'returns 0.5 when half of the subjects are retired' do
+        workflow.retired_set_member_subjects_count = 1
+        expect(worker.workflow_completeness(workflow)).to eq(0.5)
+      end
+
+      it 'returns 1.0 when there are more retired subjects than subjects' do
+        workflow.retired_set_member_subjects_count = 3
+        expect(worker.workflow_completeness(workflow)).to eq(1.0)
+      end
     end
 
-    it 'returns 1 when all the subjects of a workflow have been retired' do
-      workflow.update! classifications_count: 20, retired_set_member_subjects_count: 2
-      expect(worker.workflow_completeness(workflow)).to eq(1.0)
-    end
+    context 'classification count retirement' do
+      it 'returns 1 when all the subjects of a workflow have been retired' do
+        workflow.classifications_count = 20
+        workflow.retired_set_member_subjects_count = 2
+        expect(worker.workflow_completeness(workflow)).to eq(1.0)
+      end
 
-    it 'returns 0.5 when all subjects are halfway towards their retirement limit' do
-      workflow.update! classifications_count: 10
-      expect(worker.workflow_completeness(workflow)).to eq(0.5)
-    end
+      it 'returns 0.5 when all subjects are halfway towards their retirement limit' do
+        workflow.classifications_count = 10
+        expect(worker.workflow_completeness(workflow)).to eq(0.5)
+      end
 
-    it 'returns 1.0 when there are more classifications than needed and everything is retired' do
-      workflow.update! classifications_count: 9001, retired_set_member_subjects_count: 2
-      expect(worker.workflow_completeness(workflow)).to eq(1.0)
-    end
-
-    it 'returns 0.9 when there are more classifications than needed and there is work left' do
-      workflow.update! classifications_count: 9001, retired_set_member_subjects_count: 1
-      expect(worker.workflow_completeness(workflow)).to eq(0.9)
+      it 'returns 1.0 when there are more classifications than needed and everything is retired' do
+        workflow.classifications_count = 9001
+        workflow.retired_set_member_subjects_count = 2
+        expect(worker.workflow_completeness(workflow)).to eq(1.0)
+      end
     end
   end
 end


### PR DESCRIPTION
Projects that use never_retire will usually still have some kind of
retirement, but it will be externally managed (Nero, or custom).

In this case, since we can't tell how many classifications we will need,
we can only use the number of retired subjects as a guide to how far
along a project is.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

