### PR TITLE
Include list of active workflows in serialized projects

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -29,7 +29,7 @@ class ProjectSerializer
     :completeness, :activity, :state, :researcher_quote
 
   optional :avatar_src
-  can_include :workflows, :subject_sets, :owners, :project_contents,
+  can_include :workflows, :active_workflows, :subject_sets, :owners, :project_contents,
     :project_roles, :pages, :organization
   media_include :avatar, :background, :attached_images,
     classifications_export: { include: false},
@@ -124,6 +124,10 @@ class ProjectSerializer
     else
       ""
     end
+  end
+
+  def active_workflows
+    @model.workflows.where(active: true)
   end
 
   def fields

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -10,6 +10,7 @@ class ProjectSerializer
   PRELOADS = [
     # :project_contents, Note: re-add when the eager_load from translatable_resources is removed
     :workflows,
+    :active_workflows,
     :subject_sets,
     :project_roles,
     [ owner: { identity_membership: :user } ],
@@ -124,10 +125,6 @@ class ProjectSerializer
     else
       ""
     end
-  end
-
-  def active_workflows
-    @model.workflows.where(active: true)
   end
 
   def fields

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -143,4 +143,14 @@ describe ProjectSerializer do
       end
     end
   end
+
+  describe "active workflows" do
+    let(:active_workflow) { project.workflows.first }
+    let!(:inactive_workflow) { create(:workflow, project: project, active: false) }
+    let(:serialized) { ProjectSerializer.resource({}, Project.where(id: project.id), context) }
+
+    it "includes a list of only active workflows in the links" do
+      expect(serialized[:projects][0][:links][:active_workflows]).to contain_exactly(active_workflow.id.to_s)
+    end
+  end
 end


### PR DESCRIPTION
Only bummer here might be if the `@model.workflows.where(active: true)` call in the project serializer is making an extra db query, but hopefully it's just filtering what it's already pulled. Could have put that method on the model, but made more sense this way to me just now.

Closes https://github.com/zooniverse/Panoptes/issues/2251

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
