### PR TITLE
Keep projects as launched when set back to development

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -171,11 +171,6 @@ class Api::V1::ProjectsController < Api::ApiController
       resource.launch_date ||= Time.zone.now
     end
 
-    if update_params[:live] == false
-      update_params[:launch_approved] = false
-      update_params[:beta_approved] = false
-    end
-
     super(update_params, resource)
   end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -704,34 +704,6 @@ describe Api::V1::ProjectsController, type: :controller do
       end
     end
 
-    context "live option" do
-      context "when set false" do
-        let!(:resource) {create(:project_with_contents, owner: user, beta_approved: true, launch_approved: true) }
-
-        before(:each) do
-          default_request scopes: scopes, user_id: authorized_user.id
-        end
-
-        it 'should set beta approved to false' do
-          expect do
-            ps = update_params
-            ps[:admin] = true
-            ps[:projects][:live] = false
-            put :update, ps.merge(id: resource.id)
-          end.to change{ Project.find(resource).beta_approved}.from(true).to(false)
-        end
-
-        it 'should set launch approved to false' do
-          expect do
-            ps = update_params
-            ps[:admin] = true
-            ps[:projects][:live] = false
-            put :update, ps.merge(id: resource.id)
-          end.to change{ Project.find(resource).launch_approved}.from(true).to(false)
-        end
-      end
-    end
-
     context "project_contents" do
       before(:each) do
         default_request scopes: scopes, user_id: authorized_user.id


### PR DESCRIPTION
The idea behind this was that project owners could make malicious changes and we need to double check them. In practise it just means both they and we ourselves forget this issue, and projects disappear from the launched list because of it.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

