### PR TITLE
Duplicate gold standard classifications to own model for faster lookups

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -23,7 +23,12 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def gold_standard
-    index
+    gold_standard_page = GoldStandardAnnotationSerializer.page(
+      params,
+      controlled_resources,
+      context
+    )
+    render json_api: gold_standard_page, generate_response_obj_etag: true
   end
 
   def incomplete

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -56,15 +56,16 @@ class Classification < ActiveRecord::Base
   end
 
   def self.gold_standard_for_user(user, opts)
-    return gold_standard if user.is_admin?
+    return GoldStandardAnnotation.all if user.is_admin?
 
     public_workflows = Workflow.where("public_gold_standard IS TRUE")
     if opts[:workflow_id]
       public_workflows = public_workflows.where(id: opts[:workflow_id])
     end
     public_workflow_ids = public_workflows.pluck(:id)
-
-    where(workflow_id: public_workflow_ids).gold_standard.order(id: :asc)
+    GoldStandardAnnotation
+      .where(workflow_id: public_workflow_ids)
+      .order(id: :asc)
   end
 
   def self.classifications_for_project(user, opts)

--- a/app/models/gold_standard_annotation.rb
+++ b/app/models/gold_standard_annotation.rb
@@ -1,0 +1,16 @@
+class GoldStandardAnnotation < ActiveRecord::Base
+  belongs_to :workflow
+  belongs_to :subject
+  belongs_to :project
+  belongs_to :user
+  belongs_to :classification
+
+  validates_presence_of
+    :workflow,
+    :subject,
+    :project,
+    :user,
+    :classification,
+    :metadata,
+    :annotations
+end

--- a/app/models/gold_standard_annotation.rb
+++ b/app/models/gold_standard_annotation.rb
@@ -5,8 +5,7 @@ class GoldStandardAnnotation < ActiveRecord::Base
   belongs_to :user
   belongs_to :classification
 
-  validates_presence_of
-    :workflow,
+  validates_presence_of :workflow,
     :subject,
     :project,
     :user,

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -15,7 +15,7 @@ module FilterHasMany
       # use this custom options class to percolate the has_many filters
       # into the response meta paging urls and still use the has_many
       # join scopes built above.
-      serializer_options = Serialization::HasManyFiltering::Options.new(
+      serializer_options = ::Serialization::HasManyFiltering::Options.new(
         has_many_filters(filters),
         self,
         params,

--- a/app/serializers/gold_standard_annotation_serializer.rb
+++ b/app/serializers/gold_standard_annotation_serializer.rb
@@ -10,6 +10,10 @@ class GoldStandardAnnotationSerializer
     :classifications
   end
 
+  def id
+    @model.classification_id.to_s
+  end
+
   def add_links(model, data)
     data = super(model, data)
     data[:links][:subjects] = model.subject_id.to_s

--- a/app/serializers/gold_standard_annotation_serializer.rb
+++ b/app/serializers/gold_standard_annotation_serializer.rb
@@ -1,0 +1,27 @@
+class GoldStandardAnnotationSerializer
+  include Serialization::PanoptesRestpack
+  include NoCountSerializer
+
+  attributes :id, :annotations, :created_at, :metadata
+
+  can_include :project, :user, :workflow
+
+  def self.key
+    :classifications
+  end
+
+  def add_links(model, data)
+    data = super(model, data)
+    data[:links][:subjects] = model.subject_id.to_s
+    data
+  end
+
+  def self.links
+    links = super
+    links["#{key}.subjects"] = {
+      type: "subjects",
+      href: "/subjects/{#{key}.subjects}"
+    }
+    links
+  end
+end

--- a/db/migrate/20170320203350_create_gold_standard_annotations.rb
+++ b/db/migrate/20170320203350_create_gold_standard_annotations.rb
@@ -1,0 +1,16 @@
+class CreateGoldStandardAnnotations < ActiveRecord::Migration
+  def change
+    create_table :gold_standard_annotations do |t|
+      t.references :project, foreign_key: true
+      t.references :workflow, index: true, foreign_key: true
+      t.references :subject, index: true, foreign_key: true
+      t.references :user, foreign_key: true
+      t.references :classification, foreign_key: true
+
+      t.json :annotations, null: false
+      t.json :metadata, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -408,6 +408,43 @@ ALTER SEQUENCE flipper_gates_id_seq OWNED BY flipper_gates.id;
 
 
 --
+-- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE gold_standard_annotations (
+    id integer NOT NULL,
+    project_id integer,
+    workflow_id integer,
+    subject_id integer,
+    user_id integer,
+    classification_id integer,
+    annotations json NOT NULL,
+    metadata json NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: gold_standard_annotations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE gold_standard_annotations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: gold_standard_annotations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE gold_standard_annotations_id_seq OWNED BY gold_standard_annotations.id;
+
+
+--
 -- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1581,6 +1618,13 @@ ALTER TABLE ONLY flipper_gates ALTER COLUMN id SET DEFAULT nextval('flipper_gate
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY gold_standard_annotations ALTER COLUMN id SET DEFAULT nextval('gold_standard_annotations_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY media ALTER COLUMN id SET DEFAULT nextval('media_id_seq'::regclass);
 
 
@@ -1858,6 +1902,14 @@ ALTER TABLE ONLY flipper_features
 
 ALTER TABLE ONLY flipper_gates
     ADD CONSTRAINT flipper_gates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY gold_standard_annotations
+    ADD CONSTRAINT gold_standard_annotations_pkey PRIMARY KEY (id);
 
 
 --
@@ -2300,6 +2352,20 @@ CREATE UNIQUE INDEX index_flipper_features_on_key ON flipper_features USING btre
 --
 
 CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON flipper_gates USING btree (feature_key, key, value);
+
+
+--
+-- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_gold_standard_annotations_on_subject_id ON gold_standard_annotations USING btree (subject_id);
+
+
+--
+-- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_gold_standard_annotations_on_workflow_id ON gold_standard_annotations USING btree (workflow_id);
 
 
 --
@@ -3019,6 +3085,22 @@ ALTER TABLE ONLY subject_sets_workflows
 
 
 --
+-- Name: fk_rails_06fc22e4c3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gold_standard_annotations
+    ADD CONSTRAINT fk_rails_06fc22e4c3 FOREIGN KEY (classification_id) REFERENCES classifications(id);
+
+
+--
+-- Name: fk_rails_082b4f1af7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gold_standard_annotations
+    ADD CONSTRAINT fk_rails_082b4f1af7 FOREIGN KEY (project_id) REFERENCES projects(id);
+
+
+--
 -- Name: fk_rails_0be1922a0e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3035,11 +3117,27 @@ ALTER TABLE ONLY workflow_tutorials
 
 
 --
+-- Name: fk_rails_0e782fcb3c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gold_standard_annotations
+    ADD CONSTRAINT fk_rails_0e782fcb3c FOREIGN KEY (subject_id) REFERENCES subjects(id);
+
+
+--
 -- Name: fk_rails_107209726e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflow_contents
     ADD CONSTRAINT fk_rails_107209726e FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_1d218ca624; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gold_standard_annotations
+    ADD CONSTRAINT fk_rails_1d218ca624 FOREIGN KEY (workflow_id) REFERENCES workflows(id);
 
 
 --
@@ -3200,6 +3298,14 @@ ALTER TABLE ONLY tutorials
 
 ALTER TABLE ONLY set_member_subjects
     ADD CONSTRAINT fk_rails_93073bf3b1 FOREIGN KEY (subject_id) REFERENCES subjects(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_937b47dc37; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gold_standard_annotations
+    ADD CONSTRAINT fk_rails_937b47dc37 FOREIGN KEY (user_id) REFERENCES users(id);
 
 
 --
@@ -3763,4 +3869,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170215105309');
 INSERT INTO schema_migrations (version) VALUES ('20170310131642');
 
 INSERT INTO schema_migrations (version) VALUES ('20170316170501');
+
+INSERT INTO schema_migrations (version) VALUES ('20170320203350');
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -179,7 +179,7 @@ namespace :migrate do
 
       non_migrated_gs_scope.find_each.with_index do |classification, index|
         curr_index = index + 1
-        if curr_index % 10 == 0 || curr_index == to_migrate_count
+        if (curr_index % 10).zero? || curr_index == to_migrate_count
           puts "Migrating classification to gold standard: #{curr_index} / #{to_migrate_count}"
         end
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -165,6 +165,42 @@ namespace :migrate do
         classification.update_columns annotations: new_annotations, metadata: new_metadata
       end
     end
+
+    desc "Migrate gold standard classifiations to their own model"
+    task migrate_gold_standard_to_own_model: :environment do
+      non_migrated_gs_scope = Classification
+        .gold_standard
+        .joins("LEFT OUTER JOIN gold_standard_annotations ON gold_standard_annotations.classification_id = classifications.id")
+        .where('gold_standard_annotations.id IS NULL')
+
+      to_migrate_count = non_migrated_gs_scope.count
+      failed_ids = []
+      migrated_ids = []
+
+      non_migrated_gs_scope.find_each.with_index do |classification, index|
+        curr_index = index + 1
+        if curr_index % 10 == 0 || curr_index == to_migrate_count
+          puts "Migrating classification to gold standard: #{curr_index} / #{to_migrate_count}"
+        end
+
+        begin
+          GoldStandardAnnotation.create!(classification: classification) do |gsa|
+            gsa.project_id = classification.project_id
+            gsa.workflow_id = classification.workflow_id
+            gsa.subject_id = classification.subjects.first.id
+            gsa.user_id = classification.user_id
+            gsa.annotations = classification.annotations
+            gsa.metadata = classification.metadata
+          end
+          migrated_ids << classification.id
+        rescue ActiveRecord::RecordInvalid => e
+          failed_ids << classification.id
+        end
+      end
+      puts "Successfully migrated #{migrated_ids.count}"
+      puts "Failed to migrate #{failed_ids.count}"
+      puts "Failed classification ids #{failed_ids.join(",")}"
+    end
   end
 
   namespace :tutorial do

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -45,7 +45,10 @@ def setup_create_request(project_id: project.id,
 end
 
 def create_gold_standard
-  create(:gold_standard_classification, project: project, user: project.owner, workflow: workflow)
+  c_attrs = { project: project, user: project.owner, workflow: workflow }
+  c = create(:gold_standard_classification, c_attrs)
+  gs_attrs = c_attrs.merge(classification: c, subject_id: c.subject_ids.first)
+  create(:gold_standard_annotation, gs_attrs)
 end
 
 describe Api::V1::ClassificationsController, type: :controller do
@@ -172,10 +175,13 @@ describe Api::V1::ClassificationsController, type: :controller do
   end
 
   describe "#gold_standard" do
-    let(:gs) { create_gold_standard }
+    let(:gsa) { create_gold_standard }
+    let(:gs) { gsa.classification }
     let!(:classifications) { [ classification, gs ] }
-    let(:another_gs_in_workflow) { create_gold_standard }
-    let(:another_gs) { create(:gold_standard_classification, project: project, user: project.owner) }
+    let(:another_gsa_in_workflow) { create_gold_standard }
+    let(:another_gs_in_workflow) { another_gsa_in_workflow.classification }
+    let(:another_gsa) { create(:gold_standard_annotation, project: project, user: project.owner) }
+    let(:another_gs) { another_gsa.classification }
     let(:public_gold_standard) { true }
     let(:workflow) { create(:workflow, public_gold_standard: public_gold_standard) }
     let(:filtered_ids) do

--- a/spec/factories/gold_standard_annotations.rb
+++ b/spec/factories/gold_standard_annotations.rb
@@ -18,6 +18,14 @@ FactoryGirl.define do
     workflow
     subject
     user
-    classification
+
+    after(:build) do |gsa, evaluator|
+      gsa.classification = create(:classification,
+        project: gsa.project,
+        workflow: gsa.workflow,
+        user: gsa.user,
+        subjects: [gsa.subject]
+      )
+    end
   end
 end

--- a/spec/factories/gold_standard_annotations.rb
+++ b/spec/factories/gold_standard_annotations.rb
@@ -1,0 +1,23 @@
+FactoryGirl.define do
+  factory :gold_standard_annotation do
+    metadata(
+      {
+        user_agent: "cURL",
+        started_at: 2.minutes.ago.to_s,
+        finished_at: 1.minute.ago.to_s,
+        user_language: 'en'
+      }
+    )
+    annotations(
+      [
+        {task: "an_annotation", value: true},
+        {task: "another_one", value: [1, 2]}
+      ]
+    )
+    project
+    workflow
+    subject
+    user
+    classification
+  end
+end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -239,7 +239,7 @@ describe Classification, :type => :model do
           project: project, user: project.owner
         )
         gsa.workflow.update_column(:public_gold_standard, true)
-        expect(Classification.scope_for(:gold_standard, user)).to match_array(gsa)
+        expect(Classification.scope_for(:gold_standard, user)).to match_array([gsa])
       end
     end
   end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -235,11 +235,11 @@ describe Classification, :type => :model do
 
     describe "#gold_standard" do
       it 'should return all gold_standard project data' do
-        gsc = create(:gold_standard_classification,
+        gsa = create(:gold_standard_annotation,
           project: project, user: project.owner
         )
-        gsc.workflow.update_column(:public_gold_standard, true)
-        expect(Classification.scope_for(:gold_standard, user)).to match_array(gsc)
+        gsa.workflow.update_column(:public_gold_standard, true)
+        expect(Classification.scope_for(:gold_standard, user)).to match_array(gsa)
       end
     end
   end

--- a/spec/models/gold_standard_annotation_spec.rb
+++ b/spec/models/gold_standard_annotation_spec.rb
@@ -27,6 +27,11 @@ describe GoldStandardAnnotation, type: :model do
     expect(gsa).to_not be_valid
   end
 
+  it "must have a classification" do
+    gsa.classification = nil
+    expect(gsa).to_not be_valid
+  end
+
   it "must have annotations" do
     gsa.annotations = nil
     expect(gsa).to_not be_valid

--- a/spec/models/gold_standard_annotation_spec.rb
+++ b/spec/models/gold_standard_annotation_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe GoldStandardAnnotation, type: :model do
+  let(:gsa) { build(:gold_standard_annotation) }
+
+  it "should have a valid factory" do
+    expect(gsa).to be_valid
+  end
+
+  it "must have a project" do
+    gsa.project = nil
+    expect(gsa).to_not be_valid
+  end
+
+  it "must have a subject" do
+    gsa.subject_id = nil
+    expect(gsa).to_not be_valid
+  end
+
+  it "must have a workflow" do
+    gsa.workflow = nil
+    expect(gsa).to_not be_valid
+  end
+
+  it "must have a user" do
+    gsa.user = nil
+    expect(gsa).to_not be_valid
+  end
+
+  it "must have annotations" do
+    gsa.annotations = nil
+    expect(gsa).to_not be_valid
+  end
+
+  it "must have metadata" do
+    gsa.metadata = nil
+    expect(gsa).to_not be_valid
+  end
+end

--- a/spec/serializers/gold_standard_annotation_serializer_spec.rb
+++ b/spec/serializers/gold_standard_annotation_serializer_spec.rb
@@ -13,6 +13,13 @@ describe GoldStandardAnnotationSerializer do
     let(:resource) { gsa }
   end
 
+  it "should have the classification id as the id" do
+    create(:classification)
+    gsa
+    result = described_class.single({}, GoldStandardAnnotation.all, {})
+    expect(result[:id]).to eq(gsa.classification_id.to_s)
+  end
+
   describe "nested collection routes" do
     before do
       gsa

--- a/spec/serializers/gold_standard_annotation_serializer_spec.rb
+++ b/spec/serializers/gold_standard_annotation_serializer_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe GoldStandardAnnotationSerializer do
+  let(:gsa) { create(:gold_standard_annotation) }
+
+  it_should_behave_like "a panoptes restpack serializer" do
+    let(:resource) { gsa }
+    let(:includes) { [:project, :user, :workflow] }
+    let(:preloads) { [ ] }
+  end
+
+  it_should_behave_like "a no count serializer" do
+    let(:resource) { gsa }
+  end
+
+  describe "nested collection routes" do
+    before do
+      gsa
+    end
+
+    it "should return the correct href urls" do
+      collection_route = "gold_standard"
+      context = {url_suffix: collection_route}
+      result = described_class.page({}, GoldStandardAnnotation.all, context)
+      meta = result[:meta][:classifications]
+      expect(meta[:first_href]).to eq("/classifications/#{collection_route}")
+      expect(meta[:previous_href]).to eq("/classifications/#{collection_route}?page=0")
+      expect(meta[:next_href]).to eq("/classifications/#{collection_route}?page=2")
+      expect(meta[:last_href]).to eq("/classifications/#{collection_route}?page=0")
+    end
+  end
+end

--- a/spec/support/no_count_serializer.rb
+++ b/spec/support/no_count_serializer.rb
@@ -1,6 +1,6 @@
 shared_examples "a no count serializer" do
   let(:scope) { resource.class.all }
-  let(:lookup) { resource.model_name.plural.to_sym }
+  let(:lookup) { described_class.key.to_sym }
 
   describe "avoid heavy count queries on paging" do
     it "should manually deal with the paging information" do

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -22,8 +22,9 @@ shared_examples "a panoptes restpack serializer" do
     end
 
     it "should preload valid preloads" do
+      expectation = preloads.empty? ? :not_to : :to
       expect_any_instance_of(resource.class::ActiveRecord_Relation)
-        .to receive(:preload)
+        .send(expectation, receive(:preload))
         .with(*preloads)
       described_class.instance_variable_set(:@preloads, preloads)
       described_class.page({}, scope, {})


### PR DESCRIPTION
Searching for gold standard classifications is not efficient over the classifications table space. Long term we're moving to a different summary mechanism for the UI. Isolate the existing gold standard classifications in their own table for fast index lookup 

TODO
- [x] Hook the classification scope_for to use this model
~- [ ] Remove sparse gold standard classifications index~ do this in a future PR after data is migrated
- [x] Add rake task to migrate classification data
- [x] Test migration rake task

This can be deployed by 
1. running the migration to add the table
2. run the rake task to migrate the gold standard data
3. deploy the code to start serving the migrated gold standard data 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
