### PR TITLE
Add subject locations into stream

### DIFF
--- a/app/serializers/event_stream_serializers/subject_serializer.rb
+++ b/app/serializers/event_stream_serializers/subject_serializer.rb
@@ -1,5 +1,13 @@
 module EventStreamSerializers
   class SubjectSerializer < ActiveModel::Serializer
-    attributes :id, :metadata, :created_at, :updated_at
+    attributes :id, :locations, :metadata, :created_at, :updated_at
+
+    def locations
+      object.ordered_locations.map do |loc|
+        {
+          loc.content_type => loc.url_for_format(:get)
+        }
+      end
+    end
   end
 end

--- a/spec/serializers/event_stream_serializers/subject_serializer_spec.rb
+++ b/spec/serializers/event_stream_serializers/subject_serializer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe EventStreamSerializers::SubjectSerializer do
+  let(:subject) { create(:subject, :with_mediums) }
+  let(:serializer) { described_class.new(subject) }
+  let(:adapter) { Serialization::V1Adapter.new(serializer) }
+
+  it 'serializes the subject locations' do
+    expected = subject.ordered_locations.map do |loc|
+      { "#{loc.content_type}" => loc.url_for_format(:get) }
+    end
+    expect(adapter.as_json["subjects"][0][:locations]).to eq(expected)
+  end
+end


### PR DESCRIPTION
SOCIAM would like to get these through Pusher (for which we'll also need to update the ZooEventStats) so that they can use them in visualisations.