### PR TITLE
Move project/org linking to project controller

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -23,7 +23,6 @@ class Organization < ActiveRecord::Base
 
   can_by_role :translate, roles: [ :owner, :translator, :collaborator ]
 
-  can_be_linked :project, :scope_for, :update, :user
   can_be_linked :access_control_list, :scope_for, :update, :user
 
 end

--- a/app/schemas/project_update_schema.rb
+++ b/app/schemas/project_update_schema.rb
@@ -109,6 +109,11 @@ class ProjectUpdateSchema < JsonSchema
       end
     end
 
+    property "organization_id" do
+      type "string", "integer", nil
+      pattern "^[0-9]*$"
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -165,20 +165,5 @@ describe Api::V1::OrganizationsController, type: :controller do
 
       it_behaves_like "is deactivatable"
     end
-
-    describe "#update_links" do
-      let(:resource) { create(:organization, owner: authorized_user) }
-      let(:resource_id) { :organization_id }
-      let(:test_attr) { :display_name }
-      let(:test_relation_ids) { [ linked_resource.id.to_s ] }
-
-      describe "linking a project" do
-        let!(:linked_resource) { create(:project) }
-        let(:test_relation) { :projects }
-        let(:expected_copies_count) { 1 }
-
-        it_behaves_like "supports update_links"
-      end
-    end
   end
 end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -640,6 +640,31 @@ describe Api::V1::ProjectsController, type: :controller do
       }
     end
 
+    describe "update organization" do
+      let(:organization) { create(:organization) }
+      let!(:project_with_org) { create(:project, owner: authorized_user, organization: organization)}
+      let(:update_org_params) do
+        {
+          projects: {
+            organization_id: organization.id.to_s
+          }
+        }
+      end
+
+      it "updates the project's organization association" do
+        default_request scopes: scopes, user_id: authorized_user.id
+        put :update, update_org_params.merge(id: resource.id)
+        expect(resource.reload.organization).to eq(organization)
+      end
+
+      it "removes the project's organization association" do
+        default_request scopes: scopes, user_id: authorized_user.id
+        update_org_params[:projects][:organization_id] = nil
+        put :update, update_org_params.merge(id: project_with_org.id)
+        expect(project_with_org.reload.organization).to be nil
+      end
+    end
+
     it_behaves_like "is updatable"
 
     describe "update tags" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -27,15 +27,6 @@ describe Organization, type: :model do
     expect(build(:organization, primary_language: nil)).to_not be_valid
   end
 
-  describe "links" do
-    let(:user) { ApiUser.new(create(:user)) }
-
-    it "should allow projects to link when user has update permissions" do
-      expect(Organization).to link_to(Project).given_args(user)
-                          .with_scope(:scope_for, :update, user)
-    end
-  end
-
   describe "#organization_roles" do
     let!(:preferences) do
       [create(:access_control_list, resource: organization, roles: []),


### PR DESCRIPTION
Linking a project to an organization would makes sense if we had a more standard JSON API spec implementation. As it is, the behavior of all controllers when unlinking is to destroy the unlinked resource. This only happens with workflows that were copied when linked originally (between projects) or to SetMemberSubjects when a subject is removed from a set or collection.

It's probably not a good idea to delete projects when we remove them from organizations. Rather than changing how this works or overriding a bunch of methods, it makes mores sense to just remove the `can_be_linked :project [etc]` from orgs and just update the `organization_id` attribute on the project directly. This means that you need to have permission to edit the project, which makes sense too.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
