### PR TITLE
Add a feature flag for completed subject removal

### DIFF
--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -19,9 +19,13 @@ module Subjects
       eventlog.info("Selected subjects", desired_strategy: strategy, used_strategy: used_strategy, subject_ids: selected_ids)
 
       selected_ids = selected_ids.compact
-      incomplete_ids = Subjects::CompleteRemover.new(user, workflow, selected_ids).incomplete_ids
-      eventlog.info("Selected subjects after cleanup", desired_strategy: strategy, used_strategy: used_strategy, subject_ids: incomplete_ids)
-      incomplete_ids
+      if Panoptes.flipper[:remove_complete_subjects].enabled?
+        incomplete_ids = Subjects::CompleteRemover.new(user, workflow, selected_ids).incomplete_ids
+        eventlog.info("Selected subjects after cleanup", desired_strategy: strategy, used_strategy: used_strategy, subject_ids: incomplete_ids)
+        incomplete_ids
+      else
+        selected_ids
+      end
     end
 
     def strategy


### PR DESCRIPTION
Only remove complete subjects from the set returned from the selector if the feature flag is enabled. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
