### PR TITLE
Touch model updated_at vs cache key include

### DIFF
--- a/app/controllers/api/v1/project_contents_controller.rb
+++ b/app/controllers/api/v1/project_contents_controller.rb
@@ -1,12 +1,19 @@
 class Api::V1::ProjectContentsController < Api::ApiController
   include Versioned
 
+  CONTENT_PARAMS = [
+    :title,
+    :description,
+    :workflow_description,
+    :introduction,
+    :researcher_quote
+  ].freeze
+
   require_authentication :all, scopes: [:project]
   resource_actions :default
   schema_type :strong_params
 
-  allowed_params :create, :language, :title,
-    *Api::V1::ProjectsController::CONTENT_PARAMS, links: [:project]
+  allowed_params :create, :language, :title, *CONTENT_PARAMS, links: [:project]
 
-  allowed_params :update, :title, *Api::V1::ProjectsController::CONTENT_PARAMS
+  allowed_params :update, :title, *CONTENT_PARAMS
 end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -149,12 +149,15 @@ class Api::V1::ProjectsController < Api::ApiController
 
   def build_resource_for_create(create_params)
     admin_allowed create_params, *admin_allowed_params
-    create_params[:project_contents] = [ProjectContent.new(content_from_params(create_params))]
+
+    content_attributes = primary_content_attributes(create_params)
+    create_params[:project_contents] = [ ProjectContent.new(content_attributes) ]
     if create_params.has_key? :tags
       create_params[:tags] = create_or_update_tags(create_params)
     end
     add_user_as_linked_owner(create_params)
-    super(create_params)
+
+    super(create_params.except(*CONTENT_FIELDS))
   end
 
   def build_update_hash(update_params, resource)

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -15,12 +15,6 @@ class Api::V1::ProjectsController < Api::ApiController
 
   alias_method :project, :controlled_resource
 
-  CONTENT_PARAMS = [:description,
-                    :title,
-                    :workflow_description,
-                    :researcher_quote,
-                    :introduction].freeze
-
   CONTENT_FIELDS = [:title,
                     :description,
                     :workflow_description,

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -18,6 +18,15 @@ class Api::V1::WorkflowsController < Api::ApiController
     super
   end
 
+  def update
+    super do |resource|
+      _, strings = extract_strings(update_params[:tasks])
+      if strings
+        resource.primary_content.update(strings: strings)
+      end
+    end
+  end
+
   def update_links
     super do |workflow|
       UnfinishWorkflowWorker.perform_async(workflow.id)
@@ -88,17 +97,14 @@ class Api::V1::WorkflowsController < Api::ApiController
     end
   end
 
-  def build_update_hash(update_params, id)
-    workflow = Workflow.find(id)
-    WorkflowContent.transaction(requires_new: true) do
-      if update_params.has_key? :tasks
-        stripped_tasks, strings = extract_strings(update_params[:tasks])
-        update_params[:tasks] = stripped_tasks
-        workflow.primary_content.update(strings: strings)
-      end
-      reject_live_project_changes(workflow, update_params)
+  def build_update_hash(update_params, resource)
+    if update_params.has_key? :tasks
+      stripped_tasks, strings = extract_strings(update_params[:tasks])
+      update_params[:tasks] = stripped_tasks
     end
-    super(update_params, id)
+
+    reject_live_project_changes(resource, update_params)
+    super(update_params, resource)
   end
 
   def build_resource_for_create(create_params)
@@ -114,9 +120,10 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def extract_strings(tasks)
+    return @task_strings if @task_strings
     task_string_extractor = TasksVisitors::ExtractStrings.new
     task_string_extractor.visit(tasks)
-    [tasks, task_string_extractor.collector]
+    @task_strings = [tasks, task_string_extractor.collector]
   end
 
   def add_relation(resource, relation, value)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,7 +49,6 @@ class Project < ActiveRecord::Base
 
   enum state: [:paused, :finished]
 
-  cache_by_association :project_contents, :tags
   cache_by_resource_method :subjects_count, :retired_subjects_count, :finished?
 
   accepts_nested_attributes_for :project_contents

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -29,7 +29,7 @@ class Workflow < ActiveRecord::Base
   has_and_belongs_to_many :expert_subject_sets, -> { expert_sets }, class_name: "SubjectSet"
   belongs_to :tutorial_subject, class_name: "Subject"
 
-  cache_by_association :workflow_contents
+  # TODO: remove this association from the cache key
   cache_by_resource_method :subjects_count, :finished?
 
   enum subject_selection_strategy: [:default, :cellect, :cellect_ex]

--- a/app/operations/concerns/content_from_params.rb
+++ b/app/operations/concerns/content_from_params.rb
@@ -1,0 +1,14 @@
+module ContentFromParams
+  def content_from_params(ps, content_fields)
+    yield ps if block_given?
+    content = ps.slice(*content_fields)
+    content[:language] = ps[:primary_language]
+    if ps.has_key? :urls
+      urls, labels = extract_url_labels(ps[:urls])
+      content[:url_labels] = labels
+      ps[:urls] = urls
+    end
+    ps.except!(*content_fields)
+    content.select { |k,v| !!v }
+  end
+end

--- a/app/operations/concerns/url_labels.rb
+++ b/app/operations/concerns/url_labels.rb
@@ -1,19 +1,4 @@
 module UrlLabels
-  extend ActiveSupport::Concern
-
-  def content_from_params(ps, content_fields)
-    yield ps if block_given?
-    content = ps.slice(*content_fields)
-    content[:language] = ps[:primary_language]
-    if ps.has_key? :urls
-      urls, labels = extract_url_labels(ps[:urls])
-      content[:url_labels] = labels
-      ps[:urls] = urls
-    end
-    ps.except!(*content_fields)
-    content.select { |k,v| !!v }
-  end
-
   def extract_url_labels(urls)
     visitor = TasksVisitors::ExtractStrings.new
     visitor.visit(urls)

--- a/app/operations/concerns/url_labels.rb
+++ b/app/operations/concerns/url_labels.rb
@@ -2,7 +2,7 @@ module UrlLabels
   extend ActiveSupport::Concern
 
   def content_from_params(ps, content_fields)
-    content = ps.slice(content_fields)
+    yield ps if block_given?
     content[:language] = ps[:primary_language]
     if ps.has_key? :urls
       urls, labels = extract_url_labels(ps[:urls])

--- a/app/operations/concerns/url_labels.rb
+++ b/app/operations/concerns/url_labels.rb
@@ -3,13 +3,14 @@ module UrlLabels
 
   def content_from_params(ps, content_fields)
     yield ps if block_given?
+    content = ps.slice(*content_fields)
     content[:language] = ps[:primary_language]
     if ps.has_key? :urls
       urls, labels = extract_url_labels(ps[:urls])
       content[:url_labels] = labels
       ps[:urls] = urls
     end
-    ps.except!(content_fields)
+    ps.except!(*content_fields)
     content.select { |k,v| !!v }
   end
 

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -1,6 +1,7 @@
 module Organizations
   class Create < Operation
     include UrlLabels
+    include ContentFromParams
 
     string :name
     string :display_name

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -1,6 +1,7 @@
 module Organizations
   class Update < Operation
     include UrlLabels
+    include ContentFromParams
 
     integer :id
     string :name

--- a/lib/json_api_controller/json_schema_validator.rb
+++ b/lib/json_api_controller/json_schema_validator.rb
@@ -38,13 +38,14 @@ module JsonApiController
     end
 
     def params_for(action=action_name.to_sym)
-      ps = params.require(resource_sym).permit!
+      return @ps if @ps
+      @ps = params.require(resource_sym).permit!
       if validator = self.class.action_params[action]
-        validator.validate!(ps)
+        validator.validate!(@ps)
       else
         raise NoValidatorForActionError
       end
-      ps
+      @ps
     end
   end
 end

--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -52,10 +52,13 @@ module JsonApiController
     protected
 
     def build_update_hash(update_params, resource)
-      return update_params unless links = update_params.delete(:links)
-      links.try(:reduce, update_params) do |params, (k, v)|
-        params[k] = update_relation(resource, k.to_sym, v)
-        params
+      if links = update_params.delete(:links)
+        links.try(:reduce, update_params) do |params, (k, v)|
+          params[k] = update_relation(resource, k.to_sym, v)
+          params
+        end
+      else
+        update_params
       end
     end
 

--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -12,7 +12,8 @@ module JsonApiController
 
     def update
       controlled_resources.zip(Array.wrap(update_params)).each do |resource, update_hash|
-        resource.assign_attributes(build_update_hash(update_hash,resource))
+        update_attributes = build_update_hash(update_hash, resource)
+        resource.assign_attributes(update_attributes)
       end
 
       resource_class.transaction(requires_new: true) do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -706,22 +706,31 @@ describe Api::V1::ProjectsController, type: :controller do
     end
 
     context "project_contents" do
+      let(:params) do
+        { projects: { description: 'SC' }, id: resource.id }
+      end
+
       before(:each) do
         default_request scopes: scopes, user_id: authorized_user.id
-        params = update_params
-        params[:projects][:description] = 'SC'
-        params = params.merge(id: resource.id)
-        put :update, params
       end
 
       it 'should update the default contents when the display_name is updated' do
+        params[:projects][test_attr] = test_attr_value
+        put :update, params
         contents_title = resource.primary_content.reload
         contents_title = resource.primary_content.title
         expect(contents_title).to eq(test_attr_value)
       end
 
       it 'should update the default contents when the description changes' do
+        put :update, params
         expect(json_response['projects'][0]['description']).to eq('SC')
+      end
+
+      it "should touch the project resource to modify the cache_key / etag" do
+        expect {
+          put :update, params
+        }.to change { resource.reload.updated_at }
       end
     end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -630,7 +630,6 @@ describe Api::V1::ProjectsController, type: :controller do
           },
           beta_requested: true,
           live: true,
-          tags: ["astro", "gastro"],
           researcher_quote: "this is such a great project",
           links: {
             workflows: [workflow.id.to_s],
@@ -643,9 +642,14 @@ describe Api::V1::ProjectsController, type: :controller do
     it_behaves_like "is updatable"
 
     describe "update tags" do
+      let(:tags) { ["astro", "gastro"] }
+      let(:tag_params) do
+        { projects: { tags: tags }, id: resource.id }
+      end
+
       def tag_update
         default_request scopes: scopes, user_id: authorized_user.id
-        put :update, update_params.merge(id: resource.id)
+        put :update, tag_params
       end
 
       it 'should remove all previous tags' do
@@ -658,7 +662,13 @@ describe Api::V1::ProjectsController, type: :controller do
       it 'should update with new tags' do
         tag_update
         resource.reload
-        expect(resource.tags.pluck(:name)).to include("astro", "gastro")
+        expect(resource.tags.pluck(:name)).to match_array(tags)
+      end
+
+      it "should touch the project resource to modify the cache_key / etag" do
+        expect {
+          tag_update
+        }.to change { resource.reload.updated_at }
       end
     end
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -218,6 +218,29 @@ describe Api::V1::WorkflowsController, type: :controller do
         end
       end
     end
+
+    context "workflow_contents task strings" do
+      let(:tasks) { update_params.dig(:workflows, :tasks) }
+      let(:params) do
+        { workflows: { tasks: tasks }, id: resource.id }
+      end
+
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id
+      end
+
+      it "should update the primary content task strings" do
+        put :update, params
+        response_tasks = json_response['workflows'][0]['tasks']
+        expect(response_tasks).to eq(tasks.deep_stringify_keys)
+      end
+
+      it "should touch the workflow resource to modify the cache_key / etag" do
+        expect {
+          put :update, params
+        }.to change { resource.reload.updated_at }
+      end
+    end
   end
 
   describe "#update_links" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -33,9 +33,11 @@ describe Project, type: :model do
   context "with caching resource associations" do
     let(:cached_resource) { full_project }
 
-    it_behaves_like "has an extended cache key",
-      [:project_contents, :tags],
-      [:subjects_count, :retired_subjects_count, :finished?]
+    it_behaves_like "has an extended cache key" do
+      let(:methods) do
+        %i(subjects_count retired_subjects_count finished?)
+      end
+    end
   end
 
   it "should have a valid factory" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -26,9 +26,14 @@ describe Workflow, type: :model do
   context "with caching resource associations" do
     let(:cached_resource) { workflow }
 
-    it_behaves_like "has an extended cache key",
-      [:workflow_contents],
-      [:subjects_count, :finished?]
+    it_behaves_like "has an extended cache key" do
+      let(:associations) do
+        %i(workflow_contents)
+      end
+      let(:methods) do
+        %i(subjects_count finished?)
+      end
+    end
   end
 
   it "should have a valid factory" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -27,9 +27,6 @@ describe Workflow, type: :model do
     let(:cached_resource) { workflow }
 
     it_behaves_like "has an extended cache key" do
-      let(:associations) do
-        %i(workflow_contents)
-      end
       let(:methods) do
         %i(subjects_count finished?)
       end


### PR DESCRIPTION
Instead of including the associated resources with an N+1 in the extended cache_key call for ETAG generation this will ensure the relevant linked model gets a touched updated_at timestamp so the etag gets changed and the browser doesn't use a cached version of the resource. 

PFE - doesn't use this anymore so the original bugs that the extended cache key fixed don't necessarily apply (index vs show routes) but we're still paying the cost of lookup on the associated models here. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
