### PR TITLE
only return resource under control

### DIFF
--- a/lib/role_control/controlled.rb
+++ b/lib/role_control/controlled.rb
@@ -29,6 +29,7 @@ module RoleControl
           .select(:user_group_id)
         AccessControlList
           .where(user_group_id: user_group_memberships)
+          .where(resource_type: model_name.name)
           .select(:resource_id)
           .where.overlap(roles: roles)
       end

--- a/spec/lib/role_control/controlled_spec.rb
+++ b/spec/lib/role_control/controlled_spec.rb
@@ -12,57 +12,73 @@ describe RoleControl::Controlled do
   let(:admin_actor) { create(:user, admin: true) }
 
   describe "::scope_for" do
-    let!(:group_tables) do
-      gt1 = subject.new(private: false)
-      gt2 = subject.new
-      gt3 = subject.new
 
-      [gt1,gt2,gt3].each(&:save!)
-
-      create_roles_join_instance(%w(admin), gt1, enrolled_actor)
-      create_roles_join_instance(%w(test_role), gt2, enrolled_actor)
-      create_roles_join_instance([], gt3, enrolled_actor)
-      create_roles_join_instance([], gt3, unenrolled_actor)
-
-      [gt1, gt2, gt3]
-    end
-
-    it 'should return an active record relation' do
-      expect(subject.scope_for(:read, ApiUser.new(enrolled_actor))).to be_an(ActiveRecord::Relation)
-    end
-
-    it 'should fetch all records that are visible to an actor' do
+    it "should not return the same resource id of a different type" do
+      resource = subject.new
+      resource.save!
+      AccessControlList.create! do |rmt|
+        rmt.roles = ["test_role"]
+        rmt.resource_id = resource.id
+        rmt.resource_type = "OtherResource"
+        rmt.user_group = enrolled_actor.identity_group
+      end
       visible_records = subject.scope_for(:read, ApiUser.new(enrolled_actor))
-      expected_records = group_tables.values_at(0,1)
-      expect(visible_records).to match_array(expected_records)
+      expect(visible_records).to be_empty
     end
 
-    it 'should not fetch records that the unenrolled actor has no roles on' do
-      visible_records = subject.scope_for(:read, ApiUser.new(unenrolled_actor))
-      no_roles_instance = group_tables.values_at(2)
-      expect(visible_records).not_to include(no_roles_instance)
-    end
+    context "with resources and roles defined" do
+      let!(:group_tables) do
+        gt1 = subject.new(private: false)
+        gt2 = subject.new
+        gt3 = subject.new
 
-    it 'should fetch all publicly visible records for unenrolled actor' do
-      visible_records = subject.scope_for(:read, ApiUser.new(unenrolled_actor))
-      expected_records = group_tables.values_at(0)
-      expect(visible_records).to match_array(expected_records)
-    end
+        [gt1,gt2,gt3].each(&:save!)
 
-    it 'should not include public records when the class does not allow public scopes' do
-      visible_records = subject.scope_for(:update, ApiUser.new(enrolled_actor))
-      expect(visible_records).to_not include(group_tables[2])
-    end
+        create_roles_join_instance(%w(admin), gt1, enrolled_actor)
+        create_roles_join_instance(%w(test_role), gt2, enrolled_actor)
+        create_roles_join_instance([], gt3, enrolled_actor)
+        create_roles_join_instance([], gt3, unenrolled_actor)
 
-    it 'should incluced all rocords when the actor is an admin' do
-      visible_records = subject.scope_for(:update, ApiUser.new(admin_actor, admin: true))
-      expect(visible_records).to match_array(group_tables)
-    end
+        [gt1, gt2, gt3]
+      end
 
-    it 'should fetch all publicly visible records for non-logged in user' do
-      visible_records = subject.scope_for(:read, ApiUser.new(nil))
-      expected_records = group_tables.values_at(0)
-      expect(visible_records).to match_array(expected_records)
+      it 'should return an active record relation' do
+        expect(subject.scope_for(:read, ApiUser.new(enrolled_actor))).to be_an(ActiveRecord::Relation)
+      end
+
+      it 'should fetch all records that are visible to an actor' do
+        visible_records = subject.scope_for(:read, ApiUser.new(enrolled_actor))
+        expected_records = group_tables.values_at(0,1)
+        expect(visible_records).to match_array(expected_records)
+      end
+
+      it 'should not fetch records that the unenrolled actor has no roles on' do
+        visible_records = subject.scope_for(:read, ApiUser.new(unenrolled_actor))
+        no_roles_instance = group_tables.values_at(2)
+        expect(visible_records).not_to include(no_roles_instance)
+      end
+
+      it 'should fetch all publicly visible records for unenrolled actor' do
+        visible_records = subject.scope_for(:read, ApiUser.new(unenrolled_actor))
+        expected_records = group_tables.values_at(0)
+        expect(visible_records).to match_array(expected_records)
+      end
+
+      it 'should not include public records when the class does not allow public scopes' do
+        visible_records = subject.scope_for(:update, ApiUser.new(enrolled_actor))
+        expect(visible_records).to_not include(group_tables[2])
+      end
+
+      it 'should incluced all rocords when the actor is an admin' do
+        visible_records = subject.scope_for(:update, ApiUser.new(admin_actor, admin: true))
+        expect(visible_records).to match_array(group_tables)
+      end
+
+      it 'should fetch all publicly visible records for non-logged in user' do
+        visible_records = subject.scope_for(:read, ApiUser.new(nil))
+        expected_records = group_tables.values_at(0)
+        expect(visible_records).to match_array(expected_records)
+      end
     end
   end
 


### PR DESCRIPTION
make sure we don't test on polymorphic resource id's but only on the controlled type we're testing.

This will need some testing in staging to make sure there aren't any complications as it's been like this for a while. We could in theory be selecting the wrong resources based on other table id's in the private query.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
