### PR TITLE
do not add a next href page url if there is no data

### DIFF
--- a/app/serializers/concerns/no_count_serializer.rb
+++ b/app/serializers/concerns/no_count_serializer.rb
@@ -2,11 +2,12 @@ module NoCountSerializer
   extend ActiveSupport::Concern
 
   module ClassMethods
-
     private
 
     def serialize_meta(page, options)
       current_page = page.current_page
+      next_page = page.empty? ? nil : current_page + 1
+
       meta = {
           page: current_page,
           page_size: page.limit_value,
@@ -14,7 +15,7 @@ module NoCountSerializer
           include: options.include,
           page_count: 0,
           previous_page: current_page - 1,
-          next_page: current_page + 1
+          next_page: next_page
       }
 
       meta[:first_href] = page_href(1, options)

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -14,6 +14,10 @@ describe ClassificationSerializer do
   end
 
   describe "nested collection routes" do
+    before do
+      classification
+    end
+
     it "should return the correct href urls" do
       %w(gold_standard incomplete project).each do |collection_route|
         context = {url_suffix: collection_route}

--- a/spec/support/no_count_serializer.rb
+++ b/spec/support/no_count_serializer.rb
@@ -12,13 +12,13 @@ shared_examples "a no count serializer" do
       expect(meta[:next_page]).to eq(2)
     end
 
-    it "should handle the the previous page information" do
+    it "should handle the the previous & next page information" do
       result = described_class.page({page: 2}, scope, {})
       meta = result[:meta][lookup]
       expect(meta[:count]).to eq(0)
       expect(meta[:page_count]).to eq(0)
       expect(meta[:previous_page]).to eq(1)
-      expect(meta[:next_page]).to eq(3)
+      expect(meta[:next_page]).to be_nil
     end
   end
 end


### PR DESCRIPTION
test the page has data before adding a next page href to the metadata but still avoid counting the page scopes

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
