### PR TITLE
Fixes argument error on other mailer workers

### DIFF
--- a/app/workers/subject_data_mailer_worker.rb
+++ b/app/workers/subject_data_mailer_worker.rb
@@ -3,8 +3,8 @@ class SubjectDataMailerWorker
 
   sidekiq_options queue: :data_high
 
-  def perform(project_id, s3_url, emails)
+  def perform(resource_id, resource_type, s3_url, emails)
     return unless emails.present?
-    SubjectDataMailer.subject_data(Project.find(project_id), s3_url.to_s, emails).deliver
+    SubjectDataMailer.subject_data(Project.find(resource_id), s3_url.to_s, emails).deliver
   end
 end

--- a/app/workers/workflow_content_data_mailer_worker.rb
+++ b/app/workers/workflow_content_data_mailer_worker.rb
@@ -3,8 +3,8 @@ class WorkflowContentDataMailerWorker
 
   sidekiq_options queue: :data_high
 
-  def perform(project_id, s3_url, emails)
+  def perform(resource_id, resource_type, s3_url, emails)
     return unless emails.present?
-    WorkflowContentDataMailer.workflow_content_data(Project.find(project_id), s3_url.to_s, emails).deliver
+    WorkflowContentDataMailer.workflow_content_data(Project.find(resource_id), s3_url.to_s, emails).deliver
   end
 end

--- a/app/workers/workflow_data_mailer_worker.rb
+++ b/app/workers/workflow_data_mailer_worker.rb
@@ -3,8 +3,8 @@ class WorkflowDataMailerWorker
 
   sidekiq_options queue: :data_high
 
-  def perform(project_id, s3_url, emails)
+  def perform(resource_id, resource_type, s3_url, emails)
     return unless emails.present?
-    WorkflowDataMailer.workflow_data(Project.find(project_id), s3_url.to_s, emails).deliver
+    WorkflowDataMailer.workflow_data(Project.find(resource_id), s3_url.to_s, emails).deliver
   end
 end

--- a/spec/workers/classification_data_mailer_worker_spec.rb
+++ b/spec/workers/classification_data_mailer_worker_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe ClassificationDataMailerWorker do
   let(:s3_url) { "https://fake.s3.url.example.com" }
 
-  shared_examples 'is a mailer' do
+  shared_examples 'is a classification data mailer' do
     it 'should deliver the mail' do
       expect{ subject.perform(resource.id, resource.class.to_s.downcase, s3_url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
     end
@@ -18,11 +18,11 @@ RSpec.describe ClassificationDataMailerWorker do
 
   context 'when resource is a project' do
     let(:resource) { create(:project) }
-    it_behaves_like 'is a mailer'
+    it_behaves_like 'is a classification data mailer'
   end
 
   context 'when resource is a workflow' do
     let(:resource) { create(:workflow) }
-    it_behaves_like 'is a mailer'
+    it_behaves_like 'is a classification data mailer'
   end
 end

--- a/spec/workers/subject_data_mailer_worker_spec.rb
+++ b/spec/workers/subject_data_mailer_worker_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe SubjectDataMailerWorker do
   let(:s3_url) { "https://fake.s3.url.example.com" }
 
   it 'should deliver the mail' do
-    expect{ subject.perform(project.id, s3_url, ["ed.paget@gmail.com"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    expect{ subject.perform(project.id, "project", s3_url, ["ed.paget@gmail.com"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
 
   context 'when there are no recipients' do
     it 'does not call the mailer' do
       expect(SubjectDataMailer).to receive(:subject_data).never
-      subject.perform(project.id, s3_url, [])
+      subject.perform(project.id, "project", s3_url, [])
     end
   end
 end

--- a/spec/workers/workflow_content_data_mailer_worker_spec.rb
+++ b/spec/workers/workflow_content_data_mailer_worker_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SubjectDataMailerWorker do
+RSpec.describe WorkflowContentDataMailerWorker do
   let(:project) { create(:project) }
   let(:s3_url) { "https://fake.s3.url.example.com" }
 
@@ -10,7 +10,7 @@ RSpec.describe SubjectDataMailerWorker do
 
   context 'when there are no recipients' do
     it 'does not call the mailer' do
-      expect(SubjectDataMailer).to receive(:subject_data).never
+      expect(WorkflowContentDataMailer).to receive(:subject_data).never
       subject.perform(project.id, "project", s3_url, [])
     end
   end

--- a/spec/workers/workflow_data_mailer_worker_spec.rb
+++ b/spec/workers/workflow_data_mailer_worker_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SubjectDataMailerWorker do
+RSpec.describe WorkflowDataMailerWorker do
   let(:project) { create(:project) }
   let(:s3_url) { "https://fake.s3.url.example.com" }
 
@@ -10,7 +10,7 @@ RSpec.describe SubjectDataMailerWorker do
 
   context 'when there are no recipients' do
     it 'does not call the mailer' do
-      expect(SubjectDataMailer).to receive(:subject_data).never
+      expect(WorkflowDataMailer).to receive(:subject_data).never
       subject.perform(project.id, "project", s3_url, [])
     end
   end


### PR DESCRIPTION
The classification dump mailer worker needs the resource type ("project", "workflow") along with the other arguments, so the dump worker concern was sending it along. The other mailers, however, didn't know what to do with the extra argument. 

This is currently not tested for because the DumpMailerWorkerSpec stubs out a worker class and doesn't test sending #perform_async to each mailer worker individually, so changing the number of args didn't send up any red flags. Trying to add some there began to feel extremely hacky and I get why it was done the way it was, but it'd have been nice for tests to catch this.

That, and I can't really be sure this'll fix the issue. See https://app.honeybadger.io/projects/40595/faults/31953245 for details.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

