### PR TITLE
Add settings to project prefs update schema

### DIFF
--- a/app/schemas/project_preference_update_schema.rb
+++ b/app/schemas/project_preference_update_schema.rb
@@ -12,6 +12,16 @@ class ProjectPreferenceUpdateSchema < JsonSchema
       type "object"
     end
 
+    property "settings" do
+      type "object"
+      additional_properties false
+
+      property "workflow_id" do
+        type "string", "integer"
+        pattern "^[0-9]*$"
+      end
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
     let(:test_attr) { :email_communication }
     let(:test_attr_value) { false }
     let(:update_params) do
-      { project_preferences: { email_communication: false } }
+      { project_preferences: { email_communication: false, settings: { workflow_id: 1234 } } }
     end
 
     it_behaves_like "is updatable"


### PR DESCRIPTION
The settings property should be in the ProjectPreferencesUpdate schema so that PFE can update a user's project preferences. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
