### PR TITLE
Unfinish workflows when adding new data

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -25,8 +25,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
     super do |subject_set|
       notify_cellect(subject_set)
       reset_subject_counts(subject_set.id)
-      workflow_ids = subject_set.workflows.pluck(:id)
-      reset_workflow_finished_at(workflow_ids)
+      reset_workflow_finished_at(subject_set.workflows.pluck(:id))
     end
   end
 
@@ -123,6 +122,6 @@ class Api::V1::SubjectSetsController < Api::ApiController
   end
 
   def reset_workflow_finished_at(workflow_ids)
-    Workflow.where(id: workflow_ids).update_all(finished_at: nil)
+    workflow_ids.map { |id| UnfinishWorkflowWorker.perform_async(id) }
   end
 end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -25,6 +25,8 @@ class Api::V1::SubjectSetsController < Api::ApiController
     super do |subject_set|
       notify_cellect(subject_set)
       reset_subject_counts(subject_set.id)
+      workflow_ids = subject_set.workflows.pluck(:id)
+      reset_workflow_finished_at(workflow_ids)
     end
   end
 
@@ -33,7 +35,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
       smses = controlled_resource.set_member_subjects
       subject_ids = smses.map(&:subject_id)
       remove_linked_set_member_subjects(smses)
-      reset_subject_set_workflow_counts(controlled_resource.id)
+      reset_subject_set_workflow_counts(controlled_resource)
       controlled_resource.subject_sets_workflows.delete_all
       #avoid optimisitc locking errors
       controlled_resource.reload
@@ -98,7 +100,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
       linked_sms_ids = value.split(',').map(&:to_i)
       set_member_subjects = resource.set_member_subjects.where(subject_id: linked_sms_ids)
       remove_linked_set_member_subjects(set_member_subjects)
-      reset_subject_set_workflow_counts(controlled_resource.id)
+      reset_subject_set_workflow_counts(controlled_resource)
     else
       super
     end
@@ -110,19 +112,17 @@ class Api::V1::SubjectSetsController < Api::ApiController
     set_member_subjects.delete_all
   end
 
-  def reset_subject_set_workflow_counts(subject_set_id)
-    set_workflow_ids = Workflow
-      .joins(:subject_sets)
-      .where(subject_sets: {id: subject_set_id})
-      .select(:id)
-      .distinct
-      .pluck(:id)
-    set_workflow_ids.each do |w_id|
+  def reset_subject_set_workflow_counts(subject_set)
+    subject_set.workflows.pluck(:id).each do |w_id|
       WorkflowRetiredCountWorker.perform_async(w_id)
     end
   end
 
   def reset_subject_counts(set_id)
     SubjectSetSubjectCounterWorker.perform_async(set_id)
+  end
+
+  def reset_workflow_finished_at(workflow_ids)
+    Workflow.where(id: workflow_ids).update_all(finished_at: nil)
   end
 end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -19,7 +19,10 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def update_links
-    super { |workflow| post_link_actions(workflow) }
+    super do |workflow|
+      UnfinishWorkflowWorker.perform_async(workflow.id)
+      post_link_actions(workflow)
+    end
   end
 
   def destroy_links
@@ -79,7 +82,6 @@ class Api::V1::WorkflowsController < Api::ApiController
           end
         end
       when :subject_sets, 'subject_sets'
-        UnfinishWorkflowWorker.perform_async(workflow.id)
         ReloadCellectWorker.perform_async(workflow.id) if using_cellect
       end
 

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -154,6 +154,14 @@ describe Api::V1::SubjectSetsController, type: :controller do
         run_update_links
       end
 
+      it "should reset the workflow finished_at state" do
+        linked_workflows = resource.workflows
+        linked_workflows.map { |w| w.update_column(:finished_at, Time.zone.now) }
+        run_update_links
+        finished_ats = linked_workflows.map { |w| w.reload.finished_at }.compact
+        expect(finished_ats).to be_empty
+      end
+
       context "when the linking resources are not persisted" do
 
         it "should return a 422 with a missing subject" do

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -154,12 +154,11 @@ describe Api::V1::SubjectSetsController, type: :controller do
         run_update_links
       end
 
-      it "should reset the workflow finished_at state" do
-        linked_workflows = resource.workflows
-        linked_workflows.map { |w| w.update_column(:finished_at, Time.zone.now) }
+      it "should call the unfinish workflow worker" do
+        resource.workflows.each do |workflow|
+          expect(UnfinishWorkflowWorker).to receive(:perform_async).with(workflow.id)
+        end
         run_update_links
-        finished_ats = linked_workflows.map { |w| w.reload.finished_at }.compact
-        expect(finished_ats).to be_empty
       end
 
       context "when the linking resources are not persisted" do


### PR DESCRIPTION
closes #1384 call a worker to unfinish the workflow when adding new data to existing subject sets or linking new sets.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
