### PR TITLE
Check for retirements all at once, remove n+1

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -119,6 +119,7 @@ class Api::V1::SubjectsController < Api::ApiController
         user_seen: user_seen,
         url_format: :get,
         favorite_subject_ids: FavoritesFinder.new(api_user.user, workflow.project, selected_subject_ids).find_favorites,
+        retired_for_workflow: SubjectWorkflowRetirements.new(workflow, selected_subject_ids).find_retirees,
         select_context: true
       }.compact
     end

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -119,7 +119,7 @@ class Api::V1::SubjectsController < Api::ApiController
         user_seen: user_seen,
         url_format: :get,
         favorite_subject_ids: FavoritesFinder.new(api_user.user, workflow.project, selected_subject_ids).find_favorites,
-        retired_for_workflow: SubjectWorkflowRetirements.new(workflow, selected_subject_ids).find_retirees,
+        retired_subject_ids: SubjectWorkflowRetirements.new(workflow, selected_subject_ids).find_retirees,
         select_context: true
       }.compact
     end

--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -28,6 +28,10 @@ class SubjectWorkflowStatus < ActiveRecord::Base
     where(subject_id: subject_id)
   end
 
+  def self.by_workflow(workflow_id)
+    where(workflow_id: workflow_id)
+  end
+
   def self.by_subject_workflow(subject_id, workflow_id)
     where(subject_id: subject_id, workflow_id: workflow_id).first
   end

--- a/app/serializers/subject_selector_serializer.rb
+++ b/app/serializers/subject_selector_serializer.rb
@@ -22,7 +22,7 @@ class SubjectSelectorSerializer
   end
 
   def retired
-    @model.retired_for_workflow?(workflow)
+    @context[:retired_for_workflow].include? @model.id
   end
 
   def already_seen

--- a/app/serializers/subject_selector_serializer.rb
+++ b/app/serializers/subject_selector_serializer.rb
@@ -22,7 +22,7 @@ class SubjectSelectorSerializer
   end
 
   def retired
-    @context[:retired_for_workflow].include? @model.id
+    @context[:retired_subject_ids].include? @model.id
   end
 
   def already_seen

--- a/lib/subject_workflow_retirements.rb
+++ b/lib/subject_workflow_retirements.rb
@@ -1,0 +1,10 @@
+class SubjectWorkflowRetirements
+  def initialize(workflow, subject_ids)
+    @workflow = workflow
+    @subject_ids = subject_ids
+  end
+
+  def find_retirees
+    SubjectWorkflowStatus.retired.by_workflow(@workflow.id).where(subject_id: @subject_ids).pluck("subject_id")
+  end
+end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -161,7 +161,7 @@ describe Api::V1::SubjectsController, type: :controller do
               workflow: workflow,
               user: user,
               favorite_subject_ids: [],
-              retired_for_workflow: [],
+              retired_subject_ids: [],
               url_format: :get,
               select_context: true
             }

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -161,6 +161,7 @@ describe Api::V1::SubjectsController, type: :controller do
               workflow: workflow,
               user: user,
               favorite_subject_ids: [],
+              retired_for_workflow: [],
               url_format: :get,
               select_context: true
             }


### PR DESCRIPTION
Moves the checking of whether a subject is retired for a given workflow to the selector context and asks about them all at once rather than one at a time in the serializer. A one liner that might not need it's own lib, but looks nice next to FavoriteFinder and I got to call a method `#find_retirees`. 

Good eye, btw. Is there a good way to test for these? I tried testing this with Bullet but it didn't detect this one in particular. Didn't expect it to but it's probably just the non-obvious ones left.

Fixes #2236 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
