### PR TITLE
rake task to set the worfklow & contents version cache key

### DIFF
--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -169,4 +169,22 @@ namespace :migrate do
       puts ' done'
     end
   end
+
+  namespace :workflows do
+    desc "Set the workflows version cache key attribute"
+    task :update_version_cache_key => :environment do
+      Workflow.where(current_version_number: nil).find_each do |w|
+        w.send(:update_workflow_version_cache)
+      end
+    end
+  end
+
+  namespace :workflow_contents do
+    desc "Set the workflow_contents version cache key attribute"
+    task :update_version_cache_key => :environment do
+      WorkflowContent.where(current_version_number: nil).find_each do |wc|
+        wc.send(:update_workflow_version_cache)
+      end
+    end
+  end
 end


### PR DESCRIPTION
set the cache attribute values via a rake task to avoid lookups in the serializer.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

avoid the N+1 lookup in the serializer