### PR TITLE
Adds a new ActiveInteraction filter for Organizations

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -7,7 +7,6 @@ class Api::V1::OrganizationsController < Api::ApiController
   require_authentication :update, :create, :destroy, scopes: [:organization]
 
   resource_actions :show, :index, :create, :update, :deactivate
-  schema_type :json_schema
 
   prepend_before_action :require_login,
     only: [:create, :update, :destroy]
@@ -34,7 +33,8 @@ class Api::V1::OrganizationsController < Api::ApiController
   def update
     Organization.transaction do
       Array.wrap(resource_ids).zip(Array.wrap(params[:organizations])).map do |organization_id, organization_params|
-        Organizations::Update.with(api_user: api_user, id: organization_id).run!(organization_params)
+        wrapper = { organization_params: organization_params }
+        Organizations::Update.with(api_user: api_user, id: organization_id).run!(wrapper)
       end
     end
 

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -10,7 +10,7 @@ module Organizations
     string :title
     string :description
     string :introduction, default: ''
-    array :urls
+    array :urls, default: ''
 
     def execute
       Organization.transaction do

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -10,7 +10,7 @@ module Organizations
     string :title
     string :description
     string :introduction, default: ''
-    array :urls, default: ''
+    array :urls, default: []
 
     def execute
       Organization.transaction do

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -1,26 +1,26 @@
 module Organizations
   class Update < Operation
     include UrlLabels
+    require_relative '../../../lib/filters/organization_filter.rb'
 
-    integer :id
-    string :name
-    string :display_name
-    string :primary_language
-
-    # Organization Contents Fields
-    string :title
-    string :description
-    string :introduction, default: ''
-    array :urls
+    organization :organization_params
+    string :id
 
     def execute
       Organization.transaction do
         organization = Organization.find(id)
-        organization.update!(name: name, display_name: display_name, primary_language: primary_language)
-        organization.organization_contents.find_or_initialize_by(language: primary_language) do |content|
-          param_hash = { title: title, description: description, introduction: introduction }
-          param_hash.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
-          content.update! param_hash
+        content_update = {}
+        org_update = organization_params.dup
+        Api::V1::OrganizationsController::CONTENT_FIELDS.each do |field|
+          if organization_params[field]
+            content_update[field] = organization_params[field] if organization_params[field]
+            org_update.delete(field)
+          end
+        end
+        organization.update!(org_update.symbolize_keys)
+        organization.organization_contents.find_or_initialize_by(language: organization_params[:primary_language]) do |content|
+          content_update.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
+          content.update! content_update.symbolize_keys
         end
         organization.save!
       end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -8,7 +8,6 @@ module Organizations
 
     def execute
       Organization.transaction do
-        organization = Organization.find(id)
         content_update = {}
         org_update = organization_params.dup
         Api::V1::OrganizationsController::CONTENT_FIELDS.each do |field|
@@ -18,12 +17,22 @@ module Organizations
           end
         end
         organization.update!(org_update.symbolize_keys)
-        organization.organization_contents.find_or_initialize_by(language: organization_params[:primary_language]) do |content|
+        organization.organization_contents.find_or_initialize_by(language: language) do |content|
           content_update.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
           content.update! content_update.symbolize_keys
         end
         organization.save!
       end
+    end
+
+    private
+
+    def organization
+      @organization ||= Organization.find(id)
+    end
+
+    def language
+      @language ||= organization_params[:primary_language] ? organization_params[:primary_language] : @organization.primary_language
     end
   end
 end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -1,7 +1,8 @@
+require_relative '../../../lib/filters/organization_filter.rb'
+
 module Organizations
   class Update < Operation
     include UrlLabels
-    require_relative '../../../lib/filters/organization_filter.rb'
 
     organization :organization_params
     string :id

--- a/app/schemas/organization_update_schema.rb
+++ b/app/schemas/organization_update_schema.rb
@@ -1,0 +1,64 @@
+class OrganizationUpdateSchema < JsonSchema
+  schema do
+    type "object"
+    description "An Organization"
+    additional_properties false
+
+    property "display_name" do
+      type "string"
+      description "Human readable name for a project ie Galaxy Zoo"
+    end
+
+    property "name" do
+      type "string"
+      description "URL string for a project downcased and underscored ie galaxy_zoo"
+    end
+
+    property "primary_language" do
+      type "string"
+      description "Two character ISO 639 language code, optionally include two character ISO 3166-1 alpha-2 country code seperated by a hyphen for specific locale. ie 'en', 'zh-tw', 'es_MX'"
+    end
+
+    property "title" do
+      type "string"
+      description "Translatable name for the project"
+    end
+
+    property "description" do
+      type "string"
+    end
+
+    property "introduction" do
+       type "string"
+    end
+
+    property "listed_at" do
+       type "string"
+    end
+
+    property "urls" do
+      type "array"
+      items do
+        type "object"
+        required "label", "url"
+        property "label" do
+          type "string"
+        end
+
+        property "url" do
+          type "url"
+        end
+      end
+    end
+
+    property "links" do
+      type "object"
+      additional_properties false
+
+      property "project" do
+        type "string", "integer"
+        pattern "^[0-9]*$"
+      end
+    end
+  end
+end

--- a/lib/filters/organization_filter.rb
+++ b/lib/filters/organization_filter.rb
@@ -13,7 +13,7 @@ module ActiveInteraction
     end
 
     def valid?(value)
-      OrganizationUpdateSchema.new.validate!(value) == nil
+      OrganizationUpdateSchema.new.validate!(value).nil?
     end
   end
 end

--- a/lib/filters/organization_filter.rb
+++ b/lib/filters/organization_filter.rb
@@ -4,7 +4,7 @@ module ActiveInteraction
 
     def cast(value, context)
       schema = OrganizationUpdateSchema.schema[:properties]
-      included_keys = value.keys.map {|z| z.to_sym}
+      included_keys = value.keys.map(&:to_sym)
       if included_keys.all? {|s| schema.key? s } && valid?(value)
         value
       else

--- a/lib/filters/organization_filter.rb
+++ b/lib/filters/organization_filter.rb
@@ -13,7 +13,7 @@ module ActiveInteraction
     end
 
     def valid?(value)
-      JSON::Validator.validate(OrganizationUpdateSchema.schema, value)
+      OrganizationUpdateSchema.new.validate!(value) == nil
     end
   end
 end

--- a/lib/filters/organization_filter.rb
+++ b/lib/filters/organization_filter.rb
@@ -1,0 +1,19 @@
+module ActiveInteraction
+  class OrganizationFilter < Filter
+    register :organization
+
+    def cast(value, context)
+      schema = OrganizationUpdateSchema.schema[:properties]
+      included_keys = value.keys.map {|z| z.to_sym}
+      if included_keys.all? {|s| schema.key? s } && valid?(value)
+        value
+      else
+        raise InvalidValueError, "#{name}: #{describe(value)}"
+      end
+    end
+
+    def valid?(value)
+      JSON::Validator.validate(OrganizationUpdateSchema.schema, value)
+    end
+  end
+end

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -124,6 +124,26 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:test_attr) { :display_name }
         let(:test_attr_value) { "Def Not Illuminati" }
       end
+
+      context "includes incomplete parameters" do
+        let(:incomplete_params) do
+          {
+            organizations: {
+              name: "Just a name",
+              display_name: "Just a name"
+            }
+          }
+        end
+
+        it "succesfully updates included attributes and returns resource", :aggregate_failures do
+          default_request scopes: scopes, user_id: authorized_user.id
+          organization.save!
+          params = incomplete_params.merge(id: organization.id)
+          put :update, params
+          expect(response).to have_http_status(:ok)
+          expect(json_response["organizations"].length).to eq(1)
+        end
+      end
     end
 
     describe "#destroy" do

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -125,7 +125,7 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:test_attr_value) { "Def Not Illuminati" }
       end
 
-      context "includes incomplete parameters" do
+      context "includes exceptional parameters" do
         let(:incomplete_params) do
           {
             organizations: {
@@ -135,13 +135,29 @@ describe Api::V1::OrganizationsController, type: :controller do
           }
         end
 
-        it "succesfully updates included attributes and returns resource", :aggregate_failures do
+        before do
           default_request scopes: scopes, user_id: authorized_user.id
           organization.save!
-          params = incomplete_params.merge(id: organization.id)
-          put :update, params
+        end
+
+        after do
           expect(response).to have_http_status(:ok)
           expect(json_response["organizations"].length).to eq(1)
+        end
+
+        it "successfully updates with incomplete params", :aggregate_failures do
+          params = incomplete_params.merge(id: organization.id)
+          put :update, params
+        end
+
+        it "successfully updates with nested params", :aggregate_failures do
+          params = incomplete_params.merge(id: organization.id)
+          params[:organizations][:urls] = [
+            {label: "Blog", url: "http://blogo.com/example"},
+            {label: "Slog", url: "http://whattasite.net"},
+            {label: "Krog", url: "http://potatosalad.yum"}
+          ]
+          put :update, params
         end
       end
     end

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -111,7 +111,6 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:update_params) do
           {
             organizations: {
-              id: resource.id,
               primary_language: "tw",
               name: "A Different Name",
               display_name: "Def Not Illuminati",

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -633,8 +633,8 @@ describe Api::V1::ProjectsController, type: :controller do
           tags: ["astro", "gastro"],
           researcher_quote: "this is such a great project",
           links: {
-            workflows: [workflow.id.to_s],
-            subject_sets: [subject_set.id.to_s]
+            workflows: ["1"],
+            subject_sets: ["1"]
           }
         }
       }

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -633,8 +633,8 @@ describe Api::V1::ProjectsController, type: :controller do
           tags: ["astro", "gastro"],
           researcher_quote: "this is such a great project",
           links: {
-            workflows: ["1"],
-            subject_sets: ["1"]
+            workflows: [workflow.id.to_s],
+            subject_sets: [subject_set.id.to_s]
           }
         }
       }


### PR DESCRIPTION
Updates to organizations were failing due to missing parameters. ActiveInteraction doesn't have an "optional" flag for filters, so when the JS client only sends the changed attributes, AI validation would fail. So instead, now there's an `organization_params` filter (alongside `string`, `integer`, etc) that does it's own validation against the standard format JSON schema. 

Few things:
* Not sure why the `require_relative` is...required. Seems like it should just be loaded automatically since it's in /lib.
* Most of what's in the filter could easily be abstracted out for all Org ops or even as a generic adapter for JSONSchema-->ActiveInteraction. Don't really need that now, though.
* Opted to put the filter into `lib/filters` instead of `lib/gem_ext/active_interaction` since I'm not overriding anything.
* I found a closed (#wontfix) issue relating to this which basically said that the suggested fix was to set a nil or blank default for all your optional params, then sort through and remove the ones that aren't `given?()` from the inputs. I couldn't get this to work, though, as the request would 422 before the op's execute block was run.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
