### PR TITLE
Adds feature flag to dump workers

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -17,7 +17,8 @@ module Api
       Subjects::Selector::MissingSubjectSet,
       Subjects::Selector::MissingSubjects,                 with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
-    rescue_from Api::LiveProjectChanges,                   with: :forbidden
+    rescue_from Api::LiveProjectChanges,
+      Api::ExportDisabled,                                 with: :forbidden
     rescue_from Api::NotLoggedIn,
       Api::UnauthorizedTokenError,
       Operation::Unauthenticated,                          with: :not_authenticated

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -17,8 +17,7 @@ module Api
       Subjects::Selector::MissingSubjectSet,
       Subjects::Selector::MissingSubjects,                 with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
-    rescue_from Api::LiveProjectChanges,
-      Api::ExportDisabled,                                 with: :forbidden
+    rescue_from Api::LiveProjectChanges,                   with: :forbidden
     rescue_from Api::NotLoggedIn,
       Api::UnauthorizedTokenError,
       Operation::Unauthenticated,                          with: :not_authenticated

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -25,4 +25,9 @@ module ApiErrors
       super("Cannot create roles resource when one exists for the user and project")
     end
   end
+  class ExportDisabled < PanoptesApiError
+    def initialize
+      super("Exports are temporarily disabled")
+    end
+  end
 end

--- a/app/workers/aggregations_dump_worker.rb
+++ b/app/workers/aggregations_dump_worker.rb
@@ -6,6 +6,7 @@ class AggregationsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
+    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     # Set expiry time of signed_url to one day from now
     medium.update!(put_expires: 1.day.from_now.to_i - Time.now.to_i)
 

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -9,6 +9,7 @@ class ClassificationsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
+    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     CSV.open(csv_file_path, 'wb') do |csv|
       formatter = Formatter::Csv::Classification.new(cache)
       csv << formatter.class.headers

--- a/app/workers/subjects_dump_worker.rb
+++ b/app/workers/subjects_dump_worker.rb
@@ -9,6 +9,7 @@ class SubjectsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
+    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     CSV.open(csv_file_path, 'wb') do |csv|
       headers = Formatter::Csv::Subject.headers
 

--- a/app/workers/workflow_contents_dump_worker.rb
+++ b/app/workers/workflow_contents_dump_worker.rb
@@ -9,6 +9,7 @@ class WorkflowContentsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
+    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     csv_formatter = Formatter::Csv::WorkflowContent.new
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers

--- a/app/workers/workflows_dump_worker.rb
+++ b/app/workers/workflows_dump_worker.rb
@@ -9,6 +9,7 @@ class WorkflowsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
+    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     csv_formatter = Formatter::Csv::Workflow.new
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers

--- a/spec/support/dump_worker.rb
+++ b/spec/support/dump_worker.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
   let(:another_project) { create(:project) }
+  before { Panoptes.flipper[:dump_worker_exports].enable }
 
   context "when the project id doesn't correspond to a project" do
     before(:each) do
@@ -124,6 +125,14 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
         worker.perform(project.id, "project", medium.id)
         medium.reload
         expect(medium.metadata).to include("state" => "creating")
+      end
+    end
+
+    context "Dump workers are disabled" do
+      before { Panoptes.flipper[:dump_worker_exports].disable }
+
+      it "raises an exception" do
+        expect { worker.perform(project.id, "project", medium.id) }.to raise_error(ApiErrors::ExportDisabled)
       end
     end
   end

--- a/spec/workers/aggregations_dump_worker_spec.rb
+++ b/spec/workers/aggregations_dump_worker_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe AggregationsDumpWorker do
   let(:agg_double) {double(aggregate: nil)}
 
   before(:each) do
+    Panoptes.flipper[:dump_worker_exports].enable
     allow(AggregationClient).to receive(:new).and_return(agg_double)
   end
 
@@ -23,5 +24,13 @@ RSpec.describe AggregationsDumpWorker do
   it 'should send an aggregate message to the AggregationClient' do
     expect(agg_double).to receive(:aggregate)
     subject.perform(project, "project", medium)
+  end
+
+  context "Dump workers are disabled" do
+    before { Panoptes.flipper[:dump_worker_exports].disable }
+
+    it "raises an exception" do
+      expect { subject.perform(project, "project", medium) }.to raise_error(ApiErrors::ExportDisabled)
+    end
   end
 end

--- a/spec/workers/workflow_contents_dump_worker_spec.rb
+++ b/spec/workers/workflow_contents_dump_worker_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe WorkflowContentsDumpWorker do
   end
 
   context "with a versioned workflow content" do
+    before { Panoptes.flipper[:dump_worker_exports].enable }
 
     with_versioning do
       let(:q_workflow) { build(:workflow, :question_task) }

--- a/spec/workers/workflows_dump_worker_spec.rb
+++ b/spec/workers/workflows_dump_worker_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe WorkflowsDumpWorker do
   end
 
   context "with a versioned workflow" do
+    before { Panoptes.flipper[:dump_worker_exports].enable }
 
     with_versioning do
       let(:q_workflow) { build(:workflow, :question_task) }


### PR DESCRIPTION
Adds a feature flag check to the dump workers for classifications, workflows, subjects, and aggregations. The API will return an error that says that exports are disabled. The sidekiq jobs will hit the flag, raise an exception, and fail however many (25?) times and then be put in the dead queue where we can run them later...or not.

I have been messing with sidekiq middleware all afternoon trying to conditionally set the retry amount but it doesn't really matter. If we want to reschedule these jobs instead of basically ignoring them, I'll need to know what that schedule looks like. **If we do flip this switch, we should ensure that PFE is going to do something smart with the response.**

Closes https://github.com/zooniverse/Panoptes/issues/2252 and https://github.com/zooniverse/Panoptes/issues/2118 (more or less, depending on rescheduling thoughts).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
