### PR TITLE
use linked subject / retired ratio for project completion

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -24,22 +24,14 @@ class CalculateProjectCompletenessWorker
   end
 
   def workflow_completeness(workflow)
-    return 0.0 if workflow.subjects.count == 0
+    workflow_subjects_count = workflow.subjects_count
 
-    case workflow.retirement_scheme
-      when RetirementSchemes::NeverRetire
-        total_subjects = workflow.subjects.count
-        retired_subjects = workflow.retired_subjects_count
-
-        (0.0..1.0).clamp(retired_subjects / total_subjects.to_f)
-    when RetirementSchemes::ClassificationCount
-      total_subjects = workflow.subjects.count
-      classifications_needed = total_subjects * workflow.retirement_scheme.count
-      classifications_made = workflow.classifications_count
-
-      (0.0..1.0).clamp(classifications_made / classifications_needed.to_f)
-    else
+    if workflow_subjects_count == 0
       0.0
+    else
+      retired_subjects = workflow.retired_subjects_count
+      total_subjects = workflow_subjects_count
+      (0.0..1.0).clamp(retired_subjects / total_subjects.to_f)
     end
   end
 end


### PR DESCRIPTION
linked to https://github.com/zooniverse/Panoptes-Front-End/issues/3145

ignore the metrics based on classification counts and dealing with unlinked sets, just use the current linked set of subjects and retired counts to provide a ratio for completeness. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.