### PR TITLE
try and handle redis connection errors on critical API paths

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   def lifecycle(action, classification)
     ClassificationLifecycle.queue(classification, action)
-  rescue Redis::CannotConnectError, Redis::TimeoutError => e
+  rescue Redis::CannotConnectError, Redis::TimeoutError, Timeout::Error => e
     Honeybadger.notify(e)
   end
 

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -25,7 +25,13 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def destroy
-    super { |subject| SubjectRemovalWorker.perform_async(subject.id) }
+    super do |subject|
+      begin
+        SubjectRemovalWorker.perform_async(subject.id)
+      rescue Timeout::Error => e
+        Honeybadger.notify(e)
+      end
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -293,6 +293,8 @@ class User < ActiveRecord::Base
 
   def send_welcome_email
     UserWelcomeMailerWorker.perform_async(id, project_id)
+  rescue Timeout::Error => e
+    Honeybadger.notify(e)
   end
 
   def set_ouroboros_api_key

--- a/lib/subjects/cellect_client.rb
+++ b/lib/subjects/cellect_client.rb
@@ -81,7 +81,10 @@ module Subjects
         super(action, params) do
           params[:host] = @session.reset_host
         end
-      rescue Redis::CannotConnectError, Subjects::CellectSession::NoHostError, Timeout::Error
+      rescue Redis::CannotConnectError,
+             Subjects::CellectSession::NoHostError,
+             Timeout::Error,
+             Redis::TimeoutError
         raise ConnectionError, "Cellect can't find a server host"
       end
     end

--- a/lib/subjects/cellect_client.rb
+++ b/lib/subjects/cellect_client.rb
@@ -81,7 +81,7 @@ module Subjects
         super(action, params) do
           params[:host] = @session.reset_host
         end
-      rescue Redis::CannotConnectError, Subjects::CellectSession::NoHostError
+      rescue Redis::CannotConnectError, Subjects::CellectSession::NoHostError, Timeout::Error
         raise ConnectionError, "Cellect can't find a server host"
       end
     end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -338,7 +338,7 @@ describe Api::V1::ClassificationsController, type: :controller do
     end
 
     context "when redis is unavailable" do
-      [Redis::CannotConnectError, Redis::TimeoutError].each do |redis_error|
+      [Redis::CannotConnectError, Redis::TimeoutError, Timeout::Error].each do |redis_error|
         it 'should not raise an error but still report it' do
           stub_content_filter
           allow(ClassificationLifecycle).to receive(:queue).and_raise(redis_error)

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -494,6 +494,13 @@ describe Api::V1::SubjectsController, type: :controller do
       expect(SubjectRemovalWorker).to receive(:perform_async).with(resource.id)
       delete :destroy, id: resource.id
     end
+
+    it "should handle redis timeout error" do
+      stub_token(scopes: scopes, user_id: authorized_user.id)
+      set_preconditions
+      expect(SubjectRemovalWorker).to receive(:perform_async).and_raise(Timeout::Error)
+      delete :destroy, id: resource.id
+    end
   end
 
   describe "versioning" do

--- a/spec/lib/subjects/cellect_client_spec.rb
+++ b/spec/lib/subjects/cellect_client_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Subjects::CellectClient do
 
     #applies to all RequestToHost methods
     context "when cellect session cant choose a host due to redis error" do
-      [Redis::CannotConnectError, Timeout::Error].each do |error|
+      [Redis::CannotConnectError, Timeout::Error, Redis::TimeoutError].each do |error|
         it 'should raise a connection error' do
           allow_any_instance_of(Subjects::CellectSession)
             .to receive(:host)

--- a/spec/lib/subjects/cellect_client_spec.rb
+++ b/spec/lib/subjects/cellect_client_spec.rb
@@ -126,16 +126,18 @@ RSpec.describe Subjects::CellectClient do
 
     #applies to all RequestToHost methods
     context "when cellect session cant choose a host due to redis error" do
-      it 'should raise a connection error' do
-        allow_any_instance_of(Subjects::CellectSession)
-          .to receive(:host)
-          .and_raise(Redis::CannotConnectError)
-        expect do
-          Subjects::CellectClient.get_subjects(1, 2, nil, 4)
-        end.to raise_error(
-          Subjects::CellectClient::ConnectionError,
-         "Cellect can't find a server host"
-        )
+      [Redis::CannotConnectError, Timeout::Error].each do |error|
+        it 'should raise a connection error' do
+          allow_any_instance_of(Subjects::CellectSession)
+            .to receive(:host)
+            .and_raise(error)
+          expect do
+            Subjects::CellectClient.get_subjects(1, 2, nil, 4)
+          end.to raise_error(
+            Subjects::CellectClient::ConnectionError,
+           "Cellect can't find a server host"
+          )
+        end
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -839,6 +839,12 @@ describe User, type: :model do
       expect(UserWelcomeMailerWorker).to have_received(:perform_async).with(user.id, nil).ordered
     end
 
+    it "should handle redis being down" do
+      allow(UserWelcomeMailerWorker).to receive(:perform_async).and_raise(Timeout::Error)
+      user.save!
+      expect(UserWelcomeMailerWorker).to have_received(:perform_async).with(user.id, nil).ordered
+    end
+
     context "when the user has a project id" do
       let(:project) { create :project }
       let!(:user) { build(:user, project_id: project.id) }


### PR DESCRIPTION
Don't 500 when submitting classifications, selecting subjects, registering users or deleting subjects. Instead just move on and fallback to default behaviour. Ideally this could be improved on by adding a refinement to sidekiq `peform_async` method that rescues all these errors and notifies honeybadger but i didn't do that :( 

Happy to rework this / have it added to by others.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
