### PR TITLE
Ci ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "vendor/**/*"
     - "db/schema.rb"
   UseCache: false
+  TargetRubyVersion: 2.3
 
 Style/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-rvm:
-  - 2.2
 cache: bundler
 sudo: false
 bundler_args: --without development production
@@ -19,19 +17,19 @@ before_script: &before_script
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.3
+    - rvm: 2.3.3
       env:
         - SPECS=spec/controllers/api/v1/[a-m]*.rb
-    - rvm: 2.3
+    - rvm: 2.3.3
       env:
         - SPECS=spec/controllers/api/v1/[n-s]*.rb
-    - rvm: 2.3
+    - rvm: 2.3.3
       env:
         - SPECS=spec/controllers/api/v1/[t-z]*.rb
-    - rvm: 2.3
+    - rvm: 2.3.3
       env:
         - SPECS="spec/controllers/**.rb spec/controllers/api/*.rb spec/models spec/operations spec/counters"
-    - rvm: 2.3
+    - rvm: 2.3.3
       env:
         - SPECS="spec/lib spec/workers spec/serializers spec/services spec/requests spec/middleware spec/mailers"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
+rvm:
+  - 2.2
 cache: bundler
 sudo: false
-
 bundler_args: --without development production
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,19 @@ before_script: &before_script
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.3.0
+    - rvm: 2.3
       env:
         - SPECS=spec/controllers/api/v1/[a-m]*.rb
-    - rvm: 2.3.0
+    - rvm: 2.3
       env:
         - SPECS=spec/controllers/api/v1/[n-s]*.rb
-    - rvm: 2.3.0
+    - rvm: 2.3
       env:
         - SPECS=spec/controllers/api/v1/[t-z]*.rb
-    - rvm: 2.3.0
+    - rvm: 2.3
       env:
         - SPECS="spec/controllers/**.rb spec/controllers/api/*.rb spec/models spec/operations spec/counters"
-    - rvm: 2.3.0
+    - rvm: 2.3
       env:
         - SPECS="spec/lib spec/workers spec/serializers spec/services spec/requests spec/middleware spec/mailers"
 


### PR DESCRIPTION
Consistent and up to date ruby versions for the CI tools - it's pity that travis doesn't offer a newer rvm so we can use the 2.3 directive to install the latest minor version. In the meantime we have to manually set this or pay the cost to update upgrade rvm before install ruby... sigh.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
