### PR TITLE
Destroy should be delete in the relation manager

### DIFF
--- a/lib/json_api_controller/relation_manager.rb
+++ b/lib/json_api_controller/relation_manager.rb
@@ -24,7 +24,7 @@ module JsonApiController
 
     def destroy_relation(resource, relation, value)
       ids = value.split(',').map(&:to_i)
-      resource.send(relation).destroy(*ids)
+      resource.send(relation).delete(*ids)
     end
 
     protected

--- a/spec/lib/json_api_controller/relation_manager_spec.rb
+++ b/spec/lib/json_api_controller/relation_manager_spec.rb
@@ -154,11 +154,11 @@ describe JsonApiController::RelationManager do
     context "has_many" do
       let!(:resource) { create(:project_with_workflows) }
 
-      it 'should destroy the unlinked items' do
+      it 'should not destroy the unlinked items' do
         expect do
           del_string = resource.workflows.map(&:id).join(",")
           test_instance.destroy_relation(resource, :workflows, del_string)
-        end.to change{ Workflow.count }.from(2).to(0)
+        end.to_not change{ Workflow.count }
       end
     end
   end

--- a/spec/lib/json_api_controller/relation_manager_spec.rb
+++ b/spec/lib/json_api_controller/relation_manager_spec.rb
@@ -135,30 +135,70 @@ describe JsonApiController::RelationManager do
   end
 
   describe "#destroy_relation" do
-    let(:resource_to_remove) { resource.subjects[0..2] }
-    let(:del_string) { resource_to_remove.map(&:id).join(",") }
-
-    it 'should remove the linked relations' do
-      test_instance.destroy_relation(resource, :subjects, del_string)
-      expect(resource.subjects).to_not include(*resource_to_remove)
+    def destroy_helper
+      test_instance.destroy_relation(resource, relation, del_string)
     end
 
     context "habtm" do
-      it 'should not destroy the unlinked items' do
-        expect do
-          test_instance.destroy_relation(resource, :subjects, del_string)
-        end.to_not change{ Subject.count }
+      let(:resource_to_remove) { resource.subjects[0..2] }
+      let(:relation) { :subjects }
+      let(:del_string) { resource_to_remove.map(&:id).join(",") }
+
+      it "does not destroy the unlinked items" do
+        expect{ destroy_helper }.to_not change{Subject.count}
+      end
+
+      it "deletes the linked relations" do
+        destroy_helper
+        expect(resource.subjects).to_not include(*resource_to_remove)
       end
     end
 
     context "has_many" do
-      let!(:resource) { create(:project_with_workflows) }
+      let(:resource) { create(:project_with_workflows) }
+      let(:resource_to_remove) { resource.workflows[0..2] }
+      let(:relation) { :workflows }
+      let(:del_string) { resource.workflows.map(&:id).join(",") }
 
-      it 'should not destroy the unlinked items' do
-        expect do
-          del_string = resource.workflows.map(&:id).join(",")
-          test_instance.destroy_relation(resource, :workflows, del_string)
-        end.to_not change{ Workflow.count }
+      it "does not destroy the unlinked items" do
+        expect{ destroy_helper }.to change{ Workflow.count }.by(0)
+      end
+
+      it "deletes the linked resource" do
+        destroy_helper
+        expect(resource.workflows).to_not include(*resource_to_remove)
+      end
+    end
+
+    context "belongs_to" do
+      let(:resource) { create(:organization, projects: [project]) }
+      let(:resource_to_remove) { resource.projects[0] }
+      let(:relation) { :projects }
+      let(:del_string) { resource.projects.map(&:id).join(",") }
+
+      it "does not destroy the unlinked item" do
+        expect{ destroy_helper }.to change{ Project.count }.by(0)
+      end
+
+      it "deletes the linked resource" do
+        destroy_helper
+        expect(resource.projects).to_not include(*resource_to_remove)
+      end
+    end
+
+    context "belongs_to_many" do
+      let!(:resource) { create(:collection, projects: [project]) }
+      let(:resource_to_remove) { resource.projects[0] }
+      let(:relation) { :projects }
+      let(:del_string) { resource.projects.map(&:id).join(",") }
+
+      it "does not destroy the unlinked item" do
+        expect{ destroy_helper }.to change{ Project.count }.by(0)
+      end
+
+      it "deletes the linked resource" do
+        destroy_helper
+        expect(resource.projects).to_not include(*resource_to_remove)
       end
     end
   end

--- a/spec/lib/json_api_controller/relation_manager_spec.rb
+++ b/spec/lib/json_api_controller/relation_manager_spec.rb
@@ -139,7 +139,7 @@ describe JsonApiController::RelationManager do
       test_instance.destroy_relation(resource, relation, del_string)
     end
 
-    context "habtm" do
+    context "has_many through" do
       let(:resource_to_remove) { resource.subjects[0..2] }
       let(:relation) { :subjects }
       let(:del_string) { resource_to_remove.map(&:id).join(",") }
@@ -148,9 +148,13 @@ describe JsonApiController::RelationManager do
         expect{ destroy_helper }.to_not change{Subject.count}
       end
 
-      it "deletes the linked relations" do
+      it "removes the linked relations" do
         destroy_helper
         expect(resource.subjects).to_not include(*resource_to_remove)
+      end
+
+      it "deletes the join table record" do
+        expect{ destroy_helper }.to change{ CollectionsSubject.count }.by(-2)
       end
     end
 
@@ -164,9 +168,31 @@ describe JsonApiController::RelationManager do
         expect{ destroy_helper }.to change{ Workflow.count }.by(0)
       end
 
-      it "deletes the linked resource" do
+      it "removes the linked relation" do
         destroy_helper
         expect(resource.workflows).to_not include(*resource_to_remove)
+      end
+    end
+
+    context "has_and_belongs_to_many" do
+      let(:resource) { create(:classification}
+      let(:resource_to_remove) { resource.subjects[0] }
+      let(:resource_to_remain) { resource.subjects[1] }
+      let(:relation) { :subjects }
+      let(:del_string) { resource_to_remove.id.to_s }
+
+      it "does not destroy the unlinked items" do
+        expect{ destroy_helper }.to_not change{Subject.count}
+      end
+
+      it "removes the linked relation" do
+        destroy_helper
+        expect(resource.subjects).to_not include(*resource_to_remove)
+      end
+
+      it "removes ONLY the specified linked relation" do
+        destroy_helper
+        expect(resource.subjects).to include(*resource_to_remain)
       end
     end
 
@@ -180,7 +206,7 @@ describe JsonApiController::RelationManager do
         expect{ destroy_helper }.to change{ Project.count }.by(0)
       end
 
-      it "deletes the linked resource" do
+      it "removes the linked relation" do
         destroy_helper
         expect(resource.projects).to_not include(*resource_to_remove)
       end
@@ -196,7 +222,7 @@ describe JsonApiController::RelationManager do
         expect{ destroy_helper }.to change{ Project.count }.by(0)
       end
 
-      it "deletes the linked resource" do
+      it "removes the linked relation" do
         destroy_helper
         expect(resource.projects).to_not include(*resource_to_remove)
       end

--- a/spec/lib/json_api_controller/relation_manager_spec.rb
+++ b/spec/lib/json_api_controller/relation_manager_spec.rb
@@ -175,7 +175,7 @@ describe JsonApiController::RelationManager do
     end
 
     context "has_and_belongs_to_many" do
-      let(:resource) { create(:classification}
+      let(:resource) { create(:classification) }
       let(:resource_to_remove) { resource.subjects[0] }
       let(:resource_to_remain) { resource.subjects[1] }
       let(:relation) { :subjects }


### PR DESCRIPTION
Calling this a WIP just now because I'd like to see what color the other specs will be with just this change. Can't really think of a situation where we'd want to do the opposite of what `delete` does here, i.e. actually delete the join table row OR set the relation's foreign key on the resource to nil.

update: refactored `destroy_relation` specs a bit and added a few more to cover all association types. Seems to behave as expected/desired.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
