### PR TITLE
Don't serialize tasks, do serialize retirement rules

### DIFF
--- a/app/serializers/event_stream_serializers/workflow_serializer.rb
+++ b/app/serializers/event_stream_serializers/workflow_serializer.rb
@@ -1,5 +1,5 @@
 module EventStreamSerializers
   class WorkflowSerializer < ActiveModel::Serializer
-    attributes :id, :display_name, :created_at
+    attributes :id, :display_name, :retirement, :created_at
   end
 end

--- a/app/serializers/event_stream_serializers/workflow_serializer.rb
+++ b/app/serializers/event_stream_serializers/workflow_serializer.rb
@@ -1,5 +1,5 @@
 module EventStreamSerializers
   class WorkflowSerializer < ActiveModel::Serializer
-    attributes :id, :display_name, :tasks, :created_at
+    attributes :id, :display_name, :created_at
   end
 end


### PR DESCRIPTION
Removes the massive tasks hash from the stream. Adds the retirement config so we can get Nero to use that for its config rather than some file on S3.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
