### PR TITLE
Adds URLs to organizations

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -16,6 +16,11 @@ class Api::V1::OrganizationsController < Api::ApiController
                     :title,
                     :introduction].freeze
 
+  CONTENT_FIELDS = [:description,
+                    :title,
+                    :introduction,
+                    :url_labels].freeze
+
   def create
     organizations = Organization.transaction do
       Array.wrap(params[:organizations]).map do |organization_params|

--- a/app/operations/concerns/url_labels.rb
+++ b/app/operations/concerns/url_labels.rb
@@ -1,18 +1,20 @@
-module Organizations
-  class Organization < Operation
-    def self.content_from_params(ps)
-      content = ps.slice(Api::V1::OrganizationsController::CONTENT_FIELDS)
+module UrlLabels
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def content_from_params(ps, content_fields)
+      content = ps.slice(content_fields)
       content[:language] = ps[:primary_language]
       if ps.has_key? :urls
         urls, labels = extract_url_labels(ps[:urls])
         content[:url_labels] = labels
         ps[:urls] = urls
       end
-      ps.except!(Api::V1::OrganizationsController::CONTENT_FIELDS)
+      ps.except!(content_fields)
       content.select { |k,v| !!v }
     end
 
-    def self.extract_url_labels(urls)
+    def extract_url_labels(urls)
       visitor = TasksVisitors::ExtractStrings.new
       visitor.visit(urls)
       [urls, visitor.collector]

--- a/app/operations/concerns/url_labels.rb
+++ b/app/operations/concerns/url_labels.rb
@@ -1,23 +1,21 @@
 module UrlLabels
   extend ActiveSupport::Concern
 
-  module ClassMethods
-    def content_from_params(ps, content_fields)
-      content = ps.slice(content_fields)
-      content[:language] = ps[:primary_language]
-      if ps.has_key? :urls
-        urls, labels = extract_url_labels(ps[:urls])
-        content[:url_labels] = labels
-        ps[:urls] = urls
-      end
-      ps.except!(content_fields)
-      content.select { |k,v| !!v }
+  def content_from_params(ps, content_fields)
+    content = ps.slice(content_fields)
+    content[:language] = ps[:primary_language]
+    if ps.has_key? :urls
+      urls, labels = extract_url_labels(ps[:urls])
+      content[:url_labels] = labels
+      ps[:urls] = urls
     end
+    ps.except!(content_fields)
+    content.select { |k,v| !!v }
+  end
 
-    def extract_url_labels(urls)
-      visitor = TasksVisitors::ExtractStrings.new
-      visitor.visit(urls)
-      [urls, visitor.collector]
-    end
+  def extract_url_labels(urls)
+    visitor = TasksVisitors::ExtractStrings.new
+    visitor.visit(urls)
+    [urls, visitor.collector]
   end
 end

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -8,14 +8,36 @@ module Organizations
     string :title
     string :description
     string :introduction, default: ''
+    array :urls
 
     def execute
       Organization.transaction do
         organization = Organization.new owner: api_user.user, name: name, display_name: display_name, primary_language: primary_language
-        organization.organization_contents.build title: title, description: description, introduction: introduction, language: primary_language
+        param_hash = { title: title, description: description, introduction: introduction }
+        param_hash.merge! content_from_params(inputs)
+        # organization.organization_contents.build title: title, description: description, introduction: introduction, language: primary_language, urls: contenturls
+        organization.organization_contents.build param_hash
         organization.save!
         organization
       end
+    end
+
+    def content_from_params(ps)
+      content = ps.slice(Api::V1::OrganizationsController::CONTENT_FIELDS)
+      content[:language] = ps[:primary_language]
+      if ps.has_key? :urls
+        urls, labels = extract_url_labels(ps[:urls])
+        content[:url_labels] = labels
+        ps[:urls] = urls
+      end
+      ps.except!(Api::V1::OrganizationsController::CONTENT_FIELDS)
+      content.select { |k,v| !!v }
+    end
+
+    def extract_url_labels(urls)
+      visitor = TasksVisitors::ExtractStrings.new
+      visitor.visit(urls)
+      [urls, visitor.collector]
     end
   end
 end

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -22,22 +22,6 @@ module Organizations
       end
     end
 
-    def content_from_params(ps)
-      content = ps.slice(Api::V1::OrganizationsController::CONTENT_FIELDS)
-      content[:language] = ps[:primary_language]
-      if ps.has_key? :urls
-        urls, labels = extract_url_labels(ps[:urls])
-        content[:url_labels] = labels
-        ps[:urls] = urls
-      end
-      ps.except!(Api::V1::OrganizationsController::CONTENT_FIELDS)
-      content.select { |k,v| !!v }
-    end
 
-    def extract_url_labels(urls)
-      visitor = TasksVisitors::ExtractStrings.new
-      visitor.visit(urls)
-      [urls, visitor.collector]
-    end
   end
 end

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -1,3 +1,5 @@
+include UrlLabels
+
 module Organizations
   class Create < Operation
     string :name
@@ -14,14 +16,11 @@ module Organizations
       Organization.transaction do
         organization = Organization.new owner: api_user.user, name: name, display_name: display_name, primary_language: primary_language
         param_hash = { title: title, description: description, introduction: introduction }
-        param_hash.merge! content_from_params(inputs)
-        # organization.organization_contents.build title: title, description: description, introduction: introduction, language: primary_language, urls: contenturls
+        param_hash.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
         organization.organization_contents.build param_hash
         organization.save!
         organization
       end
     end
-
-
   end
 end

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -1,7 +1,7 @@
-include UrlLabels
-
 module Organizations
   class Create < Operation
+    include UrlLabels
+
     string :name
     string :display_name
     string :primary_language

--- a/app/operations/organizations/organizations.rb
+++ b/app/operations/organizations/organizations.rb
@@ -1,0 +1,21 @@
+module Organizations
+  class Organization < Operation
+    def self.content_from_params(ps)
+      content = ps.slice(Api::V1::OrganizationsController::CONTENT_FIELDS)
+      content[:language] = ps[:primary_language]
+      if ps.has_key? :urls
+        urls, labels = extract_url_labels(ps[:urls])
+        content[:url_labels] = labels
+        ps[:urls] = urls
+      end
+      ps.except!(Api::V1::OrganizationsController::CONTENT_FIELDS)
+      content.select { |k,v| !!v }
+    end
+
+    def self.extract_url_labels(urls)
+      visitor = TasksVisitors::ExtractStrings.new
+      visitor.visit(urls)
+      [urls, visitor.collector]
+    end
+  end
+end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -9,16 +9,38 @@ module Organizations
     string :title
     string :description
     string :introduction, default: ''
+    array :urls
 
     def execute
       Organization.transaction do
         organization = Organization.find(id)
         organization.update!(name: name, display_name: display_name, primary_language: primary_language)
         organization.organization_contents.find_or_initialize_by(language: primary_language) do |content|
-          content.update! title: title, description: description, introduction: introduction
+          param_hash = { title: title, description: description, introduction: introduction }
+          param_hash.merge! content_from_params(inputs)
+          content.update! param_hash
+          # content.update! title: title, description: description, introduction: introduction, url_labels: url_labels
         end
         organization.save!
       end
+    end
+
+    def content_from_params(ps)
+      content = ps.slice(Api::V1::OrganizationsController::CONTENT_FIELDS)
+      content[:language] = ps[:primary_language]
+      if ps.has_key? :urls
+        urls, labels = extract_url_labels(ps[:urls])
+        content[:url_labels] = labels
+        ps[:urls] = urls
+      end
+      ps.except!(Api::V1::OrganizationsController::CONTENT_FIELDS)
+      content.select { |k,v| !!v }
+    end
+
+    def extract_url_labels(urls)
+      visitor = TasksVisitors::ExtractStrings.new
+      visitor.visit(urls)
+      [urls, visitor.collector]
     end
   end
 end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -1,5 +1,7 @@
+include UrlLabels
+
 module Organizations
-  class Update < Organization
+  class Update < Operation
     integer :id
     string :name
     string :display_name
@@ -17,30 +19,11 @@ module Organizations
         organization.update!(name: name, display_name: display_name, primary_language: primary_language)
         organization.organization_contents.find_or_initialize_by(language: primary_language) do |content|
           param_hash = { title: title, description: description, introduction: introduction }
-          param_hash.merge! content_from_params(inputs)
+          param_hash.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
           content.update! param_hash
-          # content.update! title: title, description: description, introduction: introduction, url_labels: url_labels
         end
         organization.save!
       end
-    end
-
-    def content_from_params(ps)
-      content = ps.slice(Api::V1::OrganizationsController::CONTENT_FIELDS)
-      content[:language] = ps[:primary_language]
-      if ps.has_key? :urls
-        urls, labels = extract_url_labels(ps[:urls])
-        content[:url_labels] = labels
-        ps[:urls] = urls
-      end
-      ps.except!(Api::V1::OrganizationsController::CONTENT_FIELDS)
-      content.select { |k,v| !!v }
-    end
-
-    def extract_url_labels(urls)
-      visitor = TasksVisitors::ExtractStrings.new
-      visitor.visit(urls)
-      [urls, visitor.collector]
     end
   end
 end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -1,5 +1,5 @@
 module Organizations
-  class Update < Operation
+  class Update < Organization
     integer :id
     string :name
     string :display_name

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -1,7 +1,7 @@
-include UrlLabels
-
 module Organizations
   class Update < Operation
+    include UrlLabels
+
     integer :id
     string :name
     string :display_name

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module Panoptes
     config.autoload_paths += Dir[Rails.root.join('app', 'models', '**/')]
     config.autoload_paths += Dir[Rails.root.join('app', 'serializers', '**/')]
     config.autoload_paths += Dir[Rails.root.join('app', 'workers', '**/')]
+    config.autoload_paths += Dir[Rails.root.join('app', 'operations', '**/')]
     config.autoload_paths += Dir[Rails.root.join('lib', '**/')]
 
     config.action_dispatch.perform_deep_munge = false

--- a/db/migrate/20161221203241_add_urls_to_organizations.rb
+++ b/db/migrate/20161221203241_add_urls_to_organizations.rb
@@ -1,0 +1,6 @@
+class AddUrlsToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :urls, :jsonb, default: []
+    add_column :organization_contents, :url_labels, :jsonb, default: {}
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -607,7 +607,8 @@ CREATE TABLE organization_contents (
     language character varying NOT NULL,
     organization_id integer,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    url_labels jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -643,7 +644,8 @@ CREATE TABLE organizations (
     listed_at timestamp without time zone,
     activated_state integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    urls jsonb DEFAULT '[]'::jsonb
 );
 
 
@@ -3690,4 +3692,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161128193435');
 INSERT INTO schema_migrations (version) VALUES ('20161205203956');
 
 INSERT INTO schema_migrations (version) VALUES ('20161212205412');
+
+INSERT INTO schema_migrations (version) VALUES ('20161221203241');
 

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -85,6 +85,7 @@ describe Api::V1::OrganizationsController, type: :controller do
             display_name: "The Illuminati",
             title: 'Come join us',
             description: "This organization is the most organized organization to ever organize",
+            urls: [{label: "Blog", url: "http://blogo.com/example"}],
             primary_language: "zh-tw"
           }
         }
@@ -116,6 +117,7 @@ describe Api::V1::OrganizationsController, type: :controller do
               display_name: "Def Not Illuminati",
               title: "Totally Harmless",
               description: "This Organization is not affiliated with the Illuminati, absolutely not no way",
+              urls: [{label: "Blog", url: "http://blogo.com/example"}],
               introduction: "Hello and welcome to Illuminati Headquarters oh wait damn"
             }
           }

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     sequence(:display_name) { |n| "Test Organization #{ n }" }
     listed_at Time.now
     primary_language "en"
+    urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
 
     association :owner, factory: :user
 


### PR DESCRIPTION
I've added URLs to organizations! This involved duping some of the URL label translation code from the projects controller to the create and update org operations. It currently works, but that duped code is bugging me.

It seems like I should be able to inherit from an Organization class (within the same Organizations module) and put those methods in that class, but when I do, the operation doesn't run correctly. 

This is what I tried: I created `organization.rb`, which is in the Organizations module and starts with `class Organization < Operation`. Therein, `self.content_from_params` and `self.extract_url_labels` are defined. The error when the spec runs is this: `NoMethodError: undefined method `run!' for #<Organizations::Update::ActiveRecord_Relation:0x007fadbfe118c8>`

Not the end of the world, but there's no other examples of the type of service object inheritance I was trying to I figured I'd ask.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
