### PR TITLE
Collaborative Collections

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1259,7 +1259,7 @@ this action.
 
 + Response 204
 
-## Project Collection [/projects{?page,page_size,sort,owner,include}]
+## Project Collection [/projects{?page,page_size,sort,owner,editor,include}]
 A collection of _Panotpes Project_ resources.
 
 All collections add a *meta* attribute hash containing
@@ -1383,7 +1383,8 @@ Projects are returned as an array under the _projects_ key.
   + page (optional, integer) ... the index of the page to retrieve default is 1
   + page_size (optional, integer) ... number of items to include on a page default is 20
   + sort (optional, string) ... field to sort by
-  + owner (optional, string) ... string owner name of either a user or a user group to filter by.
+  + owner (optional, string) ... string owner name of either a user or a user group to filter by owner
+  + editor (optional, string) ... string name of either a user or user group to filter by owner and collaborator
   + include (optional, string) ... comma separated list of linked resources to include in the response
 
 + Request
@@ -3035,7 +3036,7 @@ owner or have edit permissions.
 
 + Response 204
 
-## Collection Collection [/collections{?page,page_size,sort,owner}]
+## Collection Collection [/collections{?page,page_size,sort,owner, editor}]
 A collection of Collection resources.
 
 All collections add a meta attribute hash containing paging
@@ -3105,7 +3106,8 @@ Collections are returned as an array under *collections*.
   + page (optional, integer) ... the index of the page to retrieve default is 1
   + page_size (optional, integer) ... number of items to include on a page default is 20
   + sort (optional, string) ... field to sort by
-  + owner (optional, string) ... string name of either a user or user group to filter by
+  + owner (optional, string) ... string name of either a user or user group to filter by owner
+  + editor (optional, string) ... string name of either a user or user group to filter by owner and collaborator
 
 + Request
 

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::CollectionsController < Api::ApiController
   include FilterByOwner
+  include FilterByEditor
   include FilterByCurrentUserRoles
   include IndexSearch
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ProjectsController < Api::ApiController
   include FilterByOwner
+  include FilterByEditor
   include FilterByCurrentUserRoles
   include TranslatableResource
   include IndexSearch

--- a/app/controllers/concerns/filter_by_editor.rb
+++ b/app/controllers/concerns/filter_by_editor.rb
@@ -1,0 +1,16 @@
+module FilterByEditor
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :add_editor_ids_to_filter_param!, only: :index
+  end
+
+  def add_editor_ids_to_filter_param!
+    editor_filter = params.delete(:editor).try(:split, ',')
+    unless editor_filter.blank?
+      editor_group_scope = UserGroup.where( UserGroup.arel_table[:name].lower.in(editor_filter.map(&:downcase)) )
+      editor_scope = resource_class.filter_by_editor(editor_group_scope)
+      @controlled_resources = controlled_resources.merge(editor_scope)
+    end
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,17 +1,20 @@
 class Collection < ActiveRecord::Base
   include RoleControl::Controlled
   include RoleControl::Owned
+  include RoleControl::Editors
   include Activatable
   include Linkable
   include PreferencesLink
   include PgSearch
   include SluggedName
   include BelongsToMany
+  include OwnersAndCollaborators
 
   belongs_to_many :projects
   has_many :collections_subjects, dependent: :destroy
   has_many :subjects, through: :collections_subjects
   has_many :collection_roles, -> { where.not(roles: []) }, class_name: "AccessControlList", as: :resource
+  has_many :acls, class_name: "AccessControlList", as: :resource, dependent: :destroy
   has_many :user_collection_preferences, dependent: :destroy
 
   validates :display_name, presence: true

--- a/app/models/concerns/owners_and_collaborators.rb
+++ b/app/models/concerns/owners_and_collaborators.rb
@@ -1,0 +1,7 @@
+module OwnersAndCollaborators
+  def owners_and_collaborators
+    User.joins(user_groups: :access_control_lists)
+      .merge(self.acls.where.overlap(roles: %w(owner collaborator)))
+      .select(:id)
+  end
+end

--- a/app/models/concerns/owners_and_collaborators.rb
+++ b/app/models/concerns/owners_and_collaborators.rb
@@ -1,7 +1,7 @@
 module OwnersAndCollaborators
   def owners_and_collaborators
     User.joins(user_groups: :access_control_lists)
-      .merge(self.acls.where.overlap(roles: %w(owner collaborator)))
+      .merge(acls.where.overlap(roles: %w(owner collaborator)))
       .select(:id)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ActiveRecord::Base
   include RoleControl::Owned
   include RoleControl::Controlled
+  include RoleControl::Editors
   include Activatable
   include Linkable
   include Translatable

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,6 +9,7 @@ class Project < ActiveRecord::Base
   include PgSearch
   include RankedModel
   include SluggedName
+  include OwnersAndCollaborators
 
   EXPERT_ROLES = [:owner, :expert].freeze
 
@@ -106,12 +107,6 @@ class Project < ActiveRecord::Base
 
   def expert_classifier?(classifier)
     !!expert_classifier_level(classifier)
-  end
-
-  def owners_and_collaborators
-    User.joins(user_groups: :access_control_lists)
-      .merge(acls.where.overlap(roles: %w(owner collaborator)))
-      .select(:id)
   end
 
   def create_talk_admin(client)

--- a/lib/role_control/editors.rb
+++ b/lib/role_control/editors.rb
@@ -1,0 +1,19 @@
+module RoleControl
+  module Editors
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :access_control_lists, as: :resource, dependent: :destroy
+      has_one :editor_list, -> { where.overlap(roles: ["owner", "collaborator"]) }, as: :resource, class_name: "AccessControlList"
+      has_many :editors, through: :editor_list, source: :user_group, as: :resource, class_name: "UserGroup"
+
+      scope :public_scope, -> { where(private: false) }
+
+      def self.filter_by_editor(editor_groups)
+        eager_load(editors: { identity_membership: :user })
+        .joins(:editors)
+        .where(access_control_lists: { user_group: editor_groups })
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -41,6 +41,8 @@ describe Api::V1::CollectionsController, type: :controller do
       let(:viewer_resource) { private_resource }
 
       it_behaves_like "filters by owner"
+      it_behaves_like "filters by editor"
+
       it_behaves_like "filters by current user roles"
 
       describe "project_ids" do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -173,6 +173,7 @@ describe Api::V1::ProjectsController, type: :controller do
           let(:authorized_user) { owner }
 
           it_behaves_like "filters by owner"
+          it_behaves_like "filters by editor"
           it_behaves_like "filters by current user roles"
 
           context "with the index request before" do

--- a/spec/support/filter_by_editor.rb
+++ b/spec/support/filter_by_editor.rb
@@ -7,6 +7,13 @@ RSpec.shared_examples "filters by editor" do
       roles: ["collaborator"])
   end
 
+  let(:private_acl) do
+    create(:access_control_list,
+      resource: private_resource,
+      user_group: collaborator.identity_group,
+      roles: ["collaborator"])
+  end
+
   let(:index_options) do
     { editor: collaborator.login }
   end
@@ -23,6 +30,11 @@ RSpec.shared_examples "filters by editor" do
 
   it "should respond with the correct item" do
     expect(collab_resource.editors).to include collaborator.identity_group
+  end
+
+  it "should not include private collections" do
+    expect(json_response[api_resource_name].map { |c| c["id"] })
+      .to_not include private_resource.id.to_s
   end
 
   context "when the editor name has a different case to the identity group" do

--- a/spec/support/filter_by_editor.rb
+++ b/spec/support/filter_by_editor.rb
@@ -1,11 +1,8 @@
 RSpec.shared_examples "filters by editor" do
-  # let(:expected_count) { collab_resource.count }
-  let(:expected_count) { 1 }
-
   let(:collaborator) { create(:user) }
   let(:acl) do
     create(:access_control_list,
-      resource: collab_collection,
+      resource: collab_resource,
       user_group: collaborator.identity_group,
       roles: ["collaborator"])
   end
@@ -16,31 +13,34 @@ RSpec.shared_examples "filters by editor" do
 
   before do
     resource
+    acl
     get :index, index_options
   end
 
   it "should respond with the correct number of items" do
-    expect(json_response[api_resource_name].length).to eq(expected_count)
+    expect(json_response[api_resource_name].length).to eq(1)
   end
 
-  xit "should respond with the correct item" do
-    owner_id = json_response[api_resource_name][0]['links']['owner']['id']
-    expect(owner_id).to eq(resource.owner.id.to_s)
+  it "should respond with the correct item" do
+    # owner_id = json_response[api_resource_name][0]['links']['owner']['id']
+    # expect(owner_id).to eq(resource.owner.id.to_s)
+    expect(collab_resource.editors).to include collaborator.identity_group
   end
 
-  context "when the owner name has a different case to the identity group" do
+  context "when the editor name has a different case to the identity group" do
     let(:index_options) do
       resource
-      { owner: [owner.login.upcase, 'SOMETHING'].join(',') }
+      { editor: [collaborator.login.upcase, 'SOMETHING'].join(',') }
     end
 
-    xit "should respond with the correct number of items" do
-      expect(json_response[api_resource_name].length).to eq(expected_count)
+    it "should respond with the correct number of items" do
+      expect(json_response[api_resource_name].length).to eq(1)
     end
 
-    xit "should respond with the correct item" do
-      owner_id = json_response[api_resource_name][0]['links']['owner']['id']
-      expect(owner_id).to eq(resource.owner.id.to_s)
+    it "should respond with the correct item" do
+      # owner_id = json_response[api_resource_name][0]['links']['owner']['id']
+      # expect(owner_id).to eq(resource.owner.id.to_s)
+      expect(collab_resource.editors).to include collaborator.identity_group
     end
   end
 end

--- a/spec/support/filter_by_editor.rb
+++ b/spec/support/filter_by_editor.rb
@@ -1,0 +1,46 @@
+RSpec.shared_examples "filters by editor" do
+  # let(:expected_count) { collab_resource.count }
+  let(:expected_count) { 1 }
+
+  let(:collaborator) { create(:user) }
+  let(:acl) do
+    create(:access_control_list,
+      resource: collab_collection,
+      user_group: collaborator.identity_group,
+      roles: ["collaborator"])
+  end
+
+  let(:index_options) do
+    { editor: collaborator.login }
+  end
+
+  before do
+    resource
+    get :index, index_options
+  end
+
+  it "should respond with the correct number of items" do
+    expect(json_response[api_resource_name].length).to eq(expected_count)
+  end
+
+  xit "should respond with the correct item" do
+    owner_id = json_response[api_resource_name][0]['links']['owner']['id']
+    expect(owner_id).to eq(resource.owner.id.to_s)
+  end
+
+  context "when the owner name has a different case to the identity group" do
+    let(:index_options) do
+      resource
+      { owner: [owner.login.upcase, 'SOMETHING'].join(',') }
+    end
+
+    xit "should respond with the correct number of items" do
+      expect(json_response[api_resource_name].length).to eq(expected_count)
+    end
+
+    xit "should respond with the correct item" do
+      owner_id = json_response[api_resource_name][0]['links']['owner']['id']
+      expect(owner_id).to eq(resource.owner.id.to_s)
+    end
+  end
+end

--- a/spec/support/filter_by_editor.rb
+++ b/spec/support/filter_by_editor.rb
@@ -22,8 +22,6 @@ RSpec.shared_examples "filters by editor" do
   end
 
   it "should respond with the correct item" do
-    # owner_id = json_response[api_resource_name][0]['links']['owner']['id']
-    # expect(owner_id).to eq(resource.owner.id.to_s)
     expect(collab_resource.editors).to include collaborator.identity_group
   end
 
@@ -38,8 +36,6 @@ RSpec.shared_examples "filters by editor" do
     end
 
     it "should respond with the correct item" do
-      # owner_id = json_response[api_resource_name][0]['links']['owner']['id']
-      # expect(owner_id).to eq(resource.owner.id.to_s)
       expect(collab_resource.editors).to include collaborator.identity_group
     end
   end


### PR DESCRIPTION
Collections and projects can be filtered with the `editor` param. Index GET requests to either resource that includes that param will return projects/collections that the included user name/group name is either an owner or collaborator on.


# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [x] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
