### PR TITLE
eager load the linked resources used in the serializer

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -68,6 +68,15 @@ class Workflow < ActiveRecord::Base
     where(project: subject_set.project)
   end
 
+  def self.scope_for(action, user, opts={})
+    super.eager_load(
+      :subject_sets,
+      :expert_subject_sets,
+      :tutorial_subject,
+      :attached_images
+    )
+  end
+
   def tasks
     read_attribute(:tasks).with_indifferent_access
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -42,7 +42,9 @@ class Workflow < ActiveRecord::Base
   DEFAULT_RETIREMENT_OPTIONS = {
     'criteria' => 'classification_count',
     'options' => {'count' => 15}
-  }
+  }.freeze
+
+  EAGER_LOADS = %i(subject_sets expert_subject_sets tutorial_subject attached_images).freeze
 
   validates_presence_of :project, :display_name
 
@@ -68,13 +70,12 @@ class Workflow < ActiveRecord::Base
     where(project: subject_set.project)
   end
 
-  def self.scope_for(action, user, opts={})
-    super.eager_load(
-      :subject_sets,
-      :expert_subject_sets,
-      :tutorial_subject,
-      :attached_images
-    )
+  def self.scope_for(action, user, opts={eager_loads: EAGER_LOADS})
+    workflows = super
+    if opts.has_key?(:eager_loads)
+      workflows = workflows.eager_load(*opts[:eager_loads])
+    end
+    workflows
   end
 
   def tasks

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -38,6 +38,21 @@ describe Workflow, type: :model do
         .and_call_original
       Workflow.scope_for(:index, ApiUser.new(nil))
     end
+
+    it "eager load the supplied relations" do
+      eager_loads = %i(subject_sets)
+      expect_any_instance_of(Workflow::ActiveRecord_Relation)
+        .to receive(:eager_load)
+        .with(*eager_loads)
+        .and_call_original
+      Workflow.scope_for(:index, ApiUser.new(nil), { eager_loads: eager_loads })
+    end
+
+    it "should skip eager load if not set" do
+      expect_any_instance_of(Workflow::ActiveRecord_Relation)
+        .not_to receive(:eager_load)
+      Workflow.scope_for(:index, ApiUser.new(nil), {})
+    end
   end
 
   it "should have a valid factory" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -29,6 +29,17 @@ describe Workflow, type: :model do
       [:subjects_count, :finished?]
   end
 
+  describe ".scope_for" do
+    it "should eager load the linked resources used in the serializer" do
+      eager_loads = %i(subject_sets expert_subject_sets tutorial_subject attached_images)
+      expect_any_instance_of(Workflow::ActiveRecord_Relation)
+        .to receive(:eager_load)
+        .with(*eager_loads)
+        .and_call_original
+      Workflow.scope_for(:index, ApiUser.new(nil))
+    end
+  end
+
   it "should have a valid factory" do
     expect(workflow).to be_valid
   end


### PR DESCRIPTION
Avoid N+1 queries in the serializer

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

