### PR TITLE
Adds feature flag for classification lifecycle processing

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -44,6 +44,7 @@ module Api
       ActiveRecord::RecordNotUnique,
       Operation::Error,
       ActiveInteraction::InvalidInteractionError,          with: :unprocessable_entity
+    rescue_from Api::FeatureDisabled,                      with: :service_unavailable
 
     prepend_before_action :require_login, only: [:create, :update, :destroy]
     prepend_before_action :ban_user, only: [:create, :update, :destroy]

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -64,15 +64,13 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def lifecycle(action, classification)
-    begin
-      if Panoptes.flipper[:cls_lifecycle_queue].enabled?
-        ClassificationLifecycle.queue(classification, action)
-      else
-        ClassificationLifecycle.perform(classification, action.to_s)
-      end
+    if Panoptes.flipper[:cls_lifecycle_queue].enabled?
+      ClassificationLifecycle.queue(classification, action)
+    else
+      ClassificationLifecycle.perform(classification, action.to_s)
+    end
     rescue Redis::CannotConnectError, Redis::TimeoutError, Timeout::Error => e
       Honeybadger.notify(e)
-    end
   end
 
   def completed_error

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -69,7 +69,7 @@ class Api::V1::ClassificationsController < Api::ApiController
     else
       ClassificationLifecycle.perform(classification, action.to_s)
     end
-    rescue Redis::CannotConnectError, Redis::TimeoutError, Timeout::Error => e
+  rescue Redis::CannotConnectError, Redis::TimeoutError, Timeout::Error => e
       Honeybadger.notify(e)
   end
 

--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -64,7 +64,7 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def lifecycle(action, classification)
-    if Panoptes.flipper[:cls_lifecycle_queue].enabled?
+    if Panoptes.flipper[:classification_lifecycle_in_background].enabled?
       ClassificationLifecycle.queue(classification, action)
     else
       ClassificationLifecycle.perform(classification, action.to_s)

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -31,6 +31,7 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def create
+    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:subject_uploading].enabled?
     super { |subject| subject.uploader.increment_subjects_count_cache }
   end
 

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -25,9 +25,9 @@ module ApiErrors
       super("Cannot create roles resource when one exists for the user and project")
     end
   end
-  class ExportDisabled < PanoptesApiError
+  class FeatureDisabled < PanoptesApiError
     def initialize
-      super("Exports are temporarily disabled")
+      super("Feature has been temporarily disabled")
     end
   end
 end

--- a/app/workers/aggregations_dump_worker.rb
+++ b/app/workers/aggregations_dump_worker.rb
@@ -6,7 +6,7 @@ class AggregationsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
-    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
+    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     # Set expiry time of signed_url to one day from now
     medium.update!(put_expires: 1.day.from_now.to_i - Time.now.to_i)
 

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -9,7 +9,7 @@ class ClassificationsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
-    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
+    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     CSV.open(csv_file_path, 'wb') do |csv|
       formatter = Formatter::Csv::Classification.new(cache)
       csv << formatter.class.headers

--- a/app/workers/subjects_dump_worker.rb
+++ b/app/workers/subjects_dump_worker.rb
@@ -9,7 +9,7 @@ class SubjectsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
-    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
+    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     CSV.open(csv_file_path, 'wb') do |csv|
       headers = Formatter::Csv::Subject.headers
 

--- a/app/workers/workflow_contents_dump_worker.rb
+++ b/app/workers/workflow_contents_dump_worker.rb
@@ -9,7 +9,7 @@ class WorkflowContentsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
-    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
+    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     csv_formatter = Formatter::Csv::WorkflowContent.new
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers

--- a/app/workers/workflows_dump_worker.rb
+++ b/app/workers/workflows_dump_worker.rb
@@ -9,7 +9,7 @@ class WorkflowsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
-    raise ApiErrors::ExportDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
+    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     csv_formatter = Formatter::Csv::Workflow.new
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -316,6 +316,20 @@ describe Api::V1::ClassificationsController, type: :controller do
           create_action
         end
       end
+
+      context "when the lifecycle should be processed immediately" do
+        before { Panoptes.flipper[:cls_lifecycle_queue].disable }
+
+        it "does not queue the job" do
+          expect(ClassificationLifecycle).to_not receive(:perform_async)
+          create_action
+        end
+
+        it "executes the job" do
+          expect_any_instance_of(ClassificationLifecycle).to receive(:execute)
+          create_action
+        end
+      end
     end
 
     context "a non-logged in user" do

--- a/spec/controllers/api/v1/classifications_controller_spec.rb
+++ b/spec/controllers/api/v1/classifications_controller_spec.rb
@@ -318,7 +318,7 @@ describe Api::V1::ClassificationsController, type: :controller do
       end
 
       context "when the lifecycle should be processed immediately" do
-        before { Panoptes.flipper[:cls_lifecycle_queue].disable }
+        before { Panoptes.flipper[:classification_lifecycle_in_background].disable }
 
         it "does not queue the job" do
           expect(ClassificationLifecycle).to_not receive(:perform_async)

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -561,6 +561,16 @@ describe Api::V1::SubjectsController, type: :controller do
       }
     end
 
+    context "Uploading is disabled" do
+      before { Panoptes.flipper[:subject_uploading].disable }
+
+      it "raises an error when uploading is disabled" do
+        default_request user_id: authorized_user.id, scopes: scopes
+        post :create, create_params
+        expect(response.status).to be(503)
+      end
+    end
+
     it "should incremement the user's subjects_count cache" do
       expect_any_instance_of(User).to receive(:increment_subjects_count_cache)
       default_request user_id: authorized_user.id, scopes: scopes

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe Subjects::StrategySelection do
     end
 
     context "removing completes is enabled" do
-      before { Panoptes.flipper[:remove_complete_subjects].enable }
-
       it "should call the complete remover after selection", :aggregate_failures do
         expect(subject).to receive(:select_sms_ids).and_return([:default, [1,2,3]]).ordered
         expect(Subjects::CompleteRemover)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.include APIResponseHelpers, type: :request
   config.include ValidUserRequestHelper, type: :request
   config.include CellectHelpers
+  config.include Flipper
   config.extend RSpec::Helpers::ActiveRecordMocks
 
   config.filter_run focus: true
@@ -60,10 +61,6 @@ RSpec.configure do |config|
     # Enable all Scientist experiments
     CodeExperiment.always_enabled = true
     CodeExperiment.raise_on_mismatches = true
-
-    allow(Panoptes).to receive(:flipper).and_return(Flipper.new(Flipper::Adapters::Memory.new))
-    Panoptes.flipper["cellect"].enable
-    Panoptes.flipper["designator"].enable
 
     case example.metadata[:sidekiq]
     when :fake

--- a/spec/support/dump_worker.rb
+++ b/spec/support/dump_worker.rb
@@ -1,6 +1,5 @@
 RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
   let(:another_project) { create(:project) }
-  before { Panoptes.flipper[:dump_worker_exports].enable }
 
   context "when the project id doesn't correspond to a project" do
     before(:each) do
@@ -132,7 +131,7 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
       before { Panoptes.flipper[:dump_worker_exports].disable }
 
       it "raises an exception" do
-        expect { worker.perform(project.id, "project", medium.id) }.to raise_error(ApiErrors::ExportDisabled)
+        expect { worker.perform(project.id, "project", medium.id) }.to raise_error(ApiErrors::FeatureDisabled)
       end
     end
   end

--- a/spec/support/flipper.rb
+++ b/spec/support/flipper.rb
@@ -1,0 +1,12 @@
+module Flipper
+  RSpec.configure do |config|
+    config.before(:each) do |example|
+      allow(Panoptes).to receive(:flipper).and_return(Flipper.new(Flipper::Adapters::Memory.new))
+      Panoptes.flipper["cellect"].enable
+      Panoptes.flipper["designator"].enable
+      Panoptes.flipper[:remove_complete_subjects].enable
+      Panoptes.flipper[:dump_worker_exports].enable
+      Panoptes.flipper[:subject_uploading].enable
+    end
+  end
+end

--- a/spec/support/flipper.rb
+++ b/spec/support/flipper.rb
@@ -7,6 +7,7 @@ module Flipper
       Panoptes.flipper[:remove_complete_subjects].enable
       Panoptes.flipper[:dump_worker_exports].enable
       Panoptes.flipper[:subject_uploading].enable
+      Panoptes.flipper[:cls_lifecycle_queue].enable
     end
   end
 end

--- a/spec/support/flipper.rb
+++ b/spec/support/flipper.rb
@@ -7,7 +7,7 @@ module Flipper
       Panoptes.flipper[:remove_complete_subjects].enable
       Panoptes.flipper[:dump_worker_exports].enable
       Panoptes.flipper[:subject_uploading].enable
-      Panoptes.flipper[:cls_lifecycle_queue].enable
+      Panoptes.flipper[:classification_lifecycle_in_background].enable
     end
   end
 end

--- a/spec/workers/aggregations_dump_worker_spec.rb
+++ b/spec/workers/aggregations_dump_worker_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AggregationsDumpWorker do
     before { Panoptes.flipper[:dump_worker_exports].disable }
 
     it "raises an exception" do
-      expect { subject.perform(project, "project", medium) }.to raise_error(ApiErrors::ExportDisabled)
+      expect { subject.perform(project, "project", medium) }.to raise_error(ApiErrors::FeatureDisabled)
     end
   end
 end

--- a/spec/workers/workflow_contents_dump_worker_spec.rb
+++ b/spec/workers/workflow_contents_dump_worker_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe WorkflowContentsDumpWorker do
   end
 
   context "with a versioned workflow content" do
-    before { Panoptes.flipper[:dump_worker_exports].enable }
-
     with_versioning do
       let(:q_workflow) { build(:workflow, :question_task) }
       let(:strings) { q_workflow.workflow_contents.first.strings }

--- a/spec/workers/workflows_dump_worker_spec.rb
+++ b/spec/workers/workflows_dump_worker_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe WorkflowsDumpWorker do
   end
 
   context "with a versioned workflow" do
-    before { Panoptes.flipper[:dump_worker_exports].enable }
-
     with_versioning do
       let(:q_workflow) { build(:workflow, :question_task) }
       let(:tasks) { q_workflow.tasks }


### PR DESCRIPTION
Builds on the subject uploading feature flag and adds one for classification lifecycle processing. When it is on, lifecycle processing is done normally: thrown into sidekiq via `perform_async` and left in the queue. When the flag is turned off, the processing will be done immediately at the cost of performance but preventing a race condition on postgresql subject selection.

Flag exists and enabled on production and staging.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
