### PR TITLE
Include non-enum states in serialized projects

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -21,12 +21,20 @@ class ProjectSerializer
     subjects_export: { include: false },
     aggregations_export: { include: false }
   can_filter_by :display_name, :slug, :beta_requested, :beta_approved,
-    :launch_requested, :launch_approved, :private, :state
+    :launch_requested, :launch_approved, :private, :state, :live
   can_sort_by :launch_date, :activity, :completeness, :classifiers_count,
     :updated_at, :display_name
 
   def self.page(params = {}, scope = nil, context = {})
-    params["state"] = Project.states[params["state"]] if params.key?("state")
+    if params.key?("state")
+      if Project.states.include?(params["state"])
+        params["state"] = Project.states[params["state"]]
+      else
+        params[params["state"]] = true
+        params.delete("state")
+      end
+    end
+
     super(params, scope, context)
   end
 

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -29,8 +29,8 @@ class ProjectSerializer
     if params.key?("state")
       if Project.states.include?(params["state"])
         params["state"] = Project.states[params["state"]]
-      else
-        params[params["state"]] = true
+      elsif params["state"] == "live"
+        params["live"] = true
         params.delete("state")
       end
     end


### PR DESCRIPTION
Serializes non-enum (presently `paused` and `finished`) states. If your params include `{ state: [live] }` (or any other boolean on Project, all of which are indexed), your results will be filtered by that attribute. Might have made this _too_ flexible, since any `state` sent that isn't in the enum will be set to `true` and thrown into the serializer, but we'll see if you think so.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

