### PR TITLE
Remove workflow contents from Kinesis

### DIFF
--- a/app/workers/publish_classification_worker.rb
+++ b/app/workers/publish_classification_worker.rb
@@ -17,7 +17,7 @@ class PublishClassificationWorker
 
   def serialized_classification
     @serialized_classification ||= EventStreamSerializers::ClassificationSerializer
-      .serialize(classification, include: ['project', 'workflow', 'workflow_content', 'user', 'subjects'])
+      .serialize(classification, include: ['project', 'workflow', 'user', 'subjects'])
       .as_json
       .with_indifferent_access
   end

--- a/spec/workers/publish_classification_worker_spec.rb
+++ b/spec/workers/publish_classification_worker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PublishClassificationWorker do
     end
 
     describe "internal classification event stream" do
-      let(:serialiser_opts) { { include: ['project', 'workflow', 'workflow_content', 'user', 'subjects'] } }
+      let(:serialiser_opts) { { include: ['project', 'workflow', 'user', 'subjects'] } }
 
       it "should format the data using the serializer" do
         expect(EventStreamSerializers::ClassificationSerializer)


### PR DESCRIPTION
Turns out NfN has a huge list of names in their workflow strings, which makes things too big to fit in the stream.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

