### PR TITLE
Automatic Cellect activation should not happen when CellectEx is configured

### DIFF
--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -26,10 +26,12 @@ module Subjects
 
     def strategy
       @strategy ||= case
-      when cellect_strategy?
+      when configured_to_use_cellect?
         :cellect
-      when cellect_ex_strategy?
+      when configured_to_use_cellect_ex?
         :cellect_ex
+      when automatically_use_cellect?
+        :cellect
       else
         nil
       end
@@ -43,14 +45,19 @@ module Subjects
       [:default, default_strategy_sms_ids]
     end
 
-    def cellect_strategy?
+    def configured_to_use_cellect?
       return nil unless Panoptes.flipper.enabled?("cellect")
-      strategy_param == :cellect || workflow.using_cellect?
+      strategy_param == :cellect || workflow.subject_selection_strategy.to_s == 'cellect'
     end
 
-    def cellect_ex_strategy?
+    def configured_to_use_cellect_ex?
       return nil unless Panoptes.flipper.enabled?("cellect_ex")
-      strategy_param == :cellect_ex || workflow.subject_selection_strategy == 'cellect_ex'
+      strategy_param == :cellect_ex || workflow.subject_selection_strategy.to_s == 'cellect_ex'
+    end
+
+    def automatically_use_cellect?
+      return nil unless Panoptes.flipper.enabled?("cellect")
+      workflow.using_cellect?
     end
 
     def strategy_sms_ids

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe Subjects::StrategySelection do
     context "when Cellect config is on" do
       before do
         allow(Panoptes.flipper).to receive(:enabled?).with("cellect").and_return(true)
+        allow(Panoptes.flipper).to receive(:enabled?).with("cellect_ex").and_return(true)
       end
 
       context "when providing cellect strategy param" do
@@ -238,6 +239,16 @@ RSpec.describe Subjects::StrategySelection do
       context "when the workflow is set to use cellect_ex" do
         it "should use the workflow config strategy" do
           allow(workflow).to receive(:subject_selection_strategy).and_return("cellect_ex")
+          expect(subject.strategy).to eq(:cellect_ex)
+        end
+      end
+
+      context 'when the workflow has a lot of subjects' do
+        it 'should still use cellect_ex' do
+          allow(workflow).to receive(:subject_selection_strategy).and_return("cellect_ex")
+          allow(workflow).to receive_message_chain("set_member_subjects.count") do
+            cellect_size
+          end
           expect(subject.strategy).to eq(:cellect_ex)
         end
       end


### PR DESCRIPTION
Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

…et explicitly