### PR TITLE
Ensure subjects_count only includes sets from active workflows

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,7 +20,7 @@ class Project < ActiveRecord::Base
   # uses the active attribute on the workflow
   has_many :active_workflows, -> { where(active: true) }, class_name: "Workflow"
   has_many :subject_sets, dependent: :destroy
-  has_many :live_subject_sets, through: :workflows, source: 'subject_sets'
+  has_many :live_subject_sets, through: :active_workflows, source: 'subject_sets'
   has_many :classifications, dependent: :restrict_with_exception
   has_many :subjects, dependent: :restrict_with_exception
   has_many :acls, class_name: "AccessControlList", as: :resource, dependent: :destroy

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -135,6 +135,11 @@ describe Project, type: :model do
     it "should have many subject_sets" do
       expect(project.live_subject_sets).not_to include(unlinked_subject_set)
     end
+
+    it "should only get subject_sets from active workflows" do
+      inactive_workflow = create(:workflow_with_subjects, num_sets: 1, active: false, project: project)
+      expect(project.live_subject_sets).not_to include(inactive_workflow.subject_sets.first) 
+    end
   end
 
   describe "#classifications" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -138,7 +138,7 @@ describe Project, type: :model do
 
     it "should only get subject_sets from active workflows" do
       inactive_workflow = create(:workflow_with_subjects, num_sets: 1, active: false, project: project)
-      expect(project.live_subject_sets).not_to include(inactive_workflow.subject_sets.first) 
+      expect(project.live_subject_sets).not_to include(inactive_workflow.subject_sets.first)
     end
   end
 


### PR DESCRIPTION
Fix #2052, so project subjects_counts only respect the active set of workflows -> subject_sets and not all workflows -> subject_sets

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

