### PR TITLE
Remove redundant name column from Org

### DIFF
--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -13,7 +13,7 @@ module Organizations
 
     def execute
       Organization.transaction do
-        organization = Organization.new owner: api_user.user, name: name, display_name: display_name, primary_language: primary_language
+        organization = Organization.new owner: api_user.user, display_name: display_name, primary_language: primary_language
         param_hash = { title: title, description: description, introduction: introduction }
         param_hash.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
         organization.organization_contents.build param_hash

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -2,7 +2,6 @@ module Organizations
   class Create < Operation
     include UrlLabels
 
-    string :name
     string :display_name
     string :primary_language
 

--- a/app/schemas/organization_update_schema.rb
+++ b/app/schemas/organization_update_schema.rb
@@ -9,11 +9,6 @@ class OrganizationUpdateSchema < JsonSchema
       description "Human readable name for a project ie Galaxy Zoo"
     end
 
-    property "name" do
-      type "string"
-      description "URL string for a project downcased and underscored ie galaxy_zoo"
-    end
-
     property "primary_language" do
       type "string"
       description "Two character ISO 639 language code, optionally include two character ISO 3166-1 alpha-2 country code seperated by a hyphen for specific locale. ie 'en', 'zh-tw', 'es_MX'"

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -3,7 +3,7 @@ class OrganizationSerializer
   include ContentSerializer
   include MediaLinksSerializer
 
-  attributes :id, :name, :display_name, :description, :introduction, :title, :href, :primary_language
+  attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language
   optional :avatar_src
   media_include :avatar, :background
   can_include :organization_contents, :organization_roles, :projects

--- a/db/migrate/20170202200131_remove_name_from_organization.rb
+++ b/db/migrate/20170202200131_remove_name_from_organization.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromOrganization < ActiveRecord::Migration
+  def change
+    remove_column :organizations, :name
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -637,7 +637,6 @@ ALTER SEQUENCE organization_contents_id_seq OWNED BY organization_contents.id;
 
 CREATE TABLE organizations (
     id integer NOT NULL,
-    name character varying,
     display_name character varying,
     slug character varying DEFAULT ''::character varying,
     primary_language character varying NOT NULL,
@@ -2534,10 +2533,31 @@ CREATE INDEX index_recents_on_classification_id ON recents USING btree (classifi
 
 
 --
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
+
+
+--
 -- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
+
+
+--
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
+
+
+--
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
@@ -3705,4 +3725,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170112163747');
 INSERT INTO schema_migrations (version) VALUES ('20170113113532');
 
 INSERT INTO schema_migrations (version) VALUES ('20170116134142');
+
+INSERT INTO schema_migrations (version) VALUES ('20170202200131');
 

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -26,7 +26,7 @@ describe Api::V1::OrganizationsController, type: :controller do
       it_behaves_like "is indexable" do
         let(:private_resource) { unlisted_organization }
         let(:api_resource_name) { "organizations" }
-        let(:api_resource_attributes) { %w(id name display_name) }
+        let(:api_resource_attributes) { %w(id display_name) }
         let(:api_resource_links) { %w() }
 
         let(:n_visible) { 1 }
@@ -72,7 +72,7 @@ describe Api::V1::OrganizationsController, type: :controller do
       it_behaves_like "is showable" do
         let(:resource) { organization }
         let(:api_resource_name) { "organizations" }
-        let(:api_resource_attributes) { %w(id name display_name) }
+        let(:api_resource_attributes) { %w(id display_name) }
         let(:api_resource_links) { %w() }
       end
     end
@@ -81,7 +81,6 @@ describe Api::V1::OrganizationsController, type: :controller do
       let(:create_params) do
         {
           organizations: {
-            name: "The Illuminati",
             display_name: "The Illuminati",
             title: "Come join us",
             description: "This organization is the most organized organization to ever organize",
@@ -96,7 +95,7 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:test_attr_value) { "The Illuminati" }
         let(:resource_class) { Organization }
         let(:api_resource_name) { "organizations" }
-        let(:api_resource_attributes) { %w(id name display_name) }
+        let(:api_resource_attributes) { %w(id display_name) }
         let(:api_resource_links) { %w() }
       end
     end
@@ -106,13 +105,12 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:resource) { create(:organization, owner: authorized_user) }
         let(:resource_class) { Organization }
         let(:api_resource_name) { "organizations" }
-        let(:api_resource_attributes) { ["name", "display_name", "title", "description"] }
+        let(:api_resource_attributes) { ["display_name", "title", "description"] }
         let(:api_resource_links) { [] }
         let(:update_params) do
           {
             organizations: {
               primary_language: "tw",
-              name: "A Different Name",
               display_name: "Def Not Illuminati",
               title: "Totally Harmless",
               description: "This Organization is not affiliated with the Illuminati, absolutely not no way",
@@ -129,7 +127,6 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:incomplete_params) do
           {
             organizations: {
-              name: "Just a name",
               display_name: "Just a name"
             }
           }

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
       build_media false
     end
 
-    sequence(:name) { |n| "test_org_#{ n }" }
     sequence(:display_name) { |n| "Test Organization #{ n }" }
     listed_at Time.now
     primary_language "en"


### PR DESCRIPTION
Removes `name` attribute from db, serializer, and schema. It is redundant with `display_name` and will cause confusion.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
