### PR TITLE
Rename CellectEx to Designator, and start sending authentication

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -32,7 +32,7 @@ class Workflow < ActiveRecord::Base
   cache_by_association :workflow_contents
   cache_by_resource_method :subjects_count, :finished?
 
-  enum subject_selection_strategy: [:default, :cellect, :cellect_ex]
+  enum subject_selection_strategy: [:default, :cellect, :designator]
 
   scope :using_cellect, -> { where(subject_selection_strategy: subject_selection_strategies[:cellect]) }
 
@@ -93,8 +93,8 @@ class Workflow < ActiveRecord::Base
       case
       when subject_selection_strategy == "cellect"
         Subjects::CellectSelector.new(self)
-      when subject_selection_strategy == "cellect_ex"
-        Subjects::CellectExSelector.new(self)
+      when subject_selection_strategy == "designator"
+        Subjects::DesignatorSelector.new(self)
       when using_cellect?
         Subjects::CellectSelector.new(self)
       else
@@ -110,7 +110,7 @@ class Workflow < ActiveRecord::Base
     Rails.cache.fetch(model_cache_key(:using_cellect?), expires_in: 1.hour) do
       if cellect?
         true
-      elsif cellect_ex?
+      elsif designator?
         false
       else
         cellect_size_subject_space?

--- a/app/services/cellect_ex_client.rb
+++ b/app/services/cellect_ex_client.rb
@@ -7,9 +7,11 @@ class CellectExClient
   class ServerError < GenericError; end
 
   self.config_file = "cellect_ex_api"
-  self.api_prefix = "cellect_ex_api"
+  self.api_prefix = "designator_api"
 
   configure :host
+  configure :username
+  configure :password
 
   attr_reader :connection
 
@@ -19,6 +21,7 @@ class CellectExClient
 
   def connect!(adapter)
     Faraday.new(host, ssl: {verify: false}) do |faraday|
+      faraday.request  :basic_auth, username, password
       faraday.response :json, content_type: /\bjson$/
       faraday.adapter(*adapter)
     end

--- a/app/services/designator_client.rb
+++ b/app/services/designator_client.rb
@@ -1,4 +1,4 @@
-class CellectExClient
+class DesignatorClient
   include Configurable
 
   class GenericError < StandardError; end
@@ -6,7 +6,7 @@ class CellectExClient
   class ResourceNotFound < GenericError; end
   class ServerError < GenericError; end
 
-  self.config_file = "cellect_ex_api"
+  self.config_file = "designator_api"
   self.api_prefix = "designator_api"
 
   configure :host

--- a/config/initializers/cellect_ex.rb
+++ b/config/initializers/cellect_ex.rb
@@ -1,1 +1,0 @@
-CellectExClient.load_configuration

--- a/config/initializers/designator.rb
+++ b/config/initializers/designator.rb
@@ -1,0 +1,1 @@
+DesignatorClient.load_configuration

--- a/lib/subjects/designator_selector.rb
+++ b/lib/subjects/designator_selector.rb
@@ -1,5 +1,5 @@
 module Subjects
-  class CellectExSelector
+  class DesignatorSelector
     attr_reader :workflow
 
     def initialize(workflow)
@@ -7,7 +7,7 @@ module Subjects
     end
 
     def id
-      :cellect_ex
+      :designator
     end
 
     def add_seen(user_id, subject_id)
@@ -39,11 +39,11 @@ module Subjects
     end
 
     def enabled?
-      Panoptes.flipper["cellect_ex"].enabled?
+      Panoptes.flipper["designator"].enabled?
     end
 
     def self.client
-      @client ||= CellectExClient.new
+      @client ||= DesignatorClient.new
     end
   end
 end

--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -28,8 +28,8 @@ module Subjects
       @strategy ||= case
       when configured_to_use_cellect?
         :cellect
-      when configured_to_use_cellect_ex?
-        :cellect_ex
+      when configured_to_use_designator?
+        :designator
       when automatically_use_cellect?
         :cellect
       else
@@ -41,7 +41,7 @@ module Subjects
 
     def select_sms_ids
       select_with(desired_selector)
-    rescue CellectClient::ConnectionError, CellectExClient::GenericError
+    rescue CellectClient::ConnectionError, DesignatorClient::GenericError
       select_with(default_selector)
     end
 
@@ -50,9 +50,9 @@ module Subjects
       workflow.subject_selection_strategy.to_s == 'cellect'
     end
 
-    def configured_to_use_cellect_ex?
-      return nil unless Panoptes.flipper.enabled?("cellect_ex")
-      workflow.subject_selection_strategy.to_s == 'cellect_ex'
+    def configured_to_use_designator?
+      return nil unless Panoptes.flipper.enabled?("designator")
+      workflow.subject_selection_strategy.to_s == 'designator'
     end
 
     def automatically_use_cellect?

--- a/spec/lib/subjects/designator_selector_spec.rb
+++ b/spec/lib/subjects/designator_selector_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Subjects::CellectExSelector do
-  let(:client) { instance_double(CellectExClient) }
+describe Subjects::DesignatorSelector do
+  let(:client) { instance_double(DesignatorClient) }
   let(:workflow) { instance_double(Workflow, id: 1) }
   let(:selector) { described_class.new(workflow)}
   
@@ -16,7 +16,7 @@ describe Subjects::CellectExSelector do
     end
 
     it 'does nothing unless enabled' do
-      Panoptes.flipper["cellect_ex"].disable
+      Panoptes.flipper["designator"].disable
       expect(client).not_to receive(:add_seen)
       selector.add_seen(2, 3)
     end
@@ -29,7 +29,7 @@ describe Subjects::CellectExSelector do
     end
 
     it 'does nothing unless enabled' do
-      Panoptes.flipper["cellect_ex"].disable
+      Panoptes.flipper["designator"].disable
       expect(client).not_to receive(:load_user)
       selector.load_user(2)
     end
@@ -42,7 +42,7 @@ describe Subjects::CellectExSelector do
     end
 
     it 'does nothing unless enabled' do
-      Panoptes.flipper["cellect_ex"].disable
+      Panoptes.flipper["designator"].disable
       expect(client).not_to receive(:reload_workflow)
       selector.reload_workflow
     end
@@ -55,7 +55,7 @@ describe Subjects::CellectExSelector do
     end
 
     it 'does nothing unless enabled' do
-      Panoptes.flipper["cellect_ex"].disable
+      Panoptes.flipper["designator"].disable
       expect(client).not_to receive(:remove_subject)
       selector.remove_subject(3)
     end
@@ -81,7 +81,7 @@ describe Subjects::CellectExSelector do
     end
 
     it 'returns an empty array unless enabled', :aggregate_failures do
-      Panoptes.flipper["cellect_ex"].disable
+      Panoptes.flipper["designator"].disable
       expect(client).not_to receive(:get_subjects)
 
       subject_ids = selector.get_subjects(user, nil, 10)

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -120,23 +120,23 @@ RSpec.describe Subjects::StrategySelection do
         end
       end
 
-      context "with cellect_ex" do
+      context "with designator" do
         let(:run_selection) { subject.select }
 
         before do
-          workflow.subject_selection_strategy = "cellect_ex"
+          workflow.subject_selection_strategy = "designator"
         end
 
-        it "should use the cellect_ex client" do
-          expect_any_instance_of(Subjects::CellectExSelector)
+        it "should use the designator client" do
+          expect_any_instance_of(Subjects::DesignatorSelector)
             .to receive(:get_subjects)
             .with(user, subject_set.id, limit)
             .and_return(result_ids)
           run_selection
         end
 
-        it "should convert the cellect_ex subject_ids to panoptes sms_ids" do
-          allow_any_instance_of(CellectExClient).to receive(:get_subjects)
+        it "should convert the designator subject_ids to panoptes sms_ids" do
+          allow_any_instance_of(DesignatorClient).to receive(:get_subjects)
             .and_return(result_ids)
           expect(SetMemberSubject).to receive(:by_subject_workflow)
             .with(result_ids, workflow.id).and_call_original
@@ -160,7 +160,7 @@ RSpec.describe Subjects::StrategySelection do
     context "when Cellect config is on" do
       before do
         allow(Panoptes.flipper).to receive(:enabled?).with("cellect").and_return(true)
-        allow(Panoptes.flipper).to receive(:enabled?).with("cellect_ex").and_return(true)
+        allow(Panoptes.flipper).to receive(:enabled?).with("designator").and_return(true)
       end
 
       context "when the workflow is set to use cellect" do
@@ -193,7 +193,7 @@ RSpec.describe Subjects::StrategySelection do
     context "when Cellect Config is off" do
       before do
         allow(Panoptes.flipper).to receive(:enabled?).with("cellect").and_return(false)
-        allow(Panoptes.flipper).to receive(:enabled?).with("cellect_ex").and_return(false)
+        allow(Panoptes.flipper).to receive(:enabled?).with("designator").and_return(false)
       end
 
       context "when the workflow config has a selection strategy" do
@@ -211,19 +211,19 @@ RSpec.describe Subjects::StrategySelection do
       end
     end
 
-    describe 'cellect_ex' do
-      context "when the workflow is set to use cellect_ex" do
+    describe 'designator' do
+      context "when the workflow is set to use designator" do
         it "should use the workflow config strategy" do
-          allow(workflow).to receive(:subject_selection_strategy).and_return("cellect_ex")
-          expect(subject.strategy).to eq(:cellect_ex)
+          allow(workflow).to receive(:subject_selection_strategy).and_return("designator")
+          expect(subject.strategy).to eq(:designator)
         end
       end
 
       context 'when the workflow has a lot of subjects' do
-        it 'should still use cellect_ex' do
-          allow(workflow).to receive(:subject_selection_strategy).and_return("cellect_ex")
+        it 'should still use designator' do
+          allow(workflow).to receive(:subject_selection_strategy).and_return("designator")
           allow(workflow).to receive(:subjects_count).and_return(cellect_size)
-          expect(subject.strategy).to eq(:cellect_ex)
+          expect(subject.strategy).to eq(:designator)
         end
       end
     end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -368,8 +368,8 @@ describe Workflow, type: :model do
         expect(workflow.using_cellect?).to be_truthy
       end
 
-      it "should return false if cellect_ex is set" do
-        workflow.cellect_ex!
+      it "should return false if designator is set" do
+        workflow.designator!
         expect(workflow.using_cellect?).to be_falsey
       end
     end

--- a/spec/services/designator_client_spec.rb
+++ b/spec/services/designator_client_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
-RSpec.describe CellectExClient do
+RSpec.describe DesignatorClient do
   shared_examples "handles server errors" do
-    it "raises if cellect_ex can't connect" do
+    it "raises if designator can't connect" do
       stubs = Faraday::Adapter::Test::Stubs.new do |stub|
         stub.send(http_method, url) do |env|
           raise Faraday::ConnectionFailed.new("execution expired")
@@ -11,10 +11,10 @@ RSpec.describe CellectExClient do
 
       expect do
         described_class.new([:test, stubs]).send(method, *params)
-      end.to raise_error(CellectExClient::GenericError)
+      end.to raise_error(DesignatorClient::GenericError)
     end
 
-    it "raises if cellect_ex times out" do
+    it "raises if designator times out" do
       stubs = Faraday::Adapter::Test::Stubs.new do |stub|
         stub.send(http_method, url) do |env|
           raise Faraday::TimeoutError
@@ -23,7 +23,7 @@ RSpec.describe CellectExClient do
 
       expect do
         described_class.new([:test, stubs]).send(method, *params)
-      end.to raise_error(CellectExClient::GenericError)
+      end.to raise_error(DesignatorClient::GenericError)
     end
 
     it "raises if response is an HTTP 500" do
@@ -35,7 +35,7 @@ RSpec.describe CellectExClient do
 
       expect do
         described_class.new([:test, stubs]).send(method, *params)
-      end.to raise_error(CellectExClient::ServerError)
+      end.to raise_error(DesignatorClient::ServerError)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
 
     allow(Panoptes).to receive(:flipper).and_return(Flipper.new(Flipper::Adapters::Memory.new))
     Panoptes.flipper["cellect"].enable
-    Panoptes.flipper["cellect_ex"].enable
+    Panoptes.flipper["designator"].enable
 
     case example.metadata[:sidekiq]
     when :fake


### PR DESCRIPTION
This pushes the service rename through to Panoptes. Additionally, this adds support for the authentication that will soon be required on reload/retire endpoints of Designator.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
