### PR TITLE
Shortcut task type value is an array, not a string

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -51,7 +51,7 @@ module Formatter
         {}.tap do |new_anno|
           new_anno['task'] = @current['task']
           new_anno['task_label'] = task_label(task_info)
-          new_anno['value'] = task_info['type'] == 'multiple' ? answer_labels : answer_label
+          new_anno['value'] = ['multiple', 'shortcut'].include?(task_info['type']) ? answer_labels : answer_labels.first
         end
       end
 
@@ -136,10 +136,6 @@ module Formatter
         have_tool_lookup_info = !!(task_info["tools"] && tool_index)
         known_tool = have_tool_lookup_info && task_info["tools"][tool_index]
         translate(known_tool["label"]) if known_tool
-      end
-
-      def answer_label
-        answer_labels.first
       end
 
       def answer_labels

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         it 'should add the correct answer labels' do
           formatted = described_class.new(classification, annotation, cache).to_h
           expect(formatted["task_label"]).to eq("Fire present?")
-          expect(formatted["value"]).to eq("yes")
+          expect(formatted["value"]).to eq(["yes"])
         end
       end
     end


### PR DESCRIPTION
Shortcut tasks, like multiples, should export as their values an array instead of a string. This is the only difference between these two tasks. This, along with the rest of the exporter, is on the list of things to refactor.

Fixes #2228 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
