### PR TITLE
compare weak etags for update / destroy actions precondition checks

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -128,7 +128,7 @@ class Api::V1::MediaController < Api::ApiController
             else
               Medium.where(id: params[:id])
             end
-    !(gen_etag(query) == precondition)
+    run_etag_validation(query)
   end
 
   def resource_scope(resources)

--- a/lib/json_api_controller/precondition_check.rb
+++ b/lib/json_api_controller/precondition_check.rb
@@ -21,13 +21,17 @@ module JsonApiController
 
     def precondition_fails?
       query = resource_class.where(id: resource_ids)
-      current_etag = gen_etag(query)
-      current_etag = "W/#{current_etag}" if weak_etag?(precondition)
-      !(current_etag == precondition)
+      run_etag_validation(query)
     end
 
     def precondition_error_msg
       "Request requires #{HEADER_NAME} header to be present"
+    end
+
+    def run_etag_validation(query)
+      current_etag = gen_etag(query)
+      current_etag = "W/#{current_etag}" if weak_etag?(precondition)
+      !(current_etag == precondition)
     end
 
     def weak_etag?(etag)

--- a/lib/json_api_controller/precondition_check.rb
+++ b/lib/json_api_controller/precondition_check.rb
@@ -35,7 +35,7 @@ module JsonApiController
     end
 
     def weak_etag?(etag)
-      !!etag.match(/^\AW\//)
+      !!etag.match(%r{^\AW/})
     end
   end
 end

--- a/lib/json_api_controller/precondition_check.rb
+++ b/lib/json_api_controller/precondition_check.rb
@@ -1,6 +1,6 @@
 module JsonApiController
   module PreconditionCheck
-    HEADER_NAME = "If-Match"
+    HEADER_NAME = "If-Match".freeze
 
     def precondition_check
       if !precondition
@@ -21,11 +21,17 @@ module JsonApiController
 
     def precondition_fails?
       query = resource_class.where(id: resource_ids)
-      !(gen_etag(query) == precondition)
+      current_etag = gen_etag(query)
+      current_etag = "W/#{current_etag}" if weak_etag?(precondition)
+      !(current_etag == precondition)
     end
 
     def precondition_error_msg
       "Request requires #{HEADER_NAME} header to be present"
+    end
+
+    def weak_etag?(etag)
+      !!etag.match(/^\AW\//)
     end
   end
 end

--- a/spec/requests/v1/api_conditional_request_spec.rb
+++ b/spec/requests/v1/api_conditional_request_spec.rb
@@ -56,6 +56,12 @@ describe "api should allow conditional requests", type: :request do
       send method, url, body.to_json, request_params
       expect(response).to have_http_status(ok_status)
     end
+
+    it "should succeed if correct weak etag precondition is met" do
+      weak_etag = "W/#{etag}"
+      send method, url, body.to_json, request_params.merge("If-Match" => weak_etag)
+      expect(response).to have_http_status(ok_status)
+    end
   end
 
   shared_examples "returns etag" do
@@ -78,7 +84,7 @@ describe "api should allow conditional requests", type: :request do
     end
   end
 
-  context "PUT requests"  do
+  context "PUT requests" do
     let(:method) { :put }
     let(:body) do
       { "projects" => { "name" => "dave" } }


### PR DESCRIPTION
Allow weak etag comparison if we receive a weak_etag server side for modifications, etc. This is due to adding gzip compression to nginx as it modifes the etag to be weak as this is correct etag spec. Rails is off spec with strong etags (changing in ver 5 to be weak) and this change allows the etags to not be rejected api side.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
