### PR TITLE
Http caching public resources on index / show routes

### DIFF
--- a/app/controllers/concerns/json_api_render.rb
+++ b/app/controllers/concerns/json_api_render.rb
@@ -7,9 +7,32 @@ module JSONApiRender
       if options[:generate_response_obj_etag]
         self.headers["ETag"] = JSONApiResponse.response_etag_header(response_body)
       end
+      if options[:add_http_cache] == "true"
+        if all_public_resources?
+
+          # def public_resources?
+          #   binding.pry
+          #   controlled_class, controlled_attribute = if resource_class.respond_to?(:parent_class)
+          #     parent_relation = resource_class.reflect_on_association(resource_class.parent_relation)
+          #     [ resource_class.parent_class, parent_relation.foreign_key ]
+          #   else
+          #     [ resource_class, :id ]
+          #   end
+          #   # MOVE THIS TO SOME SET EQUALITY OPERATOR INSTEAD OF COMPARING request_params
+          #   # OF ID's before a limit is applied
+          #   # this may not even be feasible
+          #   # if not then we'll have to cache public routes only
+          #   controlled_resource_ids = controlled_resources.pluck(controlled_attribute)
+          #   controlled_class.public_scope.where(id: controlled_resource_ids).pluck(:id)
+          # end
+
+          self.headers["Cache-Control"] = ""
+        end
+      end
       self.content_type ||= Mime::Type.lookup("application/vnd.api+json; version=1")
       self.response_body = response_body
     end
+
   end
 
   def json_api_render(status, content, location=nil)

--- a/app/controllers/concerns/json_api_render.rb
+++ b/app/controllers/concerns/json_api_render.rb
@@ -1,32 +1,20 @@
 module JSONApiRender
   extend ActiveSupport::Concern
 
-  CACHEABLE_RESOURCES = { subjects: "public max-age: 60" }.freeze
-
   included do
     ActionController.add_renderer :json_api do |obj, options|
       response_body = JSONApiResponse.format_response_body(obj)
       if options[:generate_response_obj_etag]
         self.headers["ETag"] = JSONApiResponse.response_etag_header(response_body)
       end
-      resource_cache_directive = CACHEABLE_RESOURCES[resource_sym]
-      if resource_cache_directive && options[:add_http_cache] == "true"
 
-        #TODO: move this to some infelctor or render options
-        parent_class = resource_class.parent_class
-        parent_resource_ids = controlled_resources.map do |cr|
-          cr.send resource_class.parent_foreign_key
-        end
-
-        contains_private_data = parent_class
-          .private_scope
-          .where(id: parent_resource_ids)
-          .exists?
-
-        if !contains_private_data
-          self.headers["Cache-Control"] = resource_cache_directive
+      if options[:add_http_cache] == "true"
+        http_cacheable = HttpCacheable.new(controlled_resources)
+        if http_cacheable.public_resources?
+          self.headers["Cache-Control"] = http_cacheable.resource_cache_directive
         end
       end
+
       self.content_type ||= Mime::Type.lookup("application/vnd.api+json; version=1")
       self.response_body = response_body
     end

--- a/app/controllers/concerns/json_api_render.rb
+++ b/app/controllers/concerns/json_api_render.rb
@@ -18,7 +18,6 @@ module JSONApiRender
       self.content_type ||= Mime::Type.lookup("application/vnd.api+json; version=1")
       self.response_body = response_body
     end
-
   end
 
   def json_api_render(status, content, location=nil)

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -1,5 +1,3 @@
-require 'serialization/has_many_filtering/options'
-
 module FilterHasMany
   extend ActiveSupport::Concern
 

--- a/lib/http_cacheable.rb
+++ b/lib/http_cacheable.rb
@@ -1,0 +1,48 @@
+class HttpCacheable
+  CACHEABLE_RESOURCES = {
+    subjects: "public max-age: 60",
+    projects: "public max-age: 60"
+  }.freeze
+
+  attr_reader :controlled_resources, :resource_class, :resource_symbol
+
+  def initialize(controlled_resources)
+    @controlled_resources = controlled_resources
+    @resource_class = controlled_resources.klass
+    @resource_symbol = resource_class.model_name.plural.to_sym
+  end
+
+  def public_resources?
+    return false unless resource_cache_directive
+
+    private_resources = if resource_class.respond_to?(:parent_class)
+      any_private_parent_resources?
+    else
+      any_private_resources?
+    end
+
+    !private_resources
+  end
+
+  private
+
+  def resource_cache_directive
+    CACHEABLE_RESOURCES[resource_symbol]
+  end
+
+  def any_private_parent_resources?
+    parent_fk_scope = controlled_resources.select(
+      resource_class.parent_foreign_key
+    )
+
+    resource_class
+      .parent_class
+      .private_scope
+      .where(id: parent_fk_scope)
+      .exists?
+  end
+
+  def any_private_resources?
+    controlled_resources.private_scope.exists?
+  end
+end

--- a/lib/http_cacheable.rb
+++ b/lib/http_cacheable.rb
@@ -24,11 +24,11 @@ class HttpCacheable
     !private_resources
   end
 
-  private
-
   def resource_cache_directive
-    CACHEABLE_RESOURCES[resource_symbol]
+    @resource_cache_directive ||= CACHEABLE_RESOURCES[resource_symbol]
   end
+
+  private
 
   def any_private_parent_resources?
     parent_fk_scope = controlled_resources.select(

--- a/lib/http_cacheable.rb
+++ b/lib/http_cacheable.rb
@@ -11,14 +11,7 @@ class HttpCacheable
 
   def public_resources?
     return false unless cacheable_resource?
-
-    private_resources = if resource_class.respond_to?(:parent_class)
-      any_private_parent_resources?
-    else
-      any_private_resources?
-    end
-
-    !private_resources
+    !controlled_resources_any_private?
   end
 
   def resource_cache_directive
@@ -47,11 +40,12 @@ class HttpCacheable
   end
 
   def public_private_directive
-    @public_private_directive ||= if Panoptes.flipper[:private_http_caching].enabled?
-      "private"
-    else
-      "public"
-    end
+    @public_private_directive ||=
+      if Panoptes.flipper[:private_http_caching].enabled?
+        "private"
+      else
+        "public"
+      end
   end
 
   def max_age_directive
@@ -60,5 +54,13 @@ class HttpCacheable
 
   def cacheable_resource?
     Panoptes.flipper[:http_caching].enabled? && !!resource_cache_directive
+  end
+
+  def controlled_resources_any_private?
+    if resource_class.respond_to?(:parent_class)
+      any_private_parent_resources?
+    else
+      any_private_resources?
+    end
   end
 end

--- a/lib/http_cacheable.rb
+++ b/lib/http_cacheable.rb
@@ -10,7 +10,7 @@ class HttpCacheable
   end
 
   def public_resources?
-    return false if resource_cache_directive.blank?
+    return false unless cacheable_resource?
 
     private_resources = if resource_class.respond_to?(:parent_class)
       any_private_parent_resources?
@@ -56,5 +56,9 @@ class HttpCacheable
 
   def max_age_directive
     @max_age_directive ||= ENV.fetch("HTTP_#{resource_symbol.to_s.upcase}_MAX_AGE", 60)
+  end
+
+  def cacheable_resource?
+    Panoptes.flipper[:http_caching].enabled? && !!resource_cache_directive
   end
 end

--- a/lib/json_api_controller/indexable_resource.rb
+++ b/lib/json_api_controller/indexable_resource.rb
@@ -2,7 +2,8 @@ module JsonApiController
   module IndexableResource
     def index
       render json_api: serializer.page(params, controlled_resources, context),
-             generate_response_obj_etag: true
+             generate_response_obj_etag: true,
+             add_http_cache: params[:http_cache]
     end
   end
 end

--- a/lib/json_api_controller/showable_resource.rb
+++ b/lib/json_api_controller/showable_resource.rb
@@ -2,7 +2,8 @@ module JsonApiController
   module ShowableResource
     def show
       headers['ETag'] = gen_etag(controlled_resources)
-      render json_api: serializer.resource(params, controlled_resources, context)
+      render json_api: serializer.resource(params, controlled_resources, context),
+             add_http_cache: params[:http_cache]
     end
   end
 end

--- a/lib/role_control/parental_controlled.rb
+++ b/lib/role_control/parental_controlled.rb
@@ -38,6 +38,7 @@ module RoleControl
 
       def parent_foreign_key
         reflect_on_association(@parent).foreign_key
+      end
 
       def parent_relation
         @parent

--- a/lib/role_control/parental_controlled.rb
+++ b/lib/role_control/parental_controlled.rb
@@ -38,6 +38,9 @@ module RoleControl
 
       def parent_foreign_key
         reflect_on_association(@parent).foreign_key
+
+      def parent_relation
+        @parent
       end
 
       def scope_for(action, user, opts={})

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -452,7 +452,9 @@ describe Api::V1::ProjectsController, type: :controller do
 
     describe "create talk admin" do
       it 'should queue a talk admin create worker' do
-        expect(TalkAdminCreateWorker).to receive(:perform_async).with(instance_of Fixnum)
+        expect(TalkAdminCreateWorker)
+          .to receive(:perform_async)
+          .with(instance_of(Fixnum))
         default_request scopes: scopes, user_id: authorized_user.id
         post :create, create_params
       end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -50,6 +50,9 @@ describe Api::V1::ProjectsController, type: :controller do
 
       it_behaves_like "an indexable unauthenticated http cacheable response" do
         let(:action) { :index }
+        let(:private_resource) do
+          create(:project, owner: user, private: true)
+        end
       end
 
       it_behaves_like "is indexable"

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -38,8 +38,8 @@ describe Api::V1::ProjectsController, type: :controller do
   let(:unapproved_resource) { create(:project, beta_approved: false, launch_approved: false) }
   let(:deactivated_resource) { create(:project, activated_state: :inactive) }
 
-  describe "when not logged in" do
-    describe "#index" do
+  describe "#index" do
+    context "not logged in" do
       let(:authorized_user) { nil }
       let(:n_visible) { 2 }
 
@@ -56,14 +56,8 @@ describe Api::V1::ProjectsController, type: :controller do
       it_behaves_like "it has custom owner links", "display_name"
       it_behaves_like "it only lists active resources"
     end
-  end
 
-  describe "a logged in user" do
-    before(:each) do
-      default_request(scopes: scopes, user_id: user.id)
-    end
-
-    describe "#index" do
+    context "logged in " do
 
       it_behaves_like "an indexable authenticated http cacheable response" do
         let(:action) { :index }
@@ -373,247 +367,256 @@ describe Api::V1::ProjectsController, type: :controller do
         end
       end
     end
+  end
 
-    describe "#show" do
-      let(:resource) { project }
+  describe "#show" do
+    let(:resource) { project }
 
-      it_behaves_like "is showable"
+    it_behaves_like "is showable"
 
-      it_behaves_like "an api response" do
-        before do
-          get :show, id: resource.id
-        end
+    it_behaves_like "an api response" do
+      before do
+        get :show, id: resource.id
       end
-
-
-      it_behaves_like "an api response"
     end
 
-    describe "#create" do
-      let(:created_project_id) { created_instance_id("projects") }
-      let(:test_attr) { :display_name }
-      let(:test_attr_value) { "New Zoo" }
-      let(:display_name) { test_attr_value }
-      let(:owner_params) { nil }
+    describe "http caching" do
+      let(:action) { :show }
+      let(:private_resource) do
+        create(:project, owner: user, private: true)
+      end
+      let(:private_resource_id) { private_resource.id }
+      let(:public_resource_id) { resource.id }
 
-      let(:default_create_params) do
-        { projects: { display_name: display_name,
-                     description: "A new Zoo for you!",
-                     primary_language: 'en',
-                     workflow_description: "some more text",
-                     urls: [{label: "Twitter", url: "http://twitter.com/example"}],
-                     tags: ["astro", "gastro"],
-                     configuration: {
-                                     an_option: "a setting"
-                                    },
-                     beta_requested: true,
-                     private: true } }
+      it_behaves_like "a showable unauthenticated http cacheable response"
+      it_behaves_like "a showable authenticated http cacheable response"
+    end
+  end
+
+  describe "#create" do
+    let(:created_project_id) { created_instance_id("projects") }
+    let(:test_attr) { :display_name }
+    let(:test_attr_value) { "New Zoo" }
+    let(:display_name) { test_attr_value }
+    let(:owner_params) { nil }
+
+    let(:default_create_params) do
+      { projects: { display_name: display_name,
+                   description: "A new Zoo for you!",
+                   primary_language: 'en',
+                   workflow_description: "some more text",
+                   urls: [{label: "Twitter", url: "http://twitter.com/example"}],
+                   tags: ["astro", "gastro"],
+                   configuration: {
+                                   an_option: "a setting"
+                                  },
+                   beta_requested: true,
+                   private: true } }
+    end
+
+    let (:create_params) do
+      ps = default_create_params
+      if owner_params
+        ps[:projects][:links] ||= Hash.new
+        ps[:projects][:links][:owner] = owner_params
+      end
+      ps
+    end
+
+    describe "redirect option" do
+      it_behaves_like "admin only option", :redirect, "http://example.com"
+    end
+
+    describe "launch approved option" do
+      it_behaves_like "admin only option", :launch_approved, true
+    end
+
+    describe "beta approved option" do
+      it_behaves_like "admin only option", :beta_approved, true
+    end
+
+    describe "launched_row_order_position option" do
+      it_behaves_like "admin only option", :launched_row_order_position, 10
+    end
+
+    describe "beta_row_order_position option" do
+      it_behaves_like "admin only option", :beta_row_order_position, 10
+    end
+
+    describe "experiemntal_tools option" do
+      it_behaves_like "admin only option", :experimental_tools, ["survey"]
+    end
+
+    describe "create talk admin" do
+      it 'should queue a talk admin create worker' do
+        expect(TalkAdminCreateWorker).to receive(:perform_async).with(instance_of Fixnum)
+        default_request scopes: scopes, user_id: authorized_user.id
+        post :create, create_params
+      end
+    end
+
+    describe "correct serializer configuration" do
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id
+        post :create, create_params
       end
 
-      let (:create_params) do
-        ps = default_create_params
-        if owner_params
-          ps[:projects][:links] ||= Hash.new
-          ps[:projects][:links][:owner] = owner_params
-        end
-        ps
-      end
+      context "without commas in the display name" do
 
-      describe "redirect option" do
-        it_behaves_like "admin only option", :redirect, "http://example.com"
-      end
-
-      describe "launch approved option" do
-        it_behaves_like "admin only option", :launch_approved, true
-      end
-
-      describe "beta approved option" do
-        it_behaves_like "admin only option", :beta_approved, true
-      end
-
-      describe "launched_row_order_position option" do
-        it_behaves_like "admin only option", :launched_row_order_position, 10
-      end
-
-      describe "beta_row_order_position option" do
-        it_behaves_like "admin only option", :beta_row_order_position, 10
-      end
-
-      describe "experiemntal_tools option" do
-        it_behaves_like "admin only option", :experimental_tools, ["survey"]
-      end
-
-      describe "create talk admin" do
-        it 'should queue a talk admin create worker' do
-          expect(TalkAdminCreateWorker).to receive(:perform_async).with(instance_of Fixnum)
-          default_request scopes: scopes, user_id: authorized_user.id
-          post :create, create_params
-        end
-      end
-
-      describe "correct serializer configuration" do
-        before(:each) do
-          default_request scopes: scopes, user_id: authorized_user.id
-          post :create, create_params
-        end
-
-        context "without commas in the display name" do
-
-          it "should return the correct resource in the response" do
-            expect(json_response["projects"]).to_not be_empty
-          end
-        end
-
-        context "when the display name has commas in it" do
-          let!(:display_name) { "My parents, Steve McQueen, and God" }
-
-          it "should return a created response" do
-            expect(json_response["projects"]).to_not be_empty
-          end
-        end
-
-        describe "owner links" do
-          it "should include the link" do
-            expect(json_response['linked']['owners']).to_not be_nil
-          end
-        end
-
-        describe "project contents" do
-          let(:contents) { Project.find(created_project_id).project_contents.first }
-
-          it "should create an associated project_content model" do
-            expect(contents).to_not be_nil
-          end
-
-          it 'should extract labels from the urls' do
-            expect(Project.find(created_project_id).urls).to eq([{"label" => "0.label", "url" => "http://twitter.com/example"}])
-          end
-
-
-          it 'should save labels to contents' do
-            expect(contents.url_labels).to eq({"0.label" => "Twitter"})
-          end
-
-          it 'should set the contents title do' do
-            expect(contents.title).to eq('New Zoo')
-          end
-
-          it 'should set the description' do
-            expect(contents.description).to eq('A new Zoo for you!')
-          end
-
-          it 'should set the language' do
-            expect(contents.language).to eq('en')
-          end
+        it "should return the correct resource in the response" do
+          expect(json_response["projects"]).to_not be_empty
         end
       end
 
-      describe "tags" do
-        let(:tags) { Tag.where(name: ["astro", "gastro"]) }
+      context "when the display name has commas in it" do
+        let!(:display_name) { "My parents, Steve McQueen, and God" }
 
-        def tag_request
-          default_request scopes: scopes, user_id: authorized_user.id
-          post :create, create_params
+        it "should return a created response" do
+          expect(json_response["projects"]).to_not be_empty
+        end
+      end
+
+      describe "owner links" do
+        it "should include the link" do
+          expect(json_response['linked']['owners']).to_not be_nil
+        end
+      end
+
+      describe "project contents" do
+        let(:contents) { Project.find(created_project_id).project_contents.first }
+
+        it "should create an associated project_content model" do
+          expect(contents).to_not be_nil
         end
 
-        context "when the tags did not exist" do
-          it 'should create tag models for the project tags' do
-            tag_request
-            expect(tags.pluck(:tagged_resources_count)).to all( eq(1) )
-          end
+        it 'should extract labels from the urls' do
+          expect(Project.find(created_project_id).urls).to eq([{"label" => "0.label", "url" => "http://twitter.com/example"}])
         end
 
-        context "when the tags did exist" do
-          it 'should reuse existing tags' do
-            create(:tag, name: "astro")
-            create(:tag, name: "gastro")
-            tag_request
-            expect(tags.pluck(:tagged_resources_count)).to all( eq(2) )
-          end
+
+        it 'should save labels to contents' do
+          expect(contents.url_labels).to eq({"0.label" => "Twitter"})
         end
 
-        it 'should associate the tags with the project' do
+        it 'should set the contents title do' do
+          expect(contents.title).to eq('New Zoo')
+        end
+
+        it 'should set the description' do
+          expect(contents.description).to eq('A new Zoo for you!')
+        end
+
+        it 'should set the language' do
+          expect(contents.language).to eq('en')
+        end
+      end
+    end
+
+    describe "tags" do
+      let(:tags) { Tag.where(name: ["astro", "gastro"]) }
+
+      def tag_request
+        default_request scopes: scopes, user_id: authorized_user.id
+        post :create, create_params
+      end
+
+      context "when the tags did not exist" do
+        it 'should create tag models for the project tags' do
           tag_request
-          resource_id = json_response[api_resource_name][0]["id"].to_i
-          expect(tags.flat_map{ |t| t.projects.pluck(:id) }).to all( eq(resource_id) )
+          expect(tags.pluck(:tagged_resources_count)).to all( eq(1) )
         end
       end
 
-      context "created with user as owner" do
-        it_behaves_like "is creatable"
-
-        context "with invalid create params" do
-
-          it "should not orphan an ACL instance when the model is invalid" do
-            default_request scopes: scopes, user_id: authorized_user.id
-            create_params[:projects] = create_params[:projects].except(:primary_language)
-            expect{ post :create, create_params }.not_to change{ AccessControlList.count }
-          end
+      context "when the tags did exist" do
+        it 'should reuse existing tags' do
+          create(:tag, name: "astro")
+          create(:tag, name: "gastro")
+          tag_request
+          expect(tags.pluck(:tagged_resources_count)).to all( eq(2) )
         end
       end
 
-      context "created with specified user as owner" do
-        context "user is the current user" do
-          let(:owner_params) do
-            {
-             id: authorized_user.id.to_s,
-             type: "users"
-            }
-          end
+      it 'should associate the tags with the project' do
+        tag_request
+        resource_id = json_response[api_resource_name][0]["id"].to_i
+        expect(tags.flat_map{ |t| t.projects.pluck(:id) }).to all( eq(resource_id) )
+      end
+    end
 
-          it_behaves_like "is creatable"
-        end
+    context "created with user as owner" do
+      it_behaves_like "is creatable"
 
-        context "user is not the current user" do
-          let(:req) do
-            default_request scopes: scopes, user_id: authorized_user.id
-            post :create, create_params
-          end
+      context "with invalid create params" do
 
-
-          let(:owner_params) do
-            user = create(:user)
-            {
-              id: user.id.to_s,
-                type: "users"
-            }
-          end
-
-          it "should not create a new project" do
-            expect{ req }.to_not change{Project.count}
-          end
-
-          it "should return 422" do
-            req
-            expect(response).to have_http_status(:unprocessable_entity)
-          end
+        it "should not orphan an ACL instance when the model is invalid" do
+          default_request scopes: scopes, user_id: authorized_user.id
+          create_params[:projects] = create_params[:projects].except(:primary_language)
+          expect{ post :create, create_params }.not_to change{ AccessControlList.count }
         end
       end
+    end
 
-      context "create with user_group as owner" do
-        let(:owner) { create(:user_group) }
-        let!(:membership) { create(:membership,
-                                   state: :active,
-                                   user: user,
-                                   user_group: owner,
-                                   roles: ["group_admin"]) }
-
+    context "created with specified user as owner" do
+      context "user is the current user" do
         let(:owner_params) do
           {
-           id: owner.id.to_s,
-           type: "user_groups"
+           id: authorized_user.id.to_s,
+           type: "users"
           }
         end
 
-        it 'should have the user group as its owner' do
-          default_request scopes: scopes, user_id: authorized_user.id
-          post :create, create_params
-          project = Project.find(json_response['projects'][0]['id'])
-          expect(project.owner).to eq(owner)
-        end
-
         it_behaves_like "is creatable"
       end
+
+      context "user is not the current user" do
+        let(:req) do
+          default_request scopes: scopes, user_id: authorized_user.id
+          post :create, create_params
+        end
+
+
+        let(:owner_params) do
+          user = create(:user)
+          {
+            id: user.id.to_s,
+              type: "users"
+          }
+        end
+
+        it "should not create a new project" do
+          expect{ req }.to_not change{Project.count}
+        end
+
+        it "should return 422" do
+          req
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context "create with user_group as owner" do
+      let(:owner) { create(:user_group) }
+      let!(:membership) { create(:membership,
+                                 state: :active,
+                                 user: user,
+                                 user_group: owner,
+                                 roles: ["group_admin"]) }
+
+      let(:owner_params) do
+        {
+         id: owner.id.to_s,
+         type: "user_groups"
+        }
+      end
+
+      it 'should have the user group as its owner' do
+        default_request scopes: scopes, user_id: authorized_user.id
+        post :create, create_params
+        project = Project.find(json_response['projects'][0]['id'])
+        expect(project.owner).to eq(owner)
+      end
+
+      it_behaves_like "is creatable"
     end
   end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -454,7 +454,7 @@ describe Api::V1::ProjectsController, type: :controller do
       it 'should queue a talk admin create worker' do
         expect(TalkAdminCreateWorker)
           .to receive(:perform_async)
-          .with(instance_of(Fixnum))
+          .with(be_kind_of(Integer))
         default_request scopes: scopes, user_id: authorized_user.id
         post :create, create_params
       end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -48,6 +48,10 @@ describe Api::V1::ProjectsController, type: :controller do
         projects
       end
 
+      it_behaves_like "an indexable unauthenticated http cacheable response" do
+        let(:action) { :index }
+      end
+
       it_behaves_like "is indexable"
       it_behaves_like "it has custom owner links", "display_name"
       it_behaves_like "it only lists active resources"
@@ -60,6 +64,14 @@ describe Api::V1::ProjectsController, type: :controller do
     end
 
     describe "#index" do
+
+      it_behaves_like "an indexable authenticated http cacheable response" do
+        let(:action) { :index }
+        let(:private_resource) do
+          create(:project, owner: user, private: true)
+        end
+      end
+
       describe "custom owner links" do
         before(:each) do
           projects

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -375,20 +375,16 @@ describe Api::V1::ProjectsController, type: :controller do
     end
 
     describe "#show" do
-      let(:project_id) { project.id }
+      let(:resource) { project }
 
-      before(:each) do
-        get :show, id: project_id
+      it_behaves_like "is showable"
+
+      it_behaves_like "an api response" do
+        before do
+          get :show, id: resource.id
+        end
       end
 
-      it "should return 200" do
-        expect(response.status).to eq(200)
-      end
-
-      it "should return the only requested project" do
-        expect(json_response[api_resource_name].length).to eq(1)
-        expect(json_response[api_resource_name][0]['id']).to eq(project_id.to_s)
-      end
 
       it_behaves_like "an api response"
     end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -134,30 +134,12 @@ describe Api::V1::SubjectsController, type: :controller do
         default_request user_id: user.id, scopes: scopes
       end
 
-      describe "http caching" do
-        let(:query_params) { { } }
-
-        before(:each) do
-          get :index, query_params
-        end
-
-        context "for a public project", :focus do
-          it "should return 200" do
-            binding.pry
-            expect(response.status).to eq(200)
+      it_behaves_like "http cacheable response" do
+        let(:private_resource) do
+          project = create(:project, private: true) do |project|
+            project.owner = user
           end
-
-          it "should not have a default value" do
-            expect(response.headers.key?("Cache-Control")).to be_falsey
-          end
-
-          context "with the http cache query param setup" do
-            let(:query_params) { { http_cache: "true" } }
-
-            it "should set the cache-control value" do
-              expect(response.headers["Cache-Control"]).to eq("public max-age: 60")
-            end
-          end
+          create(:subject, project: project)
         end
       end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -21,7 +21,7 @@ describe Api::V1::SubjectsController, type: :controller do
   describe "#index" do
     context "logged out user" do
 
-      it_behaves_like "an unauthenticated http cacheable response" do
+      it_behaves_like "an indexable unauthenticated http cacheable response" do
         let(:action) { :index }
         let(:private_resource) do
           project = create(:project, private: true) do |p|
@@ -150,7 +150,7 @@ describe Api::V1::SubjectsController, type: :controller do
         default_request user_id: user.id, scopes: scopes
       end
 
-      it_behaves_like "an authenticated http cacheable response" do
+      it_behaves_like "an indexable authenticated http cacheable response" do
         let(:action) { :index }
         let(:private_resource) do
           project = create(:project, private: true) do |p|
@@ -501,13 +501,11 @@ describe Api::V1::SubjectsController, type: :controller do
         end
         create(:subject, project: project)
       end
+      let(:private_resource_id) { private_resource.id }
+      let(:public_resource_id) { resource.id }
 
-      it_behaves_like "an showable unauthenticated http cacheable response" do
-        let(:query_params) { { id: resource.id } }
-      end
-      it_behaves_like "an showable authenticated http cacheable response" do
-        let(:query_params) { { id: private_resource.id } }
-      end
+      it_behaves_like "an showable unauthenticated http cacheable response"
+      it_behaves_like "an showable authenticated http cacheable response"
     end
   end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -493,7 +493,7 @@ describe Api::V1::SubjectsController, type: :controller do
 
     it_behaves_like "is showable"
 
-    describe "http caching", :focus do
+    describe "http caching" do
       let(:action) { :show }
       let(:private_resource) do
         project = create(:project, private: true) do |p|

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -136,8 +136,8 @@ describe Api::V1::SubjectsController, type: :controller do
 
       it_behaves_like "http cacheable response" do
         let(:private_resource) do
-          project = create(:project, private: true) do |project|
-            project.owner = user
+          project = create(:project, private: true) do |p|
+            p.owner = user
           end
           create(:subject, project: project)
         end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -134,6 +134,30 @@ describe Api::V1::SubjectsController, type: :controller do
         default_request user_id: user.id, scopes: scopes
       end
 
+      context "for a public project", :focus do
+        let(:query_params) { { } }
+
+        before(:each) do
+          get :index, query_params
+        end
+
+        it "should return 200" do
+          expect(response.status).to eq(200)
+        end
+
+        it "should default to private cache-control value" do
+          expect(response.headers["Cache-Control"]).to eq("none")
+        end
+
+        context "with the http cache query param setup" do
+          let(:query_params) { http_cache: true }
+
+          it "should set the cache-control value" do
+            expect(response.headers["Cache-Control"]).to eq("public max-age: 30)
+          end
+        end
+      end
+
       context "without any sort" do
         before(:each) do
           get :index

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -138,6 +138,7 @@ describe Api::V1::SubjectsController, type: :controller do
         let(:query_params) { { } }
 
         before(:each) do
+          binding.pry
           get :index, query_params
         end
 
@@ -146,14 +147,15 @@ describe Api::V1::SubjectsController, type: :controller do
         end
 
         it "should default to private cache-control value" do
+          binding.pry
           expect(response.headers["Cache-Control"]).to eq("none")
         end
 
         context "with the http cache query param setup" do
-          let(:query_params) { http_cache: true }
+          let(:query_params) { { http_cache: true } }
 
           it "should set the cache-control value" do
-            expect(response.headers["Cache-Control"]).to eq("public max-age: 30)
+            expect(response.headers["Cache-Control"]).to eq("public max-age: 30")
           end
         end
       end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -504,8 +504,8 @@ describe Api::V1::SubjectsController, type: :controller do
       let(:private_resource_id) { private_resource.id }
       let(:public_resource_id) { resource.id }
 
-      it_behaves_like "an showable unauthenticated http cacheable response"
-      it_behaves_like "an showable authenticated http cacheable response"
+      it_behaves_like "a showable unauthenticated http cacheable response"
+      it_behaves_like "a showable authenticated http cacheable response"
     end
   end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -21,6 +21,16 @@ describe Api::V1::SubjectsController, type: :controller do
   describe "#index" do
     context "logged out user" do
 
+      it_behaves_like "an unauthenticated http cacheable response" do
+        let(:action) { :index }
+        let(:private_resource) do
+          project = create(:project, private: true) do |p|
+            p.owner = user
+          end
+          create(:subject, project: project)
+        end
+      end
+
       describe "filtering" do
         let(:expected_filtered_ids) { formated_string_ids(filterable_resources) }
 
@@ -81,6 +91,12 @@ describe Api::V1::SubjectsController, type: :controller do
         let(:api_resource_links) { [] }
 
         context "with queued subjects" do
+
+          it_behaves_like "is not a http cacheable response" do
+            let(:action) { :queued }
+            let(:params) { { workflow_id: workflow.id } }
+          end
+
           context "when firing the request before the test" do
             before(:each) do
               get :index, request_params
@@ -134,7 +150,8 @@ describe Api::V1::SubjectsController, type: :controller do
         default_request user_id: user.id, scopes: scopes
       end
 
-      it_behaves_like "http cacheable response" do
+      it_behaves_like "an authenticated http cacheable response" do
+        let(:action) { :index }
         let(:private_resource) do
           project = create(:project, private: true) do |p|
             p.owner = user

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -134,28 +134,29 @@ describe Api::V1::SubjectsController, type: :controller do
         default_request user_id: user.id, scopes: scopes
       end
 
-      context "for a public project", :focus do
+      describe "http caching" do
         let(:query_params) { { } }
 
         before(:each) do
-          binding.pry
           get :index, query_params
         end
 
-        it "should return 200" do
-          expect(response.status).to eq(200)
-        end
+        context "for a public project", :focus do
+          it "should return 200" do
+            binding.pry
+            expect(response.status).to eq(200)
+          end
 
-        it "should default to private cache-control value" do
-          binding.pry
-          expect(response.headers["Cache-Control"]).to eq("none")
-        end
+          it "should not have a default value" do
+            expect(response.headers.key?("Cache-Control")).to be_falsey
+          end
 
-        context "with the http cache query param setup" do
-          let(:query_params) { { http_cache: true } }
+          context "with the http cache query param setup" do
+            let(:query_params) { { http_cache: "true" } }
 
-          it "should set the cache-control value" do
-            expect(response.headers["Cache-Control"]).to eq("public max-age: 30")
+            it "should set the cache-control value" do
+              expect(response.headers["Cache-Control"]).to eq("public max-age: 60")
+            end
           end
         end
       end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -492,6 +492,23 @@ describe Api::V1::SubjectsController, type: :controller do
     let(:resource) { create(:subject) }
 
     it_behaves_like "is showable"
+
+    describe "http caching", :focus do
+      let(:action) { :show }
+      let(:private_resource) do
+        project = create(:project, private: true) do |p|
+          p.owner = user
+        end
+        create(:subject, project: project)
+      end
+
+      it_behaves_like "an showable unauthenticated http cacheable response" do
+        let(:query_params) { { id: resource.id } }
+      end
+      it_behaves_like "an showable authenticated http cacheable response" do
+        let(:query_params) { { id: private_resource.id } }
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -48,6 +48,21 @@ describe Api::V1::WorkflowsController, type: :controller do
 
     it_behaves_like 'has many filterable', :subject_sets
 
+    it_behaves_like "an indexable unauthenticated http cacheable response" do
+      let(:action) { :index }
+      let(:private_resource) do
+        create(:workflow, project: private_project)
+      end
+    end
+
+    it_behaves_like "an indexable authenticated http cacheable response" do
+      let(:action) { :index }
+      let(:private_resource) do
+        create(:workflow, project: private_project)
+      end
+      let(:authorized_user) { private_project.owner }
+    end
+
     describe "filter by" do
       before(:each) do
         filterable_resources

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -37,10 +37,15 @@ describe Api::V1::WorkflowsController, type: :controller do
     let(:filterable_resources) { create_list(:workflow_with_subjects, 2) }
     let(:expected_filtered_ids) { [ filterable_resources.first.id.to_s ] }
     let(:private_project) { create(:private_project) }
-    let!(:private_resource) { create(:workflow, project: private_project) }
+    let(:private_resource) { create(:workflow, project: private_project) }
     let(:n_visible) { 2 }
 
-    it_behaves_like 'is indexable'
+    it_behaves_like 'is indexable' do
+      before do
+        private_resource
+      end
+    end
+
     it_behaves_like 'has many filterable', :subject_sets
 
     describe "filter by" do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -514,6 +514,19 @@ describe Api::V1::WorkflowsController, type: :controller do
     let(:resource) { workflows.first }
 
     it_behaves_like "is showable"
+
+    describe "http caching" do
+      let(:action) { :show }
+      let(:private_resource) do
+        project = create(:private_project, owner: authorized_user)
+        create(:workflow, project: project)
+      end
+      let(:private_resource_id) { private_resource.id }
+      let(:public_resource_id) { resource.id }
+
+      it_behaves_like "a showable unauthenticated http cacheable response"
+      it_behaves_like "a showable authenticated http cacheable response"
+    end
   end
 
   describe '#retired_subjects' do

--- a/spec/lib/http_cacheable_spec.rb
+++ b/spec/lib/http_cacheable_spec.rb
@@ -15,10 +15,19 @@ describe HttpCacheable do
   end
 
   before do
+    Panoptes.flipper["http_caching"].enable
     resource
   end
 
   describe '#public_resources?' do
+    context "when http caching is disabled" do
+      let(:controlled_resources) { Project.all }
+
+      it "should return false for a public resource" do
+        Panoptes.flipper["http_caching"].disable
+        expect(http_cache.public_resources?).to be false
+      end
+    end
     describe "a non-cacheable resource" do
       let(:controlled_resources) { Collection.all }
 

--- a/spec/lib/http_cacheable_spec.rb
+++ b/spec/lib/http_cacheable_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe HttpCacheable do
+  let(:resource) do
+    factory_name = controlled_resources.klass.model_name.singular.to_sym
+    create(factory_name)
+  end
+  let(:http_cache) do
+    HttpCacheable.new(controlled_resources)
+  end
+
+  def make_private(public_resource)
+    public_resource.update_column(:private, true)
+  end
+
+  before do
+    resource
+  end
+
+  describe '#public_resources?' do
+
+    describe "a non-cacheable resource" do
+      let(:controlled_resources) { Collection.all }
+
+      it "should return false for a public resource" do
+        expect(http_cache.public_resources?).to be false
+      end
+
+      it "should return false for a private resource" do
+        make_private(resource)
+        expect(http_cache.public_resources?).to be false
+      end
+    end
+
+    describe "parental controlled resources" do
+      let(:controlled_resources) { Subject.all }
+
+      it "should return true with a public resource" do
+        expect(http_cache.public_resources?).to be true
+      end
+
+      it "should return false with a private resource" do
+        parent_relation = resource.class.parent_relation
+        parent_resource = resource.send(parent_relation)
+        make_private(parent_resource)
+        expect(http_cache.public_resources?).to be false
+      end
+    end
+
+    describe "controlled resources" do
+      let(:controlled_resources) { Project.all }
+
+      it "should return true with a public resource" do
+        expect(http_cache.public_resources?).to be true
+      end
+
+      it "should return false with a private resource" do
+        make_private(resource)
+        expect(http_cache.public_resources?).to be false
+      end
+    end
+  end
+end

--- a/spec/lib/http_cacheable_spec.rb
+++ b/spec/lib/http_cacheable_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe HttpCacheable do
+  let(:resource_name) { controlled_resources.klass.model_name }
   let(:resource) do
-    factory_name = controlled_resources.klass.model_name.singular.to_sym
+    factory_name = resource_name.singular.to_sym
     create(factory_name)
   end
   let(:http_cache) do
@@ -57,6 +58,26 @@ describe HttpCacheable do
       it "should return false with a private resource" do
         make_private(resource)
         expect(http_cache.public_resources?).to be false
+      end
+    end
+
+    describe "#resource_cache_directive" do
+      context "with a non-cacheable resource" do
+        let(:controlled_resources) { Collection.all }
+
+        it "should response with nil if not cacheable" do
+          expect(http_cache.resource_cache_directive).to be_nil
+        end
+      end
+
+      context "with a cacheable resource" do
+        let(:controlled_resources) { Project.all }
+
+        it "should response with the correct cache directive" do
+          resource_key = resource_name.plural.to_sym
+          cache_directive = HttpCacheable::CACHEABLE_RESOURCES[resource_key]
+          expect(http_cache.resource_cache_directive).to eq(cache_directive)
+        end
       end
     end
   end

--- a/spec/support/flipper.rb
+++ b/spec/support/flipper.rb
@@ -8,6 +8,7 @@ module Flipper
       Panoptes.flipper[:dump_worker_exports].enable
       Panoptes.flipper[:subject_uploading].enable
       Panoptes.flipper[:classification_lifecycle_in_background].enable
+      Panoptes.flipper["http_caching"].enable
     end
   end
 end

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -1,20 +1,48 @@
-shared_examples "http cacheable response" do
+shared_examples "public resources http cache" do
+  before(:each) do
+    get action, query_params
+  end
+
+  it "should return 200" do
+    expect(response.status).to eq(200)
+  end
+
+  it "should not have a default value" do
+    expect(response.headers.key?("Cache-Control")).to be_falsey
+  end
+
+  context "with the http cache query param setup" do
+    let(:query_params) { { http_cache: "true" } }
+
+    it "should set the cache-control value" do
+      expect(response.headers["Cache-Control"]).to eq("public max-age: 60")
+    end
+  end
+end
+
+shared_examples "private resources http cache" do
+  before do
+    private_resource
+    get action, query_params
+  end
+
+  it "should return 200" do
+    expect(response.status).to eq(200)
+  end
+
+  it "should not have a default value" do
+    expect(response.headers["Cache-Control"]).to be_nil
+  end
+end
+
+shared_examples "an authenticated http cacheable response" do
   let(:query_params) { { } }
 
-  context "for a private resource" do
-    before do
-      private_resource
-      get :index, query_params
-    end
+  before do
+    Panoptes.flipper["http_caching"].enable
+  end
 
-    it "should return 200" do
-      expect(response.status).to eq(200)
-    end
-
-    it "should not have a default value" do
-      expect(response.headers["Cache-Control"]).to be_nil
-    end
-
+  it_behaves_like "private resources http cache" do
     context "with the http cache query param setup" do
       let(:query_params) { { http_cache: "true" } }
 
@@ -24,25 +52,50 @@ shared_examples "http cacheable response" do
     end
   end
 
+  it_behaves_like "public resources http cache"
+end
+
+shared_examples "an unauthenticated http cacheable response" do
+  let(:query_params) { { } }
+
+  before do
+    Panoptes.flipper["http_caching"].enable
+  end
+
+  it_behaves_like "private resources http cache" do
+    context "with the http cache query param setup" do
+      let(:query_params) { { http_cache: "true" } }
+
+      it "should not return the private resource in the response" do
+        response_ids = created_instance_ids(api_resource_name)
+        expect(response_ids).not_to include(private_resource.id.to_s)
+      end
+
+      it "should set the cache-control value" do
+        expect(response.headers["Cache-Control"]).to eq("public max-age: 60")
+      end
+    end
+  end
+
+  it_behaves_like "public resources http cache"
+end
+
+shared_examples "is not a http cacheable response" do
+  before do
+    Panoptes.flipper["http_caching"].enable
+  end
+
   context "for a public resource" do
     before(:each) do
-      get :index, query_params
+      get action, params.merge(http_cache: "true")
     end
 
     it "should return 200" do
       expect(response.status).to eq(200)
     end
 
-    it "should not have a default value" do
-      expect(response.headers.key?("Cache-Control")).to be_falsey
-    end
-
-    context "with the http cache query param setup" do
-      let(:query_params) { { http_cache: "true" } }
-
-      it "should set the cache-control value" do
-        expect(response.headers["Cache-Control"]).to eq("public max-age: 60")
-      end
+    it "should not have a cache directive" do
+      expect(response.headers["Cache-Control"]).to be_nil
     end
   end
 end

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -54,10 +54,6 @@ shared_examples "an indexable authenticated http cacheable response" do
   let(:query_params) { { } }
 
   before do
-    Panoptes.flipper["http_caching"].enable
-  end
-
-  before do
     default_request user_id: user.id, scopes: scopes
     get action, query_params
   end
@@ -84,10 +80,6 @@ end
 shared_examples "an indexable unauthenticated http cacheable response" do
   let(:query_params) { { } }
 
-  before do
-    Panoptes.flipper["http_caching"].enable
-  end
-
   it_behaves_like "private resources http cache" do
     context "with the http cache query param setup" do
       let(:query_params) { { http_cache: "true" } }
@@ -108,10 +100,6 @@ end
 
 shared_examples "an showable authenticated http cacheable response" do
   before do
-    Panoptes.flipper["http_caching"].enable
-  end
-
-  before do
     default_request user_id: user.id, scopes: scopes
     get action, query_params
   end
@@ -126,10 +114,6 @@ shared_examples "an showable authenticated http cacheable response" do
 end
 
 shared_examples "an showable unauthenticated http cacheable response" do
-  before do
-    Panoptes.flipper["http_caching"].enable
-  end
-
   before do
     get action, query_params
   end
@@ -152,9 +136,6 @@ shared_examples "an showable unauthenticated http cacheable response" do
 end
 
 shared_examples "is not a http cacheable response" do
-  before do
-    Panoptes.flipper["http_caching"].enable
-  end
 
   context "for a public resource" do
     before(:each) do

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -1,6 +1,8 @@
 shared_examples "public resources http cache" do
+  let(:cache_params) { { } }
+
   before(:each) do
-    get action, query_params
+    get action, query_params.merge(cache_params)
   end
 
   it "should return 200" do
@@ -12,7 +14,7 @@ shared_examples "public resources http cache" do
   end
 
   context "with the http cache query param setup" do
-    let(:query_params) { { http_cache: "true" } }
+    let(:cache_params) { { http_cache: "true" } }
 
     it "should set the cache-control value" do
       expect(response.headers["Cache-Control"]).to eq("public max-age: 60")
@@ -21,9 +23,10 @@ shared_examples "public resources http cache" do
 end
 
 shared_examples "private resources http cache" do
+  let(:cache_params) { { } }
+
   before do
-    private_resource
-    get action, query_params
+    get action, query_params.merge(cache_params)
   end
 
   it "should return 200" do
@@ -32,6 +35,18 @@ shared_examples "private resources http cache" do
 
   it "should not have a default value" do
     expect(response.headers["Cache-Control"]).to be_nil
+  end
+
+  context "with the http cache query param setup" do
+    let(:cache_params) { { http_cache: "true" } }
+
+    it "should return 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "should not have a cache-control value" do
+      expect(response.headers["Cache-Control"]).to be_nil
+    end
   end
 end
 
@@ -42,13 +57,24 @@ shared_examples "an indexable authenticated http cacheable response" do
     Panoptes.flipper["http_caching"].enable
   end
 
-  it_behaves_like "private resources http cache" do
-    context "with the http cache query param setup" do
-      let(:query_params) { { http_cache: "true" } }
+  before do
+    default_request user_id: user.id, scopes: scopes
+    get action, query_params
+  end
 
-      it "should not have a cache directive value" do
-        expect(response.headers["Cache-Control"]).to be_nil
-      end
+  it "should return 200" do
+    expect(response.status).to eq(200)
+  end
+
+  it "should not have a default value" do
+    expect(response.headers["Cache-Control"]).to be_nil
+  end
+
+  context "with the http cache query param setup" do
+    let(:query_params) { { http_cache: "true" } }
+
+    it "should not have a cache directive value" do
+      expect(response.headers["Cache-Control"]).to be_nil
     end
   end
 
@@ -78,6 +104,51 @@ shared_examples "an indexable unauthenticated http cacheable response" do
   end
 
   it_behaves_like "public resources http cache"
+end
+
+shared_examples "an showable authenticated http cacheable response" do
+  before do
+    Panoptes.flipper["http_caching"].enable
+  end
+
+  before do
+    default_request user_id: user.id, scopes: scopes
+    get action, query_params
+  end
+
+  it_behaves_like "private resources http cache" do
+    let(:query_params) { { id: private_resource_id } }
+  end
+
+  it_behaves_like "public resources http cache" do
+    let(:query_params) { { id: public_resource_id } }
+  end
+end
+
+shared_examples "an showable unauthenticated http cacheable response" do
+  before do
+    Panoptes.flipper["http_caching"].enable
+  end
+
+  before do
+    get action, query_params
+  end
+
+  context "when trying to access a private resource" do
+    let(:query_params) { { id: private_resource_id } }
+
+    it "should return 404" do
+      expect(response.status).to eq(404)
+    end
+
+    it "should not have a cache value" do
+      expect(response.headers["Cache-Control"]).to be_nil
+    end
+  end
+
+  it_behaves_like "public resources http cache" do
+    let(:query_params) { { id: public_resource_id } }
+  end
 end
 
 shared_examples "is not a http cacheable response" do

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -101,7 +101,7 @@ shared_examples "an indexable unauthenticated http cacheable response" do
   it_behaves_like "public resources http cache"
 end
 
-shared_examples "an showable authenticated http cacheable response" do
+shared_examples "a showable authenticated http cacheable response" do
   let(:cache_params) { { } }
 
   before do
@@ -118,7 +118,7 @@ shared_examples "an showable authenticated http cacheable response" do
   end
 end
 
-shared_examples "an showable unauthenticated http cacheable response" do
+shared_examples "a showable unauthenticated http cacheable response" do
   let(:cache_params) { { } }
 
   before do

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -1,10 +1,4 @@
 shared_examples "public resources http cache" do
-  let(:cache_params) { { } }
-
-  before(:each) do
-    get action, query_params.merge(cache_params)
-  end
-
   it "should return 200" do
     expect(response.status).to eq(200)
   end
@@ -23,12 +17,6 @@ shared_examples "public resources http cache" do
 end
 
 shared_examples "private resources http cache" do
-  let(:cache_params) { { } }
-
-  before do
-    get action, query_params.merge(cache_params)
-  end
-
   it "should return 200" do
     expect(response.status).to eq(200)
   end
@@ -99,9 +87,11 @@ shared_examples "an indexable unauthenticated http cacheable response" do
 end
 
 shared_examples "an showable authenticated http cacheable response" do
+  let(:cache_params) { { } }
+
   before do
     default_request user_id: user.id, scopes: scopes
-    get action, query_params
+    get action, query_params.merge(cache_params)
   end
 
   it_behaves_like "private resources http cache" do
@@ -114,8 +104,10 @@ shared_examples "an showable authenticated http cacheable response" do
 end
 
 shared_examples "an showable unauthenticated http cacheable response" do
+  let(:cache_params) { { } }
+
   before do
-    get action, query_params
+    get action, query_params.merge(cache_params)
   end
 
   context "when trying to access a private resource" do

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -35,7 +35,7 @@ shared_examples "private resources http cache" do
   end
 end
 
-shared_examples "an authenticated http cacheable response" do
+shared_examples "an indexable authenticated http cacheable response" do
   let(:query_params) { { } }
 
   before do
@@ -55,7 +55,7 @@ shared_examples "an authenticated http cacheable response" do
   it_behaves_like "public resources http cache"
 end
 
-shared_examples "an unauthenticated http cacheable response" do
+shared_examples "an indexable unauthenticated http cacheable response" do
   let(:query_params) { { } }
 
   before do

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -39,38 +39,53 @@ shared_examples "private resources http cache" do
 end
 
 shared_examples "an indexable authenticated http cacheable response" do
+  let(:cache_params) { { } }
   let(:query_params) { { } }
 
-  before do
+  def index_request
     default_request user_id: user.id, scopes: scopes
-    get action, query_params
+    get action, query_params.merge(cache_params)
   end
 
-  it "should return 200" do
-    expect(response.status).to eq(200)
-  end
-
-  it "should not have a default value" do
-    expect(response.headers["Cache-Control"]).to be_nil
-  end
-
-  context "with the http cache query param setup" do
-    let(:query_params) { { http_cache: "true" } }
-
-    it "should not have a cache directive value" do
-      expect(response.headers["Cache-Control"]).to be_nil
+  it_behaves_like "private resources http cache" do
+    before do
+      private_resource
+      index_request
     end
   end
 
-  it_behaves_like "public resources http cache"
+  it_behaves_like "public resources http cache" do
+    before do
+      index_request
+    end
+  end
 end
 
 shared_examples "an indexable unauthenticated http cacheable response" do
+  let(:cache_params) { { } }
   let(:query_params) { { } }
 
-  it_behaves_like "private resources http cache" do
+  before do
+    private_resource
+    get action, query_params.merge(cache_params)
+  end
+
+  describe "private resources http cache" do
+
+    it "should return 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "should not have a default value" do
+      expect(response.headers["Cache-Control"]).to be_nil
+    end
+
     context "with the http cache query param setup" do
-      let(:query_params) { { http_cache: "true" } }
+      let(:cache_params) { { http_cache: "true" } }
+
+      it "should return 200" do
+        expect(response.status).to eq(200)
+      end
 
       it "should not return the private resource in the response" do
         response_ids = created_instance_ids(api_resource_name)

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -1,0 +1,48 @@
+shared_examples "http cacheable response" do
+  let(:query_params) { { } }
+
+  context "for a private resource" do
+    before do
+      private_resource
+      get :index, query_params
+    end
+
+    it "should return 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "should not have a default value" do
+      expect(response.headers["Cache-Control"]).to be_nil
+    end
+
+    context "with the http cache query param setup" do
+      let(:query_params) { { http_cache: "true" } }
+
+      it "should not have a cache directive value" do
+        expect(response.headers["Cache-Control"]).to be_nil
+      end
+    end
+  end
+
+  context "for a public resource" do
+    before(:each) do
+      get :index, query_params
+    end
+
+    it "should return 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "should not have a default value" do
+      expect(response.headers.key?("Cache-Control")).to be_falsey
+    end
+
+    context "with the http cache query param setup" do
+      let(:query_params) { { http_cache: "true" } }
+
+      it "should set the cache-control value" do
+        expect(response.headers["Cache-Control"]).to eq("public max-age: 60")
+      end
+    end
+  end
+end

--- a/spec/support/http_cacheable_resource.rb
+++ b/spec/support/http_cacheable_resource.rb
@@ -43,7 +43,7 @@ shared_examples "an indexable authenticated http cacheable response" do
   let(:query_params) { { } }
 
   def index_request
-    default_request user_id: user.id, scopes: scopes
+    default_request user_id: authorized_user.id, scopes: scopes
     get action, query_params.merge(cache_params)
   end
 
@@ -105,7 +105,7 @@ shared_examples "a showable authenticated http cacheable response" do
   let(:cache_params) { { } }
 
   before do
-    default_request user_id: user.id, scopes: scopes
+    default_request user_id: authorized_user.id, scopes: scopes
     get action, query_params.merge(cache_params)
   end
 

--- a/spec/support/showable.rb
+++ b/spec/support/showable.rb
@@ -14,6 +14,7 @@ RSpec.shared_examples "is showable" do
 
   it 'should return the requested resource' do
     expect(json_response[api_resource_name].length).to eq 1
+    expect(json_response[api_resource_name][0]['id']).to eq(resource.id.to_s)
   end
 
   it_behaves_like 'an api response'


### PR DESCRIPTION
Add ability to cache public resources with http cache directives, currently only subjects, worfklows, projects but expandable to others. 

This uses the json_api render to test the serialized controlled_resources scope for any private resources. If the response is not cacheable or has any private resources it will not add the cache directives. Additionally a specific query param has to be provided to turn the caching feature on, e.g. `/subjects?http_cache=true`.

# Todo
- [x] add feature flag to use private cache directive for testing
- [x] add feature flag to turn this off api side (off by default)
- [x] test the show action for subjects
- [x] test the index / show actions for project and workflow controllers
- [x] manually test this via dev api and PFE 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
