### PR TITLE
handle redis timeout errors on classification lifecycle

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   def lifecycle(action, classification)
     ClassificationLifecycle.queue(classification, action)
-  rescue Redis::CannotConnectError => e
+  rescue Redis::CannotConnectError, Redis::TimeoutError => e
     Honeybadger.notify(e)
   end
 

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -338,13 +338,15 @@ describe Api::V1::ClassificationsController, type: :controller do
     end
 
     context "when redis is unavailable" do
-      it 'should not raise an error but still report it' do
-        stub_content_filter
-        allow(ClassificationLifecycle).to receive(:queue).and_raise(Redis::CannotConnectError)
-        expect(Honeybadger).to receive(:notify)
-        expect do
-          setup_create_request
-        end.not_to raise_error
+      [Redis::CannotConnectError, Redis::TimeoutError].each do |redis_error|
+        it 'should not raise an error but still report it' do
+          stub_content_filter
+          allow(ClassificationLifecycle).to receive(:queue).and_raise(redis_error)
+          expect(Honeybadger).to receive(:notify)
+          expect do
+            setup_create_request
+          end.not_to raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
don't 500, catch this, report and return 201 so we don't get a duplicate submission

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
