### PR TITLE
Use loaded associations to avoid sum db queries

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -138,7 +138,13 @@ class Project < ActiveRecord::Base
   end
 
   def subjects_count
-    @subject_count ||= live_subject_sets.sum :set_member_subjects_count
+    @subject_count ||= if live_subject_sets.loaded?
+      live_subject_sets.inject(0) do |sum,set|
+        sum + set.set_member_subjects_count
+      end
+    else
+      live_subject_sets.sum :set_member_subjects_count
+    end
   end
 
   def retired_subjects_count

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -148,7 +148,13 @@ class Project < ActiveRecord::Base
   end
 
   def retired_subjects_count
-    @retired_subject_count ||= active_workflows.sum :retired_set_member_subjects_count
+    @retired_subject_count ||= if active_workflows.loaded?
+      active_workflows.inject(0) do |sum,w|
+        sum + w.retired_set_member_subjects_count
+      end
+    else
+      active_workflows.sum :retired_set_member_subjects_count
+    end
   end
 
   def finished?

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -275,6 +275,35 @@ describe Project, type: :model do
     end
   end
 
+  describe "#subjects_count" do
+    before do
+      subject_sets.map { |set| set.update_column(:set_member_subjects_count, 1) }
+    end
+
+    context "without a loaded association" do
+      let(:subject_sets) { SubjectSet.where(project_id: full_project.id) }
+
+      it "should hit the db with a sum query when the association is not loaded" do
+        expect(full_project.live_subject_sets)
+          .to receive(:sum)
+          .with(:set_member_subjects_count)
+          .and_call_original
+        expect(full_project.subjects_count).to eq(2)
+      end
+    end
+
+    context "with a loaded assocation" do
+      let(:subject_sets) { full_project.live_subject_sets }
+
+      it "should use the association values when loaded" do
+        expect(full_project.live_subject_sets)
+          .to receive(:inject)
+          .and_call_original
+        expect(full_project.subjects_count).to eq(2)
+      end
+    end
+  end
+
   describe "#retired_subjects_count" do
     let(:workflows) { full_project.workflows }
     before do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -283,7 +283,7 @@ describe Project, type: :model do
     context "without a loaded association" do
       let(:subject_sets) { SubjectSet.where(project_id: full_project.id) }
 
-      it "should hit the db with a sum query when the association is not loaded" do
+      it "should hit the db with a sum query" do
         expect(full_project.live_subject_sets)
           .to receive(:sum)
           .with(:set_member_subjects_count)
@@ -295,7 +295,7 @@ describe Project, type: :model do
     context "with a loaded assocation" do
       let(:subject_sets) { full_project.live_subject_sets }
 
-      it "should use the association values when loaded" do
+      it "should use the association values" do
         expect(full_project.live_subject_sets)
           .to receive(:inject)
           .and_call_original
@@ -305,18 +305,36 @@ describe Project, type: :model do
   end
 
   describe "#retired_subjects_count" do
-    let(:workflows) { full_project.workflows }
-    before do
-      workflows.map { |w| w.update_column(:retired_set_member_subjects_count, 1) }
-    end
+    it "should use the association values when loaded" do
+      full_project.active_workflows.update_all(retired_set_member_subjects_count: 1)
+      # i had to call inspect to actually get the association to stay loaded..wtf?!
+      full_project.active_workflows.inspect
+      expect(full_project.active_workflows)
+        .to receive(:inject)
+        .and_call_original
 
-    it "return a count of the associated retired subjects" do
       expect(full_project.retired_subjects_count).to eq(1)
     end
 
-    it "should not count inactive workflows" do
-      workflows.sample.update_column(:active, false)
-      expect(full_project.retired_subjects_count).to eq(0)
+    context "without a loaded association" do
+      let(:workflows) { Workflow.where(project_id: full_project.id, active: true) }
+
+      before do
+        workflows.update_all(retired_set_member_subjects_count: 1)
+      end
+
+      it "should not count inactive workflows" do
+        workflows.sample.update_column(:active, false)
+        expect(full_project.retired_subjects_count).to eq(0)
+      end
+
+      it "should hit the db with a sum query" do
+        expect(full_project.active_workflows)
+          .to receive(:sum)
+          .with(:retired_set_member_subjects_count)
+          .and_call_original
+        expect(full_project.retired_subjects_count).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
Avoid calling sum N+1 queries in the project serializer if the model is preloaded (paging).

The subject_set & workflow calls here are the sum queries (note preloading was turned on @ 16:18):

![image](https://cloud.githubusercontent.com/assets/295329/21726663/a2cd8766-d435-11e6-8dab-84bf8b706363.png)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
