### PR TITLE
Send email if redis is down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
 
 services:
   - postgresql
-  - redis-server
 
 addons:
   postgresql: "9.4"

--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,5 @@ group :test do
   gem 'guard-rspec', require: false
   gem 'factory_girl_rails'
   gem 'spring-commands-rspec'
+  gem 'mock_redis'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,7 @@ GEM
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    mock_redis (0.17.2)
     modware (0.1.2)
       its-it
       key_struct (~> 0.4)
@@ -464,6 +465,7 @@ DEPENDENCIES
   json-schema (~> 2.0)
   librato-metrics (~> 1.6.1)
   logstasher (~> 0.6)
+  mock_redis
   newrelic_rpm (~> 3.0)
   oauth2!
   omniauth (~> 1.0)

--- a/lib/devise_mailer/background_mailer.rb
+++ b/lib/devise_mailer/background_mailer.rb
@@ -21,6 +21,8 @@ module Devise
 
     def deliver
       Devise::Mailer.delay.send(@method, @record, @token, @opts)
+    rescue Redis::CannotConnectError, Redis::TimeoutError, Timeout::Error
+      Devise::Mailer.send(@method, @record, @token, @opts).deliver
     end
   end
 end

--- a/spec/lib/background_mailer_spec.rb
+++ b/spec/lib/background_mailer_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Devise::BackgroundMailer, sidekiq: :inline do
+  let(:user) { create(:user) }
+  let(:mailer) do
+    Devise::BackgroundMailer.reset_password_instructions(user, "token")
+  end
+
+  before do
+    allow_any_instance_of(User).to receive(:send_welcome_email)
+  end
+
+  it "should send an email" do
+    expect {
+      mailer.deliver
+    }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  context "when redis is down" do
+    it "should send an email normally" do
+      [ Redis::CannotConnectError, Redis::TimeoutError, Timeout::Error ].each do |redis_error|
+        allow(Devise::Mailer).to receive(:delay).and_raise(redis_error)
+        expect {
+          mailer.deliver
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,13 @@ RSpec.configure do |config|
       suj_config.redis_test_mode = :mock
     end
 
+    MOCK_REDIS ||= MockRedis.new
+    MOCK_REDIS.keys.each do |key|
+      MOCK_REDIS.del(key)
+    end
+
+    allow(Redis).to receive(:new).and_return(MOCK_REDIS)
+
     # Clears out the jobs for tests using the fake testing
     Sidekiq::Worker.clear_all
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,8 +33,14 @@ RSpec.configure do |config|
   # work around https://github.com/celluloid/celluloid/issues/696
   Celluloid.shutdown_timeout = 1
 
+  MOCK_REDIS ||= MockRedis.new
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+
+    SidekiqUniqueJobs.configure do |suj_config|
+      suj_config.redis_test_mode = :mock
+    end
   end
 
   config.before(:each) do |example|
@@ -42,16 +48,11 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
 
-    SidekiqUniqueJobs.configure do |suj_config|
-      suj_config.redis_test_mode = :mock
-    end
+    allow(Redis).to receive(:new).and_return(MOCK_REDIS)
 
-    MOCK_REDIS ||= MockRedis.new
     MOCK_REDIS.keys.each do |key|
       MOCK_REDIS.del(key)
     end
-
-    allow(Redis).to receive(:new).and_return(MOCK_REDIS)
 
     # Clears out the jobs for tests using the fake testing
     Sidekiq::Worker.clear_all

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,8 +42,8 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
 
-    SidekiqUniqueJobs.configure do |config|
-      config.redis_test_mode = :mock
+    SidekiqUniqueJobs.configure do |suj_config|
+      suj_config.redis_test_mode = :mock
     end
 
     # Clears out the jobs for tests using the fake testing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,10 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
 
+    SidekiqUniqueJobs.configure do |config|
+      config.redis_test_mode = :mock
+    end
+
     # Clears out the jobs for tests using the fake testing
     Sidekiq::Worker.clear_all
 


### PR DESCRIPTION
make sure we still send emails for devise user registrations, passwords, etc if redis is down.

@marten this sets up mock redis for sidekiq unique testing as i didn't want to run another redis dep for local testing. Should i remove redis setup for travis?

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
