### PR TITLE
avoid count queries on classifications end point that timeout / stress the db

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -417,8 +417,11 @@ A User may delete an incomplete classification.
 ## Classification Collection [/classifications{?page,page_size,sort,project_id,user_group_id,include,for}]
 A representation of all the Classifications in a collection
 
-All collections add a *meta* attribute hash containing
-paging information.
+All collections add a *meta* attribute hash containing paging information.
+
+Please note that due to the cost of the page count queries on the
+classifications table we are not returning the page counts for
+this end point, please use the previous and next hrefs to page into the data.
 
 Classifications are returned as an array under the _classifications_
 key.

--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -1,5 +1,7 @@
 class ClassificationSerializer
   include RestPack::Serializer
+  include NoCountSerializer
+
   attributes :id, :annotations, :created_at, :metadata, :href
   can_include :project, :user, :user_group, :workflow
 

--- a/app/serializers/concerns/no_count_serializer.rb
+++ b/app/serializers/concerns/no_count_serializer.rb
@@ -1,0 +1,27 @@
+module NoCountSerializer
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+
+    private
+
+    def serialize_meta(page, options)
+      current_page = page.current_page
+      meta = {
+          page: current_page,
+          page_size: page.limit_value,
+          count: 0,
+          include: options.include,
+          page_count: 0,
+          previous_page: current_page - 1,
+          next_page: current_page + 1
+      }
+
+      meta[:first_href] = page_href(1, options)
+      meta[:previous_href] = page_href(meta[:previous_page], options)
+      meta[:next_href] = page_href(meta[:next_page], options)
+      meta[:last_href] = page_href(meta[:page_count], options)
+      meta
+    end
+  end
+end

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -10,4 +10,24 @@ describe ClassificationSerializer do
       .and_call_original
     ClassificationSerializer.page({}, Classification.all, {})
   end
+
+  describe "avoid heavy count queries on paging" do
+    it "should manually deal with the paging information" do
+      result = ClassificationSerializer.page({}, Classification.all, {})
+      meta = result[:meta][:classifications]
+      expect(meta[:count]).to eq(0)
+      expect(meta[:page_count]).to eq(0)
+      expect(meta[:previous_page]).to eq(0)
+      expect(meta[:next_page]).to eq(2)
+    end
+
+    it "should handle the the previous page information" do
+      result = ClassificationSerializer.page({page: 2}, Classification.all, {})
+      meta = result[:meta][:classifications]
+      expect(meta[:count]).to eq(0)
+      expect(meta[:page_count]).to eq(0)
+      expect(meta[:previous_page]).to eq(1)
+      expect(meta[:next_page]).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
Work around very query count calls that consume a lot of db resources / timeout api side buy manually set the classification serializer page values based on paging params to ensure we don't break clients that use the next/prev hrefs.

Long term this should be replaced with a modified Restpack::Serializer that uses the kaminari without_count page scopes, https://github.com/kaminari/kaminari#paginating-without-issuing-select-count-query

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
