### PR TITLE
Add sorting to organizations

### DIFF
--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -7,6 +7,7 @@ class OrganizationSerializer
   optional :avatar_src
   media_include :avatar, :background
   can_include :organization_contents, :organization_roles, :projects
+  can_sort_by :display_name, :updated_at, :listed_at
 
   def title
     content[:title]

--- a/db/migrate/20170202202724_add_indices_to_organization.rb
+++ b/db/migrate/20170202202724_add_indices_to_organization.rb
@@ -1,0 +1,6 @@
+class AddIndicesToOrganization < ActiveRecord::Migration
+  def change
+    add_index :organizations, :updated_at
+    add_index :organizations, :display_name
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -637,7 +637,6 @@ ALTER SEQUENCE organization_contents_id_seq OWNED BY organization_contents.id;
 
 CREATE TABLE organizations (
     id integer NOT NULL,
-    name character varying,
     display_name character varying,
     slug character varying DEFAULT ''::character varying,
     primary_language character varying NOT NULL,
@@ -2394,10 +2393,24 @@ CREATE INDEX index_organizations_on_activated_state ON organizations USING btree
 
 
 --
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_organizations_on_display_name ON organizations USING btree (display_name);
+
+
+--
 -- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_listed_at ON organizations USING btree (listed_at);
+
+
+--
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
 
 
 --
@@ -2534,10 +2547,31 @@ CREATE INDEX index_recents_on_classification_id ON recents USING btree (classifi
 
 
 --
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
+
+
+--
 -- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
+
+
+--
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
+
+
+--
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
@@ -3705,4 +3739,8 @@ INSERT INTO schema_migrations (version) VALUES ('20170112163747');
 INSERT INTO schema_migrations (version) VALUES ('20170113113532');
 
 INSERT INTO schema_migrations (version) VALUES ('20170116134142');
+
+INSERT INTO schema_migrations (version) VALUES ('20170202200131');
+
+INSERT INTO schema_migrations (version) VALUES ('20170202202724');
 


### PR DESCRIPTION
Adds `can_sort_by :display_name, :updated_at, :listed_at` to the org serializer as well as the appropriate indices for those three columns.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
