### PR TITLE
respect tasks params on update

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -20,8 +20,8 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   def update
     super do |resource|
-      _, strings = extract_strings(update_params[:tasks])
-      if strings
+      if update_params.key? :tasks
+        _, strings = extract_strings(update_params[:tasks])
         resource.primary_content.update(strings: strings)
       end
     end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -172,7 +172,7 @@ describe Api::V1::WorkflowsController, type: :controller do
           }
         end
 
-        it "should touch the worklfow resource" do
+        it "should touch the workflow resource" do
           expect {
             put :update, task_only_update_params
           }.to change {
@@ -185,6 +185,39 @@ describe Api::V1::WorkflowsController, type: :controller do
           instance = Workflow.find(created_instance_id(api_resource_name))
           updated_string = instance.primary_content.strings["interest.question"]
           expect(updated_string).to eq(new_question)
+        end
+      end
+
+      context "when updating without tasks" do
+        let(:no_task_update_params) do
+          {
+            workflows: { active: true },
+            id: resource.id
+          }
+        end
+
+        it "should update the workflow active state" do
+          expect {
+            put :update, no_task_update_params
+          }.to change {
+            resource.reload.active
+          }.to(true)
+        end
+
+        it "should not update the workflow tasks" do
+          expect {
+            put :update, no_task_update_params
+          }.not_to change {
+            resource.reload.tasks
+          }
+        end
+
+        it "should not update the workflow content strings" do
+          expect {
+            put :update, no_task_update_params
+          }.not_to change {
+            resource.primary_content.reload.strings
+          }
         end
       end
     end


### PR DESCRIPTION
only update the tasks and strings if the tasks params is provided. this was setting content strings to the empty hash when not supplied with a tasks param

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
