### PR TITLE
Move FeatureDisabled raise to DumpWorker#perform

### DIFF
--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -9,7 +9,6 @@ class ClassificationsDumpWorker
   sidekiq_options queue: :data_high
 
   def perform_dump
-    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     CSV.open(csv_file_path, 'wb') do |csv|
       formatter = Formatter::Csv::Classification.new(cache)
       csv << formatter.class.headers

--- a/app/workers/concerns/dump_worker.rb
+++ b/app/workers/concerns/dump_worker.rb
@@ -8,6 +8,7 @@ module DumpWorker
   end
 
   def perform(resource_id, resource_type, medium_id=nil, requester_id=nil, *args)
+    raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     @resource_type = resource_type
     @resource_id = resource_id
     if @resource = get_resource


### PR DESCRIPTION
This should prevent the generic begin/ensure that runs #perform_dump from suppressing the FeatureDisabled error. This appears to only happen in certain cases as I've definitely seen that error in Sidekiq's retry queue, so I'll be looking into this more later.


Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
