### PR TITLE
Optimize gold standard queries

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -9,9 +9,6 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   schema_type :json_schema
 
-  before_action :filter_by_subject_id,
-    only: [ :index, :gold_standard, :incomplete, :project ]
-
   rescue_from RoleControl::AccessDenied, with: :access_denied
 
   def create
@@ -38,15 +35,6 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   def scope_context
     params
-  end
-
-  def filter_by_subject_id
-    subject_ids = (params.delete(:subject_ids) || params.delete(:subject_id)).try(:split, ',')
-    unless subject_ids.blank?
-      @controlled_resources = controlled_resources
-      .joins(:subjects)
-      .where(subjects: {id: subject_ids})
-    end
   end
 
   def access_denied(exception)

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -11,6 +11,9 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   rescue_from RoleControl::AccessDenied, with: :access_denied
 
+  before_action :filter_plural_subject_ids,
+    only: [ :index, :gold_standard, :incomplete, :project ]
+
   def create
     super { |classification| lifecycle(:create, classification) }
   end
@@ -87,6 +90,13 @@ class Api::V1::ClassificationsController < Api::ApiController
       super.merge(url_suffix: action_name)
     else
       super
+    end
+  end
+
+  # backwards compat for api subject filtering before moving to FilterHasMany
+  def filter_plural_subject_ids
+    if subject_ids = params.delete(:subject_ids)
+      params[:subject_id] = subject_ids
     end
   end
 end

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -57,11 +57,8 @@ class Classification < ActiveRecord::Base
 
   def self.gold_standard_for_user(user)
     return gold_standard if user.is_admin?
-    gold_standard
-    .joins(:workflow)
-    .where("workflows.public_gold_standard IS TRUE")
-    .order(id: :asc)
-    .distinct
+    public_workflow_ids = Workflow.where("public_gold_standard IS TRUE").pluck(:id)
+    where(workflow_id: public_workflow_ids).gold_standard.order(id: :asc)
   end
 
   def self.classifications_for_project(user, opts)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -41,7 +41,7 @@ class Classification < ActiveRecord::Base
     when :project
       classifications_for_project(user, opts)
     when :gold_standard
-      gold_standard_for_user(user)
+      gold_standard_for_user(user, opts)
     else
       none
     end
@@ -55,9 +55,15 @@ class Classification < ActiveRecord::Base
     incomplete.merge(created_by(user))
   end
 
-  def self.gold_standard_for_user(user)
+  def self.gold_standard_for_user(user, opts)
     return gold_standard if user.is_admin?
-    public_workflow_ids = Workflow.where("public_gold_standard IS TRUE").pluck(:id)
+
+    public_workflows = Workflow.where("public_gold_standard IS TRUE")
+    if opts[:workflow_id]
+      public_workflows = public_workflows.where(id: opts[:workflow_id])
+    end
+    public_workflow_ids = public_workflows.pluck(:id)
+
     where(workflow_id: public_workflow_ids).gold_standard.order(id: :asc)
   end
 

--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -9,6 +9,15 @@ class ClassificationSerializer
 
   preload :subjects
 
+  def self.page(params = {}, scope = nil, context = {})
+    # only distinct classifications for multiple subjects
+    if params.key?(:subject_id)
+      scope = scope.distinct
+    end
+
+    super(params, scope, context)
+  end
+
   def metadata
     @model.metadata.merge(workflow_version: @model.workflow_version)
   end

--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -1,6 +1,7 @@
 class ClassificationSerializer
   include Serialization::PanoptesRestpack
   include NoCountSerializer
+  include FilterHasMany
 
   attributes :id, :annotations, :created_at, :metadata, :href
 

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -5,12 +5,7 @@ module FilterHasMany
 
   module ClassMethods
     def page(params = {}, scope = nil, context = {})
-      filters = has_many_filterable_by.map do |filter|
-        filter_ids = params.delete(filter[1])
-        filter << filter_ids&.split(",")
-      end.delete_if do |filter|
-        filter[2].nil?
-      end
+      filters = scope_filters_from_params(params)
 
       scope = filters.reduce(scope || self.model_class.all) do |query, filter|
         query.joins(filter[0]).where(filter[0] => {id: filter[2]})
@@ -30,6 +25,15 @@ module FilterHasMany
 
       # Use the custom paging instance to create a paged response
       page_with_options serializer_options
+    end
+
+    def scope_filters_from_params(params)
+      has_many_filterable_by.map do |filter|
+        filter_ids = params.delete(filter[1])
+        filter << "#{filter_ids}".split(",")
+      end.delete_if do |filter|
+        filter[2].blank?
+      end
     end
 
     def has_many_filterable_by

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -6,7 +6,8 @@ module FilterHasMany
   module ClassMethods
     def page(params = {}, scope = nil, context = {})
       filters = has_many_filterable_by.map do |filter|
-        filter << params.delete(filter[1])
+        filter_ids = params.delete(filter[1])
+        filter << filter_ids&.split(",")
       end.delete_if do |filter|
         filter[2].nil?
       end

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -30,7 +30,7 @@ module FilterHasMany
     def scope_filters_from_params(params)
       has_many_filterable_by.map do |filter|
         filter_ids = params.delete(filter[1])
-        filter << "#{filter_ids}".split(",")
+        filter << filter_ids.to_s.split(",")
       end.delete_if do |filter|
         filter[2].blank?
       end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -214,7 +214,7 @@ describe Api::V1::ClassificationsController, type: :controller do
       end
 
       it 'should be filterable by a workflow id' do
-        another_gs
+        another_gs.workflow.update_column(:public_gold_standard, true)
         get :gold_standard, workflow_id: gs.workflow_id
         expect(filtered_ids).to match_array([gs.id])
       end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -228,7 +228,7 @@ describe Api::V1::ClassificationsController, type: :controller do
         end
 
         it 'should be filterable by a list of subject ids' do
-          get :gold_standard, subject_id: gs.subject_ids.join(',')
+          get :gold_standard, subject_ids: gs.subject_ids.join(',')
           expect(filtered_ids).to match_array([gs.id])
         end
       end

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -228,7 +228,7 @@ describe Api::V1::ClassificationsController, type: :controller do
         end
 
         it 'should be filterable by a list of subject ids' do
-          get :gold_standard, subject_ids: gs.subject_ids.join(',')
+          get :gold_standard, subject_id: gs.subject_ids.join(',')
           expect(filtered_ids).to match_array([gs.id])
         end
       end


### PR DESCRIPTION
Avoid the join on public workflows, use an in query for filtering the gold standard index hits. Also use the filter_has_many serializer for proper paging urls in #2239. Will need a rebase after that is in.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
