### PR TITLE
move to IN sub select queries instead of JOINS on parental controlled

### DIFF
--- a/lib/role_control/parental_controlled.rb
+++ b/lib/role_control/parental_controlled.rb
@@ -20,6 +20,10 @@ module RoleControl
         @parent_class ||= @parent.to_s.camelize.constantize
       end
 
+      def parent_relation
+       @parent
+     end
+
       def parent_foreign_key
         reflect_on_association(@parent).foreign_key
       end

--- a/lib/role_control/parental_controlled.rb
+++ b/lib/role_control/parental_controlled.rb
@@ -25,7 +25,7 @@ module RoleControl
       end
 
       def parent_scope(scope)
-        where(parent_foreign_key => scope.pluck(:id))
+        where(parent_foreign_key => scope.select(:id))
       end
 
       def scope_for(action, user, opts={})

--- a/spec/lib/role_control/parental_controlled_spec.rb
+++ b/spec/lib/role_control/parental_controlled_spec.rb
@@ -16,10 +16,9 @@ describe RoleControl::ParentalControlled do
 
   shared_examples_for "a parental controlled" do
     it "should call filter on belongs_to parent fk" do
-      parent_scope_for = parent.class.scope_for(:update, enrolled_actor, {})
       expect(klass)
         .to receive(:where)
-        .with(klass.parent_foreign_key => parent_scope_for.pluck(:id))
+        .with(klass.parent_foreign_key => parent_select_scope.select(:id))
         .and_call_original
     end
   end
@@ -28,7 +27,7 @@ describe RoleControl::ParentalControlled do
     let(:parent) { ControlledTable.create!(private: false) }
 
     it_behaves_like "a parental controlled" do
-      let(:sub_select_scope) { parent.class.public_scope }
+      let(:parent_select_scope) { parent.class.public_scope }
       after do
         klass.public_scope
       end
@@ -37,7 +36,7 @@ describe RoleControl::ParentalControlled do
 
   describe "::private_scope" do
     it_behaves_like "a parental controlled" do
-      let(:sub_select_scope) { parent.class.private_scope }
+      let(:parent_select_scope) { parent.class.private_scope }
       after do
         klass.private_scope
       end
@@ -45,7 +44,9 @@ describe RoleControl::ParentalControlled do
   end
 
   describe "::scope_for" do
-    let(:sub_select_scope) { parent.class.scope_for(:update, enrolled_actor, {}) }
+    let(:parent_select_scope) do
+      parent.class.scope_for(:update, enrolled_actor, {})
+    end
     after do
       klass.scope_for(:update, enrolled_actor, {})
     end

--- a/spec/lib/role_control/parental_controlled_spec.rb
+++ b/spec/lib/role_control/parental_controlled_spec.rb
@@ -15,27 +15,12 @@ describe RoleControl::ParentalControlled do
   end
 
   shared_examples_for "a parental controlled" do
-    context "without test no join parent scope feature flag" do
-      it "should call join on the parent" do
-        expect(klass)
-          .to receive(:joins)
-          .with(parent.class.model_name.singular.to_sym)
-          .and_call_original
-      end
-    end
-
-    context "with test no join scope feature flag" do
-      let(:parent_fk) do
-        klass.reflect_on_association(parent.model_name.singular).foreign_key
-      end
-
-      it "should call filter on belongs_to parent fk" do
-        Panoptes.flipper[:test_no_join_parental_scope].enable
-        expect(klass)
-          .to receive(:where)
-          .with(parent_fk => sub_select_scope.select(:id))
-          .and_call_original
-      end
+    it "should call filter on belongs_to parent fk" do
+      parent_scope_for = parent.class.scope_for(:update, enrolled_actor, {})
+      expect(klass)
+        .to receive(:where)
+        .with(klass.parent_foreign_key => parent_scope_for.pluck(:id))
+        .and_call_original
     end
   end
 
@@ -68,7 +53,10 @@ describe RoleControl::ParentalControlled do
     it_behaves_like "a parental controlled"
 
     it "should call scope_for on the parent" do
-      expect(parent.class).to receive(:scope_for).with(:update, enrolled_actor, {})
+      expect(parent.class)
+        .to receive(:scope_for)
+        .with(:update, enrolled_actor, {})
+        .and_call_original
     end
   end
 end


### PR DESCRIPTION
remove the feature flag conditional behaviour and implement the IN avoiding join scopes for queries.

~**DO NOT MERGE THIS** until we've tested the behaviour and determined that we want to move away from the join scopes on all parental controlled resources.~

I've tested this live without incident.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
