### PR TITLE
fix version serializer caching

### DIFF
--- a/app/serializers/concerns/cached_serializer.rb
+++ b/app/serializers/concerns/cached_serializer.rb
@@ -4,7 +4,7 @@ module CachedSerializer
   module ClassMethods
     def as_json(model, context)
       if Panoptes.flipper["cached_serializer"].enabled?
-        cache_key = "#{model.class.to_s}/#{model.id}/#{model.updated_at.to_i}/context-#{Digest::MD5.hexdigest(context.to_json)}"
+        cache_key = serializer_cache_key(model, Digest::MD5.hexdigest(context.to_json))
 
         Rails.cache.fetch(cache_key) do
           super
@@ -12,6 +12,10 @@ module CachedSerializer
       else
         super
       end
+    end
+
+    def serializer_cache_key(model, context_hash)
+      "#{model.class.to_s}/#{model.id}/#{model.updated_at.to_i}/context-#{context_hash}"
     end
   end
 end

--- a/app/serializers/concerns/cached_serializer.rb
+++ b/app/serializers/concerns/cached_serializer.rb
@@ -15,7 +15,7 @@ module CachedSerializer
     end
 
     def serializer_cache_key(model, context_hash)
-      "#{model.class.to_s}/#{model.id}/#{model.updated_at.to_i}/context-#{context_hash}"
+      "#{model.class}/#{model.id}/#{model.updated_at.to_i}/context-#{context_hash}"
     end
   end
 end

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -8,7 +8,6 @@ class UserProjectPreferenceSerializer
   can_sort_by :updated_at, :display_name
 
   CACHE_MINS = (ENV["UPP_ACTIVITY_COUNT_CACHE_MINS"] || 5).freeze
-  FLIPPER_KEY = "upp_activity_count_cache".freeze
 
   def self.key
     "project_preferences"
@@ -58,12 +57,8 @@ class UserProjectPreferenceSerializer
   end
 
   def perform_cached_lookup(method_to_send)
-    if Panoptes.flipper[FLIPPER_KEY].enabled?
-      cache_key = "#{@model.class}/#{@model.id}/#{method_to_send}"
-      Rails.cache.fetch(cache_key, expires_in: CACHE_MINS.minutes) do
-        send method_to_send
-      end
-    else
+    cache_key = "#{@model.class}/#{@model.id}/#{method_to_send}"
+    Rails.cache.fetch(cache_key, expires_in: CACHE_MINS.minutes) do
       send method_to_send
     end
   end

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -2,11 +2,13 @@ class VersionSerializer
   include RestPack::Serializer
   include CachedSerializer
 
-  using VirtualUpdatedAt
-
   attributes :id, :changeset, :whodunnit, :created_at, :type, :href
 
   can_include :item
+
+  def self.serializer_cache_key(model, context_hash)
+    "#{model.class.to_s}/#{model.id}/#{model.created_at.to_i}/context-#{context_hash}"
+  end
 
   def type
     "versions"

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -2,6 +2,8 @@ class VersionSerializer
   include RestPack::Serializer
   include CachedSerializer
 
+  using VirtualUpdatedAt
+
   attributes :id, :changeset, :whodunnit, :created_at, :type, :href
 
   can_include :item

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -7,7 +7,7 @@ class VersionSerializer
   can_include :item
 
   def self.serializer_cache_key(model, context_hash)
-    "#{model.class.to_s}/#{model.id}/#{model.created_at.to_i}/context-#{context_hash}"
+    "#{model.class}/#{model.id}/#{model.created_at.to_i}/context-#{context_hash}"
   end
 
   def type

--- a/lib/gem_ext/paper_trail/virtual_updated_at.rb
+++ b/lib/gem_ext/paper_trail/virtual_updated_at.rb
@@ -1,7 +1,0 @@
-module VirtualUpdatedAt
-  refine PaperTrail::Version do
-    def updated_at
-      created_at
-    end
-  end
-end

--- a/lib/gem_ext/paper_trail/virtual_updated_at.rb
+++ b/lib/gem_ext/paper_trail/virtual_updated_at.rb
@@ -1,0 +1,7 @@
+module VirtualUpdatedAt
+  refine PaperTrail::Version do
+    def updated_at
+      created_at
+    end
+  end
+end

--- a/spec/support/flipper.rb
+++ b/spec/support/flipper.rb
@@ -10,6 +10,7 @@ module Flipper
       Panoptes.flipper[:classification_lifecycle_in_background].enable
       Panoptes.flipper["http_caching"].enable
       Panoptes.flipper["classification_counters"].enable
+      Panoptes.flipper["cached_serializer"].enable
     end
   end
 end


### PR DESCRIPTION
Use the created_at timestamp when generating the version cache key as PaperTrail::Version has no updated_at timestamp. I tried to use refinements to add a virtual attribute to the model but couldn't get it working in the for just the VersionSerializer through the CachedSerializer module due to refinement lexical scope. Oh well...it was a refinement adventure.

~Add a refined virtual updated_at attribute to PaperTrail::Version model that proxies the created_at attribute. This is only used in the version serializer. I used the refinement to avoid serializer code duplication and should not impact anywhere else in the system with the refinement.~
~Side note, this was so much nicer than monkey patching the virtual attribute and wondering about the impact of such a change.~

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
