### PR TITLE
handle more redis errors on registration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -293,8 +293,8 @@ class User < ActiveRecord::Base
 
   def send_welcome_email
     UserWelcomeMailerWorker.perform_async(id, project_id)
-  rescue Timeout::Error, Redis::TimeoutError, Redis::CannotConnectError => e
-    Honeybadger.notify(e)
+  rescue Timeout::Error, Redis::TimeoutError, Redis::CannotConnectError
+    UserWelcomeMailerWorker.new.perform(id, project_id)
   end
 
   def set_ouroboros_api_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -293,7 +293,7 @@ class User < ActiveRecord::Base
 
   def send_welcome_email
     UserWelcomeMailerWorker.perform_async(id, project_id)
-  rescue Timeout::Error => e
+  rescue Timeout::Error, Redis::TimeoutError, Redis::CannotConnectError => e
     Honeybadger.notify(e)
   end
 


### PR DESCRIPTION
ensure we don't 500 during registration when redis is down / hard to reach and we still send the email.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
