### PR TITLE
fix serialzied paging url's for custom nested resource routes

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -93,4 +93,12 @@ class Api::V1::ClassificationsController < Api::ApiController
       context
     )
   end
+
+  def context
+    if %w(gold_standard incomplete project).include?(action_name)
+      super.merge(url_suffix: action_name)
+    else
+      super
+    end
+  end
 end

--- a/app/controllers/concerns/recents.rb
+++ b/app/controllers/concerns/recents.rb
@@ -5,7 +5,7 @@ module Recents
     render json_api: RecentSerializer.page(
       ps,
       Recent.where(:"#{resource_name}_id" => resource_ids),
-      { type: resource_sym.to_s, owner_id: resource_ids }
+      { url_prefix: "#{resource_sym.to_s.pluralize}/#{resource_ids}" }
     )
   end
 end

--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -1,13 +1,13 @@
+require 'panoptes/restpack_serializer'
+
 class ClassificationSerializer
-  include RestPack::Serializer
+  include Panoptes::RestpackSerializer
   include NoCountSerializer
 
   attributes :id, :annotations, :created_at, :metadata, :href
   can_include :project, :user, :user_group, :workflow
 
-  def self.page(params = {}, scope = nil, context = {})
-    super(params, scope.preload(:subjects), context)
-  end
+  preload :subjects
 
   def metadata
     @model.metadata.merge(workflow_version: @model.workflow_version)

--- a/app/serializers/concerns/panoptes/restpack_serializer.rb
+++ b/app/serializers/concerns/panoptes/restpack_serializer.rb
@@ -30,6 +30,34 @@ module Panoptes
 
         super(params, scope, context)
       end
+
+      private
+
+      def page_href(page, options)
+        return nil unless page
+
+        params = []
+        params << "page=#{page}" unless page == 1
+        params << "page_size=#{options.page_size}" unless options.default_page_size?
+        params << "include=#{options.include.join(',')}" if options.include.any?
+        params << options.sorting_as_url_params if options.sorting.any?
+        params << options.filters_as_url_params if options.filters.any?
+
+        url = page_url(options.context)
+        url += '?' + params.join('&') if params.any?
+        url
+      end
+
+      def page_url(context)
+        case
+        when context[:url_prefix]
+          "#{href_prefix}/#{context[:url_prefix]}/#{key}"
+        when context[:url_suffix]
+          "#{href_prefix}/#{key}/#{context[:url_suffix]}"
+        else
+          "#{href_prefix}/#{key}"
+        end
+      end
     end
   end
 end

--- a/app/serializers/recent_serializer.rb
+++ b/app/serializers/recent_serializer.rb
@@ -1,17 +1,16 @@
+require 'panoptes/restpack_serializer'
+
 class RecentSerializer
-  include RestPack::Serializer
+  include Panoptes::RestpackSerializer
 
   attributes :id, :created_at, :locations, :href
   can_include :project, :workflow, :subject
   can_sort_by :created_at
 
-  def self.page(params = {}, scope = nil, context = {})
-    scope = scope.preload(:locations)
-    super(params, scope, context)
-  end
+  preload :locations
 
   def href
-    "/#{@context[:type].pluralize}/#{@context[:owner_id]}/recents/#{@model.id}"
+    "/#{@context[:url_prefix]}/recents/#{@model.id}"
   end
 
   def locations

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -11,6 +11,20 @@ describe ClassificationSerializer do
     ClassificationSerializer.page({}, Classification.all, {})
   end
 
+  describe "nested collection routes" do
+    it "should return the correct href urls" do
+      %w(gold_standard incomplete project).each do |collection_route|
+        context = {url_suffix: collection_route}
+        result = ClassificationSerializer.page({}, Classification.all, context)
+        meta = result[:meta][:classifications]
+        expect(meta[:first_href]).to eq("/classifications/#{collection_route}")
+        expect(meta[:previous_href]).to eq("/classifications/#{collection_route}?page=0")
+        expect(meta[:next_href]).to eq("/classifications/#{collection_route}?page=2")
+        expect(meta[:last_href]).to eq("/classifications/#{collection_route}?page=0")
+      end
+    end
+  end
+
   describe "avoid heavy count queries on paging" do
     it "should manually deal with the paging information" do
       result = ClassificationSerializer.page({}, Classification.all, {})

--- a/spec/serializers/recent_serializer_spec.rb
+++ b/spec/serializers/recent_serializer_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe RecentSerializer do
+  let(:prefix) { "users/1" }
   let(:context) do
-    { type: "user", owner_id: "1" }
+    { url_prefix: prefix }
   end
 
   it "should preload the serialized associations" do
@@ -13,7 +14,7 @@ describe RecentSerializer do
     RecentSerializer.page({}, Recent.all, context)
   end
 
-  describe "locations" do
+  describe "#locations" do
     let!(:recent) { create(:recent) }
     let(:result_locs) do
       RecentSerializer.single({}, Recent.all, context)[:locations]
@@ -34,10 +35,16 @@ describe RecentSerializer do
     end
   end
 
-  describe "nested member routes" do
+  describe "#href" do
+    it "should include the url_prefix for the resource route" do
+      recent = create(:recent)
+      result = RecentSerializer.single({}, Recent.all, context)
+      expect(result[:href]).to eq("/#{prefix}/recents/#{recent.id}")
+    end
+  end
+
+  describe "meta paging urls" do
     it "should return the correct href urls" do
-      prefix = "users/1"
-      context = { url_prefix: prefix }
       result = RecentSerializer.page({}, Recent.all, context)
       meta = result[:meta][:recents]
       expect(meta[:first_href]).to eq("/#{prefix}/recents")

--- a/spec/serializers/recent_serializer_spec.rb
+++ b/spec/serializers/recent_serializer_spec.rb
@@ -33,4 +33,15 @@ describe RecentSerializer do
       expect(expected).to match_array(result_locs)
     end
   end
+
+  describe "nested member routes" do
+    it "should return the correct href urls" do
+      prefix = "users/1"
+      context = { url_prefix: prefix }
+      result = RecentSerializer.page({}, Recent.all, context)
+      meta = result[:meta][:recents]
+      expect(meta[:first_href]).to eq("/#{prefix}/recents")
+      expect(meta[:last_href]).to eq("/#{prefix}/recents?page=0")
+    end
+  end
 end


### PR DESCRIPTION
Custom member / collection routes weren't serializing the correct paging *_href url's in the resource responses. This PR adds the ability to modify the paging URL's with serializer contexts via the Restpack::Serializer wrapper.

I still need to finalize testing on the serializer wrapper before merging this

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
