### PR TITLE
Avoid subject workflow link checks on a retire operation

### DIFF
--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -13,6 +13,7 @@ class SubjectWorkflowStatus < ActiveRecord::Base
 
   validates :subject, presence: true, uniqueness: {scope: :workflow_id}
   validates :workflow, presence: true
+  validate :subject_belongs_to_workflow, on: :create
 
   delegate :set_member_subjects, to: :subject
   delegate :project, to: :workflow
@@ -48,5 +49,15 @@ class SubjectWorkflowStatus < ActiveRecord::Base
 
   def set_member_subject_ids
     set_member_subjects.pluck(:id)
+  end
+
+  private
+
+  def subject_belongs_to_workflow
+    return unless subject_id && workflow_id
+
+    unless SetMemberSubject.by_subject_workflow(subject_id, workflow_id).exists?
+      errors.add(:subject, "must be linked to the workflow")
+    end
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -77,10 +77,8 @@ class Workflow < ActiveRecord::Base
   end
 
   def retire_subject(subject_id, reason=nil)
-    if set_member_subjects.where(subject_id: subject_id).any?
-      count = subject_workflow_statuses.where(subject_id: subject_id).first_or_create!
-      count.retire!(reason)
-    end
+    count = subject_workflow_statuses.where(subject_id: subject_id).first_or_create!
+    count.retire!(reason)
   end
 
   def retirement_scheme

--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -7,7 +7,10 @@ class RetireSubjectWorker
     workflow = Workflow.find(workflow_id)
     Workflow.transaction do
       subject_ids.each do |subject_id|
-        workflow.retire_subject(subject_id, reason)
+        begin
+          workflow.retire_subject(subject_id, reason)
+        rescue ActiveRecord::RecordInvalid
+        end
       end
     end
 

--- a/spec/controllers/api/v1/subject_worfklow_statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_worfklow_statuses_controller_spec.rb
@@ -13,8 +13,12 @@ RSpec.describe Api::V1::SubjectWorkflowStatusesController, type: :controller do
   let(:resource_class) { SubjectWorkflowStatus }
 
   describe "#index" do
-    let(:workflow) { create(:workflow) }
-    let!(:swcs) { create_list(:subject_workflow_status, 2, workflow: workflow) }
+    let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
+    let!(:swcs) do
+      workflow.subjects.map do |subject|
+        create(:subject_workflow_status, subject: subject, workflow: workflow)
+      end
+    end
     let(:private_project) { create(:project_with_workflow, private: true) }
     let(:private_workflow) { private_project.workflows.first }
     let!(:private_resource) do

--- a/spec/factories/subject_workflow_statuses.rb
+++ b/spec/factories/subject_workflow_statuses.rb
@@ -3,13 +3,13 @@ FactoryGirl.define do
     transient do
       link_subject_sets true
     end
-    subject
+    association :subject, :with_subject_sets, num_sets: 1
     workflow
     classifications_count 1
 
-    after(:build) do |swc, env|
-      if env.link_subject_sets && swc.workflow && swc.workflow.subject_sets.empty?
-        swc.workflow.subject_sets += swc.subject.subject_sets
+    after(:build) do |sws, env|
+      if env.link_subject_sets && sws.workflow && sws.workflow.subject_sets.empty?
+        sws.workflow.subject_sets += sws.subject.subject_sets
       end
     end
   end

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -54,10 +54,11 @@ RSpec.describe Formatter::Csv::Subject do
     end
 
     context "with an old unlinked subject" do
-      let(:sms) { nil }
       let(:subject_set_ids) { [ ] }
 
       it "should match the expected output" do
+        sms.destroy
+        subject.reload
         expect(result).to match_array(fields)
       end
     end

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe Subjects::StrategySelection do
         end
 
         context "when the sms is retired for a different workflow" do
-          let(:retired_workflow) { create(:workflow_with_subjects, num_sets: 1) }
+          let(:retired_workflow) do
+            create(:workflow, subject_sets: workflow.subject_sets)
+          end
 
           it 'should return all the subjects' do
             expect(result).to include(sms.id)

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -242,9 +242,8 @@ describe Workflow, type: :model do
     context 'when the subject does not belong to the workflow' do
       let(:subject) { create(:subject) }
 
-      it 'does not retire' do
-        workflow.retire_subject(subject.id)
-        expect(SubjectWorkflowStatus.count).to eq(0)
+      it 'should raise an error' do
+        expect { workflow.retire_subject(subject.id) }.to raise_error
       end
     end
   end

--- a/spec/workers/reset_project_counters_worker_spec.rb
+++ b/spec/workers/reset_project_counters_worker_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe ResetProjectCountersWorker do
   let(:project)  { create :project, launch_date: Date.new(2015, 1, 1) }
-  let(:workflow) { create :workflow, project: project }
-  let(:subject)  { create :subject, project: project }
+  let(:workflow) { create :workflow_with_subjects, num_sets: 1, project: project }
+  let(:subject)  { workflow.subjects.first }
   let(:user1)    { create :user }
   let(:user2)    { create :user }
   let(:sws)      { create :subject_workflow_status, subject: subject, workflow: workflow, classifications_count: 3 }

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 RSpec.describe RetireSubjectWorker do
   let(:worker) { described_class.new }
-  let(:sms) { create(:set_member_subject) }
+  let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
+  let(:subject) { workflow.subjects.first }
+  let(:sms) { subject.set_member_subjects.first }
   let(:set) { sms.subject_set }
   let(:sms2) { create(:set_member_subject, subject_set: set) }
-  let(:workflow) { create :workflow, subject_sets: [set] }
-  let!(:count) { create(:subject_workflow_status, subject: sms.subject, workflow: workflow) }
+  let!(:count) { create(:subject_workflow_status, subject: subject, workflow: workflow) }
   let(:subject_ids) { [sms.subject_id, sms2.subject_id] }
 
   describe "#perform" do


### PR DESCRIPTION
Avoid the counters running on each retire operation and hitting the db hard. Instead pay this cost once when creating the status resource. Note this doesn't check on updates as subjects can be unlinked form workflows over time. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
