### PR TITLE
handle missing location metadata for older subjects

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -51,7 +51,11 @@ class Subject < ActiveRecord::Base
 
   def ordered_locations
     if locations.loaded?
-      locations.sort_by { |loc| loc.metadata&.dig("index") || loc.id }
+      if locations.all? { |loc| loc.metadata&.key?("index") }
+        locations.sort_by { |loc| loc.metadata["index"] }
+      else
+        locations
+      end
     else
       locations.order("\"media\".\"metadata\"->>'index' ASC")
     end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -48,4 +48,12 @@ class Subject < ActiveRecord::Base
       false
     end
   end
+
+  def ordered_locations
+    if locations.loaded?
+      locations.sort_by { |loc| loc.metadata&.dig("index") || loc.id }
+    else
+      locations.order("\"media\".\"metadata\"->>'index' ASC")
+    end
+  end
 end

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -15,7 +15,7 @@ class SubjectSerializer
   end
 
   def locations
-    index_ordered_locations.map do |loc|
+    @model.ordered_locations.map do |loc|
       {
        loc.content_type => loc.url_for_format(@context[:url_format] || :get)
       }
@@ -62,13 +62,5 @@ class SubjectSerializer
 
   def finished_workflow
     user&.has_finished?(workflow)
-  end
-
-  def index_ordered_locations
-    if @model.locations.loaded?
-      @model.locations.sort_by { |loc| loc.metadata&.dig("index") || loc.id }
-    else
-      @model.locations.order("\"media\".\"metadata\"->>'index' ASC")
-    end
   end
 end

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -66,7 +66,7 @@ class SubjectSerializer
 
   def index_ordered_locations
     if @model.locations.loaded?
-      @model.locations.sort_by { |loc| loc.metadata["index"] }
+      @model.locations.sort_by { |loc| loc.metadata&.dig("index") || loc.id }
     else
       @model.locations.order("\"media\".\"metadata\"->>'index' ASC")
     end

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -39,9 +39,8 @@ module Formatter
       end
 
       def locations
-        subject_locs = subject.locations.sort_by { |loc| loc.metadata["index"] }
         {}.tap do |locs|
-          subject_locs.each_with_index.map do |loc, index|
+          subject.ordered_locations.each_with_index.map do |loc, index|
             locs[index] = loc.get_url
           end
         end.to_json

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -62,5 +62,13 @@ RSpec.describe Formatter::Csv::Subject do
         expect(result).to match_array(fields)
       end
     end
+
+    context "with a subject that has no location metadata" do
+
+      it "should match the expected output" do
+        allow_any_instance_of(Medium).to receive(:metadata).and_return(nil)
+        expect(result).to match_array(fields)
+      end
+    end
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -82,6 +82,26 @@ describe Subject, :type => :model do
     end
   end
 
+  describe "#ordered_locations" do
+    let(:subject) do
+      create(:subject, :with_mediums, :with_subject_sets, num_sets: 1)
+    end
+
+    it "should sort the related locations index" do
+      expected = subject.locations.sort_by { |loc| loc.metadata["index"] }
+      expect(expected.map(&:id)).to eq(subject.ordered_locations.map(&:id))
+    end
+
+    context "subject without location metadata" do
+
+      it "should fall back to the relation ordering" do
+        allow_any_instance_of(Medium).to receive(:metadata).and_return(nil)
+        expected = subject.locations.sort_by(&:id)
+        expect(expected.map(&:id)).to eq(subject.ordered_locations.map(&:id))
+      end
+    end
+  end
+
   describe "#migrated_subject?" do
     it "should be falsy when the flag is not set" do
       expect(subject.migrated_subject?).to be_falsey

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -87,16 +87,29 @@ describe Subject, :type => :model do
       create(:subject, :with_mediums, :with_subject_sets, num_sets: 1)
     end
 
-    it "should sort the related locations index" do
+    it "should sort the loaded locations by index" do
       expected = subject.locations.sort_by { |loc| loc.metadata["index"] }
       expect(expected.map(&:id)).to eq(subject.ordered_locations.map(&:id))
     end
 
-    context "subject without location metadata" do
+    it "should sort the non-loaded locations by db index" do
+      lone_subject = Subject.find(subject.id)
+      expect_any_instance_of(Medium::ActiveRecord_Associations_CollectionProxy)
+        .to receive(:order)
+        .with("\"media\".\"metadata\"->>'index' ASC")
+        .and_call_original
+      expected = subject.locations.sort_by { |loc| loc.metadata["index"] }
+      expect(expected.map(&:id)).to eq(lone_subject.ordered_locations.map(&:id))
+    end
 
-      it "should fall back to the relation ordering" do
-        allow_any_instance_of(Medium).to receive(:metadata).and_return(nil)
-        expected = subject.locations.sort_by(&:id)
+    context "subject without location metadata", :focus do
+
+      it "should mimic the database order by using the relation ordering" do
+        Medium.update_all(metadata: nil)
+        allow_any_instance_of(Medium::ActiveRecord_Associations_CollectionProxy)
+          .to receive(:loaded?)
+          .and_return(true)
+        expected = subject.locations.order("\"media\".\"metadata\"->>'index' ASC")
         expect(expected.map(&:id)).to eq(subject.ordered_locations.map(&:id))
       end
     end

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -23,22 +23,18 @@ describe SubjectSerializer do
       SubjectSerializer.single({}, scope, {})[:locations]
     end
 
-    it "should sort the related locations index" do
-      subject_locs = subject.locations.sort_by { |loc| loc.metadata["index"] }
-      expected = subject_locs.map { |loc| loc.src.split("/").last }
-      results = result_locs.map { |loc| loc[:"image/jpeg"].split("/").last }
-      expect(expected).to eq(results)
+    it "should use the model ordered locations sort order" do
+      expect_any_instance_of(Subject)
+        .to receive(:ordered_locations)
+        .and_call_original
+      result_locs
     end
 
-    context "subject without location metadata" do
-
-      it "should fall back to the relation ordering" do
-        allow_any_instance_of(Medium).to receive(:metadata).and_return(nil)
-        subject_locs = subject.locations.sort_by(&:id)
-        expected = subject_locs.map { |loc| loc.src.split("/").last }
-        results = result_locs.map { |loc| loc[:"image/jpeg"].split("/").last }
-        expect(expected).to eq(results)
+    it "should serialize the locations into a mime : url hash" do
+      expected = subject.ordered_locations.map do |loc|
+        { :"#{loc.content_type}" => loc.url_for_format(:get) }
       end
+      expect(expected).to eq(result_locs)
     end
   end
 


### PR DESCRIPTION
Recent deploy breaks when serialising older subjects that have no location index metadata

# Review checklist

- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

