### PR TITLE
Send emails to the right people

### DIFF
--- a/app/controllers/api/v1/project_roles_controller.rb
+++ b/app/controllers/api/v1/project_roles_controller.rb
@@ -10,13 +10,13 @@ class Api::V1::ProjectRolesController < Api::ApiController
   end
 
   def update
-    UserAddedToProjectMailerWorker.perform_async(acl_user_id, controlled_resource.resource.id, roles) if new_roles_present?(roles)
     super
+    UserAddedToProjectMailerWorker.perform_async(acl_user_id, controlled_resource.resource.id, roles) if new_roles_present?(roles)
   end
 
   def create
-    UserAddedToProjectMailerWorker.perform_async(new_user_id, project_id, roles) if new_roles_present?(roles)
     super
+    UserAddedToProjectMailerWorker.perform_async(new_user_id, project_id, roles) if new_roles_present?(roles)
   end
 
   private

--- a/app/controllers/api/v1/project_roles_controller.rb
+++ b/app/controllers/api/v1/project_roles_controller.rb
@@ -10,15 +10,31 @@ class Api::V1::ProjectRolesController < Api::ApiController
   end
 
   def update
-    super do
-      UserAddedToProjectMailerWorker.perform_async(api_user.id, controlled_resource.resource.id, roles) if new_roles_present?(roles)
-    end
+    UserAddedToProjectMailerWorker.perform_async(acl_user_id, controlled_resource.resource.id, roles) if new_roles_present?(roles)
+    super
+  end
+
+  def create
+    UserAddedToProjectMailerWorker.perform_async(new_user_id, project_id, roles) if new_roles_present?(roles)
+    super
   end
 
   private
 
   def roles
     params[:project_roles][:roles]
+  end
+
+  def acl_user_id
+    controlled_resource.user_group.users.first.id.to_i
+  end
+
+  def new_user_id
+    params[:project_roles][:links][:user].to_i
+  end
+
+  def project_id
+    params[:project_roles][:links][:project].to_i
   end
 
   def new_roles_present?(roles)

--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
 
     context "mailers" do
       let(:user) do
-        create(:user).tap do |user|
+        create(:user) do |user|
           create :access_control_list, user_group: user.identity_group, resource: project
         end
       end
@@ -175,11 +175,7 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
     end
 
     context "mailers" do
-      let(:user) do
-        create(:user).tap do |user|
-          create :access_control_list, user_group: user.identity_group, resource: project
-        end
-      end
+      let(:user) { create(:user) }
 
       before(:each) do
         default_request scopes: scopes, user_id: authorized_user.id

--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -73,19 +73,25 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
     it_behaves_like "is updatable"
 
     context "mailers" do
+      let(:user) do
+        create(:user).tap do |user|
+          create :access_control_list, user_group: user.identity_group, resource: project
+        end
+      end
+
       before(:each) do
         default_request scopes: scopes, user_id: authorized_user.id
       end
 
       it "calls the mailer if user added to project" do
-        params = update_params.merge(id: resource.id)
-        expect(UserAddedToProjectMailerWorker).to receive(:perform_async).with(authorized_user.id, project.id, ["collaborator"]).once
+        params = update_params.merge(id: user.user_groups.first.access_control_lists.first)
+        expect(UserAddedToProjectMailerWorker).to receive(:perform_async).with(user.id, project.id, ["collaborator"]).once
         put :update, params
       end
 
       it "does not call the mailer not appropriate" do
         new_roles = { project_roles: { roles: ["tester"] } }
-        params = new_roles.merge(id: resource.id)
+        params = new_roles.merge(id: user.user_groups.first.access_control_lists.first)
         expect(UserAddedToProjectMailerWorker).to_not receive(:perform_async)
         put :update, params
       end
@@ -167,6 +173,30 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
 
       it_behaves_like "no user"
     end
+
+    context "mailers" do
+      let(:user) do
+        create(:user).tap do |user|
+          create :access_control_list, user_group: user.identity_group, resource: project
+        end
+      end
+
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id
+      end
+
+      it "calls the mailer if user added to project" do
+        expect(UserAddedToProjectMailerWorker).to receive(:perform_async).with(user.id.to_i, project.id.to_i, ["collaborator"]).once
+        post :create, create_params
+      end
+
+      it "does not call the mailer not appropriate" do
+        create_params[:project_roles][:roles] = ["tester"]
+        expect(UserAddedToProjectMailerWorker).to_not receive(:perform_async)
+        post :create, create_params
+      end
+    end
+
   end
 
   describe "#destroy" do

--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
   let(:project) { create(:project, owner: authorized_user) }
 
   let!(:acls) do
-    create_list :access_control_list, 2, resource: project,
+    create_list :access_control_list_with_user_group, 2, resource: project,
                 roles: ["tester"]
   end
 

--- a/spec/factories/access_control_lists.rb
+++ b/spec/factories/access_control_lists.rb
@@ -2,7 +2,8 @@
 
 FactoryGirl.define do
   factory :access_control_list do
-    association :user_group, factory: :user_group_with_users
+    user_group
+    # association :user_group, factory: :user_group_with_users
     roles ["collaborator"]
     association :resource, factory: :project
   end

--- a/spec/factories/access_control_lists.rb
+++ b/spec/factories/access_control_lists.rb
@@ -3,8 +3,12 @@
 FactoryGirl.define do
   factory :access_control_list do
     user_group
-    # association :user_group, factory: :user_group_with_users
     roles ["collaborator"]
     association :resource, factory: :project
+
+    factory :access_control_list_with_user_group do
+      association :user_group, factory: :user_group_with_users
+    end
+
   end
 end

--- a/spec/factories/access_control_lists.rb
+++ b/spec/factories/access_control_lists.rb
@@ -2,7 +2,7 @@
 
 FactoryGirl.define do
   factory :access_control_list do
-    user_group
+    association :user_group, factory: :user_group_with_users
     roles ["collaborator"]
     association :resource, factory: :project
   end


### PR DESCRIPTION
When a user is added to a project as a collaborator or expert, they should get an email, not the person who added them. Just looking for the first person in the ACL's user group, since 100% of the time they're identity groups.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

