### PR TITLE
Custom preloading serializer

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -11,6 +11,24 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   prepend_before_action :require_login, only: [:create, :update, :destroy, :create_classifications_export]
 
+  # temp action to test perf of Panoptes::RestpackSerializer
+  def serializer_test
+    experiment_name = "workflow_prp_serializer"
+    CodeExperiment.run(experiment_name) do |e|
+      e.run_if { Panoptes.flipper[experiment_name].enabled? }
+      e.use do
+        serializer.page(params, controlled_resources, context)
+      end
+      e.try do
+         WorkflowPrpSerializer.page(params, controlled_resources, context)
+      end
+      # skip the mismatch reporting...we just want perf metrics
+      e.ignore { true }
+
+      render nothing: true, status: 204
+    end
+  end
+
   def index
     unless params.has_key?(:sort)
       @controlled_resources = controlled_resources.rank(:display_order)

--- a/app/serializers/concerns/panoptes_restpack_serializer.rb
+++ b/app/serializers/concerns/panoptes_restpack_serializer.rb
@@ -1,0 +1,22 @@
+module Panoptes
+  module RestpackSerializer
+    extend ActiveSupport::Concern
+
+    included do
+      include RestPack::Serializer
+      extend ClassMethodOverrides
+    end
+
+    module ClassMethodOverrides
+      def page(params = {}, scope = nil, context = {})
+        if params[:include]
+          param_preloads = params[:include].split(',').map(&:to_sym)
+          preloads = param_preloads & self.can_include
+          scope = scope.preload(*preloads)
+        end
+
+        super(params, scope, context)
+      end
+    end
+  end
+end

--- a/app/serializers/concerns/panoptes_restpack_serializer.rb
+++ b/app/serializers/concerns/panoptes_restpack_serializer.rb
@@ -7,12 +7,25 @@ module Panoptes
       extend ClassMethodOverrides
     end
 
+    module ClassMethods
+      def preload(*preloads)
+        @preloads ||= []
+        @preloads += preloads
+      end
+
+      def preloads
+        @preloads || []
+      end
+    end
+
     module ClassMethodOverrides
       def page(params = {}, scope = nil, context = {})
         if params[:include]
-          param_preloads = params[:include].split(',').map(&:to_sym)
-          preloads = param_preloads & self.can_include
-          scope = scope.preload(*preloads)
+          param_preloads = params[:include].split(',').map(&:to_sym) & self.can_include
+        end
+        preload_relations = self.preloads | Array.wrap(param_preloads)
+        unless preload_relations.empty?
+          scope = scope.preload(*preload_relations)
         end
 
         super(params, scope, context)

--- a/app/serializers/workflow_prp_serializer.rb
+++ b/app/serializers/workflow_prp_serializer.rb
@@ -1,14 +1,11 @@
 require "tasks_visitors/inject_strings"
 require 'model_version'
 
-class WorkflowSerializer
-  include RestPack::Serializer
+class WorkflowPrpSerializer
+  include Panoptes::RestpackSerializer
   include FilterHasMany
   include MediaLinksSerializer
   include CachedSerializer
-
-  # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
-  PRELOADS = %i(subject_sets attached_images).freeze
 
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
              :created_at, :updated_at, :finished_at, :first_task, :primary_language,
@@ -22,12 +19,11 @@ class WorkflowSerializer
 
   can_filter_by :active
 
-  def self.page(params = {}, scope = nil, context = {})
-    if Panoptes.flipper["eager_load_workflows"].enabled?
-      scope = scope.preload(*PRELOADS)
-    end
+  # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
+  preload :subject_sets, :attached_images
 
-    super(params, scope, context)
+  def self.model_class
+    Workflow
   end
 
   def version

--- a/app/serializers/workflow_prp_serializer.rb
+++ b/app/serializers/workflow_prp_serializer.rb
@@ -31,7 +31,7 @@ class WorkflowPrpSerializer
   end
 
   def content_language
-    content.language if content
+    content&.language
   end
 
   def content_version

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -8,7 +8,7 @@ class WorkflowSerializer
   include CachedSerializer
 
   # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
-  PRELOADS = %i(project subject_sets tutorial_subject attached_images).freeze
+  PRELOADS = %i(subject_sets attached_images).freeze
 
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
              :created_at, :updated_at, :finished_at, :first_task, :primary_language,

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -2,7 +2,7 @@ require "tasks_visitors/inject_strings"
 require 'model_version'
 
 class WorkflowSerializer
-  include RestPack::Serializer
+  include Panoptes::RestpackSerializer
   include FilterHasMany
   include MediaLinksSerializer
   include CachedSerializer

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -35,7 +35,7 @@ class WorkflowSerializer
   end
 
   def content_language
-    content.language if content
+    content&.language
   end
 
   def content_version

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -7,9 +7,6 @@ class WorkflowSerializer
   include MediaLinksSerializer
   include CachedSerializer
 
-  # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
-  PRELOADS = %i(subject_sets attached_images).freeze
-
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
              :created_at, :updated_at, :finished_at, :first_task, :primary_language,
              :version, :content_language, :prioritized, :grouped, :pairwise,
@@ -22,13 +19,8 @@ class WorkflowSerializer
 
   can_filter_by :active
 
-  def self.page(params = {}, scope = nil, context = {})
-    if Panoptes.flipper["eager_load_workflows"].enabled?
-      scope = scope.preload(*PRELOADS)
-    end
-
-    super(params, scope, context)
-  end
+  # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
+  preload :subject_sets, :attached_images
 
   def version
     "#{@model.current_version_number}.#{content_version}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,11 @@ Rails.application.routes.draw do
 
         post "/retired_subjects", to: "workflows#retire_subjects"
         post "/classifications_export", to: "workflows#create_classifications_export", format: false
+
+        # temp route to test Panoptes::RestpackSerializer
+        collection do
+          get "/serializer_test", to: "workflows#serializer_test"
+        end
       end
 
       json_api_resources :subject_sets, links: [:subjects]

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -33,6 +33,20 @@ describe Api::V1::WorkflowsController, type: :controller do
     PaperTrail.enabled_for_controller = false
   end
 
+  describe "serializer_test" do
+    it "should use the old serializer by default" do
+      expect(WorkflowSerializer).to receive(:page)
+      get :serializer_test
+    end
+
+    it "should use the new serializer if setup" do
+      allow_any_instance_of(CodeExperiment).to receive(:enabled?).and_return(true)
+      Panoptes.flipper["workflow_prp_serializer"].enable
+      expect(WorkflowPrpSerializer).to receive(:page)
+      get :serializer_test
+    end
+  end
+
   describe '#index' do
     let(:filterable_resources) { create_list(:workflow_with_subjects, 2) }
     let(:expected_filtered_ids) { [ filterable_resources.first.id.to_s ] }

--- a/spec/serializers/workflow_prp_serializer_spec.rb
+++ b/spec/serializers/workflow_prp_serializer_spec.rb
@@ -1,33 +1,25 @@
 require 'spec_helper'
 
-describe WorkflowSerializer do
+describe WorkflowPrpSerializer do
   let(:workflow) { create(:workflow_with_contents) }
   let(:content) { workflow.workflow_contents.first }
   let(:serializer) do
-    serializer = WorkflowSerializer.new
+    serializer = WorkflowPrpSerializer.new
     serializer.instance_variable_set(:@model, workflow)
     serializer.instance_variable_set(:@context,
                                      {languages: ['en']})
     serializer
   end
 
+  it_should_behave_like "a panoptes restpack serializer" do
+    let(:resource) { workflow }
+    let(:includes) { "project,tutorial_subject" }
+    let(:preloads) { [ :project, :tutorial_subject ] }
+  end
+
   it "should have the set of preloads wired up" do
     preloads = %i(subject_sets attached_images)
-    expect(WorkflowSerializer.preloads).to match_array(preloads)
-  end
-
-  it "should not preload the serialized associations by default" do
-    expect_any_instance_of(Workflow::ActiveRecord_Relation).not_to receive(:preload)
-    WorkflowSerializer.page({}, Workflow.all, {})
-  end
-
-  it "should preload the serialized associations if enabled" do
-    Panoptes.flipper["eager_load_workflows"].enable
-    expect_any_instance_of(Workflow::ActiveRecord_Relation)
-      .to receive(:preload)
-      .with(*WorkflowSerializer::PRELOADS)
-      .and_call_original
-    WorkflowSerializer.page({}, Workflow.all, {})
+    expect(WorkflowPrpSerializer.preloads).to match_array(preloads)
   end
 
   describe "#tasks" do

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -3,13 +3,18 @@ require 'spec_helper'
 describe WorkflowSerializer do
   let(:workflow) { create(:workflow_with_contents) }
   let(:content) { workflow.workflow_contents.first }
-
   let(:serializer) do
     serializer = WorkflowSerializer.new
     serializer.instance_variable_set(:@model, workflow)
     serializer.instance_variable_set(:@context,
                                      {languages: ['en']})
     serializer
+  end
+
+  it_should_behave_like "a panoptes restpack serializer" do
+    let(:resource) { workflow }
+    let(:includes) { "project,tutorial_subject" }
+    let(:preloads) { [ :project, :tutorial_subject ] }
   end
 
   it "should not preload the serialized associations by default" do

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -13,7 +13,7 @@ describe WorkflowSerializer do
 
   it "should have the set of preloads wired up" do
     preloads = %i(subject_sets attached_images)
-    expect(WorkflowSerializer.preloads).to match_array(preloads)
+    expect(WorkflowSerializer::PRELOADS).to match_array(preloads)
   end
 
   it "should not preload the serialized associations by default" do

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -17,18 +17,9 @@ describe WorkflowSerializer do
     let(:preloads) { [ :project, :tutorial_subject ] }
   end
 
-  it "should not preload the serialized associations by default" do
-    expect_any_instance_of(Workflow::ActiveRecord_Relation).not_to receive(:preload)
-    WorkflowSerializer.page({}, Workflow.all, {})
-  end
-
-  it "should preload the serialized associations if enabled" do
-    Panoptes.flipper["eager_load_workflows"].enable
-    expect_any_instance_of(Workflow::ActiveRecord_Relation)
-      .to receive(:preload)
-      .with(*WorkflowSerializer::PRELOADS)
-      .and_call_original
-    WorkflowSerializer.page({}, Workflow.all, {})
+  it "should have the set of preloads wired up" do
+    preloads = %i(subject_sets attached_images)
+    expect(WorkflowSerializer.preloads).to match_array(preloads)
   end
 
   describe "#tasks" do

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -1,18 +1,44 @@
 shared_examples "a panoptes restpack serializer" do
-  before do
-    resource
+  let(:scope) { resource.class.all }
+
+  describe "preload associations" do
+    it "should not preload when none set" do
+      expect_any_instance_of(resource.class::ActiveRecord_Relation).not_to receive(:preload)
+      described_class.instance_variable_set(:@preloads, [])
+      described_class.page({}, scope, {})
+    end
+
+    it "should raise an error if invalid preloads" do
+      described_class.instance_variable_set(:@preloads, [:invalid])
+      expect {
+        described_class.page({}, scope, {})
+      }.to raise_error(ActiveRecord::AssociationNotFoundError)
+    end
+
+    it "should preload valid preloads" do
+      expect_any_instance_of(resource.class::ActiveRecord_Relation)
+        .to receive(:preload)
+        .with(*preloads)
+      described_class.instance_variable_set(:@preloads, preloads)
+      described_class.page({}, scope, {})
+    end
   end
 
-  it "should not preload when no included relations" do
-    expect_any_instance_of(resource.class::ActiveRecord_Relation).not_to receive(:preload)
-    described_class.page({}, Workflow.all, {})
-  end
+  describe "auto preload includes" do
+    before do
+      described_class.instance_variable_set(:@preloads, [])
+    end
 
-  it "should preload included relations" do
-    expect_any_instance_of(resource.class::ActiveRecord_Relation)
-      .to receive(:preload)
-      .with(*preloads)
-      .and_call_original
-    described_class.page({include: includes}, Workflow.all, {})
+    it "should not preload when no included relations" do
+      expect_any_instance_of(resource.class::ActiveRecord_Relation).not_to receive(:preload)
+      described_class.page({}, scope, {})
+    end
+
+    it "should preload included relations" do
+      expect_any_instance_of(resource.class::ActiveRecord_Relation)
+        .to receive(:preload)
+        .with(*preloads)
+      described_class.page({include: includes}, scope, {})
+    end
   end
 end

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -1,0 +1,18 @@
+shared_examples "a panoptes restpack serializer" do
+  before do
+    resource
+  end
+
+  it "should not preload when no included relations" do
+    expect_any_instance_of(Workflow::ActiveRecord_Relation).not_to receive(:preload)
+    WorkflowSerializer.page({}, Workflow.all, {})
+  end
+
+  it "should preload included relations" do
+    expect_any_instance_of(Workflow::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(*preloads)
+      .and_call_original
+    WorkflowSerializer.page({include: includes}, Workflow.all, {})
+  end
+end

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -4,15 +4,15 @@ shared_examples "a panoptes restpack serializer" do
   end
 
   it "should not preload when no included relations" do
-    expect_any_instance_of(Workflow::ActiveRecord_Relation).not_to receive(:preload)
-    WorkflowSerializer.page({}, Workflow.all, {})
+    expect_any_instance_of(resource.class::ActiveRecord_Relation).not_to receive(:preload)
+    described_class.page({}, Workflow.all, {})
   end
 
   it "should preload included relations" do
-    expect_any_instance_of(Workflow::ActiveRecord_Relation)
+    expect_any_instance_of(resource.class::ActiveRecord_Relation)
       .to receive(:preload)
       .with(*preloads)
       .and_call_original
-    WorkflowSerializer.page({include: includes}, Workflow.all, {})
+    described_class.page({include: includes}, Workflow.all, {})
   end
 end


### PR DESCRIPTION
replaces #2112

Added a custom panoptes wrapper over restpack serialzier to allow preloading on the page method.
This allows any valid include params to preload their associations and it provides a DSL to wire up preloads for each serializer.

I've created a code experiment to test this out on a custom route to see the performance of doing this.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
