### PR TITLE
Adds researcher quote to project update schema

### DIFF
--- a/app/schemas/project_update_schema.rb
+++ b/app/schemas/project_update_schema.rb
@@ -98,6 +98,10 @@ class ProjectUpdateSchema < JsonSchema
       type "string"
     end
 
+    property "researcher_quote" do
+      type "string"
+    end
+
     property "experimental_tools" do
       type "array"
       items do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -631,6 +631,7 @@ describe Api::V1::ProjectsController, type: :controller do
           beta_requested: true,
           live: true,
           tags: ["astro", "gastro"],
+          researcher_quote: "this is such a great project",
           links: {
             workflows: [workflow.id.to_s],
             subject_sets: [subject_set.id.to_s]


### PR DESCRIPTION
It's already in ProjectCreateSchema, but #update was throwing a 422 when researcher quote was included in an update. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

