### PR TITLE
Drops incorrectly inverted indices

### DIFF
--- a/db/migrate/20170316170501_remove_inverted_indices.rb
+++ b/db/migrate/20170316170501_remove_inverted_indices.rb
@@ -1,0 +1,6 @@
+class RemoveInvertedIndices < ActiveRecord::Migration
+  def change
+    remove_index :media, column: [:linked_type, :linked_id]
+    remove_index :tagged_resources, column: [:resource_type, :resource_id]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2310,13 +2310,6 @@ CREATE INDEX index_media_on_linked_id_and_linked_type ON media USING btree (link
 
 
 --
--- Name: index_media_on_linked_type_and_linked_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_media_on_linked_type_and_linked_id ON media USING btree (linked_type, linked_id);
-
-
---
 -- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2713,13 +2706,6 @@ CREATE INDEX index_subjects_on_upload_user_id ON subjects USING btree (upload_us
 --
 
 CREATE INDEX index_tagged_resources_on_resource_id_and_resource_type ON tagged_resources USING btree (resource_id, resource_type);
-
-
---
--- Name: index_tagged_resources_on_resource_type_and_resource_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_tagged_resources_on_resource_type_and_resource_id ON tagged_resources USING btree (resource_type, resource_id);
 
 
 --
@@ -3775,4 +3761,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170210163241');
 INSERT INTO schema_migrations (version) VALUES ('20170215105309');
 
 INSERT INTO schema_migrations (version) VALUES ('20170310131642');
+
+INSERT INTO schema_migrations (version) VALUES ('20170316170501');
 


### PR DESCRIPTION
Drops:

`index_media_on_linked_type_and_linked_id`
and
`index_tagged_resources_on_resource_type_and_resource_id`

now that the correct "id, type" indices are built and can be used for ID-only queries.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
