### PR TITLE
[WIP] ensure all workflows and contents have their cached version num

### DIFF
--- a/db/migrate/20161111173051_add_cache_key_for_workflow_versions.rb
+++ b/db/migrate/20161111173051_add_cache_key_for_workflow_versions.rb
@@ -1,0 +1,11 @@
+class AddCacheKeyForWorkflowVersions < ActiveRecord::Migration
+  def change
+    Workflow.where(current_version_number: nil).find_each do |w|
+      w.send(:update_workflow_version_cache)
+    end
+
+    WorkflowContent.where(current_version_number: nil).find_each do |wc|
+      wc.send(:update_workflow_version_cache)
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3602,3 +3602,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161017135917');
 
 INSERT INTO schema_migrations (version) VALUES ('20161017141439');
 
+INSERT INTO schema_migrations (version) VALUES ('20161111173051');
+


### PR DESCRIPTION
Use the cached version number attribute.and avoid lookups in the serializer.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

