### PR TITLE
Cache uploaded subjects count

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -20,6 +20,10 @@ class Api::V1::SubjectsController < Api::ApiController
     end
   end
 
+  def create
+    super { |subject| subject.uploader.increment_subjects_count_cache }
+  end
+
   def destroy
     super { |subject| SubjectRemovalWorker.perform_async(subject.id) }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -316,6 +316,18 @@ class User < ActiveRecord::Base
   end
 
   def uploaded_subjects_count
-    Subject.where(upload_user_id: self.id).count
+    Rails.cache.fetch(subjects_count_cache_key) do
+      Subject.where(upload_user_id: id).count
+    end
+  end
+
+  def increment_subjects_count_cache
+    Rails.cache.increment(subjects_count_cache_key)
+  end
+
+  private
+
+  def subjects_count_cache_key
+    @subjects_count_cache_key ||= "User/#{id}/uploaded_subjects_count"
   end
 end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -364,6 +364,12 @@ describe Api::V1::SubjectsController, type: :controller do
       }
     end
 
+    it "should incremement the user's subjects_count cache" do
+      expect_any_instance_of(User).to receive(:increment_subjects_count_cache)
+      default_request user_id: authorized_user.id, scopes: scopes
+      post :create, create_params
+    end
+
     it "should return locations in the order they were submitted" do
       default_request user_id: authorized_user.id, scopes: scopes
       post :create, create_params

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -694,6 +694,19 @@ describe User, type: :model do
     end
   end
 
+  describe "#increment_subjects_count_cache", :with_cache_store, :focus do
+    it 'should return nil if no cache entry' do
+      uploader = create(:user_with_uploaded_subjects)
+      expect(uploader.increment_subjects_count_cache).to eq(nil)
+    end
+
+    it 'should inc the cache entry value if exists' do
+      uploader = create(:user_with_uploaded_subjects)
+      count = uploader.uploaded_subjects_count
+      expect(uploader.increment_subjects_count_cache).to eq(count+1)
+    end
+  end
+
   describe "#update_ouroboros_created" do
     let(:user) do
       build(:ouroboros_created_user, login: "NOT ALLOWED")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -694,7 +694,7 @@ describe User, type: :model do
     end
   end
 
-  describe "#increment_subjects_count_cache", :with_cache_store, :focus do
+  describe "#increment_subjects_count_cache", :with_cache_store do
     it 'should return nil if no cache entry' do
       uploader = create(:user_with_uploaded_subjects)
       expect(uploader.increment_subjects_count_cache).to eq(nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,11 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:example, with_cache_store: true) do
+    cache_store = ActiveSupport::Cache::MemoryStore.new(size: 2.megabytes)
+    allow(Rails).to receive(:cache).and_return(cache_store)
+  end
+
   config.before(:each, type: :controller) do
     stub_cellect_connection
   end


### PR DESCRIPTION
closes #2129 - avoid recounting the subjects_count where we can, instead cache the value and increment it on each successful subject create event.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
