### PR TITLE
Allow sending in an empty collection

### DIFF
--- a/app/controllers/api/v1/subject_queues_controller.rb
+++ b/app/controllers/api/v1/subject_queues_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::SubjectQueuesController < Api::ApiController
         .where(subject_id: value)
         .order("idx(array[#{value.join(',')}], set_member_subjects.subject_id)")
 
-      relation_or_error(relation, true)
+      relation_or_error(relation, true, false)
     else
       super
     end

--- a/lib/json_api_controller/relation_manager.rb
+++ b/lib/json_api_controller/relation_manager.rb
@@ -51,17 +51,17 @@ module JsonApiController
     def relation_find(find_arg)
       relation = yield
       relation = relation.where(id: find_arg)
-      relation_or_error(relation, find_arg.is_a?(Array))
+      relation_or_error(relation, find_arg.is_a?(Array), find_arg.blank?)
     end
 
     # This is a workaround for  https://github.com/rails/arel/pull/349
-    def relation_or_error(relation, multi)
-      unless relation.empty?
-        multi ? relation : relation.first
-      else
+    def relation_or_error(relation, multi, empty_query)
+      if relation.empty? && !empty_query
         error_name = multi ? :plural : :singular
         msg = "Couldn't find linked #{relation.klass.model_name.send(error_name)} for current user"
         raise JsonApiController::NotLinkable.new(msg)
+      else
+        multi ? relation : relation.first
       end
     end
   end

--- a/spec/lib/json_api_controller/relation_manager_spec.rb
+++ b/spec/lib/json_api_controller/relation_manager_spec.rb
@@ -42,6 +42,13 @@ describe JsonApiController::RelationManager do
         expect(updated).to match_array(subjects)
       end
 
+      context 'empty link' do
+        it 'should set to empty collection' do
+          updated = test_instance.update_relation(resource, :subjects, [])
+          expect(updated).to be_empty
+        end
+      end
+
       context "not found" do
         it 'should raise an error' do
           expect do
@@ -80,15 +87,26 @@ describe JsonApiController::RelationManager do
         updated = test_instance.update_relation(resource, :projects, [project.id])
         expect(updated).to match_array([project])
       end
+
+      context 'empty link' do
+        it 'should set to empty collection' do
+          updated = test_instance.update_relation(resource, :projects, [])
+          expect(updated).to be_empty
+        end
+      end
     end
   end
 
   describe "#add_relation" do
     context "to-many" do
       it 'should add the new relation to the resource' do
-        test_instance.add_relation(resource,
-                                   :subjects,
-                                   subjects.map(&:id).map(&:to_s))
+        test_instance.add_relation(resource, :subjects, subjects.map(&:id).map(&:to_s))
+        expect(resource.subjects).to include(*subjects)
+      end
+
+      it 'should allow adding no items' do
+        test_instance.add_relation(resource, :subjects, subjects.map(&:id).map(&:to_s))
+        test_instance.add_relation(resource, :subjects, [])
         expect(resource.subjects).to include(*subjects)
       end
     end
@@ -105,6 +123,12 @@ describe JsonApiController::RelationManager do
     context "belongs-to-many" do
       it 'should replace the old relation' do
         test_instance.add_relation(resource, :projects, [project.id])
+        expect(resource.projects).to include(*project)
+      end
+
+      it 'should allow adding no items' do
+        test_instance.add_relation(resource, :projects, [project.id])
+        test_instance.add_relation(resource, :projects, [])
         expect(resource.projects).to include(*project)
       end
     end


### PR DESCRIPTION
Linking up an empty collection should not return errors, but should
simply assign the empty collection (or add no items).

Related: https://github.com/zooniverse/education-api/pull/34

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

