### PR TITLE
save the launch_approved timestamp when it's first pressed

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -172,23 +172,27 @@ class Api::V1::ProjectsController < Api::ApiController
     super(create_params)
   end
 
-  def build_update_hash(update_params, id)
+  def build_update_hash(update_params, resource)
     admin_allowed update_params, *admin_allowed_params
+
     content_update = content_from_params(update_params)
     unless content_update.blank?
-      Project.find(id).primary_content.update!(content_update)
+      resource.primary_content.update!(content_update)
     end
+
     tags = create_or_update_tags(update_params)
-    unless tags.nil?
-      p = Project.find(id)
-      p.tags = tags
-      p.save!
+    resource.tags = tags unless tags.nil?
+
+    if update_params[:launch_approved]
+      resource.launch_date ||= Time.zone.now
     end
+
     if update_params[:live] == false
       update_params[:launch_approved] = false
       update_params[:beta_approved] = false
     end
-    super(update_params, id)
+
+    super(update_params, resource)
   end
 
   def new_items(resource, relation, value)


### PR DESCRIPTION
closes #1765 - save the launch_date timestamp when we first approve a project.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

also refactored the extra finds & save for update as the updating resource is already known and any has_many relation adds auto saves in the db.