### PR TITLE
Adds researcher_quote to project contents

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -18,12 +18,14 @@ class Api::V1::ProjectsController < Api::ApiController
   CONTENT_PARAMS = [:description,
                     :title,
                     :workflow_description,
+                    :researcher_quote,
                     :introduction].freeze
 
   CONTENT_FIELDS = [:title,
                     :description,
                     :workflow_description,
                     :introduction,
+                    :researcher_quote,
                     :url_labels].freeze
 
   CARD_FIELDS = [:id,

--- a/app/models/project_content.rb
+++ b/app/models/project_content.rb
@@ -4,6 +4,7 @@ class ProjectContent < ActiveRecord::Base
   validates_presence_of :title, :description, :language
   validates_length_of :title, maximum: 255
   validates_length_of :description, maximum: 300
+  validates_length_of :researcher_quote, maximum: 255
   validates_length_of :workflow_description, maximum: 500
   validates_length_of :introduction, maximum: 5000
 end

--- a/app/schemas/project_create_schema.rb
+++ b/app/schemas/project_create_schema.rb
@@ -90,6 +90,10 @@ class ProjectCreateSchema < JsonSchema
       type "string"
     end
 
+    property "researcher_quote" do
+      type "string"
+    end
+
     property "experimental_tools" do
       type "array"
       items do

--- a/app/serializers/project_content_serializer.rb
+++ b/app/serializers/project_content_serializer.rb
@@ -1,7 +1,7 @@
 class ProjectContentSerializer
   include RestPack::Serializer
   attributes :id, :language, :title, :description, :introduction,
-    :href, :workflow_description
+    :href, :workflow_description, :researcher_quote
 
   can_include :project
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -12,7 +12,7 @@ class ProjectSerializer
     :configuration, :live, :urls, :migrated, :classifiers_count, :slug, :redirect,
     :beta_requested, :beta_approved, :launch_requested, :launch_approved, :launch_date,
     :href, :workflow_description, :primary_language, :tags, :experimental_tools,
-    :completeness, :activity, :state
+    :completeness, :activity, :state, :researcher_quote
 
   optional :avatar_src
   can_include :workflows, :subject_sets, :owners, :project_contents,
@@ -71,6 +71,10 @@ class ProjectSerializer
 
   def introduction
     content[:introduction]
+  end
+
+  def researcher_quote
+    content[:researcher_quote]
   end
 
   def urls

--- a/db/migrate/20161128193435_add_researcher_quote_to_project_contents.rb
+++ b/db/migrate/20161128193435_add_researcher_quote_to_project_contents.rb
@@ -1,0 +1,7 @@
+class AddResearcherQuoteToProjectContents < ActiveRecord::Migration
+  def change
+    add_column :project_contents, :researcher_quote, :text
+
+    add_index :project_contents, :researcher_quote
+  end
+end

--- a/db/migrate/20161128193435_add_researcher_quote_to_project_contents.rb
+++ b/db/migrate/20161128193435_add_researcher_quote_to_project_contents.rb
@@ -1,7 +1,5 @@
 class AddResearcherQuoteToProjectContents < ActiveRecord::Migration
   def change
-    add_column :project_contents, :researcher_quote, :text
-
-    add_index :project_contents, :researcher_quote
+    add_column :project_contents, :researcher_quote, :text, default: ""
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -681,7 +681,7 @@ CREATE TABLE project_contents (
     introduction text DEFAULT ''::text,
     url_labels jsonb DEFAULT '{}'::jsonb,
     workflow_description text DEFAULT ''::text,
-    researcher_quote text
+    researcher_quote text DEFAULT ''::text
 );
 
 
@@ -2370,13 +2370,6 @@ CREATE INDEX index_organizations_on_listed_at ON organizations USING btree (list
 --
 
 CREATE INDEX index_project_contents_on_project_id ON project_contents USING btree (project_id);
-
-
---
--- Name: index_project_contents_on_researcher_quote; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_project_contents_on_researcher_quote ON project_contents USING btree (researcher_quote);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -680,7 +680,8 @@ CREATE TABLE project_contents (
     updated_at timestamp without time zone,
     introduction text DEFAULT ''::text,
     url_labels jsonb DEFAULT '{}'::jsonb,
-    workflow_description text DEFAULT ''::text
+    workflow_description text DEFAULT ''::text,
+    researcher_quote text
 );
 
 
@@ -2372,6 +2373,13 @@ CREATE INDEX index_project_contents_on_project_id ON project_contents USING btre
 
 
 --
+-- Name: index_project_contents_on_researcher_quote; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_project_contents_on_researcher_quote ON project_contents USING btree (researcher_quote);
+
+
+--
 -- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3601,4 +3609,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160901141903');
 INSERT INTO schema_migrations (version) VALUES ('20161017135917');
 
 INSERT INTO schema_migrations (version) VALUES ('20161017141439');
+
+INSERT INTO schema_migrations (version) VALUES ('20161128193435');
 

--- a/spec/factories/project_contents.rb
+++ b/spec/factories/project_contents.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     description "Some Lorem Ipsum"
     introduction "MORE IPSUM"
     workflow_description "Go outside"
+    researcher_quote "This is my favorite project"
     url_labels({"0.label" => "Blog", "1.label" => "Twitter", "2.label" => "Science Case"})
   end
 end

--- a/spec/models/project_content_spec.rb
+++ b/spec/models/project_content_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe ProjectContent, :type => :model do
     expect(build(:project_content, introduction: '0' * 5001)).to_not be_valid
   end
 
+  it 'should restrict the maximum length of researcher quote' do
+    expect(build(:project_content, researcher_quote: '0' * 256)).to_not be_valid
+  end
+
   describe "versioning" do
     subject do
       create(:project_content)


### PR DESCRIPTION
Adds "researcher_quote" field to project contents, including associated serializers and constants. Character min 255. Probably didn't need the index but I thought better to include than not. No default included, nil values should be dealt with on the front end since many projects will not have this quote. That'll also mean we won't have to backfill.

Closes #2035 .

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

