### PR TITLE
respect the linked sets when counting classifications

### DIFF
--- a/app/counters/workflow_counter.rb
+++ b/app/counters/workflow_counter.rb
@@ -7,11 +7,11 @@ class WorkflowCounter
   end
 
   def classifications
-    SubjectWorkflowStatus.where(workflow: workflow).sum(:classifications_count)
+    linked_subject_workflow_status.sum(:classifications_count)
   end
 
   def retired_subjects
-    retired = SubjectWorkflowStatus.by_set(workflow.subject_sets.pluck(:id)).retired.where(workflow_id: workflow.id)
+    retired = linked_subject_workflow_status.retired
     if launch_date
       retired = retired.where("subject_workflow_counts.retired_at >= ?", launch_date)
     end
@@ -22,5 +22,11 @@ class WorkflowCounter
 
   def launch_date
     workflow.project.launch_date
+  end
+
+  def linked_subject_workflow_status
+    SubjectWorkflowStatus
+      .by_set(workflow.subject_sets.pluck(:id))
+      .where(workflow_id: workflow.id)
   end
 end

--- a/spec/counters/workflow_counter_spec.rb
+++ b/spec/counters/workflow_counter_spec.rb
@@ -20,6 +20,16 @@ describe WorkflowCounter do
       it "should return 2" do
         expect(counter.classifications).to eq(2)
       end
+
+      context "when unlinking subject_sets" do
+        let(:workflow) { create(:workflow_with_subjects, num_sets: 2) }
+
+        it "should only return the count for the linked sets" do
+          set_to_keep = workflow.subject_sets.sample
+          workflow.subject_sets = [ set_to_keep ]
+          expect(counter.classifications).to eq(2)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
only count the currently linked set classifications for the workflow. 

Found this bug after I unlined data on exoplanets, the retired counts came down but the total classifications didn't leading to the complete signal in the stats summary.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
