### PR TITLE
optimize the query for classification project scope

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -68,9 +68,9 @@ class Classification < ActiveRecord::Base
     if opts[:last_id] && !opts[:project_id]
       raise Classification::MissingParameter.new("Project ID required if last_id is included")
     end
-    updatable = Project.scope_for(:update, user)
-    updatable = updatable.where(id: opts[:project_id]) if opts[:last_id]
-    scope = joins(:project).merge(updatable)
+    projects = Project.scope_for(:update, user)
+    projects = projects.where(id: opts[:project_id]) if opts[:project_id]
+    scope = where(project_id: projects.pluck(:id))
     scope = scope.after_id(opts[:last_id]) if opts[:last_id]
     scope
   end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -194,6 +194,22 @@ describe Classification, :type => :model do
         expect(result).to be_empty
       end
 
+      context "using project_id param" do
+        it 'should not return any classifications for a non-existant project id' do
+          create(:classification, project: project, user: user.owner)
+          result = Classification.scope_for(:project, user, {project_id: -1})
+          expect(result).to be_empty
+        end
+
+        it 'should not return any classifications for another project' do
+          create(:classification, user: user.owner, project: project)
+          another_project = create(:project)
+          create(:classification, user: user.owner, project: another_project)
+          result = Classification.scope_for(:project, user, {project_id: another_project.id})
+          expect(result).to be_empty
+        end
+      end
+
       context "with last_id param provided" do
         let!(:classifications) { create_list(:classification, 2, project: project) }
 


### PR DESCRIPTION
avoid a join on projects and instead use the indexed fk relation after checking the user has access to the project. This should alleviate timeout api calls when iterating from old last_ids for projects.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
