### PR TITLE
Add queued route for subjects

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -13,11 +13,15 @@ class Api::V1::SubjectsController < Api::ApiController
   def index
     case params[:sort]
     when 'queued'
-      non_filterable_params = params.except(:project_id, :collection_id)
-      render json_api: SubjectSerializer.page(non_filterable_params, *selector.get_subjects)
+      queued
     else
       super
     end
+  end
+
+  def queued
+    non_filterable_params = params.except(:project_id, :collection_id)
+    render json_api: SubjectSerializer.page(non_filterable_params, *selector.get_subjects)
   end
 
   def create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,11 @@ Rails.application.routes.draw do
 
       json_api_resources :memberships
 
-      json_api_resources :subjects, versioned: true
+      json_api_resources :subjects, versioned: true do
+        collection do
+          get :queued
+        end
+      end
 
       json_api_resources :users, except: [:new, :edit, :create], links: [:user_groups] do
         get "/recents", to: "users#recents", format: false


### PR DESCRIPTION
Splitting this up means that it splits up in our monitoring tools too: NewRelic, logs, etc. The route does exactly the same as the index when `params[:sort] == 'queued'`, and the old method stays supported (but we should stop using it to get the most out of the mentioned benefit). 

If merged, I'll update PFE to use this for subject selection. 