### PR TITLE
make insecure oauth apps useful by default

### DIFF
--- a/db/migrate/20170215151802_change_oauth_application_default_trust_level.rb
+++ b/db/migrate/20170215151802_change_oauth_application_default_trust_level.rb
@@ -1,0 +1,6 @@
+class ChangeOauthApplicationDefaultTrustLevel < ActiveRecord::Migration
+  def change
+    Doorkeeper::Application.where(trust_level: 0).update_all(trust_level: 1)
+    change_column_default(:oauth_applications, :trust_level, 1)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -609,7 +609,7 @@ CREATE TABLE oauth_applications (
     updated_at timestamp without time zone,
     owner_id integer,
     owner_type character varying,
-    trust_level integer DEFAULT 0 NOT NULL,
+    trust_level integer DEFAULT 1 NOT NULL,
     default_scope character varying[] DEFAULT '{}'::character varying[],
     scopes character varying DEFAULT ''::character varying NOT NULL
 );
@@ -3894,6 +3894,8 @@ INSERT INTO schema_migrations (version) VALUES ('20170210163241');
 
 INSERT INTO schema_migrations (version) VALUES ('20170215105309');
 
+INSERT INTO schema_migrations (version) VALUES ('20170215151802');
+
 INSERT INTO schema_migrations (version) VALUES ('20170310131642');
 
 INSERT INTO schema_migrations (version) VALUES ('20170316170501');
@@ -3910,13 +3912,13 @@ INSERT INTO schema_migrations (version) VALUES ('20170425110939');
 
 INSERT INTO schema_migrations (version) VALUES ('20170426162708');
 
-INSERT INTO schema_migrations (version) VALUES ('20170524205300');
-
 INSERT INTO schema_migrations (version) VALUES ('20170519181110');
 
-INSERT INTO schema_migrations (version) VALUES ('20170524210302');
-
 INSERT INTO schema_migrations (version) VALUES ('20170523135118');
+
+INSERT INTO schema_migrations (version) VALUES ('20170524205300');
+
+INSERT INTO schema_migrations (version) VALUES ('20170524210302');
 
 INSERT INTO schema_migrations (version) VALUES ('20170525151142');
 


### PR DESCRIPTION
Oauth apps should be able to be used for authentication by default.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
