### PR TITLE
ignore the preload experiment for project cards that have no assocation links

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -56,7 +56,10 @@ class ProjectSerializer
     CodeExperiment.run(experiment_name) do |e|
       e.run_if { Panoptes.flipper[experiment_name].enabled? }
       e.use { super(params, scope, context) }
-      e.try { super(params, scope.preload(*PRELOADS), context) }
+      e.try do
+        scope = scope.preload(*PRELOADS) unless context[:cards]
+        super(params, scope, context)
+      end
       # skip the mismatch reporting...we just want perf metrics
       e.ignore { true }
     end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -16,14 +16,24 @@ describe ProjectSerializer do
     ProjectSerializer.page({}, Project.all, {})
   end
 
-  it "should preload the serialized associations if enabled" do
-    allow_any_instance_of(CodeExperiment).to receive(:enabled?).and_return(true)
-    Panoptes.flipper["eager_load_projects"].enable
-    expect_any_instance_of(Project::ActiveRecord_Relation)
-      .to receive(:preload)
-      .with(*ProjectSerializer::PRELOADS)
-      .and_call_original
-    ProjectSerializer.page({}, Project.all, {})
+  context "with enabled experiment" do
+    before do
+      allow_any_instance_of(CodeExperiment).to receive(:enabled?).and_return(true)
+      Panoptes.flipper["eager_load_projects"].enable
+    end
+
+    it "should not preload with cards context" do
+      expect_any_instance_of(Project::ActiveRecord_Relation).not_to receive(:preload)
+      ProjectSerializer.page({}, Project.all, {cards: true})
+    end
+
+    it "should preload the serialized associations without cards context" do
+      expect_any_instance_of(Project::ActiveRecord_Relation)
+        .to receive(:preload)
+        .with(*ProjectSerializer::PRELOADS)
+        .and_call_original
+      ProjectSerializer.page({}, Project.all, {})
+    end
   end
 
   describe "#content" do


### PR DESCRIPTION
compare apples and apples for this experiment, most of the index pages use the cards params. That param ignore the association links so we're testing preload against a control that doesn't use it. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

