### PR TITLE
Sgl dont reschedule counts and add feature flag to disable the count workers

### DIFF
--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -6,7 +6,7 @@ class ClassificationCountWorker
   def perform(subject_id, workflow_id, was_update=false)
     workflow = Workflow.find(workflow_id)
 
-    if workflow.project.live
+    if workflow.project.live && Panoptes.flipper["classification_counters"].enabled?
       count = nil
 
       Workflow.transaction do

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -7,7 +7,7 @@ class ProjectClassificationsCountWorker
     interval: 60,
     max_in_interval: 1,
     min_delay: 10,
-    reject_with: :reschedule,
+    reject_with: :cancel, # SGL 2017 was :reschedule
     key: ->(project_id) {
       "project_#{project_id}_classifications_count_worker"
     }

--- a/app/workers/project_classifiers_count_worker.rb
+++ b/app/workers/project_classifiers_count_worker.rb
@@ -7,7 +7,7 @@ class ProjectClassifiersCountWorker
     interval: 60,
     max_in_interval: 1,
     min_delay: 0,
-    reject_with: :reschedule,
+    reject_with: :cancel, # SGL 2017 was :reschedule
     key: ->(project_id) { "project_#{project_id}_classifiers_count_worker" }
   }
 

--- a/app/workers/reset_project_counters_worker.rb
+++ b/app/workers/reset_project_counters_worker.rb
@@ -4,7 +4,7 @@ class ResetProjectCountersWorker
   sidekiq_options queue: :data_high,
     congestion:
       Panoptes::CongestionControlConfig.counter_worker.congestion_opts.merge({
-        reject_with: :reschedule,
+        reject_with: :cancel, # SGL 2017 was :reschedule
         key: ->(project_id) { "project_id_#{ project_id }_count_worker" },
         enabled: ->(project_id, rate_limit=true) { rate_limit }
       }),

--- a/app/workers/subject_set_subject_counter_worker.rb
+++ b/app/workers/subject_set_subject_counter_worker.rb
@@ -4,7 +4,7 @@ class SubjectSetSubjectCounterWorker
   sidekiq_options queue: :data_high,
     congestion: Panoptes::CongestionControlConfig.
       counter_worker.congestion_opts.merge({
-        reject_with: :reschedule,
+        reject_with: :cancel, # SGL 2017 was :reschedule
         key: ->(subject_set_id) {
           "subject_set_#{ subject_set_id }_counter_worker"
         }

--- a/app/workers/subject_workflow_status_count_worker.rb
+++ b/app/workers/subject_workflow_status_count_worker.rb
@@ -7,7 +7,7 @@ class SubjectWorkflowStatusCountWorker
     interval: 30,
     max_in_interval: 1,
     min_delay: 5,
-    reject_with: :reschedule,
+    reject_with: :cancel, # SGL 2017 was :reschedule
     key: ->(count_id) {
       "sws_#{count_id}_count_worker"
     }

--- a/app/workers/workflow_classifications_count_worker.rb
+++ b/app/workers/workflow_classifications_count_worker.rb
@@ -7,7 +7,7 @@ class WorkflowClassificationsCountWorker
     interval: 60,
     max_in_interval: 1,
     min_delay: 10,
-    reject_with: :reschedule,
+    reject_with: :cancel, # SGL 2017 was :reschedule
     key: ->(workflow_id) {
       "workflow_#{workflow_id}_classifications_count_worker"
     }

--- a/app/workers/workflow_retired_count_worker.rb
+++ b/app/workers/workflow_retired_count_worker.rb
@@ -7,7 +7,7 @@ class WorkflowRetiredCountWorker
     interval: 10,
     max_in_interval: 1,
     min_delay: 0,
-    reject_with: :reschedule,
+    reject_with: :cancel, # SGL 2017 was :reschedule
     key: ->(workflow_id) { "workflow_#{workflow_id}_retired_count_worker" }
   }
 

--- a/spec/support/flipper.rb
+++ b/spec/support/flipper.rb
@@ -9,6 +9,7 @@ module Flipper
       Panoptes.flipper[:subject_uploading].enable
       Panoptes.flipper[:classification_lifecycle_in_background].enable
       Panoptes.flipper["http_caching"].enable
+      Panoptes.flipper["classification_counters"].enable
     end
   end
 end

--- a/spec/workers/classification_count_worker_spec.rb
+++ b/spec/workers/classification_count_worker_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe ClassificationCountWorker do
     context "when the workflow project is live" do
       let(:project) { create(:full_project, live: true) }
 
+      context "when the flipper flag is disabled" do
+        it "should not run the counters" do
+          Panoptes.flipper["classification_counters"].disable
+          expect(SubjectWorkflowStatus).not_to receive(:increment_counter)
+          worker.perform(sms.subject_id, workflow_id)
+        end
+      end
+
       context "when the count model exists" do
         let!(:count) do
           create(:subject_workflow_status, subject: sms.subject, workflow_id: workflow_id)

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe ProjectClassificationsCountWorker do
     expect(opts[:interval]).to eq(60)
     expect(opts[:max_in_interval]).to eq(1)
     expect(opts[:min_delay]).to eq(10)
-    expect(opts[:reject_with]).to eq(:reschedule)
+    # SGL 2017
+    # expect(opts[:reject_with]).to eq(:reschedule)
+    expect(opts[:reject_with]).to eq(:cancel)
   end
 
   describe "#perform" do

--- a/spec/workers/subject_workflow_status_count_worker_spec.rb
+++ b/spec/workers/subject_workflow_status_count_worker_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe SubjectWorkflowStatusCountWorker do
     expect(opts[:interval]).to eq(30)
     expect(opts[:max_in_interval]).to eq(1)
     expect(opts[:min_delay]).to eq(5)
-    expect(opts[:reject_with]).to eq(:reschedule)
+    # SGL 2017
+    # expect(opts[:reject_with]).to eq(:reschedule)
+    expect(opts[:reject_with]).to eq(:cancel)
   end
 
   describe "#perform" do

--- a/spec/workers/workflow_classifications_count_worker_spec.rb
+++ b/spec/workers/workflow_classifications_count_worker_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe WorkflowClassificationsCountWorker do
     expect(opts[:interval]).to eq(60)
     expect(opts[:max_in_interval]).to eq(1)
     expect(opts[:min_delay]).to eq(10)
-    expect(opts[:reject_with]).to eq(:reschedule)
+    # SGL 2017
+    # expect(opts[:reject_with]).to eq(:reschedule)
+    expect(opts[:reject_with]).to eq(:cancel)
   end
 
   describe "#perform" do


### PR DESCRIPTION
add a feature flag to disable count workers and cancel count workers if rate limited to avoid feedback loop.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
