### PR TITLE
do nothing when retirement subject_id(s) are missing

### DIFF
--- a/app/operations/workflows/retire_subjects.rb
+++ b/app/operations/workflows/retire_subjects.rb
@@ -16,6 +16,8 @@ module Workflows
     string :retirement_reason, default: nil
 
     def execute
+      return if subject_ids.empty?
+
       Workflow.transaction do
         subject_ids.each do |subject_id|
           workflow.retire_subject(subject_id, retirement_reason)
@@ -35,7 +37,7 @@ module Workflows
     end
 
     def subject_ids
-      Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+      @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
     end
 
     private


### PR DESCRIPTION
return as fast as possible and don't do any work if the params are missing.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

