### PR TITLE
override the last_id paging hrefs for classification project routes

### DIFF
--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -29,5 +29,19 @@ describe ClassificationSerializer do
         expect(meta[:last_href]).to eq("/classifications/#{collection_route}?page=0")
       end
     end
+
+    context "project context with last_id param present" do
+      let(:project) { classification.project }
+
+      it "should insert the next hightest last_id into the next_href" do
+        second = create(:classification, project: project)
+        last_id = classification.id
+        params = {project_id: project.id, last_id: last_id, page_size: 1}
+        result = ClassificationSerializer.page(params, Classification.all, {})
+        meta = result[:meta][:classifications]
+        expect(meta[:previous_href]).to eq("/classifications?last_id=#{last_id}&page_size=1&project_id=#{project.id}")
+        expect(meta[:next_href]).to eq("/classifications?last_id=#{second.id}&page_size=1&project_id=#{project.id}")
+      end
+    end
   end
 end


### PR DESCRIPTION
avoid paging with offsets when using the last_id param on the classification/project route. Instead manually override the next/previous hrefs to track the last_id for the client.

This should speed up the `/api/classifications/project?last_id=X` routes by providing the correct page last_id in the prev/next paging hrefs.

Also in theory this could be applied to the `/api/classifications/project` scope as a whole (i.e. multiple projects you have access to) if the scope always returns the lowest IDs as the first page but i'm not sure the database will guarantee this order. Something to think about and test. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
