### PR TITLE
Store duration on classification

### DIFF
--- a/db/migrate/20161206233551_add_duration_to_classification.rb
+++ b/db/migrate/20161206233551_add_duration_to_classification.rb
@@ -1,0 +1,5 @@
+class AddDurationToClassification < ActiveRecord::Migration
+  def change
+    add_column :classifications, :duration, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -188,7 +188,8 @@ CREATE TABLE classifications (
     expert_classifier integer,
     metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
     workflow_version text,
-    lifecycled_at timestamp without time zone
+    lifecycled_at timestamp without time zone,
+    duration integer
 );
 
 
@@ -3604,4 +3605,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161017135917');
 INSERT INTO schema_migrations (version) VALUES ('20161017141439');
 
 INSERT INTO schema_migrations (version) VALUES ('20161128193435');
+
+INSERT INTO schema_migrations (version) VALUES ('20161206233551');
 

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -42,6 +42,7 @@ class ClassificationLifecycle
     add_seen_before_for_user
     add_project_live_state
     add_user_groups
+    add_duration
     add_lifecycled_at
     classification.save!
   end
@@ -108,6 +109,12 @@ class ClassificationLifecycle
   def add_user_groups
     return if classification.anonymous?
     update_classification_metadata(:user_group_ids, user.non_identity_user_group_ids)
+  end
+
+  def add_duration
+    if seconds = duration_seconds
+      update_classification_metadata(:duration, seconds)
+    end
   end
 
   def add_lifecycled_at
@@ -187,5 +194,13 @@ class ClassificationLifecycle
 
   def update?
     action == "update"
+  end
+
+  def duration_seconds
+    started_at, finished_at = %w(started_at finished_at).map do |attribute|
+      Time.zone.parse(classification.metadata[attribute])&.utc
+    end
+    (finished_at - started_at).to_i
+  rescue TypeError, NoMethodError
   end
 end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -112,9 +112,7 @@ class ClassificationLifecycle
   end
 
   def add_duration
-    if seconds = duration_seconds
-      update_classification_metadata(:duration, seconds)
-    end
+    classification.duration = duration_seconds
   end
 
   def add_lifecycled_at

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -570,31 +570,23 @@ describe ClassificationLifecycle do
       update_metadata(time_updates)
     end
 
-    it "should leave all other metadata intact" do
-      prev_metadata = classification.metadata
-      subject.add_duration
-      updated_metadata = classification.metadata.except(:duration)
-      expect(updated_metadata).to eq(prev_metadata)
-    end
-
     it "should add a duration metadata value" do
       expect{ subject.add_duration }.to change{
-        classification.metadata["duration"]
+        classification.duration
       }.from(nil).to(10)
     end
 
     it "should handle malformed values" do
       update_metadata({ "finished_at" => "boosh" })
       expect{ subject.add_duration }.not_to change{
-        classification.metadata["duration"]
+        classification.duration
       }
     end
 
     it "should handle missing values" do
       update_metadata({ "finished_at" => nil })
-      classification.metadata.delete("finished_at")
       expect{ subject.add_duration }.not_to change{
-        classification.metadata["duration"]
+        classification.duration
       }
     end
   end


### PR DESCRIPTION
Calculate (if available) the classification duration during the lifecycle event and store it in a summable first class column on the classification table.

I see this as a building block for an stream processor / offline worker towards https://github.com/zooniverse/rfc/issues/7. Thoughts?

**TODO**
- [ ] Ensure the duration column is included in the internal classification stream fields.
- [ ] Rake task to backfill this info where appropriate

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
