### PR TITLE
handle persistent task type in csv annotation exports

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -14,7 +14,7 @@ module Formatter
         case task['type']
         when "drawing"
           drawing
-        when /single|multiple|persistent/
+        when /single|multiple|shortcut/
           simple
         when "text"
           text

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -14,7 +14,7 @@ module Formatter
         case task['type']
         when "drawing"
           drawing
-        when "single", "multiple"
+        when /single|multiple|persistent/
           simple
         when "text"
           text

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -220,11 +220,11 @@ FactoryGirl.define do
         })
     end
 
-    trait :persistent_task do
+    trait :shortcut do
       tasks (
         {
           "init" => {
-            "type" => "persistent",
+            "type" => "shortcut",
             "answers" => [{ "label" => "init.answers.0.label" }],
             "question" => "init.question"
           }

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -219,5 +219,27 @@ FactoryGirl.define do
           }
         })
     end
+
+    trait :persistent_task do
+      tasks (
+        {
+          "init" => {
+            "type" => "persistent",
+            "answers" => [{ "label" => "init.answers.0.label" }],
+            "question" => "init.question"
+          }
+        }
+      )
+
+      after(:build) do |w, env|
+        if env.build_contents
+          strings = {
+            "init.answers.0.label" => "yes",
+            "init.question" => "Fire present?"
+          }
+          w.workflow_contents.first.update(strings: strings)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -251,6 +251,25 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
           expect(formatted["task_label"]).to eq("Draw a circle")
         end
       end
+
+      context "with a nothing_here task" do
+        let(:workflow) { build(:workflow, :persistent_task) }
+        let(:contents) { workflow.workflow_contents.first }
+        let(:tasks) { workflow.tasks }
+        let(:strings) { contents.strings }
+        let(:annotation) do
+          {
+            "task"=>"init",
+            "value"=> 0
+           }
+        end
+
+        it 'should add the correct answer labels' do
+          formatted = described_class.new(classification, annotation, cache).to_h
+          expect(formatted["task_label"]).to eq("Fire present?")
+          expect(formatted["value"]).to eq("yes")
+        end
+      end
     end
   end
 end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -252,8 +252,8 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         end
       end
 
-      context "with a nothing_here task" do
-        let(:workflow) { build(:workflow, :persistent_task) }
+      context "with a shortcut task" do
+        let(:workflow) { build(:workflow, :shortcut) }
         let(:contents) { workflow.workflow_contents.first }
         let(:tasks) { workflow.tasks }
         let(:strings) { contents.strings }


### PR DESCRIPTION
**MERGE DEPENDENT** on https://github.com/zooniverse/Panoptes-Front-End/pull/2914

Adds a new task type (persistent) that is always displayed for a workflow in PFE. This task can not be wired up in normal task flow. It's use case is for constant answers irrespective of specific tasks, e.g. nothing in the image? and fire? Similar to the way snapshot serengeti works with fire / nothing.

![image](https://cloud.githubusercontent.com/assets/295329/19601535/a5a9b98a-97a1-11e6-8af1-82ebbeefb976.png)
# Review checklist
- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
