### PR TITLE
do not attempt to remove externally hosted media resources

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -6,7 +6,7 @@ class Medium < ActiveRecord::Base
   before_validation :create_path, unless: :external_link
   validates :src, presence: true, unless: :external_link
 
-  before_destroy :queue_medium_removal
+  before_destroy :queue_medium_removal, unless: :external_link
 
   attr_writer :allow_any_content_type
 

--- a/app/workers/medium_removal_worker.rb
+++ b/app/workers/medium_removal_worker.rb
@@ -5,5 +5,6 @@ class MediumRemovalWorker
 
   def perform(medium_src)
     MediaStorage.delete_file(medium_src)
+  rescue AWS::S3::Errors::AccessDenied
   end
 end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -186,17 +186,22 @@ RSpec.describe Medium, :type => :model do
         expect(medium.location).to match(/\/workflows\/[0-9]+\/classifications_export/)
       end
     end
-
   end
 
   describe "before destroy callbacks" do
-
     it 'should queue a worker to remove the attached files' do
       medium = create(:medium)
       aggregate_failures do
         expect(medium).to receive(:queue_medium_removal).and_call_original
         expect(MediumRemovalWorker).to receive(:perform_async).with(medium.src)
       end
+      medium.destroy
+    end
+
+    it 'should not queue a worker if the src is external' do
+      medium.external_link = true
+      expect(medium).not_to receive(:queue_medium_removal)
+      expect(MediumRemovalWorker).not_to receive(:perform_async)
       medium.destroy
     end
   end

--- a/spec/workers/medium_removal_worker_spec.rb
+++ b/spec/workers/medium_removal_worker_spec.rb
@@ -5,4 +5,9 @@ RSpec.describe MediumRemovalWorker do
     expect(MediaStorage).to receive(:delete_file)
     subject.perform('test/path.txt')
   end
+
+  it 'should skip any access denied media paths' do
+    allow(MediaStorage).to receive(:delete_file).and_raise(AWS::S3::Errors::AccessDenied)
+    expect { subject.perform('test/path.txt') }.not_to raise_error
+  end
 end


### PR DESCRIPTION
closes #2065 - don't try and remove stuff we don't own.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

