### PR TITLE
record unknown answer label for out of bounds lookups

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -145,9 +145,10 @@ module Formatter
       def answer_labels
         Array.wrap(@current["value"]).map do |answer_idx|
           begin
-            answer_string = workflow_at_version.tasks[@current['task']]['answers'][answer_idx]['label']
+            task_answer = workflow_at_version.tasks[@current['task']]['answers'][answer_idx]
+            answer_string = task_answer['label']
             translate(answer_string)
-          rescue TypeError
+          rescue TypeError, NoMethodError
             "unknown answer label"
           end
         end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -85,10 +85,18 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         contents.update(strings: strings)
       end
 
-      it 'notes in the value if the annotation is invalid' do
-        annotation = {"task" => "init", "value" => "YES" }
-        formatted = described_class.new(classification, annotation, cache).to_h
-        expect(formatted["value"]).to eq("unknown answer label")
+      context "invalid annotation values" do
+        it 'records an invalid answer label lookup for invalid indexes' do
+          annotation = {"task" => "init", "value" => "YES" }
+          formatted = described_class.new(classification, annotation, cache).to_h
+          expect(formatted["value"]).to eq("unknown answer label")
+        end
+
+        it 'records an invalid answer lookup for valid indexes' do
+          annotation = {"task" => "init", "value" => 2 }
+          formatted = described_class.new(classification, annotation, cache).to_h
+          expect(formatted["value"]).to eq("unknown answer label")
+        end
       end
 
       context "with a single question workflow annotation" do


### PR DESCRIPTION
Closes #2104 - some annotations have out of bounds index lookups for the workflows answers array, this will mark them as invalid but still record the data in the export for the researcher.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
