### PR TITLE
track the first workflow finished_at event

### DIFF
--- a/app/workers/workflow_retired_count_worker.rb
+++ b/app/workers/workflow_retired_count_worker.rb
@@ -19,7 +19,7 @@ class WorkflowRetiredCountWorker
       counter.retired_subjects
     )
 
-    if workflow.finished?
+    if workflow.finished_at.nil? && workflow.finished?
       Workflow.where(id: workflow.id).update_all(finished_at: Time.now)
     end
   end


### PR DESCRIPTION
and not when each subsequent time the count worker fires

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
