### PR TITLE
update contents parent relation when saving the content

### DIFF
--- a/app/models/concerns/translated_content.rb
+++ b/app/models/concerns/translated_content.rb
@@ -5,7 +5,7 @@ module TranslatedContent
   included do
     has_paper_trail ignore: [:language]
     validates :language, format: {with: LanguageValidation.lang_regex}
-    belongs_to translated_for
+    belongs_to translated_for, touch: true
 
     can_through_parent translated_for, :show, :index, :versions, :version
   end

--- a/spec/support/translated_content.rb
+++ b/spec/support/translated_content.rb
@@ -5,6 +5,10 @@ shared_examples "is translated content" do
     expect(content).to be_valid
   end
 
+  it "should touch it's parent on save" do
+    expect { content.save }.to change { content.send(:parent).updated_at }
+  end
+
   describe "#language" do
     let(:factory) { content_factory }
     let(:locale_field) { :language }


### PR DESCRIPTION
closes #2212 - ensure updating content models updates the parent time stamps to invalidate json caches. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
