### PR TITLE
Added "contributor" role to Collections

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -19,8 +19,8 @@ class Collection < ActiveRecord::Base
   ## TODO: This potential has locking issues
   validates_with UniqueForOwnerValidator
 
-  can_by_role :destroy, :update, :update_links, :destroy_links,
-              roles: [ :owner, :collaborator ]
+  can_by_role :destroy, :update, :destroy_links, roles: [ :owner, :collaborator ]
+  can_by_role :update_links, roles: [ :owner, :collaborator, :contributor ]
   can_by_role :index, :show, public: true, roles: [ :owner, :collaborator, :viewer ]
 
   can_be_linked :access_control_list, :scope_for, :update, :user

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -21,7 +21,7 @@ class Collection < ActiveRecord::Base
 
   can_by_role :destroy, :update, :destroy_links, roles: [ :owner, :collaborator ]
   can_by_role :update_links, roles: [ :owner, :collaborator, :contributor ]
-  can_by_role :index, :show, public: true, roles: [ :owner, :collaborator, :viewer ]
+  can_by_role :index, :show, public: true, roles: [ :owner, :collaborator, :viewer, :contributor ]
 
   can_be_linked :access_control_list, :scope_for, :update, :user
 

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -190,43 +190,4 @@ describe Api::V1::CollectionsController, type: :controller do
 
     it_behaves_like "is destructable"
   end
-
-  describe "user role permissions" do
-    let(:empty_collection) { create(:collection) }
-    let(:contributor) { create(:user) }
-    let(:subjects) { create_list(:subject, 4) }
-    let(:subjects_list) { subjects.map { |s| s.id.to_s } }
-    let(:params) do
-      {
-        link_relation: "subjects",
-        "subjects" => subjects_list,
-        "collection_id" => empty_collection.id
-
-      }
-    end
-    before(:each) do
-      default_request scopes: scopes, user_id: contributor.id
-    end
-
-    context "user is a contributor" do
-      let!(:acl) do
-        create(:access_control_list,
-               user_group: contributor.identity_group,
-               resource: empty_collection,
-               roles: ["contributor"])
-      end
-
-      it "successfully updates links" do
-        post :update_links, params
-        expect(json_response["collections"][0]["links"]["subjects"]).to match_array(subjects_list)
-      end
-    end
-
-    context "user is unauthorized" do
-      it "does not update links" do
-        post :update_links, params
-        expect(response.status).to be(404)
-      end
-    end
-  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -63,4 +63,29 @@ describe Collection, type: :model do
       expect(collection.subjects).to all( be_a(Subject) )
     end
   end
+
+  context "collaboration" do
+    let(:contributor) { ApiUser.new(create(:user)) }
+    let(:collab_collection) { create(:collection) }
+    let(:subjects) { create_list(:subject, 4) }
+
+    describe "user is a collaborator" do
+      let!(:acl) do
+        create(:access_control_list,
+               user_group: contributor.user.identity_group,
+               resource: collab_collection,
+               roles: ["contributor"])
+      end
+
+      it "allows contributor to update links" do
+        expect(Collection.scope_for(:update_links, contributor)).to include(collab_collection)
+      end
+    end
+
+    describe "user is unauthorized" do
+      it "does not allow non-contributor to update links" do
+        expect(Collection.scope_for(:update_links, contributor)).to_not include(collab_collection)
+      end
+    end
+  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -73,7 +73,7 @@ describe Collection, type: :model do
         user_group: contributor.user.identity_group,
         resource: collab_collection,
         roles: ["contributor"]
-        ).save!
+      ).save!
       expect(Collection.scope_for(:update_links, contributor)).to include(collab_collection)
     end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -64,28 +64,21 @@ describe Collection, type: :model do
     end
   end
 
-  context "collaboration" do
+  context "contribution" do
     let(:contributor) { ApiUser.new(create(:user)) }
     let(:collab_collection) { create(:collection) }
-    let(:subjects) { create_list(:subject, 4) }
 
-    describe "user is a collaborator" do
-      let!(:acl) do
-        create(:access_control_list,
-               user_group: contributor.user.identity_group,
-               resource: collab_collection,
-               roles: ["contributor"])
-      end
-
-      it "allows contributor to update links" do
-        expect(Collection.scope_for(:update_links, contributor)).to include(collab_collection)
-      end
+    it "allows contributor to update links" do
+      AccessControlList.new(
+        user_group: contributor.user.identity_group,
+        resource: collab_collection,
+        roles: ["contributor"]
+        ).save!
+      expect(Collection.scope_for(:update_links, contributor)).to include(collab_collection)
     end
 
-    describe "user is unauthorized" do
-      it "does not allow non-contributor to update links" do
-        expect(Collection.scope_for(:update_links, contributor)).to_not include(collab_collection)
-      end
+    it "does not allow non-contributor to update links" do
+      expect(Collection.scope_for(:update_links, contributor)).to_not include(collab_collection)
     end
   end
 end


### PR DESCRIPTION
You can now `update_links` on Collections if you have the "contributor" role. This was extremely simple on the model side. The controller specs were more proving it to myself than anything else.

Most of the effort on this feature will be on the front end, which I'm gonna give a shot soon.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
