### PR TITLE
count the classifications correctly ignoring any subject reuse across workflows

### DIFF
--- a/app/counters/subject_workflow_counter.rb
+++ b/app/counters/subject_workflow_counter.rb
@@ -10,8 +10,8 @@ class SubjectWorkflowCounter
     scope = Classification
       .where(workflow: swc.workflow_id)
       .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
-      .where("cs.subject_id = ?", swc.workflow_id)
-    if launch_date = swc.workflow.project.launch_date
+      .where("cs.subject_id = ?", swc.subject_id)
+    if launch_date = swc.project.launch_date
       scope = scope.where("classifications.created_at >= ?", launch_date)
     end
     scope.count

--- a/app/counters/subject_workflow_counter.rb
+++ b/app/counters/subject_workflow_counter.rb
@@ -7,11 +7,10 @@ class SubjectWorkflowCounter
   end
 
   def classifications
-    scope = SubjectWorkflowStatus
-      .where(id: swc.id)
-      .joins("INNER JOIN classification_subjects cs ON cs.subject_id = subject_workflow_counts.subject_id")
-      .joins("INNER JOIN classifications ON classifications.id = cs.classification_id")
-      .joins("INNER JOIN workflows ON workflows.id = subject_workflow_counts.workflow_id")
+    scope = Classification
+      .where(workflow: swc.workflow_id)
+      .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
+      .where("cs.subject_id = ?", swc.workflow_id)
     if launch_date = swc.workflow.project.launch_date
       scope = scope.where("classifications.created_at >= ?", launch_date)
     end

--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -15,6 +15,7 @@ class SubjectWorkflowStatus < ActiveRecord::Base
   validates :workflow, presence: true
 
   delegate :set_member_subjects, to: :subject
+  delegate :project, to: :workflow
 
   can_through_parent :workflow, :show, :index
 

--- a/spec/controllers/api/v1/subject_worfklow_statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_worfklow_statuses_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Api::V1::SubjectWorkflowStatusesController, type: :controller do
 
   describe "#show" do
     let(:resource) { create(:subject_workflow_status) }
-    let(:authorized_user) { resource.workflow.project.owner }
+    let(:authorized_user) { resource.project.owner }
 
     it_behaves_like "is showable"
   end

--- a/spec/controllers/cellect_controller_spec.rb
+++ b/spec/controllers/cellect_controller_spec.rb
@@ -48,8 +48,7 @@ describe CellectController, type: :controller do
         it "should respond with all the workflows" do
           run_get
           workflows = Workflow.all.map{ |w| w.slice(:id, :pairwise, :grouped, :prioritized) }
-          expected = { workflows: workflows }.as_json
-          expect(json_response).to eq(expected)
+          expect(json_response["workflows"]).to match_array(workflows)
         end
       end
     end

--- a/spec/counters/subject_workflow_counter_spec.rb
+++ b/spec/counters/subject_workflow_counter_spec.rb
@@ -18,8 +18,7 @@ describe SubjectWorkflowCounter do
     context "with classifications" do
       before do
         2.times do
-          c = create(:classification,  subject_ids: [sws.subject_id], project: project, workflow: workflow)
-          create(:user_project_preference, project: project, user: c.user)
+          create(:classification,  subject_ids: [sws.subject_id], project: project, workflow: workflow)
         end
       end
 
@@ -32,6 +31,15 @@ describe SubjectWorkflowCounter do
         expect(counter.classifications).to eq(0)
         allow(project).to receive(:launch_date).and_return(now-1.day)
         expect(counter.classifications).to eq(2)
+      end
+
+      context "when the subject is classified for other workflows" do
+        let(:another_workflow) { create(:workflow, project: project) }
+
+        it "should still only count 2" do
+          create(:classification,  subject_ids: [sws.subject_id], project: project, workflow: another_workflow)
+          expect(counter.classifications).to eq(2)
+        end
       end
     end
   end

--- a/spec/counters/subject_workflow_counter_spec.rb
+++ b/spec/counters/subject_workflow_counter_spec.rb
@@ -37,7 +37,7 @@ describe SubjectWorkflowCounter do
         let(:another_workflow) { create(:workflow, project: project) }
 
         it "should still only count 2" do
-          create(:classification,  subject_ids: [sws.subject_id], project: project, workflow: another_workflow)
+          create(:classification, subject_ids: [sws.subject_id], project: project, workflow: another_workflow)
           expect(counter.classifications).to eq(2)
         end
       end


### PR DESCRIPTION
Closes #1932 - The subject workflow counters weren't correctly counting where subjects had been reused across worklfows.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.