### PR TITLE
Send emails on workflow classification exports

### DIFF
--- a/app/mailers/classification_data_mailer.rb
+++ b/app/mailers/classification_data_mailer.rb
@@ -1,7 +1,7 @@
 class ClassificationDataMailer < ApplicationMailer
 
-  def classification_data(project, data_url, emails)
-    @project = project
+  def classification_data(resource, data_url, emails)
+    @resource = resource
     @url = data_url
     mail(to: emails, subject: "Classification Data is Ready")
   end

--- a/app/views/classification_data_mailer/classification_data.html.erb
+++ b/app/views/classification_data_mailer/classification_data.html.erb
@@ -1,3 +1,3 @@
-<p>Classification data for <%= @project.display_name %> is ready</p>
+<p>Classification data for <%= @resource.display_name %> is ready</p>
 
 <p><a href="<%= @url %>">Click to download your data</a>. This link will be valid for 24 hours.</p>

--- a/app/views/classification_data_mailer/classification_data.text.erb
+++ b/app/views/classification_data_mailer/classification_data.text.erb
@@ -1,3 +1,3 @@
-Classification data for <%= @project.display_name %> is ready
+Classification data for <%= @resource.display_name %> is ready
 
 Download at <%= @url %>. This link will be valid for 24 hours.

--- a/app/workers/classification_data_mailer_worker.rb
+++ b/app/workers/classification_data_mailer_worker.rb
@@ -8,6 +8,7 @@ class ClassificationDataMailerWorker
     ClassificationDataMailer.classification_data(
       resource_type.camelize.constantize.find(resource_id),
       s3_url.to_s,
-      emails).deliver
+      emails
+    ).deliver
   end
 end

--- a/app/workers/classification_data_mailer_worker.rb
+++ b/app/workers/classification_data_mailer_worker.rb
@@ -3,8 +3,11 @@ class ClassificationDataMailerWorker
 
   sidekiq_options queue: :data_high
 
-  def perform(project_id, s3_url, emails)
+  def perform(resource_id, resource_type, s3_url, emails)
     return unless emails.present?
-    ClassificationDataMailer.classification_data(Project.find(project_id), s3_url.to_s, emails).deliver
+    ClassificationDataMailer.classification_data(
+      resource_type.camelize.constantize.find(resource_id),
+      s3_url.to_s,
+      emails).deliver
   end
 end

--- a/app/workers/concerns/dump_mailer_worker.rb
+++ b/app/workers/concerns/dump_mailer_worker.rb
@@ -7,7 +7,7 @@ module DumpMailerWorker
 
   def send_email
     return unless emails.present?
-    mailer.perform_async(resource.id, media_get_url, emails)
+    mailer.perform_async(resource.id, resource.class.to_s.downcase, media_get_url, emails)
   end
 
   def mailer

--- a/app/workers/concerns/dump_worker.rb
+++ b/app/workers/concerns/dump_worker.rb
@@ -124,6 +124,6 @@ module DumpWorker
   end
 
   def get_resource
-    @resource_type.capitalize.constantize.find(@resource_id)
+    @resource_type.camelize.constantize.find(@resource_id)
   end
 end

--- a/spec/support/dump_worker.rb
+++ b/spec/support/dump_worker.rb
@@ -58,6 +58,7 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
 
     it "should queue a worker to send an email" do
       expect(mailer_class).to receive(:perform_async).with(project.id,
+                                                           "project",
                                                            anything,
                                                            [project.owner.email])
       worker.perform(project.id, "project")
@@ -112,7 +113,7 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
 
     it 'should email the users in the recipients hash' do
       expect(mailer_class).to receive(:perform_async)
-        .with(anything, anything, array_including(receivers.map(&:email)))
+        .with(anything, "project", anything, array_including(receivers.map(&:email)))
       worker.perform(project.id, "project", medium.id)
     end
 

--- a/spec/workers/classification_data_mailer_worker_spec.rb
+++ b/spec/workers/classification_data_mailer_worker_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe ClassificationDataMailerWorker do
   let(:s3_url) { "https://fake.s3.url.example.com" }
 
   it 'should deliver the mail' do
-    expect{ subject.perform(project.id, s3_url, ["ed.paget@gmail.com"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    expect{ subject.perform(project.id, "project", s3_url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
 
   context 'when there are no recipients' do
     it 'does not call the mailer' do
       expect(ClassificationDataMailer).to receive(:classification_data).never
-      subject.perform(project.id, s3_url, [])
+      subject.perform(project.id, "project", s3_url, [])
     end
   end
 end

--- a/spec/workers/classification_data_mailer_worker_spec.rb
+++ b/spec/workers/classification_data_mailer_worker_spec.rb
@@ -1,17 +1,28 @@
 require 'spec_helper'
 
 RSpec.describe ClassificationDataMailerWorker do
-  let(:project) { create(:project) }
   let(:s3_url) { "https://fake.s3.url.example.com" }
 
-  it 'should deliver the mail' do
-    expect{ subject.perform(project.id, "project", s3_url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+  shared_examples 'is a mailer' do
+    it 'should deliver the mail' do
+      expect{ subject.perform(resource.id, resource.class.to_s.downcase, s3_url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    context 'when there are no recipients' do
+      it 'does not call the mailer' do
+        expect(ClassificationDataMailer).to receive(:classification_data).never
+        subject.perform(resource.id, resource.class.to_s.downcase, s3_url, [])
+      end
+    end
   end
 
-  context 'when there are no recipients' do
-    it 'does not call the mailer' do
-      expect(ClassificationDataMailer).to receive(:classification_data).never
-      subject.perform(project.id, "project", s3_url, [])
-    end
+  context 'when resource is a project' do
+    let(:resource) { create(:project) }
+    it_behaves_like 'is a mailer'
+  end
+
+  context 'when resource is a workflow' do
+    let(:resource) { create(:workflow) }
+    it_behaves_like 'is a mailer'
   end
 end


### PR DESCRIPTION
Classification data and dump mailer workers needed to be updated to handle workflow classification exports. Also fixed the email text.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

