### PR TITLE
Add memory cache for testing out caching in staging

### DIFF
--- a/app/serializers/concerns/cached_serializer.rb
+++ b/app/serializers/concerns/cached_serializer.rb
@@ -1,0 +1,17 @@
+module CachedSerializer
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def as_json(model, context)
+      if Panoptes.flipper["cached_serializer"].enabled?
+        cache_key = "#{model.class.to_s}/#{model.id}/#{model.updated_at.to_i}/context-#{Digest::MD5.hexdigest(context.to_json)}"
+
+        Rails.cache.fetch(cache_key) do
+          super
+        end
+      else
+        super
+      end
+    end
+  end
+end

--- a/app/serializers/tutorial_serializer.rb
+++ b/app/serializers/tutorial_serializer.rb
@@ -1,6 +1,7 @@
 class TutorialSerializer
   include RestPack::Serializer
   include MediaLinksSerializer
+  include CachedSerializer
 
   attributes :steps, :href, :id, :created_at, :updated_at, :language, :kind
 

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -5,6 +5,7 @@ class WorkflowSerializer
   include RestPack::Serializer
   include FilterHasMany
   include MediaLinksSerializer
+  include CachedSerializer
 
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
              :created_at, :updated_at, :finished_at, :first_task, :primary_language,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,6 +13,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  config.cache_store = :memory_store, { size: 64.megabytes, expires_in: 5.seconds }
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: 'localhost:3000' }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,6 +19,8 @@ Rails.application.configure do
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
+  config.cache_store = :null_store
+
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_files = false
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -19,6 +19,8 @@ Rails.application.configure do
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
+  config.cache_store = :memory_store, { size: 64.megabytes, expires_in: 5.minutes }
+
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_files = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,6 +21,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  config.cache_store = :null_store
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 


### PR DESCRIPTION
This adds a feature-flagged cache for the `as_json` hashes for models. 

Issues:

* Since we update counters without touching the `updated_at` timestamp, this will effectively keep them static until TTL (which I've set to 5 minutes for now).
