### PR TITLE
Report all project workflows in subject dumps

### DIFF
--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -10,7 +10,7 @@ module Formatter
 
       def initialize(project)
         @project = project
-        @project_workflow_ids = project.workflows.pluck(&:id)
+        @project_workflow_ids = project.workflows.pluck(:id)
       end
 
       def to_array(subject)

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -103,12 +103,12 @@ describe Subject, :type => :model do
     end
 
     context "subject without location metadata" do
+      before do
+        subject.locations.update_all(metadata: nil)
+        subject.locations(true)
+      end
 
       it "should mimic the database order by using the relation ordering" do
-        Medium.update_all(metadata: nil)
-        allow_any_instance_of(Medium::ActiveRecord_Associations_CollectionProxy)
-          .to receive(:loaded?)
-          .and_return(true)
         expected = subject.locations.order("\"media\".\"metadata\"->>'index' ASC")
         expect(expected.map(&:id)).to eq(subject.ordered_locations.map(&:id))
       end

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -31,6 +31,8 @@ describe SubjectSerializer do
     end
 
     it "should serialize the locations into a mime : url hash" do
+      # load the association to match the preload in the serializer scope
+      subject.locations
       expected = subject.ordered_locations.map do |loc|
         { :"#{loc.content_type}" => loc.url_for_format(:get) }
       end


### PR DESCRIPTION
ensure we pass ids into the where scope and not the full workflow resources representations

Fixes a bug reported by a researcher that the subject dumps don't include all the project workflow retirement information.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
