### PR TITLE
provide correct paging urls with has_many relations

### DIFF
--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -1,14 +1,8 @@
 class CollectionSerializer
-  include RestPack::Serializer
-  include OwnerLinkSerializer
+  include Serialization::PanoptesRestpack
   include FilterHasMany
+  include OwnerLinkSerializer
   include BelongsToManyLinks
-
-  PRELOADS = [
-    [ owner: { identity_membership: :user } ],
-    :collection_roles,
-    :subjects
-  ].freeze
 
   attributes :id, :name, :display_name, :created_at, :updated_at,
     :slug, :href, :favorite, :private
@@ -21,13 +15,10 @@ class CollectionSerializer
   can_filter_by :display_name, :slug, :favorite
   can_sort_by :display_name
 
+  preload [ owner: { identity_membership: :user } ], :collection_roles, :subjects
+
   # overridden belongs_to_many association to serialize the :projects links
   def self.btm_associations
     [ model_class.reflect_on_association(:projects) ]
-  end
-
-  def self.page(params = {}, scope = nil, context = {})
-    scope = scope.preload(*PRELOADS)
-    super(params, scope, context)
   end
 end

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -1,3 +1,5 @@
+require 'serialization/has_many_filtering/options'
+
 module FilterHasMany
   extend ActiveSupport::Concern
 
@@ -13,7 +15,8 @@ module FilterHasMany
         query.joins(filter[0]).where(filter[0] => {id: filter[2]})
       end
 
-      super params, scope, context
+      context[:has_many_filters] = has_many_filters(filters)
+      page_with_options Serialization::HasManyFiltering::Options.new(self, params, scope, context)
     end
 
     def has_many_filterable_by
@@ -26,6 +29,13 @@ module FilterHasMany
 
     def reflection_to_filter(reflection)
       [reflection.name, :"#{reflection.name.to_s.singularize}_id"]
+    end
+
+    def has_many_filters(scope_filters)
+      filters_hash = scope_filters.map do |filter|
+        [ filter[1], Array.wrap(filter[2]) ]
+      end
+      Hash[ filters_hash ]
     end
   end
 end

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -15,8 +15,15 @@ module FilterHasMany
         query.joins(filter[0]).where(filter[0] => {id: filter[2]})
       end
 
-      context[:has_many_filters] = has_many_filters(filters)
-      page_with_options Serialization::HasManyFiltering::Options.new(self, params, scope, context)
+      serializer_options = Serialization::HasManyFiltering::Options.new(
+        has_many_filters(filters),
+        self,
+        params,
+        scope,
+        context
+      )
+
+      page_with_options serializer_options
     end
 
     def has_many_filterable_by

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -15,11 +15,12 @@ module FilterHasMany
         query.joins(filter[0]).where(filter[0] => {id: filter[2]})
       end
 
+
       serializer_options = Serialization::HasManyFiltering::Options.new(
         has_many_filters(filters),
         self,
         params,
-        scope,
+        paging_scope(params, scope),
         context
       )
 

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -15,7 +15,10 @@ module FilterHasMany
         query.joins(filter[0]).where(filter[0] => {id: filter[2]})
       end
 
-
+      # As our RestPack doesn't' handle the join filtering natively, we need to
+      # use this custom options class to percolate the has_many filters
+      # into the response meta paging urls and still use the has_many
+      # join scopes built above.
       serializer_options = Serialization::HasManyFiltering::Options.new(
         has_many_filters(filters),
         self,
@@ -24,6 +27,7 @@ module FilterHasMany
         context
       )
 
+      # Use the custom paging instance to create a paged response
       page_with_options serializer_options
     end
 

--- a/app/serializers/subject_set_serializer.rb
+++ b/app/serializers/subject_set_serializer.rb
@@ -1,10 +1,13 @@
 class SubjectSetSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include FilterHasMany
 
   attributes :id, :display_name, :set_member_subjects_count, :metadata,
     :created_at, :updated_at, :href
+
   can_include :project, :workflows
   can_sort_by :display_name
   can_filter_by :display_name
+
+  preload :workflows
 end

--- a/lib/serialization/has_many_filtering/options.rb
+++ b/lib/serialization/has_many_filtering/options.rb
@@ -6,7 +6,6 @@ module Serialization
       end
 
       def filters_as_url_params
-
         has_many_scope_filters.sort.map { |k,v| map_filter_ids(k,v) }.join('&')
       end
 

--- a/lib/serialization/has_many_filtering/options.rb
+++ b/lib/serialization/has_many_filtering/options.rb
@@ -1,6 +1,13 @@
 module Serialization
   module HasManyFiltering
     class Options < RestPack::Serializer::Options
+      attr_reader :has_many_filters
+
+      def initialize(has_many_filters, serializer, params, scope, context)
+        @has_many_filters = has_many_filters
+        super(serializer, params, scope, context)
+      end
+
       def filters
         has_many_scope_filters
       end
@@ -12,7 +19,7 @@ module Serialization
       private
 
       def has_many_scope_filters
-        @filters.merge(context.fetch(:has_many_filters, []))
+        @has_many_scope_filters ||= @filters.merge(has_many_filters)
       end
     end
   end

--- a/lib/serialization/has_many_filtering/options.rb
+++ b/lib/serialization/has_many_filtering/options.rb
@@ -1,0 +1,20 @@
+module Serialization
+  module HasManyFiltering
+    class Options < RestPack::Serializer::Options
+      def filters
+        has_many_scope_filters
+      end
+
+      def filters_as_url_params
+
+        has_many_scope_filters.sort.map { |k,v| map_filter_ids(k,v) }.join('&')
+      end
+
+      private
+
+      def has_many_scope_filters
+        @filters.merge(context.fetch(:has_many_filters, []))
+      end
+    end
+  end
+end

--- a/lib/serialization/panoptes_restpack.rb
+++ b/lib/serialization/panoptes_restpack.rb
@@ -20,15 +20,20 @@ module Serialization
 
     module ClassMethodOverrides
       def page(params = {}, scope = nil, context = {})
+        super(params, paging_scope(params, scope), context)
+      end
+
+      def paging_scope(params, scope)
         if params[:include]
           param_preloads = params[:include].split(',').map(&:to_sym) & self.can_includes
         end
+
         preload_relations = self.preloads | Array.wrap(param_preloads)
         unless preload_relations.empty?
           scope = scope.preload(*preload_relations)
         end
 
-        super(params, scope, context)
+        scope
       end
 
       private

--- a/spec/serializers/collection_serializer_spec.rb
+++ b/spec/serializers/collection_serializer_spec.rb
@@ -10,16 +10,20 @@ describe CollectionSerializer do
     end
   end
 
-  it "should not have the :projects side load include setup" do
-    expect(CollectionSerializer.can_includes).not_to include(:projects)
+  it_should_behave_like "a panoptes restpack serializer" do
+    let(:resource) { collection }
+    let(:includes) { [ :owner, :collection_roles, :subjects ] }
+    let(:preloads) do
+      [ [ owner: { identity_membership: :user } ], :collection_roles, :subjects ]
+    end
   end
 
-  it "should preload the serialized associations" do
-    expect_any_instance_of(Collection::ActiveRecord_Relation)
-      .to receive(:preload)
-      .with(*CollectionSerializer::PRELOADS)
-      .and_call_original
-    CollectionSerializer.page({}, Collection.all, {})
+  it_should_behave_like "a filter has many serializer" do
+    let(:resource) { create(:collection_with_subjects) }
+    let(:relation) { :subjects }
+    let(:next_page_resource) do
+      create(:collection, subjects: resource.subjects)
+    end
   end
 
   describe "sorting" do

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -10,14 +10,13 @@ describe SubjectSerializer do
     let(:resource) { subject }
     let(:includes) { %i(project collections subject_sets) }
     let(:preloads) { %i(locations project collections subject_sets) }
+  end
 
-    it "handles paging query params for has_many_filtering" do
-      set_id = subject.subject_sets.first.id
+  it_should_behave_like "a filter has many serializer" do
+    let(:resource) { subject }
+    let(:relation) { :subject_sets }
+    let(:next_page_resource) do
       create(:subject, subject_sets: subject.subject_sets)
-      params = {page_size: 1, subject_set_id: set_id}
-      result = SubjectSerializer.page(params, Subject.all, {})
-      next_href = result.dig(:meta, :subjects, :next_href)
-      expect(next_href).to eq("/subjects?page=2&page_size=1&subject_set_id=1")
     end
   end
 

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -10,6 +10,15 @@ describe SubjectSerializer do
     let(:resource) { subject }
     let(:includes) { %i(project collections subject_sets) }
     let(:preloads) { %i(locations project collections subject_sets) }
+
+    it "handles paging query params for has_many_filtering" do
+      set_id = subject.subject_sets.first.id
+      create(:subject, subject_sets: subject.subject_sets)
+      params = {page_size: 1, subject_set_id: set_id}
+      result = SubjectSerializer.page(params, Subject.all, {})
+      next_href = result.dig(:meta, :subjects, :next_href)
+      expect(next_href).to eq("/subjects?page=2&page_size=1&subject_set_id=1")
+    end
   end
 
   describe "locations" do

--- a/spec/serializers/subject_set_serializer_spec.rb
+++ b/spec/serializers/subject_set_serializer_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe SubjectSetSerializer do
+  let(:subject_set) { create(:subject_set) }
+
+  it_should_behave_like "a panoptes restpack serializer" do
+    let(:resource) { subject_set }
+    let(:includes) { %i(project workflows) }
+    let(:preloads) { %i(workflows) }
+  end
+
+  it_should_behave_like "a filter has many serializer" do
+    let(:resource) { subject_set }
+    let(:relation) { :workflows }
+    let(:next_page_resource) do
+      create(:subject_set, workflows: subject_set.workflows)
+    end
+  end
+end

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -17,6 +17,14 @@ describe WorkflowSerializer do
     let(:preloads) { includes }
   end
 
+  it_should_behave_like "a filter has many serializer" do
+    let(:resource) { create(:workflow_with_subject_set) }
+    let(:relation) { :subject_sets }
+    let(:next_page_resource) do
+      create(:workflow, subject_sets: resource.subject_sets)
+    end
+  end
+
   describe "#tasks" do
     it 'should return the translated tasks' do
       expect(serializer.tasks['interest']['question']).to eq('Draw a circle')

--- a/spec/support/filter_has_many_serializer.rb
+++ b/spec/support/filter_has_many_serializer.rb
@@ -1,0 +1,19 @@
+shared_examples "a filter has many serializer" do
+  let(:scope) { resource.class.all }
+  let(:serializer) { described_class }
+  let(:relation_id) { resource.send(relation).first.id }
+  let(:relation_key) { "#{relation.to_s.singularize}_id" }
+  let(:params) { { page_size: 1, relation_key => relation_id }.symbolize_keys }
+  let(:resource_key) { serializer.key }
+
+  before do
+    next_page_resource
+  end
+
+  it "handles paging query params for has_many_filtering" do
+    result = serializer.page(params, scope, {})
+    next_href = result.dig(:meta, resource_key, :next_href)
+    expected_href = "/#{resource_key}?page=2&page_size=1&#{relation_key}=#{relation_id}"
+    expect(next_href).to eq(expected_href)
+  end
+end

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -2,6 +2,12 @@ shared_examples "a panoptes restpack serializer" do
   let(:scope) { resource.class.all }
 
   describe "preload associations" do
+    around do |example|
+      orig_values = described_class.instance_variable_get(:@preloads)
+      example.run
+      described_class.instance_variable_set(:@preloads, orig_values)
+    end
+
     it "should not preload when none set" do
       expect_any_instance_of(resource.class::ActiveRecord_Relation).not_to receive(:preload)
       described_class.instance_variable_set(:@preloads, [])


### PR DESCRIPTION
closes https://github.com/zooniverse/panoptes-python-client/issues/76

ensure the has many filters percolate into the paging url params

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
