### PR TITLE
Make create_params and update_params greppable

### DIFF
--- a/lib/json_api_controller/json_schema_validator.rb
+++ b/lib/json_api_controller/json_schema_validator.rb
@@ -29,6 +29,14 @@ module JsonApiController
 
     protected
 
+    def create_params
+      params_for(:create)
+    end
+
+    def update_params
+      params_for(:update)
+    end
+
     def params_for(action=action_name.to_sym)
       ps = params.require(resource_sym).permit!
       if validator = self.class.action_params[action]
@@ -38,8 +46,5 @@ module JsonApiController
       end
       ps
     end
-
-    alias_method :create_params, :params_for
-    alias_method :update_params, :params_for
   end
 end


### PR DESCRIPTION
I've searched for `def create_params` more than a few times, and obviously that didn't work because of the alias. Next time I will get a match.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

