### PR TITLE
sort location metadata index as ints not strings

### DIFF
--- a/app/models/concerns/ordered_locations.rb
+++ b/app/models/concerns/ordered_locations.rb
@@ -8,7 +8,7 @@ module OrderedLocations
         locations
       end
     else
-      locations.order("\"media\".\"metadata\"->>'index' ASC")
+      locations.order("\"media\".\"metadata\"->'index' ASC")
     end
   end
 end

--- a/spec/support/ordered_locations.rb
+++ b/spec/support/ordered_locations.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'it has ordered locations' do
     lone_resource = klass.find(resource.id)
     expect_any_instance_of(Medium::ActiveRecord_Associations_CollectionProxy)
       .to receive(:order)
-      .with("\"media\".\"metadata\"->>'index' ASC")
+      .with("\"media\".\"metadata\"->'index' ASC")
       .and_call_original
     expected = resource.locations.sort_by { |loc| loc.metadata["index"] }
     expect(expected.map(&:id)).to eq(lone_resource.ordered_locations.map(&:id))
@@ -22,7 +22,7 @@ RSpec.shared_examples 'it has ordered locations' do
     end
 
     it "should mimic the database order by using the relation ordering" do
-      expected = resource.locations.order("\"media\".\"metadata\"->>'index' ASC")
+      expected = resource.locations.order("\"media\".\"metadata\"->'index' ASC")
       expect(expected.map(&:id)).to eq(resource.ordered_locations.map(&:id))
     end
   end


### PR DESCRIPTION
closes #2293 and fixes https://github.com/zooniverse/Panoptes-Front-End/issues/3577

Ensure we sort the location metadata indexes as integers and not text in sql. This would have affected any subjects with more than 10 locations, so not many projects.

I tested the new code with the the example data in PFE issue, e.g:
```
irb(main):040:0> loc = subject.locations.sort_by { |loc| loc.metadata["index"] }.map { |loc| loc.metadata["index"] }
=> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48]

irb(main):041:0> subject.locations.order("\"media\".\"metadata\"->>'index' ASC").map { |loc| loc.metadata["index"] }
=> [0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 3, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 4, 40, 41, 42, 43, 44, 45, 46, 47, 48, 5, 6, 7, 8, 9]

irb(main):042:0> subject.locations.order("\"media\".\"metadata\"->'index' ASC").map { |loc| loc.metadata["index"] } 
=> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48]
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
