### PR TITLE
Add default subject to Collections

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2917,6 +2917,7 @@ It has the following attributes:
 - updated_at
 - name
 - display_name
+- default_subject
 
 *id*, *created_at*, and *updated_at* are set by the API.
 
@@ -2937,6 +2938,7 @@ It has the following attributes:
                     "updated_at": "2014-04-20T06:23:12Z",
                     "name" : "flowers",
                     "display_name": "Lots of Pretty flowers",
+                    "default_subject_src": "panoptes-uploads.zooniverse.org/production/subject_location/hash.jpeg",
                     "links": {
                         "owner": {
                             "id": "10",
@@ -2964,7 +2966,8 @@ It has the following attributes:
 ### Edit a collection [PUT]
 A user may edit a collection they are the owner of or have edit
 permissions for. A user may edit a collection's name, or display_name,
-and may also send a full representation of a collections subject links.
+and may also send a full representation of a collections subject links
+or a single subject id to set the default subject.
 
 Sending subject links through a put is not recommend, especially if a
 collection has many subjects.
@@ -3046,6 +3049,33 @@ owner or have edit permissions.
             Content-Type: application/json
 
 + Response 204
+
+## Add default subject link [/collections/{id}/links/default_subject]
+Links a default subject to a collection. This subject's first media
+location URL will be included in the serialized collection and used
+as the thumbnail. Update this attribute with `null` to use the first
+subject in the linked list instead.
+
+### Add links [POST]
+A user is permitted to add a default subject if they are the collection
+owner or have edit permissions.
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json; version=1
+            Content-Type: application/json
+
+    + Body
+
+            {
+                "default_subject": "1"
+            }
+
++ Response 200
+
+    [Collection][]
 
 ## Collection Collection [/collections{?page,page_size,sort,owner}]
 A collection of Collection resources.

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -11,9 +11,9 @@ class Api::V1::CollectionsController < Api::ApiController
   schema_type :strong_params
 
   allowed_params :create, :name, :display_name, :private, :favorite,
-    links: [ :project, projects: [], subjects: [], owner: polymorphic ]
+    links: [ :default_subject, :project, projects: [], subjects: [], owner: polymorphic ]
 
-  allowed_params :update, :name, :display_name, :private, links: [ subjects: [] ]
+  allowed_params :update, :name, :display_name, :private, links: [ :default_subject, subjects: [] ]
 
   search_by do |name, query|
     query.search_display_name(name.join(" "))

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -13,6 +13,7 @@ class Collection < ActiveRecord::Base
   has_many :subjects, through: :collections_subjects
   has_many :collection_roles, -> { where.not(roles: []) }, class_name: "AccessControlList", as: :resource
   has_many :user_collection_preferences, dependent: :destroy
+  belongs_to :default_subject, :class_name => "Subject"
 
   validates :display_name, presence: true
   validates :private, inclusion: { in: [true, false], message: "can't be blank" }

--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -6,7 +6,7 @@ class CollectionSerializer
   include CachedSerializer
 
   attributes :id, :name, :display_name, :created_at, :updated_at,
-    :slug, :href, :favorite, :private
+    :slug, :href, :favorite, :private, :default_subject_src
 
   # Do not include the BelongsToMany :projects relation
   # as this can't be preloaded (custom AR relation)
@@ -21,5 +21,9 @@ class CollectionSerializer
   # overridden belongs_to_many association to serialize the :projects links
   def self.btm_associations
     [ model_class.reflect_on_association(:projects) ]
+  end
+
+  def default_subject_src
+    @model.default_subject&.locations&.first&.src
   end
 end

--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -24,6 +24,10 @@ class CollectionSerializer
   end
 
   def default_subject_src
-    @model.default_subject&.locations&.first&.src
+    if @model.default_subject
+      @model.default_subject&.locations&.first&.src
+    else
+      @model.subjects.first&.locations&.first&.src
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,7 @@ Rails.application.routes.draw do
 
       json_api_resources :subject_sets, links: [:subjects]
 
-      json_api_resources :collections, links: [:subjects]
+      json_api_resources :collections, links: [:subjects, :default_subject]
 
       json_api_resources :subject_queues, links: [:subjects]
 

--- a/db/migrate/20170403194826_add_default_subject_to_collections.rb
+++ b/db/migrate/20170403194826_add_default_subject_to_collections.rb
@@ -1,5 +1,6 @@
 class AddDefaultSubjectToCollections < ActiveRecord::Migration
   def change
     add_column :collections, :default_subject_id, :integer
+    add_foreign_key :collections, :subjects, column: :default_subject_id
   end
 end

--- a/db/migrate/20170403194826_add_default_subject_to_collections.rb
+++ b/db/migrate/20170403194826_add_default_subject_to_collections.rb
@@ -1,0 +1,5 @@
+class AddDefaultSubjectToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :default_subject_id, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3283,6 +3283,14 @@ ALTER TABLE ONLY subject_sets
 
 
 --
+-- Name: fk_rails_991d5ad7ab; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY collections
+    ADD CONSTRAINT fk_rails_991d5ad7ab FOREIGN KEY (default_subject_id) REFERENCES subjects(id);
+
+
+--
 -- Name: fk_rails_99326fb65d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -257,7 +257,8 @@ CREATE TABLE collections (
     lock_version integer DEFAULT 0,
     slug character varying DEFAULT ''::character varying,
     favorite boolean DEFAULT false NOT NULL,
-    project_ids integer[] DEFAULT '{}'::integer[]
+    project_ids integer[] DEFAULT '{}'::integer[],
+    default_subject_id integer
 );
 
 
@@ -3838,4 +3839,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170316170501');
 INSERT INTO schema_migrations (version) VALUES ('20170320203350');
 
 INSERT INTO schema_migrations (version) VALUES ('20170325135953');
+
+INSERT INTO schema_migrations (version) VALUES ('20170403194826');
 

--- a/spec/serializers/collection_serializer_spec.rb
+++ b/spec/serializers/collection_serializer_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe CollectionSerializer do
   let(:collection) { create(:collection_with_subjects) }
+  let(:subject_with_media) { create(:subject, :with_mediums, num_media: 1, collections: [collection]) }
 
   describe "::btm_associations" do
     it "should be overriden" do
@@ -45,6 +46,20 @@ describe CollectionSerializer do
         expected = [ first_by_name.display_name, collection.display_name ]
         expect(results).to eq(expected)
       end
+    end
+  end
+
+  describe "default subject location" do
+    before { collection.default_subject = subject_with_media }
+    let(:serializer) do
+      s = CollectionSerializer.new
+      s.instance_variable_set(:@model, collection)
+      s.instance_variable_set(:@context, {})
+      s
+    end
+
+    it "includes the default subject's url" do
+      expect(serializer.default_subject_src).to eq(subject_with_media.locations.first.src)
     end
   end
 end


### PR DESCRIPTION
Collections now have a default subject field. It's serialized as either the media's first location's URL or just the collection's first subject's if nil. This creates an extra db query for the medium but prevents an entire extra API call from PFE for the first linked subject just to get its URL.

I need to test this on staging with the JS client and make sure it's set up to handle however it builds requests (via `/api/collections/:id` and `/api/collections/:id/links/default_subject`)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
