### PR TITLE
cache more serialiser outputs where we can

### DIFF
--- a/app/serializers/aggregation_serializer.rb
+++ b/app/serializers/aggregation_serializer.rb
@@ -1,5 +1,6 @@
 class AggregationSerializer
   include RestPack::Serializer
+  include CachedSerializer
 
   attributes :id, :created_at, :updated_at, :aggregation, :href
   can_include :workflow, :subject

--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -2,6 +2,7 @@ class ClassificationSerializer
   include Serialization::PanoptesRestpack
   include NoCountSerializer
   include FilterHasMany
+  include CachedSerializer
 
   attributes :id, :annotations, :created_at, :metadata, :href
 

--- a/app/serializers/concerns/acl_serializer.rb
+++ b/app/serializers/concerns/acl_serializer.rb
@@ -2,6 +2,7 @@ module ACLSerializer
   extend ActiveSupport::Concern
 
   include RestPack::Serializer
+  include CachedSerializer
 
   module ClassMethods
     def key

--- a/app/serializers/gold_standard_annotation_serializer.rb
+++ b/app/serializers/gold_standard_annotation_serializer.rb
@@ -1,6 +1,7 @@
 class GoldStandardAnnotationSerializer
   include Serialization::PanoptesRestpack
   include NoCountSerializer
+  include CachedSerializer
 
   attributes :id, :annotations, :created_at, :metadata
 

--- a/app/serializers/medium_serializer.rb
+++ b/app/serializers/medium_serializer.rb
@@ -1,5 +1,6 @@
 class MediumSerializer
   include RestPack::Serializer
+  include CachedSerializer
 
   attributes :id, :href, :src, :content_type, :media_type, :external_link,
     :created_at, :metadata, :updated_at

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -1,5 +1,7 @@
 class MembershipSerializer
   include RestPack::Serializer
+  include CachedSerializer
+
   attributes :id, :state, :href
   can_include :user, :user_group
 end

--- a/app/serializers/organization_content_serializer.rb
+++ b/app/serializers/organization_content_serializer.rb
@@ -1,5 +1,6 @@
 class OrganizationContentSerializer
   include RestPack::Serializer
+
   attributes :id, :language, :title, :description, :introduction, :href
 
   can_include :organization

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -3,6 +3,7 @@ class OrganizationSerializer
   include OwnerLinkSerializer
   include ContentSerializer
   include MediaLinksSerializer
+  include CachedSerializer
 
   attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language
   optional :avatar_src

--- a/app/serializers/recent_serializer.rb
+++ b/app/serializers/recent_serializer.rb
@@ -1,5 +1,6 @@
 class RecentSerializer
   include Serialization::PanoptesRestpack
+  include CachedSerializer
 
   attributes :id, :created_at, :locations, :href
   can_include :project, :workflow, :subject

--- a/app/serializers/subject_set_serializer.rb
+++ b/app/serializers/subject_set_serializer.rb
@@ -1,6 +1,7 @@
 class SubjectSetSerializer
   include Serialization::PanoptesRestpack
   include FilterHasMany
+  include CachedSerializer
 
   attributes :id, :display_name, :set_member_subjects_count, :metadata,
     :created_at, :updated_at, :href

--- a/app/serializers/user_collection_preference_serializer.rb
+++ b/app/serializers/user_collection_preference_serializer.rb
@@ -1,5 +1,7 @@
 class UserCollectionPreferenceSerializer
   include RestPack::Serializer
+  include CachedSerializer
+
   attributes :id, :preferences, :href
   can_include :user, :collection
 

--- a/app/serializers/user_group_serializer.rb
+++ b/app/serializers/user_group_serializer.rb
@@ -1,6 +1,8 @@
 class UserGroupSerializer
   include RestPack::Serializer
   include RecentLinkSerializer
+  include CachedSerializer
+
   attributes :id, :name, :display_name, :classifications_count, :created_at, :updated_at, :type, :href, :join_token
   can_include :memberships, :users,
               projects: { param: "owner", value: "name" },

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -1,5 +1,7 @@
 class UserProjectPreferenceSerializer
   include RestPack::Serializer
+  include CachedSerializer
+
   attributes :id, :email_communication, :preferences, :href,
     :activity_count, :activity_count_by_workflow, :settings
   can_include :user, :project

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -2,6 +2,7 @@ class UserSerializer
   include Serialization::PanoptesRestpack
   include RecentLinkSerializer
   include MediaLinksSerializer
+  include CachedSerializer
 
   attributes :id, :login, :display_name, :credited_name, :email, :languages,
     :created_at, :updated_at, :type, :global_email_communication,

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -1,5 +1,7 @@
 class VersionSerializer
   include RestPack::Serializer
+  include CachedSerializer
+
   attributes :id, :changeset, :whodunnit, :created_at, :type, :href
 
   can_include :item


### PR DESCRIPTION
avoid regenerating the json for the resources, do it once, cache them and serve that. 

This should help with the extra data base N+1 loads happening with all the new `?include=` sideloading that PFE is requesting. Long term we should either fix restpack to respect the model preloads when sideloading or move to another serializer lib. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
