### PR TITLE
Fix broken subject specs

### DIFF
--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -9,10 +9,9 @@ RSpec.describe Formatter::Csv::Subject do
     create(:subject, :with_mediums, project: project, uploader: project.owner)
   end
   let(:subject_set_ids) { [ subject_set.id ] }
-
-  def ordered_subject_locations
+  let(:ordered_subject_locations) do
     {}.tap do |locs|
-      Medium.all.order(:id).each_with_index.map do |m, index|
+      subject.ordered_locations.each_with_index.map do |m, index|
         locs[index] = m.get_url
       end
     end
@@ -65,7 +64,10 @@ RSpec.describe Formatter::Csv::Subject do
 
     context "with a subject that has no location metadata" do
 
-      it "should match the expected output" do
+      it "should match the db ordered subject_locations array" do
+        allow_any_instance_of(Medium::ActiveRecord_Associations_CollectionProxy)
+          .to receive(:loaded?)
+          .and_return(true)
         allow_any_instance_of(Medium).to receive(:metadata).and_return(nil)
         expect(result).to match_array(fields)
       end

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Formatter::Csv::Subject do
        project.id,
        [workflow.id, workflow_two.id].to_json,
        subject_set_ids.to_json,
-       ordered_subject_locations.to_json,
        subject.metadata.to_json,
+       ordered_subject_locations.to_json,
        {workflow.id => 10, workflow_two.id => 5}.to_json,
        [workflow.id].to_json]
     end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -102,7 +102,7 @@ describe Subject, :type => :model do
       expect(expected.map(&:id)).to eq(lone_subject.ordered_locations.map(&:id))
     end
 
-    context "subject without location metadata", :focus do
+    context "subject without location metadata" do
 
       it "should mimic the database order by using the relation ordering" do
         Medium.update_all(metadata: nil)


### PR DESCRIPTION
#2086 had an active focus set checked in, sorry, so the formatter spec failed to run properly on that PR. 

1. I had the column ordering wrong...fixed. 
2. The spec was relying on database ordering to build up an expectation, I've fixed it to be consistent with the expectations.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
