### PR TITLE
revert workflow eager load changes for scope_for

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -44,8 +44,6 @@ class Workflow < ActiveRecord::Base
     'options' => {'count' => 15}
   }.freeze
 
-  EAGER_LOADS = %i(subject_sets expert_subject_sets tutorial_subject attached_images).freeze
-
   validates_presence_of :project, :display_name
 
   validate do |workflow|
@@ -68,14 +66,6 @@ class Workflow < ActiveRecord::Base
 
   def self.same_project?(subject_set)
     where(project: subject_set.project)
-  end
-
-  def self.scope_for(action, user, opts={eager_loads: EAGER_LOADS})
-    workflows = super
-    if opts.has_key?(:eager_loads)
-      workflows = workflows.eager_load(*opts[:eager_loads])
-    end
-    workflows
   end
 
   def tasks

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -29,32 +29,6 @@ describe Workflow, type: :model do
       [:subjects_count, :finished?]
   end
 
-  describe ".scope_for" do
-    it "should eager load the linked resources used in the serializer" do
-      eager_loads = %i(subject_sets expert_subject_sets tutorial_subject attached_images)
-      expect_any_instance_of(Workflow::ActiveRecord_Relation)
-        .to receive(:eager_load)
-        .with(*eager_loads)
-        .and_call_original
-      Workflow.scope_for(:index, ApiUser.new(nil))
-    end
-
-    it "eager load the supplied relations" do
-      eager_loads = %i(subject_sets)
-      expect_any_instance_of(Workflow::ActiveRecord_Relation)
-        .to receive(:eager_load)
-        .with(*eager_loads)
-        .and_call_original
-      Workflow.scope_for(:index, ApiUser.new(nil), { eager_loads: eager_loads })
-    end
-
-    it "should skip eager load if not set" do
-      expect_any_instance_of(Workflow::ActiveRecord_Relation)
-        .not_to receive(:eager_load)
-      Workflow.scope_for(:index, ApiUser.new(nil), {})
-    end
-  end
-
   it "should have a valid factory" do
     expect(workflow).to be_valid
   end


### PR DESCRIPTION
Revert the eager load changes that seemed to be causing db cpu load.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

