### PR TITLE
simplify the recents schema for query optimization

### DIFF
--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -32,7 +32,7 @@ class Recent < ActiveRecord::Base
 
   def copy_classification_fkeys
     if classification
-      %W(project_id workflow_id user_id user_group_id).each do |key|
+      %w(project_id workflow_id user_id user_group_id).each do |key|
         send("#{key}=", classification.send(key))
       end
     end

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -33,7 +33,7 @@ class Recent < ActiveRecord::Base
   def copy_classification_fkeys
     if classification
       %W(project_id workflow_id user_id user_group_id).each do |key|
-        self.send("#{key}=", classification.send(key))
+        send("#{key}=", classification.send(key))
       end
     end
   end

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -23,8 +23,8 @@ class Recent < ActiveRecord::Base
   before_validation :copy_classification_fkeys
 
   def self.create_from_classification(classification)
-    classification.subject_ids.map do |sid|
-      create!({ subject_id: sid, classification: classification })
+    classification.subject_ids.map do |subject_id|
+      create!(subject_id: subject_id, classification: classification)
     end
   end
 

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -9,6 +9,11 @@ class Recent < ActiveRecord::Base
   has_one :user, through: :classification
   has_one :user_group, through: :classification
 
+  belongs_to :project
+  belongs_to :workflow
+  belongs_to :user
+  belongs_to :user_group
+
   validates_presence_of :classification, :subject
 
   def self.create_from_classification(classification)

--- a/db/migrate/20170112163747_modify_recents_fk_schema.rb
+++ b/db/migrate/20170112163747_modify_recents_fk_schema.rb
@@ -1,8 +1,8 @@
 class ModifyRecentsFkSchema < ActiveRecord::Migration
+
   def change
-    add_column :recents, :project_id, :integer, index: true
-    add_column :recents, :workflow_id, :integer, index: true
-    add_column :recents, :user_id, :integer, index: true
-    add_column :recents, :user_group_id, :integer
+    %i(project_id workflow_id user_id user_group_id).each do |col|
+      add_column :recents, col, :integer
+    end
   end
 end

--- a/db/migrate/20170112163747_modify_recents_fk_schema.rb
+++ b/db/migrate/20170112163747_modify_recents_fk_schema.rb
@@ -1,0 +1,8 @@
+class ModifyRecentsFkSchema < ActiveRecord::Migration
+  def change
+    add_column :recents, :project_id, :integer, index: true
+    add_column :recents, :workflow_id, :integer, index: true
+    add_column :recents, :user_id, :integer, index: true
+    add_column :recents, :user_group_id, :integer
+  end
+end

--- a/db/migrate/20170113113532_add_recents_fk_indexes.rb
+++ b/db/migrate/20170113113532_add_recents_fk_indexes.rb
@@ -1,0 +1,9 @@
+class AddRecentsFkIndexes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    %i(project_id workflow_id user_id).each do |col|
+      add_index :recents, col, algorithm: :concurrently
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -808,7 +808,11 @@ CREATE TABLE recents (
     classification_id integer,
     subject_id integer,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    project_id integer,
+    workflow_id integer,
+    user_id integer,
+    user_group_id integer
 );
 
 
@@ -2531,10 +2535,31 @@ CREATE INDEX index_recents_on_classification_id ON recents USING btree (classifi
 
 
 --
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
+
+
+--
 -- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
+
+
+--
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
+
+
+--
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
@@ -3703,4 +3728,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161207111319');
 INSERT INTO schema_migrations (version) VALUES ('20161212205412');
 
 INSERT INTO schema_migrations (version) VALUES ('20161221203241');
+
+INSERT INTO schema_migrations (version) VALUES ('20170112163747');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3731,3 +3731,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161221203241');
 
 INSERT INTO schema_migrations (version) VALUES ('20170112163747');
 
+INSERT INTO schema_migrations (version) VALUES ('20170113113532');
+

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -106,6 +106,17 @@ namespace :migrate do
         Recent.create_from_classification(classification)
       end
     end
+
+    desc "Backfill belongs_to relations from classifications"
+    task backfill_belongs_to_relations: :environment do
+      scope = Recent.all.preload(:classification)
+      total = scope.count
+      scope.find_each.with_index do |recent, i|
+        puts "#{i+1} of #{total}"
+        recent.send(:copy_classification_fkeys)
+        recent.save!(validate: false, touch: false) if recent.changed
+      end
+    end
   end
 
   namespace :classification do

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -109,7 +109,8 @@ namespace :migrate do
 
     desc "Backfill belongs_to relations from classifications"
     task backfill_belongs_to_relations: :environment do
-      scope = Recent.all.preload(:classification)
+      scope = Recent.where(project_id: nil, user_id: nil, workflow_id: nil)
+      scope = scope.preload(:classification)
       total = scope.count
       scope.find_each.with_index do |recent, i|
         puts "#{i+1} of #{total}"

--- a/spec/models/recent_spec.rb
+++ b/spec/models/recent_spec.rb
@@ -1,20 +1,54 @@
 require 'spec_helper'
 
 RSpec.describe Recent, :type => :model do
-  it 'should not be valid without a classification' do
-    expect(build(:recent, classification: nil)).to_not be_valid
-  end
+  describe "association validations" do
+    let(:classification) { create(:classification) }
+    let(:recent) { build(:recent, classification: classification) }
 
-  it 'should not be valid without a subject' do
-    expect(build(:recent, subject: nil)).to_not be_valid
+    it 'should not be valid without a classification' do
+      expect(build(:recent, classification: nil)).to_not be_valid
+    end
+
+    it 'should not be valid without a subject' do
+      recent.subject = nil
+      expect(recent).to_not be_valid
+    end
+
+    it 'should not be valid without a user_id' do
+      allow(classification).to receive(:user_id).and_return(nil)
+      recent.user_id = nil
+      expect(recent).to_not be_valid
+    end
+
+    it 'should not be valid without a project_id' do
+      allow(classification).to receive(:project_id).and_return(nil)
+      recent.project_id = nil
+      expect(recent).to_not be_valid
+    end
+
+    it 'should not be valid without a workflow_id' do
+      allow(classification).to receive(:workflow_id).and_return(nil)
+      recent.workflow_id = nil
+      expect(recent).to_not be_valid
+    end
+
+    it 'should be valid without a user_group_id' do
+      allow(classification).to receive(:user_group_id).and_return(nil)
+      recent.user_group_id = nil
+      expect(recent).to be_valid
+    end
   end
 
   describe "::create_from_classification" do
+    let(:classification) { create(:classification) }
+
     it 'should create recent for each subject' do
-      classification = create(:classification)
       subjects = classification.subject_ids
-      Recent.create_from_classification(classification)
-      expect(Recent.where(subject_id: subjects).count).to eq(subjects.length)
+      expect {
+        Recent.create_from_classification(classification)
+      }.to change {
+        Recent.where(subject_id: subjects).count
+      }.by (subjects.length)
     end
   end
 end


### PR DESCRIPTION
move the has_one :through :classifications associations to belongs_to relations with indexes. Adds the belongs_to fkeys to recent schema and provides a rake task to backfill the missing information.

Once this is done we can remove the Recent has_one associations and modify the costly / complex recents query [here](https://github.com/zooniverse/Panoptes/blob/586f239d16a00fd75ef22df8498952e778684072/app/controllers/concerns/recents.rb#L9) to just use local indexes without the joins. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
