### PR TITLE
Add :created_at attribute to UPP serializer

### DIFF
--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -3,7 +3,8 @@ class UserProjectPreferenceSerializer
   include CachedSerializer
 
   attributes :id, :email_communication, :preferences, :href,
-    :activity_count, :activity_count_by_workflow, :settings
+    :activity_count, :activity_count_by_workflow, :settings,
+    :created_at
   can_include :user, :project
   can_sort_by :updated_at, :display_name
 

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -4,7 +4,7 @@ class UserProjectPreferenceSerializer
 
   attributes :id, :email_communication, :preferences, :href,
     :activity_count, :activity_count_by_workflow, :settings,
-    :created_at
+    :created_at, :updated_at
   can_include :user, :project
   can_sort_by :updated_at, :display_name
 


### PR DESCRIPTION
This adds `:created_at` attribute to the user project preferences serializer. The first a/b split that Gravity Spy ran was to study behavior with users new to the project and the only way we can determine that is by the existence of the user project preferences for the project. If they want to run any future experiments with new users, it will be useful to have the `created_at` timestamp available via the API and possibly log it to geordi for the researcher's use in data analysis.

I looked through the spec files and didn't see anything that I would need to update in the tests, but do let me know if I missed something. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
