### PR TITLE
Fix logging for fallback

### DIFF
--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -61,7 +61,7 @@ module Subjects
       end
 
       if sms_ids.blank?
-        Rails.logger.info "Fallback failed to return unseen unretired data, falling back to selecting anything", workflow_id: workflow.id, user_id: user.id
+        Rails.logger.info "Fallback failed to return unseen unretired data, falling back to selecting anything", workflow_id: workflow.id, user_id: user&.id
         fallback_selector.any_workflow_data
       else
         sms_ids


### PR DESCRIPTION
In case of fallback we hit a logging statement which fails if there's no user.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

