### PR TITLE
decrease the celluloid shutdown time window

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,9 @@ RSpec.configure do |config|
 
   Devise.mailer = Devise::Mailer
 
+  # work around https://github.com/celluloid/celluloid/issues/696
+  Celluloid.shutdown_timeout = 1
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end


### PR DESCRIPTION
this time window will hang forked processes like spring, guard, etc until the timeout window. this will workaround it until we can bump celluloid to a fix.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
