### PR TITLE
use sub selects instead of two queries

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -62,7 +62,7 @@ class Classification < ActiveRecord::Base
     if opts[:workflow_id]
       public_workflows = public_workflows.where(id: opts[:workflow_id])
     end
-    public_workflow_ids = public_workflows.pluck(:id)
+    public_workflow_ids = public_workflows.select(:id)
     GoldStandardAnnotation
       .where(workflow_id: public_workflow_ids)
       .order(id: :asc)
@@ -74,7 +74,7 @@ class Classification < ActiveRecord::Base
     end
     projects = Project.scope_for(:update, user)
     projects = projects.where(id: opts[:project_id]) if opts[:project_id]
-    scope = where(project_id: projects.pluck(:id))
+    scope = where(project_id: projects.select(:id))
     scope = scope.after_id(opts[:last_id]) if opts[:last_id]
     scope
   end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -29,7 +29,7 @@ class Membership < ActiveRecord::Base
   def self.scope_for(action, user, opts={})
     return all if user.is_admin?
     roles, _ = parent_class.roles(action)
-    accessible_group_ids = user.user_groups.where.overlap(memberships: {roles: roles}).pluck(:id)
+    accessible_group_ids = user.user_groups.where.overlap(memberships: {roles: roles}).select(:id)
     query = not_identity.where(user_group_id: accessible_group_ids)
             .or(not_identity.where(user_id: user.id))
 

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -64,7 +64,7 @@ class UserGroup < ActiveRecord::Base
   end
 
   def self.public_query(private_query, public_flag)
-    query = where(id: private_query.pluck(:id))
+    query = where(id: private_query.select(:id))
     query = query.or(public_scope) if public_flag
     query
   end

--- a/lib/role_control/controlled.rb
+++ b/lib/role_control/controlled.rb
@@ -33,7 +33,7 @@ module RoleControl
       end
 
       def public_query(private_query, public_flag)
-        query = where(id: private_query.pluck(:resource_id))
+        query = where(id: private_query.select(:resource_id))
         query = query.or(public_scope) if public_flag
         query
       end

--- a/lib/role_control/parental_controlled.rb
+++ b/lib/role_control/parental_controlled.rb
@@ -8,7 +8,7 @@ module RoleControl
         private_scope = parent_class.private_scope
 
         if Panoptes.flipper["test_no_join_parental_scope"].enabled?
-          where(parent_foreign_key => private_scope.pluck(:id))
+          where(parent_foreign_key => private_scope.select(:id))
         else
           joins(@parent).merge(private_scope)
         end
@@ -17,7 +17,7 @@ module RoleControl
         public_scope = parent_class.public_scope
 
         if Panoptes.flipper["test_no_join_parental_scope"].enabled?
-          where(parent_foreign_key => public_scope.pluck(:id))
+          where(parent_foreign_key => public_scope.select(:id))
         else
           joins(@parent).merge(public_scope)
         end
@@ -44,7 +44,7 @@ module RoleControl
         parent_scope = parent_class.scope_for(action, user, opts)
 
         if Panoptes.flipper["test_no_join_parental_scope"].enabled?
-          where(parent_foreign_key => parent_scope.pluck(:id))
+          where(parent_foreign_key => parent_scope.select(:id))
         else
           joins(@parent).merge(parent_scope)
         end


### PR DESCRIPTION
let AR do it's job constructing sub select statements instead of plucking data from possibly big scopes and feeding them into a secondary query.

I can split this up for the non-feature flagged scopes. in theory it'll just run the same query in a subselect but won't serialize the data back to rails with AR records being created so it should be faster / more efficient. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
