### PR TITLE
No more paused projects in index

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -32,7 +32,7 @@ class ProjectSerializer
       elsif params["state"] == "live"
         params["live"] = true
         params.delete("state")
-        scope = Project.where(state: nil)
+        scope = scope.where(state: nil)
       end
     end
 

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -32,6 +32,7 @@ class ProjectSerializer
       elsif params["state"] == "live"
         params["live"] = true
         params.delete("state")
+        scope = Project.where(state: nil)
       end
     end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -34,7 +34,8 @@ describe ProjectSerializer do
     end
 
     describe 'can filter by state' do
-      let(:paused_project) { create(:full_project, state: "paused", live: true) }
+      let(:paused_live_project) { create(:full_project, state: "paused", live: true) }
+      let(:paused_project) { create(:full_project, state: "paused", live: false) }
       let(:live_project) { create(:full_project, state: nil, live: true) }
 
       before do
@@ -44,15 +45,21 @@ describe ProjectSerializer do
       end
 
       it 'includes filtered projects' do
-        results = described_class.page({"state" => "paused"})
+        results = described_class.page({"state" => "paused"}, Project)
         expect(results[:projects].map { |p| p[:id] }).to include(paused_project.id.to_s)
         expect(results[:projects].count).to eq(1)
       end
 
       it 'includes non-enum states' do
-        results = described_class.page({"state" => "live"})
+        results = described_class.page({"state" => "live"}, Project)
         expect(results[:projects].map { |p| p[:id] }).to include(live_project.id.to_s)
         expect(results[:projects].count).to eq(1)
+      end
+
+      it 'does not include projects with a state, even if live' do
+        results = described_class.page({"state" => "live"}, Project)
+        expect(results[:projects].map { |p| p[:id] }).not_to include(paused_live_project.id.to_s)
+        expect(results[:projects].map { |p| p[:id] }).not_to include(paused_project.id.to_s)
       end
     end
   end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -34,7 +34,7 @@ describe ProjectSerializer do
     end
 
     describe 'can filter by state' do
-      let(:paused_project) { create(:full_project, state: "paused", live: false) }
+      let(:paused_project) { create(:full_project, state: "paused", live: true) }
       let(:live_project) { create(:full_project, state: nil, live: true) }
 
       before do


### PR DESCRIPTION
Allows for the confusing situation where you could have a `live: true` project that was also `state: paused`. This adds a scope to the serializer call to force `Project.where(state: nil)` if `?state=live` is passed as a param. Hacky also, but this is exactly why we need to consolidate all of these.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
