### PR TITLE
only preload the has_ associations

### DIFF
--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -8,7 +8,7 @@ class WorkflowSerializer
   include CachedSerializer
 
   # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
-  PRELOADS = %i(project subject_sets tutorial_subject attached_images).freeze
+  PRELOADS = %i(subject_sets attached_images).freeze
 
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
              :created_at, :updated_at, :finished_at, :first_task, :primary_language,


### PR DESCRIPTION
Cut down on the number of preload requests, only preload has_* associations used in the serializer and not belongs_to relations as they are not needed by default (only when included by query params)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
