### PR TITLE
eager_load the workflow relations used in the serializer

### DIFF
--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -15,9 +15,11 @@ class Aggregation < ActiveRecord::Base
 
   def self.scope_for(action, user, opts={})
     if (action == :show || action == :index) && !user.is_admin?
-      controlled_scope = joins(:workflow).merge(Workflow.scope_for(:update, user, opts))
-      public_workflow_scope = joins(:workflow).where("workflows.aggregation ->> 'public' = 'true'")
-      public_workflow_scope.union(controlled_scope)
+      updatable = Workflow.scope_for(:update, user, opts.merge(skip_eager_load: true))
+      controlled_scope = joins(:workflow).merge(updatable)
+      joins(:workflow)
+        .where("workflows.aggregation ->> 'public' = 'true'")
+        .union(controlled_scope)
     else
       super
     end

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -21,7 +21,12 @@ class SubjectQueue < ActiveRecord::Base
   def self.scope_for(action, user, opts={})
     case action
     when :show, :index
-      where(workflow: Workflow.scope_for(:update, groups, opts))
+      workflows = Workflow.scope_for(
+        :update,
+        user,
+        opts.merge(skip_eager_load: true)
+      )
+      where(workflow: workflows)
     else
       super
     end

--- a/app/models/subject_queue.rb
+++ b/app/models/subject_queue.rb
@@ -18,7 +18,7 @@ class SubjectQueue < ActiveRecord::Base
 
   alias_method :subjects=, :set_member_subjects=
 
-  def self.scope_for(action, groups, opts={})
+  def self.scope_for(action, user, opts={})
     case action
     when :show, :index
       where(workflow: Workflow.scope_for(:update, groups, opts))

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -44,6 +44,8 @@ class Workflow < ActiveRecord::Base
     'options' => {'count' => 15}
   }.freeze
 
+  EAGER_LOADS = %i(project subject_sets expert_subject_sets tutorial_subject attached_images).freeze
+
   validates_presence_of :project, :display_name
 
   validate do |workflow|
@@ -66,6 +68,14 @@ class Workflow < ActiveRecord::Base
 
   def self.same_project?(subject_set)
     where(project: subject_set.project)
+  end
+
+  def self.scope_for(action, user, opts={})
+    if opts[:skip_eager_load]
+      super
+    else
+      super.eager_load(*EAGER_LOADS)
+    end
   end
 
   def tasks

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -73,7 +73,7 @@ class Workflow < ActiveRecord::Base
   def self.scope_for(action, user, opts={})
     experiment_name = "eager_load_workflows"
     scope = super
-    CodeExperiment.run "#{experiment_name}" do |e|
+    CodeExperiment.run(experiment_name) do |e|
       e.run_if { Panoptes.flipper[experiment_name].enabled? }
       e.context user: user
       e.use { scope }

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -34,18 +34,25 @@ describe Workflow, type: :model do
       %i(project subject_sets expert_subject_sets tutorial_subject attached_images)
     end
 
-    it "should eager load the linked resources used in the serializer" do
-      expect_any_instance_of(Workflow::ActiveRecord_Relation)
-        .to receive(:eager_load)
-        .with(*eager_loads)
-        .and_call_original
-      Workflow.scope_for(:index, ApiUser.new(nil))
-    end
+    context "with enabled experiment" do
+      before do
+        Panoptes.flipper["eager_load_workflows"].enable
+        allow_any_instance_of(CodeExperiment).to receive(:enabled?).and_return(true)
+      end
 
-    it "should skip eager load if not set" do
-      expect_any_instance_of(Workflow::ActiveRecord_Relation)
-        .not_to receive(:eager_load)
-      Workflow.scope_for(:index, ApiUser.new(nil), {skip_eager_load: true})
+      it "should eager load the linked resources used in the serializer" do
+        expect_any_instance_of(Workflow::ActiveRecord_Relation)
+          .to receive(:eager_load)
+          .with(*eager_loads)
+          .and_call_original
+        Workflow.scope_for(:index, ApiUser.new(nil))
+      end
+
+      it "should skip eager load if not set" do
+        expect_any_instance_of(Workflow::ActiveRecord_Relation)
+          .not_to receive(:eager_load)
+        Workflow.scope_for(:index, ApiUser.new(nil), {skip_eager_load: true})
+      end
     end
   end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -29,6 +29,26 @@ describe Workflow, type: :model do
       [:subjects_count, :finished?]
   end
 
+  describe ".scope_for" do
+    let(:eager_loads) do
+      %i(project subject_sets expert_subject_sets tutorial_subject attached_images)
+    end
+
+    it "should eager load the linked resources used in the serializer" do
+      expect_any_instance_of(Workflow::ActiveRecord_Relation)
+        .to receive(:eager_load)
+        .with(*eager_loads)
+        .and_call_original
+      Workflow.scope_for(:index, ApiUser.new(nil))
+    end
+
+    it "should skip eager load if not set" do
+      expect_any_instance_of(Workflow::ActiveRecord_Relation)
+        .not_to receive(:eager_load)
+      Workflow.scope_for(:index, ApiUser.new(nil), {skip_eager_load: true})
+    end
+  end
+
   it "should have a valid factory" do
     expect(workflow).to be_valid
   end


### PR DESCRIPTION
Make sure the controller actually eager loads the relations for the serializer. Added feature flag and experimental setup to get metrics on any performance costs of using the eager loading strategy.
# Review checklist
- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
