### PR TITLE
Remove includes classification scope for

### DIFF
--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -3,6 +3,10 @@ class ClassificationSerializer
   attributes :id, :annotations, :created_at, :metadata, :href
   can_include :project, :user, :user_group, :workflow
 
+  def self.page(params = {}, scope = nil, context = {})
+    super(params, scope.preload(:subjects), context)
+  end
+
   def metadata
     @model.metadata.merge(workflow_version: @model.workflow_version)
   end

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe ClassificationSerializer do
+
+  it "should preload the serialized associations" do
+    create(:classification)
+    expect_any_instance_of(Classification::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(:subjects)
+      .and_call_original
+    ClassificationSerializer.page({}, Classification.all, {})
+  end
+end


### PR DESCRIPTION
closes #2102 - move the subject includes from the `scope_for` to the serializer and restrict the join scope where we can in the `scope_for`.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
