### PR TITLE
don't fail to check the upload limits when uploading subjects

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -316,9 +316,10 @@ class User < ActiveRecord::Base
   end
 
   def uploaded_subjects_count
-    Rails.cache.fetch(subjects_count_cache_key) do
+    count = Rails.cache.fetch(subjects_count_cache_key) do
       Subject.where(upload_user_id: id).count
     end
+    count.to_i
   end
 
   def increment_subjects_count_cache

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -688,9 +688,18 @@ describe User, type: :model do
   end
 
   describe "#uploaded_subjects_count" do
+    let(:uploader) { create(:user_with_uploaded_subjects) }
+
     it 'should have a count of the subjects a user has uploaded' do
-      uploader = create(:user_with_uploaded_subjects)
       expect(uploader.uploaded_subjects_count).to eq(2)
+    end
+
+    it "should ensure the it casts invalid values" do
+      ["", nil].each do |cast_val|
+        cache_store = Rails.cache
+        allow(cache_store).to receive(:fetch).and_return(cast_val)
+        expect(uploader.uploaded_subjects_count).to eq(0)
+      end
     end
   end
 


### PR DESCRIPTION
Related to https://app.honeybadger.io/projects/40595/faults/32346385#notice-summary

I can't figure out why the fetch / yield is returning "" / nil values. Let's just cast this to an int to avoid 500'ing on this route right now. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
