### PR TITLE
handle unsubscribing users with arbitrary case in their email address

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -36,7 +36,7 @@ class EmailsController < ActionController::Base
   def unsubscribe_email
     if email = params.delete(:email)
       unsubscribe_from_list(email)
-      if user = User.find_by(email: email)
+      if user = User.find_for_authentication(email: email)
         revoke_email_subscriptions(user)
       end
       head :ok

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -29,6 +29,18 @@ describe EmailsController, type: :controller do
         expect(upp_emails).to match_array([false])
       end
     end
+
+    context "with a different case variant of the email" do
+      before do
+        upcase_email = user.email.upcase
+        allow(user).to receive(:email).and_return(upcase_email)
+      end
+
+      it "should find the user and revoke their prefs" do
+        expect_any_instance_of(described_class).to receive(:revoke_email_subscriptions)
+        unsubscribe_user
+      end
+    end
   end
 
   let(:user) { create(:user, email_attrs) }


### PR DESCRIPTION
devise uses case insensitive email fields (lower case) so make sure we match against this to unsubscribe users via the webform.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
