### PR TITLE
Faster classification saves

### DIFF
--- a/app/controllers/api/v1/subject_queues_controller.rb
+++ b/app/controllers/api/v1/subject_queues_controller.rb
@@ -14,8 +14,7 @@ class Api::V1::SubjectQueuesController < Api::ApiController
       relation = SetMemberSubject.link_to_resource(resource, api_user, *args)
         .where(subject_id: value)
         .order("idx(array[#{value.join(',')}], set_member_subjects.subject_id)")
-
-      relation_or_error(relation, true, false)
+      relations_or_error(relation, value)
     else
       super
     end

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -8,7 +8,9 @@ class Classification < ActiveRecord::Base
 
   has_many :recents, dependent: :destroy
 
-  has_and_belongs_to_many :subjects, join_table: :classification_subjects
+  has_and_belongs_to_many :subjects,
+    join_table: :classification_subjects,
+    validate: false
 
   enum expert_classifier: [:expert, :owner]
 

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,6 +1,4 @@
 class Classification < ActiveRecord::Base
-  include BelongsToMany
-
   class MissingParameter < StandardError; end
 
   belongs_to :project

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -63,10 +63,10 @@ class UserGroup < ActiveRecord::Base
       .where(memberships: { identity: false })
   end
 
-  def self.public_query(private_query, public_flag)
-    query = where(id: private_query.select(:id))
-    query = query.or(public_scope) if public_flag
-    query
+  def self.user_can_access_scope(private_query, public_flag)
+    scope = where(id: private_query.select(:id))
+    scope = scope.or(public_scope) if public_flag
+    scope
   end
 
   def self.roles_allowed_to_access(action, klass=nil)

--- a/lib/json_api_controller/creatable_resource.rb
+++ b/lib/json_api_controller/creatable_resource.rb
@@ -37,7 +37,8 @@ module JsonApiController
 
       resource = resource_class.new(create_params)
       link_params.try(:each) do |relation,relation_id|
-        add_relation_link(resource, relation, relation_id)
+        relation_to_link = update_relation(resource, relation, relation_id)
+        resource.send("#{relation}=", relation_to_link)
       end
       resource
     end
@@ -48,17 +49,6 @@ module JsonApiController
 
     def link_header(resource)
       send(:"api_#{ resource_name }_url", resource)
-    end
-
-    def add_relation_link(resource, relation, relation_id)
-      resource_class.reflect_on_association(relation)
-      link_reflection = resource_class.reflect_on_association(relation)
-      relation_to_link = update_relation(resource, relation, relation_id)
-      if link_reflection.macro == :belongs_to
-        resource.send("#{link_reflection.foreign_key}=", "#{relation_to_link.id}")
-      else
-        resource.send("#{relation}=", relation_to_link)
-      end
     end
   end
 end

--- a/lib/role_control/controlled.rb
+++ b/lib/role_control/controlled.rb
@@ -25,10 +25,11 @@ module RoleControl
       end
 
       def private_query(action, target, roles)
-        AccessControlList.joins(user_group: :memberships)
+        user_group_memberships = memberships_query(action, target)
+          .select(:user_group_id)
+        AccessControlList
+          .where(user_group_id: user_group_memberships)
           .select(:resource_id)
-          .merge(memberships_query(action, target))
-          .where(resource_type: name)
           .where.overlap(roles: roles)
       end
 

--- a/lib/role_control/controlled.rb
+++ b/lib/role_control/controlled.rb
@@ -33,10 +33,10 @@ module RoleControl
           .where.overlap(roles: roles)
       end
 
-      def public_query(private_query, public_flag)
-        query = where(id: private_query.select(:resource_id))
-        query = query.or(public_scope) if public_flag
-        query
+      def user_can_access_scope(private_query, public_flag)
+        scope = where(id: private_query.select(:resource_id))
+        scope = scope.or(public_scope) if public_flag
+        scope
       end
 
       def scope_for(action, user, opts={})
@@ -46,7 +46,10 @@ module RoleControl
         when user.is_admin?
           all
         when user.logged_in?
-          public_query(private_query(action, user, roles), public_flag)
+          user_can_access_scope(
+            private_query(action, user, roles),
+            public_flag
+          )
         when public_flag
           public_scope
         else


### PR DESCRIPTION
This PR tries to reduce the number of calls when saving resources generally and specifically looks at classification saves. 

I've modified the default scope_for private query to not use joins (see commit message for benchmarking). Also I've modified the relation_manager to not issue count queries when testing link resource existence where it can.

Finally a small change to not validate the subjects on classification save, seems has_many and has_and_belongs_to_many run the linked resources validations on record save. Either i've forgotten this or I never know and this caused other resource loads on classification save (subject project and uploader). We don't need to validate the subjects when saving classifications as they are just being linked. Note: the extra resource calls are only because of [this](https://github.com/zooniverse/Panoptes/blob/91ec95d77b682dd4e0715d9bdff64b225e4fb949/app/models/subject.rb#L28) validation.

** We should probably audit the other create actions (subjects) and any has_ relations to ensure we're not validating a large set of resources on resource saves. **

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
