### PR TITLE
Subject remove default scope and optimize the selector scope queries

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -72,10 +72,7 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def selector
-    @selector ||= Subjects::Selector.new(api_user.user,
-      workflow,
-      params,
-      Subject.all)
+    @selector ||= Subjects::Selector.new(api_user.user, workflow, params)
   end
 
   def location_params(locations)

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -75,7 +75,7 @@ class Api::V1::SubjectsController < Api::ApiController
     @selector ||= Subjects::Selector.new(api_user.user,
       workflow,
       params,
-      controlled_resources)
+      Subject.all)
   end
 
   def location_params(locations)

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -3,8 +3,6 @@ class Subject < ActiveRecord::Base
   include Linkable
   include Activatable
 
-  default_scope { eager_load(:locations) }
-
   has_paper_trail only: [:metadata, :locations]
 
   belongs_to :project

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -316,6 +316,6 @@ class User < ActiveRecord::Base
   end
 
   def uploaded_subjects_count
-    Subject.unscoped.where(upload_user_id: self.id).count
+    Subject.where(upload_user_id: self.id).count
   end
 end

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -57,7 +57,11 @@ class SubjectSerializer
   end
 
   def user_seen
-    @user_seen ||= UserSeenSubject.where(user: user, workflow: workflow).first
+    @user_seen ||= if user
+      UserSeenSubject.where(user: user, workflow: workflow).first
+    else
+      nil
+    end
   end
 
   def finished_workflow

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -59,8 +59,6 @@ class SubjectSerializer
   def user_seen
     @user_seen ||= if user
       UserSeenSubject.where(user: user, workflow: workflow).first
-    else
-      nil
     end
   end
 

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -27,7 +27,7 @@ class SubjectSerializer
   end
 
   def already_seen
-    !!(user_seen && user_seen.subject_ids.include?(@model.id))
+    !!(user_seen&.subjects_seen?(@model.id))
   end
 
   private
@@ -57,9 +57,7 @@ class SubjectSerializer
   end
 
   def user_seen
-    @user_seen ||= if user
-      UserSeenSubject.where(user: user, workflow: workflow).first
-    end
+    @context[:user_seen]
   end
 
   def finished_workflow

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -15,7 +15,7 @@ class SubjectSerializer
   end
 
   def locations
-    @model.locations.order("\"media\".\"metadata\"->>'index' ASC").map do |loc|
+    index_ordered_locations.map do |loc|
       {
        loc.content_type => loc.url_for_format(@context[:url_format] || :get)
       }
@@ -62,5 +62,13 @@ class SubjectSerializer
 
   def finished_workflow
     user&.has_finished?(workflow)
+  end
+
+  def index_ordered_locations
+    if @model.locations.loaded?
+      @model.locations.sort_by { |loc| loc.metadata["index"] }
+    else
+      @model.locations.order("\"media\".\"metadata\"->>'index' ASC")
+    end
   end
 end

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -27,29 +27,25 @@ class SubjectSerializer
   end
 
   def already_seen
-    !!(user_seen&.subject_ids.include?(@model.id))
+    !!(user_seen && user_seen.subject_ids.include?(@model.id))
   end
 
   private
 
   def include_retired?
-    enabled_selection_context
+    select_context?
   end
 
   def include_already_seen?
-    enabled_selection_context
+    select_context?
   end
 
   def include_finished_workflow?
-    enabled_selection_context
+    select_context?
   end
 
-  def enabled_selection_context
-    selected? && !Panoptes.flipper[:skip_subject_selection_context].enabled?
-  end
-
-  def selected?
-    @context[:selected]
+  def select_context?
+    @context[:select_context]
   end
 
   def workflow

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -34,7 +34,7 @@ class ClassificationsDumpWorker
     c_s_ids = ActiveRecord::Base.connection.select_rows(sql)
     cache.reset_classification_subjects(c_s_ids)
     subject_ids = c_s_ids.map { |_, subject_id| subject_id }
-    cache.reset_subjects(Subject.unscoped.where(id: subject_ids).load)
+    cache.reset_subjects(Subject.where(id: subject_ids).load)
     subject_ids
   end
 

--- a/db/migrate/20161125123824_add_active_controlled_indexes.rb
+++ b/db/migrate/20161125123824_add_active_controlled_indexes.rb
@@ -1,0 +1,18 @@
+class AddActiveControlledIndexes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    #controlled public scopes
+    add_index :projects, :private, algorithm: :concurrently
+    add_index :collections, :private, algorithm: :concurrently
+
+    # @active scope indexes
+    add_index :subjects, :activated_state, algorithm: :concurrently
+    add_index :collections, :activated_state, algorithm: :concurrently
+    add_index :organizations, :activated_state, algorithm: :concurrently
+    add_index :projects, :activated_state, algorithm: :concurrently
+    add_index :user_groups, :activated_state, algorithm: :concurrently
+    add_index :users, :activated_state, algorithm: :concurrently
+    add_index :workflows, :activated_state, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2220,10 +2220,24 @@ CREATE INDEX index_collections_display_name_trgrm ON collections USING gin ((COA
 
 
 --
+-- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_collections_on_activated_state ON collections USING btree (activated_state);
+
+
+--
 -- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_favorite ON collections USING btree (favorite);
+
+
+--
+-- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_collections_on_private ON collections USING btree (private);
 
 
 --
@@ -2360,6 +2374,13 @@ CREATE UNIQUE INDEX index_oauth_applications_on_uid ON oauth_applications USING 
 
 
 --
+-- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_organizations_on_activated_state ON organizations USING btree (activated_state);
+
+
+--
 -- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2392,6 +2413,13 @@ CREATE INDEX index_project_pages_on_project_id ON project_pages USING btree (pro
 --
 
 CREATE INDEX index_projects_display_name_trgrm ON projects USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
+
+
+--
+-- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_projects_on_activated_state ON projects USING btree (activated_state);
 
 
 --
@@ -2455,6 +2483,13 @@ CREATE INDEX index_projects_on_migrated ON projects USING btree (migrated) WHERE
 --
 
 CREATE INDEX index_projects_on_organization_id ON projects USING btree (organization_id);
+
+
+--
+-- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_projects_on_private ON projects USING btree (private);
 
 
 --
@@ -2591,6 +2626,13 @@ CREATE INDEX index_subject_workflow_counts_on_workflow_id ON subject_workflow_co
 
 
 --
+-- Name: index_subjects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_subjects_on_activated_state ON subjects USING btree (activated_state);
+
+
+--
 -- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2675,6 +2717,13 @@ CREATE INDEX index_user_groups_display_name_trgrm ON user_groups USING gin ((COA
 
 
 --
+-- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_user_groups_on_activated_state ON user_groups USING btree (activated_state);
+
+
+--
 -- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2700,6 +2749,13 @@ CREATE UNIQUE INDEX index_user_project_preferences_on_user_id_and_project_id ON 
 --
 
 CREATE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON user_seen_subjects USING btree (user_id, workflow_id);
+
+
+--
+-- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_users_on_activated_state ON users USING btree (activated_state);
 
 
 --
@@ -2819,6 +2875,13 @@ CREATE INDEX index_workflow_tutorials_on_workflow_id ON workflow_tutorials USING
 --
 
 CREATE UNIQUE INDEX index_workflow_tutorials_on_workflow_id_and_tutorial_id ON workflow_tutorials USING btree (workflow_id, tutorial_id);
+
+
+--
+-- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_workflows_on_activated_state ON workflows USING btree (activated_state);
 
 
 --
@@ -3618,6 +3681,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160901141903');
 INSERT INTO schema_migrations (version) VALUES ('20161017135917');
 
 INSERT INTO schema_migrations (version) VALUES ('20161017141439');
+
+INSERT INTO schema_migrations (version) VALUES ('20161125123824');
 
 INSERT INTO schema_migrations (version) VALUES ('20161128193435');
 

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -39,7 +39,7 @@ module Formatter
       end
 
       def locations
-        subject_locs = subject.locations.order("\"media\".\"metadata\"->>'index' ASC")
+        subject_locs = subject.locations.sort_by { |loc| loc.metadata["index"] }
         {}.tap do |locs|
           subject_locs.each_with_index.map do |loc, index|
             locs[index] = loc.get_url

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -6,9 +6,9 @@ module Subjects
     class MissingSubjectSet < StandardError; end
     class MissingSubjects < StandardError; end
 
-    attr_reader :user, :params, :workflow
+    attr_reader :user, :params, :workflow, :scope
 
-    def initialize(user, workflow, params, scope)
+    def initialize(user, workflow, params, scope=Subject.all)
       @user, @workflow, @params, @scope = user, workflow, params, scope
     end
 
@@ -74,7 +74,7 @@ module Subjects
     end
 
     def active_subjects_in_selection_order(sms_ids)
-      @scope.active
+      scope.active
         .eager_load(:set_member_subjects)
         .where(set_member_subjects: {id: sms_ids})
         .order("idx(array[#{sms_ids.join(',')}], set_member_subjects.id)")

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -104,11 +104,7 @@ module Subjects
     end
 
     def context
-      @context ||= {
-        workflow: workflow,
-        user_seen: UserSeenSubject.where(user: user, workflow: workflow),
-        finished_workflow: user&.has_finished?(workflow)
-      }
+      @context ||= { workflow: workflow, user: user }
     end
 
     def subject_set_id

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -17,7 +17,10 @@ module Subjects
       raise group_id_error if needs_set_id?
       raise missing_subject_set_error if workflow.subject_sets.empty?
       raise missing_subjects_error if workflow.set_member_subjects.empty?
-      [ selected_subjects, context.merge(selected: true, url_format: :get) ]
+      selected_context = context.merge(
+        url_format: :get, select_context: subject_selection_context
+      ).compact
+      [ selected_subjects, selected_context ]
     end
 
     def selected_subjects
@@ -109,6 +112,14 @@ module Subjects
 
     def subject_set_id
       params[:subject_set_id]
+    end
+
+    def subject_selection_context
+      if Panoptes.flipper[:skip_subject_selection_context].enabled?
+        nil
+      else
+        true
+      end
     end
   end
 end

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -17,9 +17,6 @@ module Subjects
       raise group_id_error if needs_set_id?
       raise missing_subject_set_error if workflow.subject_sets.empty?
       raise missing_subjects_error if workflow.set_member_subjects.empty?
-      selected_context = context.merge(
-        url_format: :get, select_context: subject_selection_context
-      ).compact
       [ selected_subjects, selected_context ]
     end
 
@@ -106,19 +103,31 @@ module Subjects
       page_size
     end
 
-    def context
-      @context ||= { workflow: workflow, user: user }
+    def selected_context
+      {
+        workflow: workflow,
+        user: user,
+        user_seen: user_seen,
+        url_format: :get,
+        select_context: selection_context_on
+      }.compact
     end
 
     def subject_set_id
       params[:subject_set_id]
     end
 
-    def subject_selection_context
+    def selection_context_on
       if Panoptes.flipper[:skip_subject_selection_context].enabled?
         nil
       else
         true
+      end
+    end
+
+    def user_seen
+      if user
+        UserSeenSubject.where(user: user, workflow: workflow).first
       end
     end
   end

--- a/spec/factories/media.rb
+++ b/spec/factories/media.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     association :linked, factory: :subject
     content_type "image/jpeg"
     path_opts ["1"]
-    src "panoptes-uploads.zooniverse.org/1/1/#{SecureRandom.uuid}.jpeg"
+    src { "panoptes-uploads.zooniverse.org/1/1/#{SecureRandom.uuid}.jpeg" }
     metadata { {index: generate(:loc_index) } }
   end
 end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -25,8 +25,12 @@ FactoryGirl.define do
     end
 
     trait :with_subject_sets do
-      after(:create) do |s|
-        2.times do |i|
+      ignore do
+        num_sets 2
+      end
+
+      after(:create) do |s, evaluator|
+        evaluator.num_sets.times do |i|
           create(:set_member_subject, subject: s, subject_set: create(:subject_set, project: s.project))
         end
       end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -10,9 +10,21 @@ RSpec.describe Subjects::Selector do
   subject { described_class.new(user, workflow, params, Subject.all) }
 
   describe "#get_subjects" do
-    it 'should return url_format: :get in the context object' do
-      _, ctx = subject.get_subjects
-      expect(ctx).to include(url_format: :get)
+    describe "context object" do
+      let(:ctx) { subject.get_subjects.last }
+
+      it 'should return url_format: :get' do
+        expect(ctx).to include(url_format: :get)
+      end
+
+      it 'should return select_context' do
+        expect(ctx).to include(select_context: true)
+      end
+
+      it 'should not return select_context in the context object' do
+        Panoptes.flipper[:skip_subject_selection_context].enable
+        expect(ctx).not_to include(:select_context)
+      end
     end
 
     context "when the workflow doesn't have any subject sets" do

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Subjects::Selector do
   let!(:smses) { create_list(:set_member_subject, 10, subject_set: subject_set).reverse }
   let(:params) { {} }
 
-  subject { described_class.new(user, workflow, params, Subject.all) }
+  subject { described_class.new(user, workflow, params) }
 
   describe "#get_subjects" do
     describe "context object" do

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe OrganizationSerializer do
+describe SubjectSerializer do
   let(:subject) { create(:subject, :with_subject_sets, num_sets: 1) }
   let!(:collection) do
     create(:collection, build_projects: false, owner: subject.project.owner, subjects: [subject])

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe OrganizationSerializer do
+  let(:subject) { create(:subject, :with_subject_sets, num_sets: 1) }
+  let!(:collection) do
+    create(:collection, build_projects: false, owner: subject.project.owner, subjects: [subject])
+  end
+
+  it "should preload the serialized associations" do
+    expect_any_instance_of(Subject::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(:locations, :project, :collections, :subject_sets)
+      .and_call_original
+    SubjectSerializer.page({}, Subject.all, {})
+  end
+
+  context "subject selection", :focus do
+    let(:run_serializer) do
+      SubjectSerializer.single({}, Subject.all, {selected: true})
+    end
+
+    describe "seen and retired" do
+      it "should run the lookups if the feature flag is off" do
+        expect_any_instance_of(SubjectSerializer).to receive(:retired)
+        expect_any_instance_of(SubjectSerializer).to receive(:already_seen)
+        expect_any_instance_of(SubjectSerializer).to receive(:finished_workflow)
+        run_serializer
+      end
+
+      it "should not run the lookups if the feature flag is on" do
+        Panoptes.flipper[:skip_subject_selection_context].enable
+        expect_any_instance_of(SubjectSerializer).not_to receive(:retired)
+        expect_any_instance_of(SubjectSerializer).not_to receive(:already_seen)
+        expect_any_instance_of(SubjectSerializer).not_to receive(:finished_workflow)
+        run_serializer
+      end
+    end
+  end
+end

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -14,6 +14,24 @@ describe SubjectSerializer do
     SubjectSerializer.page({}, Subject.all, {})
   end
 
+  describe "locations" do
+    let(:subject) do
+      create(:subject, :with_mediums, :with_subject_sets, num_sets: 1)
+    end
+    let(:subject_locs) do
+      subject.locations.sort_by { |loc| loc.metadata["index"] }
+    end
+    let(:result_locs) do
+      SubjectSerializer.single({}, Subject.all, {})[:locations]
+    end
+
+    it "should sort the related locations index" do
+      expected = subject_locs.map { |loc| loc.src.split("/").last }
+      results = result_locs.map { |loc| loc[:"image/jpeg"].split("/").last }
+      expect(expected).to eq(results)
+    end
+  end
+
   context "subject selection" do
     let(:selection_context) { { select_context: true } }
     let(:run_serializer) do


### PR DESCRIPTION
supersedes #2060 and closes #1614 #1841 

- Remove the Subject locations default scope
- Add public/private & active scope indexes for controlled resources
- Add preloading to the subject serializer to avoid N+1 lookups and added the ability to turn off extra selection lookups (seen / retired / user_finished) in the serializer for peak load events (SGL) to avoid multiple extra db queries.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
