### PR TITLE
Recents schema, index and serialzier updates

### DIFF
--- a/app/controllers/concerns/recents.rb
+++ b/app/controllers/concerns/recents.rb
@@ -2,13 +2,10 @@ module Recents
   def recents
     ps = params.dup
     ps.delete "#{resource_name}_id"
-    render json_api: RecentSerializer.page(ps, recent_scope, { type: resource_sym.to_s, owner_id: resource_ids })
-  end
-
-  def recent_scope
-    scope = Recent.where(:"#{resource_name}_id" => resource_ids)
-    scope = scope.where(project_id: params[:project_id]) if params.key?(:project_id)
-    scope = scope.where(workflow_id: params[:workflow_id]) if params.key?(:workflow_id)
-    scope
+    render json_api: RecentSerializer.page(
+      ps,
+      Recent.where(:"#{resource_name}_id" => resource_ids),
+      { type: resource_sym.to_s, owner_id: resource_ids }
+    )
   end
 end

--- a/app/models/concerns/ordered_locations.rb
+++ b/app/models/concerns/ordered_locations.rb
@@ -1,0 +1,14 @@
+module OrderedLocations
+
+  def ordered_locations
+    if locations.loaded?
+      if locations.all? { |loc| loc.metadata&.key?("index") }
+        locations.sort_by { |loc| loc.metadata["index"] }
+      else
+        locations
+      end
+    else
+      locations.order("\"media\".\"metadata\"->>'index' ASC")
+    end
+  end
+end

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -1,4 +1,6 @@
 class Recent < ActiveRecord::Base
+  include OrderedLocations
+
   belongs_to :classification
   belongs_to :subject
 

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -9,11 +9,7 @@ class Recent < ActiveRecord::Base
   belongs_to :user
   belongs_to :user_group
 
-  validates_presence_of :classification, :subject
-
-  # TODO: modify the following validation to run all the time
-  # once the recents schema has been migrated from has_one through associations
-  validates_presence_of :project_id, :workflow_id, :user_id, only: :create
+  validates_presence_of :classification, :subject, :project_id, :workflow_id, :user_id
 
   before_validation :copy_classification_fkeys
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,6 +2,7 @@ class Subject < ActiveRecord::Base
   include RoleControl::ParentalControlled
   include Linkable
   include Activatable
+  include OrderedLocations
 
   has_paper_trail only: [:metadata, :locations]
 
@@ -46,18 +47,6 @@ class Subject < ActiveRecord::Base
       SubjectWorkflowStatus.retired.by_subject_workflow(self.id, workflow.id).present?
     else
       false
-    end
-  end
-
-  def ordered_locations
-    if locations.loaded?
-      if locations.all? { |loc| loc.metadata&.key?("index") }
-        locations.sort_by { |loc| loc.metadata["index"] }
-      else
-        locations
-      end
-    else
-      locations.order("\"media\".\"metadata\"->>'index' ASC")
     end
   end
 end

--- a/app/serializers/recent_serializer.rb
+++ b/app/serializers/recent_serializer.rb
@@ -5,11 +5,18 @@ class RecentSerializer
   can_include :project, :workflow, :subject
   can_sort_by :created_at
 
+  def self.page(params = {}, scope = nil, context = {})
+    scope = scope.preload(subject: :locations)
+    super(params, scope, context)
+  end
+
   def href
     "/#{@context[:type].pluralize}/#{@context[:owner_id]}/recents/#{@model.id}"
   end
 
   def locations
-    @model.locations.map{ |loc| {loc.content_type => loc.get_url} }
+    @model.subject.ordered_locations.map do |loc|
+      { loc.content_type => loc.get_url }
+    end
   end
 end

--- a/app/serializers/recent_serializer.rb
+++ b/app/serializers/recent_serializer.rb
@@ -6,7 +6,7 @@ class RecentSerializer
   can_sort_by :created_at
 
   def self.page(params = {}, scope = nil, context = {})
-    scope = scope.preload(subject: :locations)
+    scope = scope.preload(:locations)
     super(params, scope, context)
   end
 
@@ -15,7 +15,7 @@ class RecentSerializer
   end
 
   def locations
-    @model.subject.ordered_locations.map do |loc|
+    @model.ordered_locations.map do |loc|
       { loc.content_type => loc.get_url }
     end
   end

--- a/db/migrate/20170118141452_add_recents_foreign_keys.rb
+++ b/db/migrate/20170118141452_add_recents_foreign_keys.rb
@@ -1,8 +1,34 @@
 class AddRecentsForeignKeys < ActiveRecord::Migration
 
   def change
+    remove_deleted_project_recents
     add_foreign_key :recents, :projects
+
+    remove_deleted_workflow_recents
     add_foreign_key :recents, :workflows
+
+    remove_deleted_user_recents
     add_foreign_key :recents, :users
+  end
+
+  def remove_deleted_project_recents
+    Recent
+      .joins("LEFT OUTER JOIN projects ON projects.id = recents.project_id")
+      .where("recents.id IS NOT NULL AND projects.id IS NULL")
+      .delete_all
+  end
+
+  def remove_deleted_workflow_recents
+    Recent
+      .joins("LEFT OUTER JOIN workflows ON workflows.id = recents.workflow_id")
+      .where("recents.id IS NOT NULL AND workflows.id IS NULL")
+      .delete_all
+  end
+
+  def remove_deleted_user_recents
+    Recent
+      .joins("LEFT OUTER JOIN users ON users.id = recents.user_id")
+      .where("recents.id IS NOT NULL AND users.id IS NULL")
+      .delete_all
   end
 end

--- a/db/migrate/20170210163241_recents_index_updates.rb
+++ b/db/migrate/20170210163241_recents_index_updates.rb
@@ -1,0 +1,10 @@
+class RecentsIndexUpdates < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    %i(classification_id project_id subject_id user_id workflow_id).each do |col|
+      remove_index :recents, col
+      add_index :recents, col, algorithm: :concurrently
+    end
+  end
+end

--- a/db/migrate/20170210163241_recents_index_updates.rb
+++ b/db/migrate/20170210163241_recents_index_updates.rb
@@ -3,8 +3,10 @@ class RecentsIndexUpdates < ActiveRecord::Migration
 
   def change
     %i(classification_id project_id subject_id user_id workflow_id).each do |col|
-      remove_index :recents, col
+      remove_index :recents, column: col
       add_index :recents, col, algorithm: :concurrently
     end
+
+    add_index :recents, :created_at, algorithm: :concurrently
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3773,3 +3773,5 @@ INSERT INTO schema_migrations (version) VALUES ('20170202202724');
 
 INSERT INTO schema_migrations (version) VALUES ('20170206161946');
 
+INSERT INTO schema_migrations (version) VALUES ('20170210163241');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2548,6 +2548,13 @@ CREATE INDEX index_recents_on_classification_id ON recents USING btree (classifi
 
 
 --
+-- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recents_on_created_at ON recents USING btree (created_at);
+
+
+--
 -- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 

--- a/spec/models/recent_spec.rb
+++ b/spec/models/recent_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Recent, :type => :model do
     let(:recent) { build(:recent, classification: classification) }
 
     it 'should not be valid without a classification' do
-      expect(build(:recent, classification: nil)).to_not be_valid
+      recent.classification = nil
+      expect(recent).to_not be_valid
     end
 
     it 'should not be valid without a subject' do

--- a/spec/models/recent_spec.rb
+++ b/spec/models/recent_spec.rb
@@ -52,4 +52,11 @@ RSpec.describe Recent, :type => :model do
       }.by (subjects.length)
     end
   end
+
+  describe "ordered_locations" do
+    it_behaves_like "it has ordered locations" do
+      let(:resource) { create(:recent) }
+      let(:klass) { Recent }
+    end
+  end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -82,36 +82,12 @@ describe Subject, :type => :model do
     end
   end
 
-  describe "#ordered_locations" do
-    let(:subject) do
-      create(:subject, :with_mediums, :with_subject_sets, num_sets: 1)
-    end
-
-    it "should sort the loaded locations by index" do
-      expected = subject.locations.sort_by { |loc| loc.metadata["index"] }
-      expect(expected.map(&:id)).to eq(subject.ordered_locations.map(&:id))
-    end
-
-    it "should sort the non-loaded locations by db index" do
-      lone_subject = Subject.find(subject.id)
-      expect_any_instance_of(Medium::ActiveRecord_Associations_CollectionProxy)
-        .to receive(:order)
-        .with("\"media\".\"metadata\"->>'index' ASC")
-        .and_call_original
-      expected = subject.locations.sort_by { |loc| loc.metadata["index"] }
-      expect(expected.map(&:id)).to eq(lone_subject.ordered_locations.map(&:id))
-    end
-
-    context "subject without location metadata" do
-      before do
-        subject.locations.update_all(metadata: nil)
-        subject.locations(true)
+  describe "ordered_locations" do
+    it_behaves_like "it has ordered locations" do
+      let(:resource) do
+        create(:subject, :with_mediums, :with_subject_sets, num_sets: 1)
       end
-
-      it "should mimic the database order by using the relation ordering" do
-        expected = subject.locations.order("\"media\".\"metadata\"->>'index' ASC")
-        expect(expected.map(&:id)).to eq(subject.ordered_locations.map(&:id))
-      end
+      let(:klass) { Subject }
     end
   end
 

--- a/spec/serializers/recent_serializer_spec.rb
+++ b/spec/serializers/recent_serializer_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe RecentSerializer do
+  let(:context) do
+    { type: "user", owner_id: "1" }
+  end
+
+  it "should preload the serialized associations" do
+    expect_any_instance_of(Recent::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(subject: :locations)
+      .and_call_original
+    RecentSerializer.page({}, Recent.all, context)
+  end
+
+  describe "locations" do
+    let!(:recent) { create(:recent) }
+    let(:result_locs) do
+      RecentSerializer.single({}, Recent.all, context)[:locations]
+    end
+
+    it "should use the subject ordered locations method" do
+      expect_any_instance_of(Subject)
+        .to receive(:ordered_locations)
+        .and_call_original
+      result_locs
+    end
+
+    it "should serialize the locations into a mime : url hash" do
+      expected = recent.subject.ordered_locations.map do |loc|
+        { :"#{loc.content_type}" => loc.url_for_format(:get) }
+      end
+      expect(expected).to match_array(result_locs)
+    end
+  end
+end

--- a/spec/serializers/recent_serializer_spec.rb
+++ b/spec/serializers/recent_serializer_spec.rb
@@ -8,7 +8,7 @@ describe RecentSerializer do
   it "should preload the serialized associations" do
     expect_any_instance_of(Recent::ActiveRecord_Relation)
       .to receive(:preload)
-      .with(subject: :locations)
+      .with(:locations)
       .and_call_original
     RecentSerializer.page({}, Recent.all, context)
   end
@@ -20,7 +20,7 @@ describe RecentSerializer do
     end
 
     it "should use the subject ordered locations method" do
-      expect_any_instance_of(Subject)
+      expect_any_instance_of(Recent)
         .to receive(:ordered_locations)
         .and_call_original
       result_locs

--- a/spec/support/ordered_locations.rb
+++ b/spec/support/ordered_locations.rb
@@ -1,0 +1,29 @@
+RSpec.shared_examples 'it has ordered locations' do
+
+  it "should sort the loaded locations by index" do
+    expected = resource.locations.sort_by { |loc| loc.metadata["index"] }
+    expect(expected.map(&:id)).to eq(resource.ordered_locations.map(&:id))
+  end
+
+  it "should sort the non-loaded locations by db index" do
+    lone_resource = klass.find(resource.id)
+    expect_any_instance_of(Medium::ActiveRecord_Associations_CollectionProxy)
+      .to receive(:order)
+      .with("\"media\".\"metadata\"->>'index' ASC")
+      .and_call_original
+    expected = resource.locations.sort_by { |loc| loc.metadata["index"] }
+    expect(expected.map(&:id)).to eq(lone_resource.ordered_locations.map(&:id))
+  end
+
+  context "resource without location metadata" do
+    before do
+      resource.locations.update_all(metadata: nil)
+      resource.locations(true)
+    end
+
+    it "should mimic the database order by using the relation ordering" do
+      expected = resource.locations.order("\"media\".\"metadata\"->>'index' ASC")
+      expect(expected.map(&:id)).to eq(resource.ordered_locations.map(&:id))
+    end
+  end
+end


### PR DESCRIPTION
Cleanup invalid recent data to allow the fk migrations to pass. Rebuild the indexes as they are bloated and referencing old removed rows. Preload the recent media locations by reusing the extracted subject#ordered_locations code and finally add an index for created_at sorting without scans. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
