### PR TITLE
using_cellect? should not return true if cellect_ex is set

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -108,7 +108,13 @@ class Workflow < ActiveRecord::Base
 
   def using_cellect?
     Rails.cache.fetch(model_cache_key(:using_cellect?), expires_in: 1.hour) do
-      subject_selection_strategy.to_s == "cellect" || cellect_size_subject_space?
+      if cellect?
+        true
+      elsif cellect_ex?
+        false
+      else
+        cellect_size_subject_space?
+      end
     end
   end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -348,14 +348,30 @@ describe Workflow, type: :model do
     end
 
     it "should return true if the config is set" do
-      allow(workflow).to receive(:subject_selection_strategy).and_return("cellect")
+      allow(workflow).to receive(:cellect?).and_return(true)
       expect(workflow.using_cellect?).to be_truthy
     end
 
-    it "should return true if the subjects space is large enough" do
-      allow(workflow).to receive(:subjects_count)
-        .and_return(Panoptes.cellect_min_pool_size)
-      expect(workflow.using_cellect?).to be_truthy
+    context "when the subject space is large enough" do
+      before do
+        allow(workflow)
+          .to receive(:subjects_count)
+          .and_return(Panoptes.cellect_min_pool_size)
+      end
+
+      it "should return true if no selection strategy" do
+        expect(workflow.using_cellect?).to be_truthy
+      end
+
+      it "should return true if cellect strategy" do
+        workflow.cellect!
+        expect(workflow.using_cellect?).to be_truthy
+      end
+
+      it "should return false if cellect_ex is set" do
+        workflow.cellect_ex!
+        expect(workflow.using_cellect?).to be_falsey
+      end
     end
   end
 


### PR DESCRIPTION
keep the distributed systems seperate, if we're using cellect talk to cellect, if we using cellect_ex do that..otherwise default back to the subjects space size.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
