### PR TITLE
handle incorrectly formatted annotation values in classification dumps

### DIFF
--- a/lib/classification_dump_cache.rb
+++ b/lib/classification_dump_cache.rb
@@ -35,19 +35,17 @@ class ClassificationDumpCache
     (@subject_workflow_statuses[subject_id] || []).find {|swc| swc.workflow_id == workflow_id }
   end
 
-  def workflow_at_version(workflow_id, version)
-    @workflows[workflow_id] ||= {}
-    @workflows[workflow_id][version] ||= begin
-      workflow = Workflow.find(workflow_id)
+  def workflow_at_version(workflow, version)
+    @workflows[workflow.id] ||= {}
+    @workflows[workflow.id][version] ||= begin
       old_version = workflow.versions[version].try(:reify)
       old_version || workflow
     end
   end
 
-  def workflow_content_at_version(workflow_content_id, version)
-    @workflow_contents[workflow_content_id] ||= {}
-    @workflow_contents[workflow_content_id][version] ||= begin
-      workflow_content = WorkflowContent.find(workflow_content_id)
+  def workflow_content_at_version(workflow_content, version)
+    @workflow_contents[workflow_content.id] ||= {}
+    @workflow_contents[workflow_content.id][version] ||= begin
       old_version = workflow_content.versions[version].try(:reify)
       old_version || workflow_content
     end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -149,9 +149,6 @@ module Formatter
             translate(answer_string)
           rescue TypeError
             "unknown answer label"
-          rescue NoMethodError => e
-            report_to_honey_badger(answer_idx)
-            raise e
           end
         end
       end
@@ -195,22 +192,6 @@ module Formatter
          key == annotation["task"]
         end
         @task = task_annotation.try(:last) || {}
-      end
-
-      def report_to_honey_badger(answer_idx)
-        Honeybadger.notify(
-          error_class:   "Task export error",
-          error_message: "The task cannot be exported",
-          context: {
-            classification: @classification.id,
-            annotation: @annotation,
-            workflow_at_version: workflow_at_version.id,
-            workflow_version: workflow_version,
-            content_version: content_version,
-            current_task: @current['task'],
-            answer_idx: answer_idx
-          }
-        )
       end
     end
   end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -134,11 +134,8 @@ module Formatter
       end
 
       def tool_label(task_info, tool)
-        begin
-          tool_index = tool["tool"]
-        rescue TypeError => e
-          raise ToolFormattingError.new(e.message)
-        end
+        raise ToolFormattingError unless tool.is_a?(Hash)
+        tool_index = tool["tool"]
         have_tool_lookup_info = !!(task_info["tools"] && tool_index)
         known_tool = have_tool_lookup_info && task_info["tools"][tool_index]
         translate(known_tool["label"]) if known_tool

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -1,8 +1,6 @@
 module Formatter
   module Csv
     class AnnotationForCsv
-      class ToolFormattingError < StandardError; end
-
       attr_reader :classification, :annotation, :cache
 
       def initialize(classification, annotation, cache)
@@ -36,16 +34,16 @@ module Formatter
           new_anno['task'] = @current['task']
           new_anno['task_label'] = task_label(task_info)
 
-          value_with_tool = begin
-            Array.wrap(@current["value"]).map do |drawn_item|
+          added_tool_lables = Array.wrap(@current["value"]).map do |drawn_item|
+            if drawn_item.is_a?(Hash)
               tool_label = tool_label(task_info, drawn_item)
               drawn_item.merge("tool_label" => tool_label)
+            else
+              drawn_item
             end
-          rescue ToolFormattingError => e
-            @current["value"]
           end
 
-          new_anno["value"] = value_with_tool
+          new_anno["value"] = added_tool_lables
         end
       end
 
@@ -134,7 +132,6 @@ module Formatter
       end
 
       def tool_label(task_info, tool)
-        raise ToolFormattingError unless tool.is_a?(Hash)
         tool_index = tool["tool"]
         have_tool_lookup_info = !!(task_info["tools"] && tool_index)
         known_tool = have_tool_lookup_info && task_info["tools"][tool_index]

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -1,6 +1,8 @@
 module Formatter
   module Csv
     class AnnotationForCsv
+      class ToolFormattingError < StandardError; end
+
       attr_reader :classification, :annotation, :cache
 
       def initialize(classification, annotation, cache)
@@ -33,14 +35,18 @@ module Formatter
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
           new_anno['task_label'] = task_label(task_info)
-          value_with_tool = (@current["value"] || []).map do |drawn_item|
-            tool_label = tool_label(task_info, drawn_item)
-            drawn_item.merge("tool_label" => tool_label)
+
+          value_with_tool = begin
+            Array.wrap(@current["value"]).map do |drawn_item|
+              tool_label = tool_label(task_info, drawn_item)
+              drawn_item.merge("tool_label" => tool_label)
+            end
+          rescue ToolFormattingError => e
+            @current["value"]
           end
+
           new_anno["value"] = value_with_tool
         end
-      rescue => e
-        binding.pry
       end
 
       def simple(task_info=task)
@@ -128,11 +134,14 @@ module Formatter
       end
 
       def tool_label(task_info, tool)
-        tool_index = tool["tool"]
+        begin
+          tool_index = tool["tool"]
+        rescue TypeError => e
+          raise ToolFormattingError.new(e.message)
+        end
         have_tool_lookup_info = !!(task_info["tools"] && tool_index)
         known_tool = have_tool_lookup_info && task_info["tools"][tool_index]
         translate(known_tool["label"]) if known_tool
-      # rescue TypeError
       end
 
       def answer_label

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -155,11 +155,11 @@ module Formatter
       end
 
       def primary_content_at_version
-        cache.workflow_content_at_version(classification.workflow.primary_content.id, content_version)
+        cache.workflow_content_at_version(classification.workflow.primary_content, content_version)
       end
 
       def workflow_at_version
-        cache.workflow_at_version(classification.workflow_id, workflow_version)
+        cache.workflow_at_version(classification.workflow, workflow_version)
       end
 
       def workflow_version

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -34,11 +34,13 @@ module Formatter
           new_anno['task'] = @current['task']
           new_anno['task_label'] = task_label(task_info)
           value_with_tool = (@current["value"] || []).map do |drawn_item|
-            tool_label = tool_label(task_info, drawn_item["tool"])
+            tool_label = tool_label(task_info, drawn_item)
             drawn_item.merge("tool_label" => tool_label)
           end
           new_anno["value"] = value_with_tool
         end
+      rescue => e
+        binding.pry
       end
 
       def simple(task_info=task)
@@ -125,10 +127,12 @@ module Formatter
         translate(task_info["question"] || task_info["instruction"])
       end
 
-      def tool_label(task_info, tool_index)
+      def tool_label(task_info, tool)
+        tool_index = tool["tool"]
         have_tool_lookup_info = !!(task_info["tools"] && tool_index)
         known_tool = have_tool_lookup_info && task_info["tools"][tool_index]
         translate(known_tool["label"]) if known_tool
+      # rescue TypeError
       end
 
       def answer_label

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
     expect(formatted["value"][0]["tool_label"]).to be_nil
   end
 
+  it 'just records the tool index if the tool label cannot be translated' do
+    annotation = {"task" => "interest", "value" => [{"x"=>1, "y"=>2, "tool"=>0}]}
+    formatter = described_class.new(classification, annotation, cache)
+    content = double(strings: {})
+    allow(formatter).to receive(:primary_content_at_version).and_return(content)
+    formatted = formatter.to_h
+    expect(formatted["value"][0]["tool_label"]).to be_nil
+    expect(formatted["value"][0]["tool"]).to eq(0)
+  end
+
   it 'returns an empty list of values when annotation itself has no value' do
     annotation = {"task" => "interest"}
     formatted = described_class.new(classification, annotation, cache).to_h

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
     expect(formatted["value"][0]["tool_label"]).to be_nil
   end
 
+  it 'adds an unknown tool label if the tool index is missing', :focus do
+    binding.pry
+    wierd_annotation = weird_annotation.merge("value" => 0)
+    formatted = described_class.new(classification, weird_annotation, cache).to_h
+    expect(formatted["value"][0]["tool_label"]).to be_nil
+  end
+
   it 'has a nil label when the tool is not found in the workflow' do
     annotation = {"task" => "interest", "value" => [{"x"=>1, "y"=>2, "tool"=>1000}]}
     formatted = described_class.new(classification, annotation, cache).to_h

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
   it 'returns the raw value if it is in an unexpected format' do
     weird_annotation["value"] = 0
     formatted = described_class.new(classification, weird_annotation, cache).to_h
-    expect(formatted["value"]).to eq(weird_annotation["value"])
+    expect(formatted["value"]).to eq(Array.wrap(weird_annotation["value"]))
   end
 
   it 'has a nil label when the tool is not found in the workflow' do

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -49,11 +49,10 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
     expect(formatted["value"][0]["tool_label"]).to be_nil
   end
 
-  it 'adds an unknown tool label if the tool index is missing', :focus do
-    binding.pry
-    wierd_annotation = weird_annotation.merge("value" => 0)
+  it 'returns the raw value if it is in an unexpected format' do
+    weird_annotation["value"] = 0
     formatted = described_class.new(classification, weird_annotation, cache).to_h
-    expect(formatted["value"][0]["tool_label"]).to be_nil
+    expect(formatted["value"]).to eq(weird_annotation["value"])
   end
 
   it 'has a nil label when the tool is not found in the workflow' do

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -24,14 +24,6 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
     }
   end
 
-  describe '#report_to_honey_badger' do
-    it 'reports the correct details' do
-      annotator = described_class.new(classification, annotation, cache)
-      expect(Honeybadger).to receive(:notify)
-      annotator.send(:report_to_honey_badger, 1)
-    end
-  end
-
   it 'adds the task label' do
     formatted = described_class.new(classification, annotation, cache).to_h
     expect(formatted["task_label"]).to eq("Draw a circle")

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         end
 
         it 'should add the correct version task label' do
-          allow(cache).to receive(:workflow_at_version).with(workflow.id, 1).and_return(workflow.versions[1].reify)
-          allow(cache).to receive(:workflow_content_at_version).with(contents.id, 1).and_return(contents.versions[1].reify)
+          allow(cache).to receive(:workflow_at_version).with(workflow, 1).and_return(workflow.versions[1].reify)
+          allow(cache).to receive(:workflow_content_at_version).with(contents, 1).and_return(contents.versions[1].reify)
           formatted = described_class.new(classification, annotation, cache).to_h
           expect(formatted["task_label"]).to eq("Draw a circle")
         end


### PR DESCRIPTION
Return the raw data instead of crashing on invalid annotation values. Also removed unnecessary db lookups in the annotation cache as we had the resource already.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
