### PR TITLE
use workers to run the retire_subject code

### DIFF
--- a/app/operations/workflows/retire_subjects.rb
+++ b/app/operations/workflows/retire_subjects.rb
@@ -17,23 +17,7 @@ module Workflows
 
     def execute
       return if subject_ids.empty?
-
-      Workflow.transaction do
-        subject_ids.each do |subject_id|
-          workflow.retire_subject(subject_id, retirement_reason)
-        end
-      end
-
-      WorkflowRetiredCountWorker.perform_async(workflow.id)
-      notify_cellect
-    end
-
-    def notify_cellect
-      return unless Panoptes.use_cellect?(workflow)
-
-      subject_ids.each do |subject_id|
-        RetireCellectWorker.perform_async(subject_id, workflow.id)
-      end
+      RetireSubjectWorker.perform_async(workflow.id, subject_ids, retirement_reason)
     end
 
     def subject_ids

--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -1,0 +1,22 @@
+class RetireSubjectWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :high
+
+  def perform(workflow_id, subject_ids, reason=nil)
+    workflow = Workflow.find(workflow_id)
+    Workflow.transaction do
+      subject_ids.each do |subject_id|
+        workflow.retire_subject(subject_id, reason)
+      end
+    end
+
+    WorkflowRetiredCountWorker.perform_async(workflow.id)
+
+    return unless Panoptes.use_cellect?(workflow)
+    subject_ids.each do |subject_id|
+      RetireCellectWorker.perform_async(subject_id, workflow.id)
+    end
+  rescue ActiveRecord::RecordNotFound
+  end
+end

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe RetireSubjectWorker do
+  let(:worker) { described_class.new }
+  let(:sms) { create(:set_member_subject) }
+  let(:set) { sms.subject_set }
+  let(:sms2) { create(:set_member_subject, subject_set: set) }
+  let(:workflow) { create :workflow, subject_sets: [set] }
+  let!(:count) { create(:subject_workflow_status, subject: sms.subject, workflow: workflow) }
+  let(:subject_ids) { [sms.subject_id, sms2.subject_id] }
+
+  describe "#perform" do
+    it 'should retire the subject for the workflow' do
+      expect(count.reload.retired_at).to be_nil
+      worker.perform(workflow.id, subject_ids)
+      expect(count.reload.retired_at).not_to be_nil
+    end
+
+    it 'should retire the subject for the workflow with a reason' do
+      reason = "nothing_here"
+      worker.perform(workflow.id, subject_ids, reason)
+      expect(count.reload.retirement_reason).to eq(reason)
+    end
+
+    it 'should ignore unknown workflows' do
+      expect(count.reload.retired_at).to be_nil
+      worker.perform(-1, subject_ids)
+      expect(count.reload.retired_at).to be_nil
+    end
+
+    it 'should ignore unknown subjects' do
+      expect(count.reload.retired_at).to be_nil
+      worker.perform(workflow.id, [-1, sms.subject_id])
+      expect(count.reload.retired_at).not_to be_nil
+    end
+
+    it 'queues a workflow retired counter' do
+      expect(WorkflowRetiredCountWorker).to receive(:perform_async).with(workflow.id)
+      worker.perform(workflow.id, [sms.subject_id])
+    end
+
+    it 'queues a cellect retirement if the workflow uses cellect' do
+      allow(Panoptes).to receive(:use_cellect?).and_return(true)
+      expect(RetireCellectWorker).to receive(:perform_async).with(sms.subject_id, workflow.id)
+      worker.perform(workflow.id, [sms.subject_id])
+    end
+
+    it 'does not queue workers if something went wrong' do
+      allow(Panoptes).to receive(:use_cellect?).and_return(true)
+      allow(Workflow).to receive(:find).and_return(workflow)
+      allow(workflow).to receive(:retire_subject).with(sms.subject_id, nil) { raise "some error" }
+      expect(WorkflowRetiredCountWorker).not_to receive(:perform_async)
+      expect(RetireCellectWorker).not_to receive(:perform_async)
+      expect {
+        worker.perform(workflow.id, [sms.subject_id])
+      }.to raise_error(RuntimeError, 'some error')
+    end
+  end
+end


### PR DESCRIPTION
Use queued workers to retire subjects out of band as the serialized response doesn't depend on the actual retire operation [here](https://github.com/zooniverse/Panoptes/blob/7c0106054b20b4e13dc8e5f345784d8679b60e58/app/controllers/api/v1/workflows_controller.rb#L31)

Should see a marked improvement in performance when systems like aggregation bulk retire subjects at regular intervals.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
