### PR TITLE
Remove recents has associations and optimize recent scope

### DIFF
--- a/app/controllers/concerns/recents.rb
+++ b/app/controllers/concerns/recents.rb
@@ -6,14 +6,9 @@ module Recents
   end
 
   def recent_scope
-    Recent.eager_load(:classification, :subject, :locations, :workflow, :project)
-      .where(classifications: classification_query)
-  end
-
-  def classification_query
-    query = { :"#{resource_name}_id" => resource_ids }
-    query['project_id'] = params[:project_id] if params.has_key?(:project_id)
-    query['workflow_id'] = params[:workflow_id] if params.has_key?(:workflow_id)
-    query
+    scope = Recent.where(:"#{resource_name}_id" => resource_ids)
+    scope = scope.where(project_id: params[:project_id]) if params.key?(:project_id)
+    scope = scope.where(workflow_id: params[:workflow_id]) if params.key?(:workflow_id)
+    scope
   end
 end

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -4,11 +4,6 @@ class Recent < ActiveRecord::Base
 
   has_many :locations, through: :subject
 
-  has_one :project, through: :classification
-  has_one :workflow, through: :classification
-  has_one :user, through: :classification
-  has_one :user_group, through: :classification
-
   belongs_to :project
   belongs_to :workflow
   belongs_to :user

--- a/db/migrate/20170118141452_add_recents_foreign_keys.rb
+++ b/db/migrate/20170118141452_add_recents_foreign_keys.rb
@@ -1,13 +1,6 @@
 class AddRecentsForeignKeys < ActiveRecord::Migration
 
   def change
-    # remove all recents that have no traceable user in the classification
-    # should have picked these up in the rake task to backfill :(
-    Recent.where(user_id: nil)
-      .joins(:classification)
-      .where(classifications: { user_id: nil})
-      .delete_all
-
     add_foreign_key :recents, :projects
     add_foreign_key :recents, :workflows
     add_foreign_key :recents, :users

--- a/db/migrate/20170118141452_add_recents_foreign_keys.rb
+++ b/db/migrate/20170118141452_add_recents_foreign_keys.rb
@@ -1,0 +1,15 @@
+class AddRecentsForeignKeys < ActiveRecord::Migration
+
+  def change
+    # remove all recents that have no traceable user in the classification
+    # should have picked these up in the rake task to backfill :(
+    Recent.where(user_id: nil)
+      .joins(:classification)
+      .where(classifications: { user_id: nil})
+      .delete_all
+
+    add_foreign_key :recents, :projects
+    add_foreign_key :recents, :workflows
+    add_foreign_key :recents, :users
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -58,7 +58,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE access_control_lists (
@@ -408,7 +408,7 @@ ALTER SEQUENCE flipper_gates_id_seq OWNED BY flipper_gates.id;
 
 
 --
--- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE media (
@@ -1483,7 +1483,8 @@ CREATE TABLE workflows (
     activity integer DEFAULT 0 NOT NULL,
     current_version_number character varying,
     activated_state integer DEFAULT 0 NOT NULL,
-    subject_selection_strategy integer DEFAULT 0
+    subject_selection_strategy integer DEFAULT 0,
+    nero_config jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -2393,28 +2394,28 @@ CREATE INDEX index_organizations_on_activated_state ON organizations USING btree
 
 
 --
--- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_display_name ON organizations USING btree (display_name);
 
 
 --
--- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_listed_at ON organizations USING btree (listed_at);
 
 
 --
--- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
 
 
 --
--- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_contents_on_project_id ON project_contents USING btree (project_id);
@@ -2547,35 +2548,35 @@ CREATE INDEX index_recents_on_classification_id ON recents USING btree (classifi
 
 
 --
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
-tru-
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
 
 CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
 
 
 --
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
 
 
 --
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
--- Name: index_set_member_subjects_on_priority; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_priority; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_priority ON set_member_subjects USING btree (priority);
@@ -3771,3 +3772,4 @@ INSERT INTO schema_migrations (version) VALUES ('20170202200131');
 INSERT INTO schema_migrations (version) VALUES ('20170202202724');
 
 INSERT INTO schema_migrations (version) VALUES ('20170206161946');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -58,7 +58,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE access_control_lists (
@@ -408,7 +408,7 @@ ALTER SEQUENCE flipper_gates_id_seq OWNED BY flipper_gates.id;
 
 
 --
--- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE media (
@@ -1483,8 +1483,7 @@ CREATE TABLE workflows (
     activity integer DEFAULT 0 NOT NULL,
     current_version_number character varying,
     activated_state integer DEFAULT 0 NOT NULL,
-    subject_selection_strategy integer DEFAULT 0,
-    nero_config jsonb DEFAULT '{}'::jsonb
+    subject_selection_strategy integer DEFAULT 0
 );
 
 
@@ -2394,28 +2393,28 @@ CREATE INDEX index_organizations_on_activated_state ON organizations USING btree
 
 
 --
--- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_organizations_on_display_name ON organizations USING btree (display_name);
 
 
 --
--- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_organizations_on_listed_at ON organizations USING btree (listed_at);
 
 
 --
--- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
 
 
 --
--- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_project_contents_on_project_id ON project_contents USING btree (project_id);
@@ -2548,35 +2547,35 @@ CREATE INDEX index_recents_on_classification_id ON recents USING btree (classifi
 
 
 --
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+tru-
 
 CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
 
 
 --
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
 
 
 --
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
--- Name: index_set_member_subjects_on_priority; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_set_member_subjects_on_priority; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_set_member_subjects_on_priority ON set_member_subjects USING btree (priority);
@@ -3156,11 +3155,27 @@ ALTER TABLE ONLY user_collection_preferences
 
 
 --
+-- Name: fk_rails_6c609bbfd1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY recents
+    ADD CONSTRAINT fk_rails_6c609bbfd1 FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+--
 -- Name: fk_rails_732cb83ab7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_access_tokens
     ADD CONSTRAINT fk_rails_732cb83ab7 FOREIGN KEY (application_id) REFERENCES oauth_applications(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_7504acfc82; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY recents
+    ADD CONSTRAINT fk_rails_7504acfc82 FOREIGN KEY (workflow_id) REFERENCES workflows(id);
 
 
 --
@@ -3241,6 +3256,14 @@ ALTER TABLE ONLY memberships
 
 ALTER TABLE ONLY field_guides
     ADD CONSTRAINT fk_rails_a1b35288b8 FOREIGN KEY (project_id) REFERENCES projects(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_ae363bfedc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY recents
+    ADD CONSTRAINT fk_rails_ae363bfedc FOREIGN KEY (project_id) REFERENCES projects(id);
 
 
 --
@@ -3741,9 +3764,10 @@ INSERT INTO schema_migrations (version) VALUES ('20170113113532');
 
 INSERT INTO schema_migrations (version) VALUES ('20170116134142');
 
+INSERT INTO schema_migrations (version) VALUES ('20170118141452');
+
 INSERT INTO schema_migrations (version) VALUES ('20170202200131');
 
 INSERT INTO schema_migrations (version) VALUES ('20170202202724');
 
 INSERT INTO schema_migrations (version) VALUES ('20170206161946');
-

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -109,7 +109,10 @@ namespace :migrate do
 
     desc "Backfill belongs_to relations from classifications"
     task backfill_belongs_to_relations: :environment do
-      scope = Recent.preload(:classification, :subject)
+      scope = Recent.where(user_id: nil)
+        .includes(:classification)
+        .where.not(classifications: { user_id: nil })
+        .preload(:subject)
       total = scope.count
       scope.find_each.with_index do |recent, i|
         # some recents are for non-logged in classifications

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -107,6 +107,19 @@ namespace :migrate do
       end
     end
 
+    desc "Remove all recents that have no traceable user in the classification"
+    task remove_no_user_recents: :environment do
+      no_user_recents = Recent.where(user_id: nil)
+        .joins(:classification)
+        .where(classifications: { user_id: nil })
+        .select(:id)
+
+      no_user_recents.find_in_batches.with_index do |batch, batch_index|
+        puts "Processing relation ##{batch_index}"
+        Recent.where(id: batch.map(&:id)).delete_all
+      end
+    end
+
     desc "Backfill belongs_to relations from classifications"
     task backfill_belongs_to_relations: :environment do
       scope = Recent.where(user_id: nil)

--- a/spec/support/recents.rb
+++ b/spec/support/recents.rb
@@ -11,12 +11,6 @@ RSpec.shared_examples "has recents" do
     default_request(scopes: scopes, user_id: authorized_user.id)
   end
 
-  it "should call the correct eager_loads join queries" do
-    eager_loads = %i(classification subject locations workflow project)
-    expect(Recent).to receive(:eager_load).with(*eager_loads).and_call_original
-    get :recents, { resource_key_id => resource.id }
-  end
-
   context "with the controller action run" do
     before do
       get :recents, filter_params.merge(resource_key_id => resource.id)


### PR DESCRIPTION
~~**DO NOT MERGE** until after the #2126 is deployed and backfilled. this will need a rebase and test to ensure the new recent_scope works as expected.~~

Rake task to cleanup invalid recents and a refactor of the recent's lookup scopes to use indexed cols and not joins on the classification table. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
