### PR TITLE
reset sws cache for each subject

### DIFF
--- a/app/workers/subjects_dump_worker.rb
+++ b/app/workers/subjects_dump_worker.rb
@@ -9,11 +9,10 @@ class SubjectsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
-    csv_formatter = Formatter::Csv::Subject.new(resource)
     CSV.open(csv_file_path, 'wb') do |csv|
-      csv << csv_formatter.class.headers
+      csv << Formatter::Csv::Subject.headers
       project_subjects.find_each do |subject|
-        csv << csv_formatter.to_array(subject)
+        csv << Formatter::Csv::Subject.new(resource, subject).to_array
       end
     end
   end

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -8,14 +8,13 @@ module Formatter
            classifications_by_workflow retired_in_workflow)
       end
 
-      def initialize(project)
+      def initialize(project, subject)
         @project = project
         @project_workflow_ids = project.workflows.pluck(:id)
+        @subject = subject
       end
 
-      def to_array(subject)
-        @subject = subject
-        @swses = nil
+      def to_array
         self.class.headers.map do |header|
           send(header)
         end

--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -15,6 +15,7 @@ module Formatter
 
       def to_array(subject)
         @subject = subject
+        @swses = nil
         self.class.headers.map do |header|
           send(header)
         end
@@ -66,8 +67,7 @@ module Formatter
       end
 
       def subject_workflow_statuses
-        @swses ||= SubjectWorkflowStatus
-          .by_subject(subject.id)
+        @swses ||= SubjectWorkflowStatus.by_subject(subject.id)
           .where(workflow_id: project_workflow_ids)
           .to_a
       end

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -47,10 +47,18 @@ RSpec.describe Formatter::Csv::Subject do
        {workflow.id => 10, workflow_two.id => 5}.to_json,
        [workflow.id].to_json]
     end
-    let(:result) { described_class.new(project).to_array(subject) }
+    let(:formatter) { described_class.new(project) }
+    let(:result) { formatter.to_array(subject) }
 
     it "should match the expected output" do
       expect(result).to match_array(fields)
+    end
+
+    it "should not cache between subjects" do
+      expect(result).to match_array(fields)
+      new_subject = create(:subject, :with_mediums, project: project, uploader: project.owner)
+      new_result = formatter.to_array(new_subject)
+      expect(new_result[-2..-1]).not_to match_array(fields[-2..-1])
     end
 
     context "with an old unlinked subject" do

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -47,18 +47,10 @@ RSpec.describe Formatter::Csv::Subject do
        {workflow.id => 10, workflow_two.id => 5}.to_json,
        [workflow.id].to_json]
     end
-    let(:formatter) { described_class.new(project) }
-    let(:result) { formatter.to_array(subject) }
+    let(:result) { described_class.new(project, subject).to_array }
 
     it "should match the expected output" do
       expect(result).to match_array(fields)
-    end
-
-    it "should not cache between subjects" do
-      expect(result).to match_array(fields)
-      new_subject = create(:subject, :with_mediums, project: project, uploader: project.owner)
-      new_result = formatter.to_array(new_subject)
-      expect(new_result[-2..-1]).not_to match_array(fields[-2..-1])
     end
 
     context "with an old unlinked subject" do


### PR DESCRIPTION
Fixes #2101 - reset the subject workflow status cache for each new subject

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
