### PR TITLE
Adds 'favorite' to subject serializer

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -21,7 +21,9 @@ class Api::V1::SubjectsController < Api::ApiController
 
   def queued
     non_filterable_params = params.except(:project_id, :collection_id)
-    render json_api: SubjectSerializer.page(non_filterable_params, *selector.get_subjects)
+    scope, context = selector.get_subjects
+    context[:include_favorite?] = false unless Panoptes.flipper[:subject_include_favorite].enabled?
+    render json_api: SubjectSerializer.page(non_filterable_params, scope, context)
   end
 
   def create

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -3,7 +3,7 @@ class SubjectSerializer
   include FilterHasMany
 
   attributes :id, :metadata, :locations, :zooniverse_id,
-    :created_at, :updated_at, :href
+    :created_at, :updated_at, :href, :favorite
 
   optional :retired, :already_seen, :finished_workflow
 
@@ -28,6 +28,10 @@ class SubjectSerializer
 
   def already_seen
     !!(user_seen&.subjects_seen?(@model.id))
+  end
+
+  def favorite
+    !!user ? user.collections.where(favorite: true).first.subjects.include?(@model) : nil
   end
 
   private

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -329,6 +329,23 @@ describe Api::V1::SubjectsController, type: :controller do
         let!(:sms) { create_list(:set_member_subject, 2, subject_set: subject_set) }
         let(:request_params) { { workflow_id: workflow.id.to_s } }
 
+        describe "subject favorite flag" do
+          let!(:collection) do
+            create(:collection, build_projects: false, owner: user, subjects: subjects, favorite: true)
+          end
+          it "does not include subject favorites when the flag is disabled" do
+            Panoptes.flipper[:subject_include_favorite].disable
+            get :queued, request_params
+            expect(json_response["subjects"].first.has_key?("favorite")).to be_falsey
+          end
+
+          it "includes subject favorite when the flag is enabled" do
+            Panoptes.flipper[:subject_include_favorite].enable
+            get :queued, request_params
+            expect(json_response["subjects"].map{ |s| s['favorite']}).to include(true)
+          end
+        end
+
         context "with subjects" do
           before(:each) do
             get :queued, request_params

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe Subjects::Selector do
         Panoptes.flipper[:skip_subject_selection_context].enable
         expect(ctx).not_to include(:select_context)
       end
+
+      it "includes the favorite when enabled" do
+        Panoptes.flipper[:subject_include_favorite].enable
+        expect(ctx[:include_favorite?]).to be(true)
+      end
+
+      it "does not include the favorite when disabled" do
+        Panoptes.flipper[:subject_include_favorite].disable
+        expect(ctx[:include_favorite?]).to be(false)
+      end
     end
 
     context "when the workflow is finished_at" do

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -6,6 +6,40 @@ describe SubjectSerializer do
     create(:collection, build_projects: false, owner: subject.project.owner, subjects: [subject])
   end
 
+  describe "favorite" do
+    let(:fav_collection) do
+      create(:collection, build_projects: false, subjects: [subject], favorite: true)
+    end
+
+    let(:context) { {languages: ['en'], user: fav_collection.owner} }
+    let(:serializer) do
+      s = SubjectSerializer.new
+      s.instance_variable_set(:@model, subject)
+      s.instance_variable_set(:@context, context)
+      s
+    end
+
+    before do
+      Panoptes.flipper[:subject_include_favorite].enable
+    end
+
+    it "is true if the subject is included in the current user's favorites" do
+      expect(serializer.favorite).to be true
+    end
+
+    it "is false if the subject is not included in the current user's favorites" do
+      fav_collection.subjects.clear
+      expect(serializer.favorite).to be false
+    end
+
+    it "does not include a user" do
+      s = SubjectSerializer.new
+      s.instance_variable_set(:@model, subject)
+      s.instance_variable_set(:@context, {})
+      expect(s.favorite).to be_nil
+    end
+  end
+
   it "should preload the serialized associations" do
     expect_any_instance_of(Subject::ActiveRecord_Relation)
       .to receive(:preload)


### PR DESCRIPTION
Adds a Flipper flag to toggle inclusion of the new `favorite` attribute to the subject serializer. It should only be included when the toggle is on and the user is logged in. It indicates whether the serialized subject is in the user's Favorites collection.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
