### PR TITLE
only use fallback selection if the workflow is finished

### DIFF
--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe Subjects::Selector do
       end
     end
 
+    context "when the workflow is finished_at" do
+      before do
+        allow(workflow).to receive(:finished_at).and_return(Time.zone.now)
+      end
+
+      it "should not run the strategy selector" do
+        expect(subject).not_to receive(:run_strategy_selection)
+        subject.get_subjects
+      end
+
+      it "should run the fallback selector only" do
+        expect(subject).to receive(:fallback_selection).and_call_original
+        subject.get_subjects
+      end
+    end
+
     context "when the workflow doesn't have any subject sets" do
       it 'should raise an informative error' do
         allow_any_instance_of(Workflow).to receive(:subject_sets).and_return([])


### PR DESCRIPTION
avoid the potential heavy cost of selection diffs when all subjects are retired, just fallback to anything. This may frustrate some users so we need to combine this with a signal in the subject_selector_serializer.rb that the workflow is finished

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
