### PR TITLE
speed up the collection serializer

### DIFF
--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -4,8 +4,29 @@ class CollectionSerializer
   include FilterHasMany
   include BelongsToManyLinks
 
+  PRELOADS = [
+    [ owner: { identity_membership: :user } ],
+    :collection_roles,
+    :subjects
+  ].freeze
+
   attributes :id, :name, :display_name, :created_at, :updated_at,
     :slug, :href, :favorite, :private
-  can_include :projects, :owner, :collection_roles, :subjects
+
+  # Do not include the BelongsToMany :projects relation
+  # as this can't be preloaded (custom AR relation)
+  # Note: this won't allow ?include=projects side loading of the resource
+  can_include :owner, :collection_roles, :subjects
+
   can_filter_by :display_name, :slug, :favorite
+
+  # overridden belongs_to_many association to serialize the :projects links
+  def self.btm_associations
+    [ model_class.reflect_on_association(:projects) ]
+  end
+
+  def self.page(params = {}, scope = nil, context = {})
+    scope = scope.preload(*PRELOADS)
+    super(params, scope, context)
+  end
 end

--- a/spec/serializers/collection_serializer_spec.rb
+++ b/spec/serializers/collection_serializer_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe CollectionSerializer do
+  let(:collection) { create(:collection_with_subjects) }
+
+  describe "::btm_associations" do
+    it "should be overriden" do
+      expected = [ Collection.reflect_on_association(:projects) ]
+      expect(CollectionSerializer.btm_associations).to match_array(expected)
+    end
+  end
+
+  it "should not have the :projects side load include setup" do
+    expect(CollectionSerializer.can_includes).not_to include(:projects)
+  end
+
+  it "should preload the serialized associations" do
+    expect_any_instance_of(Collection::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(*CollectionSerializer::PRELOADS)
+      .and_call_original
+    CollectionSerializer.page({}, Collection.all, {})
+  end
+end


### PR DESCRIPTION
preload included relations where we can.
avoid N+1 on the belongs_to_many array relation, instead just serializer the fk_ids in the links at the cost of full resource side loading via ?includes=projects. 
Long term if this is an issue we will have to modify the custom AR Relation to preload properly.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

