### PR TITLE
Cleanup eager loading in projects controller

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -34,7 +34,6 @@ class Api::V1::ProjectsController < Api::ApiController
                  :avatar_src,
                  :updated_at].freeze
 
-  before_action :eager_load_relations, only: :index
   before_action :filter_by_tags, only: :index
   before_action :downcase_slug, only: :index
 
@@ -111,23 +110,6 @@ class Api::V1::ProjectsController < Api::ApiController
     if tags = params.delete(:tags).try(:split, ",").try(:map, &:downcase)
       @controlled_resources = controlled_resources
       .joins(:tags).where(tags: {name: tags})
-    end
-  end
-
-  def default_eager_loads
-    !!params[:cards] ? [:avatar] : [:tags, :background, :avatar, :owner]
-  end
-
-  def allowed_eager_loads
-    non_owner_role_params = [true, false].include?(@owner_eager_load)
-    excepts = non_owner_role_params ? [:owner] : []
-    (default_eager_loads - excepts).uniq
-  end
-
-  def eager_load_relations
-    eager_loads = allowed_eager_loads
-    unless eager_loads.empty?
-      @controlled_resources = controlled_resources.eager_load(*eager_loads)
     end
   end
 

--- a/app/controllers/concerns/filter_by_current_user_roles.rb
+++ b/app/controllers/concerns/filter_by_current_user_roles.rb
@@ -12,17 +12,9 @@ module FilterByCurrentUserRoles
         .joins(:access_control_lists)
         .where(access_control_lists: {user_group_id: api_user.user.identity_group.id})
         .where.overlap(access_control_lists: { roles: roles_filter })
-
-      if owner_eager_load(roles_filter)
-        @controlled_resources = @controlled_resources.preload(:owner)
-      end
+        .preload(
+          owner: { identity_membership: :user }
+        )
     end
-  end
-
-  private
-
-  def owner_eager_load(roles)
-    non_owner_roles = roles - ["owner"]
-    @owner_eager_load = non_owner_roles.empty?
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,7 +18,8 @@ class Project < ActiveRecord::Base
      :pages,
      :avatar,
      :background,
-     :attached_images
+     :attached_images,
+     :tags
    ].freeze
    PRELOADS = [
      :project_roles,

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -29,7 +29,8 @@ describe Project, type: :model do
          :pages,
          :avatar,
          :background,
-         :attached_images
+         :attached_images,
+         :tags
       ]
     end
 


### PR DESCRIPTION
If we're running an experiment then we should only call eager loading from one spot (project.scope_for) to isolate this testing. Also ensure we are preloading the owner relation that is used in the owner test and eager load the `project.tags` association as it's used in the serializer.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
