### PR TITLE
smarter fallback subject selection when using cellect

### DIFF
--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -41,7 +41,9 @@ module Subjects
       if workflow.using_cellect?
         sms_ids = fallback_selector.select
         if data_available = !sms_ids.empty?
-          ReloadCellectWorker.perform_async(workflow.id)
+          if Panoptes.flipper[:cellect_sync_error_reload].enabled?
+            ReloadCellectWorker.perform_async(workflow.id)
+          end
           Honeybadger.notify(
             error_class:   "Cellect data sync error",
             error_message: "Cellect returns no data but PG selector does",

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -35,7 +35,16 @@ module Subjects
 
     def fallback_selection
       opts = { limit: subjects_page_size, subject_set_id: subject_set_id }
-      PostgresqlSelection.new(workflow, user, opts).any_workflow_data
+      fallback_selector = PostgresqlSelection.new(workflow, user, opts)
+
+      sms_ids = []
+      sms_ids = fallback_selector.select if workflow.using_cellect?
+
+      if sms_ids.blank?
+        fallback_selector.any_workflow_data
+      else
+        sms_ids
+      end
     end
 
     def needs_set_id?

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Subjects::Selector do
     context "when the database selection strategy returns an empty set" do
       before do
         allow_any_instance_of(Subjects::PostgresqlSelection)
-        .to receive(:select).and_return([])
+          .to receive(:select).and_return([])
         expect_any_instance_of(Subjects::PostgresqlSelection)
           .to receive(:any_workflow_data)
           .and_call_original
@@ -82,6 +82,36 @@ RSpec.describe Subjects::Selector do
 
         it 'should fallback to selecting some grouped data' do
           allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
+          subjects, _context = subject.get_subjects
+        end
+      end
+    end
+
+    context "when the cellect selection strategy returns an empty set"do
+      before do
+        stub_cellect_connection
+        stub_redis_connection
+        allow(workflow).to receive(:using_cellect?).and_return(true)
+      end
+
+      it 'should fallback to using postgres selection' do
+        expect_any_instance_of(Subjects::PostgresqlSelection)
+          .to receive(:select)
+          .and_call_original
+        subjects, _context = subject.get_subjects
+      end
+
+      context "when the default postgres selector returns no data" do
+        before do
+          allow_any_instance_of(Subjects::PostgresqlSelection)
+            .to receive(:select)
+            .and_return([])
+        end
+
+        it "should fallback to just returning any data" do
+          expect_any_instance_of(Subjects::PostgresqlSelection)
+            .to receive(:any_workflow_data)
+            .and_call_original
           subjects, _context = subject.get_subjects
         end
       end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -102,7 +102,13 @@ RSpec.describe Subjects::Selector do
       end
 
       it "should notify cellect to reload" do
+        Panoptes.flipper[:cellect_sync_error_reload].enable
         expect(ReloadCellectWorker).to receive(:perform_async).with(workflow.id)
+        subject.get_subjects
+      end
+
+      it "should not notify cellect to reload if the feature is disabled" do
+        expect(ReloadCellectWorker).not_to receive(:perform_async)
         subject.get_subjects
       end
 


### PR DESCRIPTION
I'm not sure this is the best solution as it could swamp the database. 

The reason i'm proposing this is that cellect can be out of sync re loaded data so try and return useful data. This happened today with a project, for some reason cellect wasn't told / hadn't reloaded the new data that was linked up (not sure why) but there was plenty of data left to classify and the fallback selector was just showing any data...sad times. 
# Review checklist
- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
