### PR TITLE
use the reired_at timestamp not created_at

### DIFF
--- a/app/counters/workflow_counter.rb
+++ b/app/counters/workflow_counter.rb
@@ -13,7 +13,7 @@ class WorkflowCounter
   def retired_subjects
     retired = SubjectWorkflowStatus.by_set(workflow.subject_sets.pluck(:id)).retired.where(workflow_id: workflow.id)
     if launch_date
-      retired = retired.where("subject_workflow_counts.created_at >= ?", launch_date)
+      retired = retired.where("subject_workflow_counts.retired_at >= ?", launch_date)
     end
     retired.count
   end

--- a/spec/counters/workflow_counter_spec.rb
+++ b/spec/counters/workflow_counter_spec.rb
@@ -30,9 +30,13 @@ describe WorkflowCounter do
     end
 
     context "with workflow counts" do
+      let(:sws_params) do
+        { workflow: workflow, retired_at: DateTime.now, created_at: DateTime.now + 2.days }
+      end
+
       before do
         workflow.subjects.each do |subject|
-          create(:subject_workflow_status, workflow: workflow, subject: subject, retired_at: DateTime.now)
+          create(:subject_workflow_status, sws_params.merge(subject: subject))
         end
       end
 
@@ -41,7 +45,7 @@ describe WorkflowCounter do
       end
 
       it "should respect the project launch date" do
-        workflow.project.update_column(:launch_date, DateTime.now+1.day)
+        workflow.project.update_column(:launch_date, DateTime.now + 1.day)
         expect(counter.retired_subjects).to eq(0)
       end
 


### PR DESCRIPTION
fixes #2023 compare apples and apples here as the SubjectWorkflowStatus will be created the first time it's classified not retired.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

