### PR TITLE
respect activated_state enum for workflows association

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -29,7 +29,9 @@ class Project < ActiveRecord::Base
 
   has_many :tutorials
   has_many :field_guides, dependent: :destroy
-  has_many :workflows, dependent: :restrict_with_exception
+  # uses the activated_state enum on the workflow
+  has_many :workflows, -> { active }, dependent: :restrict_with_exception
+  # uses the active attribute on the workflow
   has_many :active_workflows, -> { where(active: true) }, class_name: "Workflow"
   has_many :subject_sets, dependent: :destroy
   has_many :live_subject_sets, through: :workflows, source: 'subject_sets'

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -141,6 +141,11 @@ describe Project, type: :model do
     it "should have many workflows" do
       expect(project.workflows).to all( be_a(Workflow) )
     end
+
+    it "should not have any deactivated workflows" do
+      Activation.disable_instances!(project.workflows)
+      expect(project.workflows.reload).to be_empty
+    end
   end
 
   describe "#active_workflows" do


### PR DESCRIPTION
closes #1861 only link active workflows from the project resource

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

