### PR TITLE
Optional 'favorite' attr now available on subject

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -113,18 +113,12 @@ class Api::V1::SubjectsController < Api::ApiController
     if Panoptes.flipper[:skip_subject_selection_context].enabled?
       {}
     else
-      if api_user.logged_in?
-        fav_collections = api_user.user.favorite_collections_for_project(workflow.project)
-        fav_subjects = fav_collections.joins(:subjects).where(subjects: {id: selected_subject_ids}).pluck("subjects.id")
-      else
-        fav_subjects = []
-      end
       {
         workflow: workflow,
         user: api_user.user,
         user_seen: user_seen,
         url_format: :get,
-        favorite_subject_ids: fav_subjects,
+        favorite_subject_ids: FavoritesFinder.new(api_user.user, workflow.project, selected_subject_ids).find_favorites,
         select_context: true
       }.compact
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,6 +328,10 @@ class User < ActiveRecord::Base
     Rails.cache.increment(subjects_count_cache_key)
   end
 
+  def favorite_collections_for_project(project)
+    collections.where(favorite: true, projects: [project])
+  end
+
   private
 
   def subjects_count_cache_key

--- a/app/serializers/subject_selector_serializer.rb
+++ b/app/serializers/subject_selector_serializer.rb
@@ -7,7 +7,7 @@ class SubjectSelectorSerializer
   attributes :id, :metadata, :locations, :zooniverse_id,
     :created_at, :updated_at, :href
 
-  optional :retired, :already_seen, :finished_workflow
+  optional :retired, :already_seen, :finished_workflow, :favorite
 
   preload :locations
 
@@ -31,6 +31,10 @@ class SubjectSelectorSerializer
     !!(user_seen&.subjects_seen?(@model.id))
   end
 
+  def favorite
+    user&.collections&.where(favorite: true)&.first&.subjects&.include? @model
+  end
+
   private
 
   def include_retired?
@@ -42,6 +46,10 @@ class SubjectSelectorSerializer
   end
 
   def include_finished_workflow?
+    select_context?
+  end
+
+  def include_favorite?
     select_context?
   end
 

--- a/app/serializers/subject_selector_serializer.rb
+++ b/app/serializers/subject_selector_serializer.rb
@@ -32,7 +32,7 @@ class SubjectSelectorSerializer
   end
 
   def favorite
-    user&.collections&.where(favorite: true)&.first&.subjects&.include? @model
+    @context[:favorite_subject_ids].include? @model.id
   end
 
   private

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -7,7 +7,7 @@ class SubjectSerializer
   attributes :id, :metadata, :locations, :zooniverse_id,
     :created_at, :updated_at, :href
 
-  optional :retired, :already_seen, :finished_workflow
+  optional :retired, :already_seen, :finished_workflow, :favorite
 
   can_include :project, :collections, :subject_sets
 

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -7,8 +7,6 @@ class SubjectSerializer
   attributes :id, :metadata, :locations, :zooniverse_id,
     :created_at, :updated_at, :href
 
-  optional :retired, :already_seen, :finished_workflow, :favorite
-
   can_include :project, :collections, :subject_sets
 
   preload :locations, :project, :collections, :subject_sets

--- a/lib/favorites_finder.rb
+++ b/lib/favorites_finder.rb
@@ -1,0 +1,13 @@
+class FavoritesFinder
+  def initialize(user, project, subject_ids)
+    @user = user
+    @project = project
+    @subject_ids = subject_ids
+  end
+
+  def find_favorites
+    return [] unless @user
+    fav_collections = @user.favorite_collections_for_project(@project)
+    fav_collections.joins(:subjects).where(subjects: {id: @subject_ids}).pluck("subjects.id")
+  end
+end

--- a/spec/lib/favorites_finder_spec.rb
+++ b/spec/lib/favorites_finder_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe FavoritesFinder do
+  let(:user) { create(:user) }
+  let(:project) { create(:project) }
+  let(:subjects) { create_list(:subject, 2) }
+  let(:non_fav_subject) { subjects.first }
+  let(:fav_subject) { subjects.last }
+  let(:subject_ids) { subjects.map(&:id) }
+  let!(:collection) do
+    create(:collection, owner: user, subjects: [fav_subject], favorite: true, projects: [project])
+  end
+  context "user has no favorites" do
+    it "returns favorite as false" do
+      user.collections.destroy_all
+      expect(FavoritesFinder.new(user, project, subject_ids).find_favorites).to eq([])
+    end
+  end
+
+  context "user has favorites" do
+    it "favorite returns true for favorited subjects" do
+      expect(FavoritesFinder.new(user, project, subject_ids).find_favorites).to include(fav_subject.id)
+    end
+
+    it "favorite returns false for non-favorited subjects" do
+      expect(FavoritesFinder.new(user, project, subject_ids).find_favorites).to_not include(non_fav_subject.id)
+    end
+  end
+
+  context "not logged in" do
+    it "returns favorites as false" do
+      expect(FavoritesFinder.new(nil, project, subject_ids).find_favorites).to eq([])
+    end
+  end
+end

--- a/spec/lib/favorites_finder_spec.rb
+++ b/spec/lib/favorites_finder_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe FavoritesFinder do
   let(:non_fav_subject) { subjects.first }
   let(:fav_subject) { subjects.last }
   let(:subject_ids) { subjects.map(&:id) }
-  let!(:collection) do
+  let(:collection) do
     create(:collection, owner: user, subjects: [fav_subject], favorite: true, projects: [project])
   end
   context "user has no favorites" do
     it "returns favorite as false" do
-      user.collections.destroy_all
       expect(FavoritesFinder.new(user, project, subject_ids).find_favorites).to eq([])
     end
   end
 
   context "user has favorites" do
+    before { collection }
     it "favorite returns true for favorited subjects" do
       expect(FavoritesFinder.new(user, project, subject_ids).find_favorites).to include(fav_subject.id)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -940,4 +940,12 @@ describe User, type: :model do
       expect(user.identity_group.display_name).to eq("test")
     end
   end
+
+  describe "#favorite_collections_for_project" do
+    let!(:fav_collection) { create(:collection, projects: [owned], owner: user, favorite: true) }
+
+    it "returns the favorite collections for the project" do
+      expect(user.favorite_collections_for_project(owned)).to eq([fav_collection])
+    end
+  end
 end

--- a/spec/serializers/subject_selector_serializer_spec.rb
+++ b/spec/serializers/subject_selector_serializer_spec.rb
@@ -50,6 +50,7 @@ describe SubjectSelectorSerializer do
         expect_any_instance_of(SubjectSelectorSerializer).to receive(:retired)
         expect_any_instance_of(SubjectSelectorSerializer).to receive(:already_seen)
         expect_any_instance_of(SubjectSelectorSerializer).to receive(:finished_workflow)
+        expect_any_instance_of(SubjectSelectorSerializer).to receive(:favorite)
         run_serializer
       end
 
@@ -60,6 +61,7 @@ describe SubjectSelectorSerializer do
           expect_any_instance_of(SubjectSelectorSerializer).not_to receive(:retired)
           expect_any_instance_of(SubjectSelectorSerializer).not_to receive(:already_seen)
           expect_any_instance_of(SubjectSelectorSerializer).not_to receive(:finished_workflow)
+          expect_any_instance_of(SubjectSelectorSerializer).not_to receive(:favorite)
           run_serializer
         end
       end

--- a/spec/support/favorited_subjects.rb
+++ b/spec/support/favorited_subjects.rb
@@ -1,37 +1,9 @@
 shared_examples "favorited subjects" do
-  let(:fav_subject) { subjects.last }
-  let!(:collection) do
-    create(:collection, owner: user, subjects: [fav_subject], favorite: true, projects: [workflow.project])
-  end
-  context "user has no favorites" do
-    it "returns favorite as false" do
-      user.collections.destroy_all
-      get :queued, request_params
-      favorites = json_response["subjects"].map{ |s| s['favorite']}
-      expect(favorites).to all( be false )
-    end
-  end
-
-  context "user has favorites" do
-    before(:each) { get :queued, request_params }
-
-    it "favorite returns true for favorited subjects" do
-      fav = json_response["subjects"].find{ |s| s["id"] == fav_subject.id.to_s }
-      expect(fav["favorite"]).to be true
-    end
-
-    it "favorite returns false for non-favorited subjects" do
-      fav = json_response["subjects"].find{ |s| s["id"] != fav_subject.id.to_s }
-      expect(fav["favorite"]).to be false
-    end
-  end
-
-  context "not logged in" do
-    it "returns favorites as false" do
-      default_request
-      get :queued, request_params
-      favorites = json_response["subjects"].map{ |s| s['favorite']}
-      expect(favorites).to all( be false )
-    end
+  it "creates a new FavoritesFinder instance" do
+    allow_any_instance_of(FavoritesFinder)
+       .to receive(:find_favorites).and_return([])
+    expect_any_instance_of(FavoritesFinder)
+      .to receive(:find_favorites)
+    get :queued, request_params
   end
 end

--- a/spec/support/favorited_subjects.rb
+++ b/spec/support/favorited_subjects.rb
@@ -1,0 +1,37 @@
+shared_examples "favorited subjects" do
+  let(:fav_subject) { subjects.last }
+  let!(:collection) do
+    create(:collection, owner: user, subjects: [fav_subject], favorite: true, projects: [workflow.project])
+  end
+  context "user has no favorites" do
+    it "returns favorite as false" do
+      user.collections.destroy_all
+      get :queued, request_params
+      favorites = json_response["subjects"].map{ |s| s['favorite']}
+      expect(favorites).to all( be false )
+    end
+  end
+
+  context "user has favorites" do
+    before(:each) { get :queued, request_params }
+
+    it "favorite returns true for favorited subjects" do
+      fav = json_response["subjects"].find{ |s| s["id"] == fav_subject.id.to_s }
+      expect(fav["favorite"]).to be true
+    end
+
+    it "favorite returns false for non-favorited subjects" do
+      fav = json_response["subjects"].find{ |s| s["id"] != fav_subject.id.to_s }
+      expect(fav["favorite"]).to be false
+    end
+  end
+
+  context "not logged in" do
+    it "returns favorites as false" do
+      default_request
+      get :queued, request_params
+      favorites = json_response["subjects"].map{ |s| s['favorite']}
+      expect(favorites).to all( be false )
+    end
+  end
+end


### PR DESCRIPTION
Now with includes @camallen's updated subject serializer! `favorite` is an optional subject attribute along with the others, all behind a single flipper. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
