### PR TITLE
remove subject -> workflow link validation

### DIFF
--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -13,7 +13,6 @@ class SubjectWorkflowStatus < ActiveRecord::Base
 
   validates :subject, presence: true, uniqueness: {scope: :workflow_id}
   validates :workflow, presence: true
-  validate :subject_belongs_to_workflow, on: :create
 
   delegate :set_member_subjects, to: :subject
   delegate :project, to: :workflow
@@ -49,15 +48,5 @@ class SubjectWorkflowStatus < ActiveRecord::Base
 
   def set_member_subject_ids
     set_member_subjects.pluck(:id)
-  end
-
-  private
-
-  def subject_belongs_to_workflow
-    return unless subject_id && workflow_id
-
-    unless SetMemberSubject.by_subject_workflow(subject_id, workflow_id).exists?
-      errors.add(:subject, "must be linked to the workflow")
-    end
   end
 end

--- a/spec/models/subject_workflow_status_spec.rb
+++ b/spec/models/subject_workflow_status_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe SubjectWorkflowStatus, type: :model do
     expect(built_sws).to_not be_valid
   end
 
-  it 'should not be valid with a subject not in the workflow' do
+  it 'should be valid with a subject not linked to the workflow' do
     built_sws = build(:subject_workflow_status)
     subject = create(:subject, :with_subject_sets, num_sets: 1)
     built_sws.subject = subject
-    expect(built_sws).to_not be_valid
-    expect(built_sws.errors[:subject]).to eq(["must be linked to the workflow"])
+    expect(built_sws).to be_valid
   end
 
   context "when re-saving the sws after subject has been unlinked for the workflow" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -244,10 +244,10 @@ describe Workflow, type: :model do
     context 'when the subject does not belong to the workflow' do
       let(:subject) { create(:subject) }
 
-      it 'should raise an error' do
+      it 'should retire the subject' do
         expect {
           workflow.retire_subject(subject.id)
-        }.to raise_error(ActiveRecord::RecordInvalid)
+        }.to change { SubjectWorkflowStatus.retired.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
allow counts for subjects not linked to workflows. We should respect the classification data record and ignore any set linkage state as it changes with time. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
