### PR TITLE
Cache using_cellect? workflow call

### DIFF
--- a/app/controllers/cellect_controller.rb
+++ b/app/controllers/cellect_controller.rb
@@ -2,6 +2,9 @@ class CellectController < ApplicationController
   before_filter :html_to_json_override
 
   EXPIRY = 10.minutes.freeze
+  SELECT_COLS = %i(
+    id subject_selection_strategy pairwise prioritized grouped updated_at
+  ).freeze
 
   def workflows
     respond_to do |format|
@@ -28,7 +31,7 @@ class CellectController < ApplicationController
       .joins(:project)
       .where("projects.launch_approved IS TRUE")
       .order(:id)
-      .select(:id, :subject_selection_strategy, :pairwise, :prioritized, :grouped)
+      .select(SELECT_COLS)
   end
 
   def workflows_using_cellect

--- a/app/models/concerns/model_cache_key.rb
+++ b/app/models/concerns/model_cache_key.rb
@@ -1,5 +1,5 @@
 module ModelCacheKey
   def model_cache_key(method_name)
-    "#{self.class.to_s}/#{id.to_i}/#{updated_at.to_i}/#{method_name}"
+    "#{self.class}/#{id.to_i}/#{updated_at.to_i}/#{method_name}"
   end
 end

--- a/app/models/concerns/model_cache_key.rb
+++ b/app/models/concerns/model_cache_key.rb
@@ -1,0 +1,5 @@
+module ModelCacheKey
+  def model_cache_key(method_name)
+    "#{self.class.to_s}/#{id.to_i}/#{updated_at.to_i}/#{method_name}"
+  end
+end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -6,6 +6,7 @@ class Workflow < ActiveRecord::Base
   include ExtendedCacheKey
   include RankedModel
   include CacheModelVersion
+  include ModelCacheKey
 
   has_paper_trail only: [:tasks, :grouped, :pairwise, :prioritized]
 
@@ -92,7 +93,9 @@ class Workflow < ActiveRecord::Base
   end
 
   def using_cellect?
-    subject_selection_strategy.to_s == "cellect" || cellect_size_subject_space?
+    Rails.cache.fetch(model_cache_key(:using_cellect?), expires_in: 1.hour) do
+      subject_selection_strategy.to_s == "cellect" || cellect_size_subject_space?
+    end
   end
 
   def subjects_count
@@ -119,5 +122,4 @@ class Workflow < ActiveRecord::Base
         retired_subjects_count >= subjects_count
       end
   end
-
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -7,10 +7,6 @@ class Workflow < ActiveRecord::Base
   include RankedModel
   include CacheModelVersion
 
-  def self.columns
-    super.reject { |c| c.name == "use_cellect" }
-  end
-
   has_paper_trail only: [:tasks, :grouped, :pairwise, :prioritized]
 
   belongs_to :project

--- a/db/migrate/20170116134142_workflow_drop_use_cellect.rb
+++ b/db/migrate/20170116134142_workflow_drop_use_cellect.rb
@@ -1,0 +1,5 @@
+class WorkflowDropUseCellect < ActiveRecord::Migration
+  def change
+    remove_column :workflows, :use_cellect
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1484,7 +1484,6 @@ CREATE TABLE workflows (
     activity integer DEFAULT 0 NOT NULL,
     current_version_number character varying,
     activated_state integer DEFAULT 0 NOT NULL,
-    use_cellect boolean DEFAULT false NOT NULL,
     subject_selection_strategy integer DEFAULT 0
 );
 
@@ -2535,31 +2534,10 @@ CREATE INDEX index_recents_on_classification_id ON recents USING btree (classifi
 
 
 --
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
-
-
---
 -- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
-
-
---
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
-
-
---
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
@@ -2952,13 +2930,6 @@ CREATE INDEX index_workflows_on_public_gold_standard ON workflows USING btree (p
 --
 
 CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tutorial_subject_id);
-
-
---
--- Name: index_workflows_on_use_cellect; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_workflows_on_use_cellect ON workflows USING btree (use_cellect);
 
 
 --
@@ -3732,4 +3703,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161221203241');
 INSERT INTO schema_migrations (version) VALUES ('20170112163747');
 
 INSERT INTO schema_migrations (version) VALUES ('20170113113532');
+
+INSERT INTO schema_migrations (version) VALUES ('20170116134142');
 


### PR DESCRIPTION
Avoid checking the subjects counts all the time, cache this value, expire every hour. 

Ideally it would be nice to cache the subjects_count method too but i'm not sure how to invalidate the cache on a new upload to a linked subject_set. Thoughts?

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
