### PR TITLE
use the subjects_count method

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -92,7 +92,7 @@ class Workflow < ActiveRecord::Base
   end
 
   def cellect_size_subject_space?
-    set_member_subjects.count >= Panoptes.cellect_min_pool_size
+    subjects_count >= Panoptes.cellect_min_pool_size
   end
 
   def using_cellect?

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -180,9 +180,7 @@ RSpec.describe Subjects::StrategySelection do
 
       context "when the number of set_member_subjects is large" do
         it "should use the cellect strategy" do
-          allow(workflow).to receive_message_chain("set_member_subjects.count") do
-            cellect_size
-          end
+          allow(workflow).to receive(:subjects_count).and_return(cellect_size)
           expect(subject.strategy).to eq(:cellect)
         end
       end
@@ -248,9 +246,7 @@ RSpec.describe Subjects::StrategySelection do
       context 'when the workflow has a lot of subjects' do
         it 'should still use cellect_ex' do
           allow(workflow).to receive(:subject_selection_strategy).and_return("cellect_ex")
-          allow(workflow).to receive_message_chain("set_member_subjects.count") do
-            cellect_size
-          end
+          allow(workflow).to receive(:subjects_count).and_return(cellect_size)
           expect(subject.strategy).to eq(:cellect_ex)
         end
       end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -353,7 +353,7 @@ describe Workflow, type: :model do
     end
 
     it "should return true if the subjects space is large enough" do
-      allow(workflow).to receive_message_chain("set_member_subjects.count")
+      allow(workflow).to receive(:subjects_count)
         .and_return(Panoptes.cellect_min_pool_size)
       expect(workflow.using_cellect?).to be_truthy
     end
@@ -366,7 +366,7 @@ describe Workflow, type: :model do
 
     context "when more subjects than the cellect min pool" do
       it "should be true" do
-        allow(workflow).to receive_message_chain("set_member_subjects.count")
+        allow(workflow).to receive(:subjects_count)
           .and_return(Panoptes.cellect_min_pool_size)
         expect(workflow.cellect_size_subject_space?).to be_truthy
       end


### PR DESCRIPTION
use the optimized subjects_count method instead of a seq scan with a join query to avoid more complex join count calls when lots of subjects retire at once (think aggregation). 


This method ideally will be cached too.
# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
