### PR TITLE
Add project/workflow mobile_friendly

### DIFF
--- a/app/schemas/project_create_schema.rb
+++ b/app/schemas/project_create_schema.rb
@@ -38,6 +38,10 @@ class ProjectCreateSchema < JsonSchema
       type "boolean"
     end
 
+    property "mobile_friendly" do
+      type "boolean"
+    end
+
     property "launched_row_order_position" do
       type "integer"
     end

--- a/app/schemas/project_update_schema.rb
+++ b/app/schemas/project_update_schema.rb
@@ -50,6 +50,10 @@ class ProjectUpdateSchema < JsonSchema
       type "boolean"
     end
 
+    property "mobile_friendly" do
+      type "boolean"
+    end
+
     property "live" do
       type "boolean"
     end

--- a/app/schemas/workflow_create_schema.rb
+++ b/app/schemas/workflow_create_schema.rb
@@ -22,6 +22,10 @@ class WorkflowCreateSchema < JsonSchema
       type "boolean"
     end
 
+    property "mobile_friendly" do
+      type "boolean"
+    end
+
     property "public_gold_standard" do
       type "boolean"
     end

--- a/app/schemas/workflow_update_schema.rb
+++ b/app/schemas/workflow_update_schema.rb
@@ -21,6 +21,10 @@ class WorkflowUpdateSchema < JsonSchema
       type "boolean"
     end
 
+    property "mobile_friendly" do
+      type "boolean"
+    end
+
     property "public_gold_standard" do
       type "boolean"
     end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -27,7 +27,7 @@ class ProjectSerializer
     :configuration, :live, :urls, :migrated, :classifiers_count, :slug, :redirect,
     :beta_requested, :beta_approved, :launch_requested, :launch_approved, :launch_date,
     :href, :workflow_description, :primary_language, :tags, :experimental_tools,
-    :completeness, :activity, :state, :researcher_quote
+    :completeness, :activity, :state, :researcher_quote, :mobile_friendly
 
   optional :avatar_src
   can_include :workflows, :active_workflows, :subject_sets, :owners, :project_contents,
@@ -37,7 +37,7 @@ class ProjectSerializer
     subjects_export: { include: false },
     aggregations_export: { include: false }
   can_filter_by :display_name, :slug, :beta_requested, :beta_approved,
-    :launch_requested, :launch_approved, :private, :state, :live
+    :launch_requested, :launch_approved, :private, :state, :live, :mobile_friendly
   can_sort_by :launch_date, :activity, :completeness, :classifiers_count,
     :updated_at, :display_name
 

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -10,14 +10,14 @@ class WorkflowSerializer
   attributes :id, :display_name, :tasks, :classifications_count, :subjects_count,
              :created_at, :updated_at, :finished_at, :first_task, :primary_language,
              :version, :content_language, :prioritized, :grouped, :pairwise,
-             :retirement, :retired_set_member_subjects_count, :href, :active,
+             :retirement, :retired_set_member_subjects_count, :href, :active, :mobile_friendly,
              :aggregation, :nero_config, :configuration, :public_gold_standard, :completeness
 
   can_include :project, :subject_sets, :tutorial_subject
 
   media_include :attached_images, classifications_export: { include: false }
 
-  can_filter_by :active
+  can_filter_by :active, :mobile_friendly
 
   # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
   preload :subject_sets, :attached_images

--- a/db/migrate/20170420095703_alter_projects_add_mobile_friendly.rb
+++ b/db/migrate/20170420095703_alter_projects_add_mobile_friendly.rb
@@ -1,0 +1,5 @@
+class AlterProjectsAddMobileFriendly < ActiveRecord::Migration
+  def change
+    add_column :projects, :mobile_friendly, :boolean, null: false, default: false, index: true
+  end
+end

--- a/db/migrate/20170425110939_alter_workflows_add_mobile_friendly.rb
+++ b/db/migrate/20170425110939_alter_workflows_add_mobile_friendly.rb
@@ -1,0 +1,5 @@
+class AlterWorkflowsAddMobileFriendly < ActiveRecord::Migration
+  def change
+    add_column :workflows, :mobile_friendly, :boolean, null: false, default: false, index: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1523,7 +1523,8 @@ CREATE TABLE workflows (
     current_version_number character varying,
     activated_state integer DEFAULT 0 NOT NULL,
     subject_selection_strategy integer DEFAULT 0,
-    nero_config jsonb DEFAULT '{}'::jsonb
+    nero_config jsonb DEFAULT '{}'::jsonb,
+    mobile_friendly boolean DEFAULT false NOT NULL
 );
 
 
@@ -2994,7 +2995,14 @@ CREATE INDEX index_workflows_on_display_order ON workflows USING btree (display_
 
 
 --
--- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_workflows_on_mobile_friendly ON workflows USING btree (mobile_friendly);
+
+
+--
+-- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_project_id ON workflows USING btree (project_id);
@@ -3859,4 +3867,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170325135953');
 INSERT INTO schema_migrations (version) VALUES ('20170403194826');
 
 INSERT INTO schema_migrations (version) VALUES ('20170420095703');
+
+INSERT INTO schema_migrations (version) VALUES ('20170425110939');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -813,7 +813,8 @@ CREATE TABLE projects (
     activity integer DEFAULT 0 NOT NULL,
     tsv tsvector,
     state integer,
-    organization_id integer
+    organization_id integer,
+    mobile_friendly boolean DEFAULT false NOT NULL
 );
 
 
@@ -2566,7 +2567,14 @@ CREATE INDEX index_projects_on_migrated ON projects USING btree (migrated) WHERE
 
 
 --
--- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_projects_on_mobile_friendly ON projects USING btree (mobile_friendly);
+
+
+--
+-- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_organization_id ON projects USING btree (organization_id);
@@ -3849,4 +3857,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170320203350');
 INSERT INTO schema_migrations (version) VALUES ('20170325135953');
 
 INSERT INTO schema_migrations (version) VALUES ('20170403194826');
+
+INSERT INTO schema_migrations (version) VALUES ('20170420095703');
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::ProjectsController, type: :controller do
      "description", "introduction", "migrated","private", "live",
      "retired_subjects_count", "urls", "classifiers_count", "redirect",
      "workflow_description", "tags", "experimental_tools",
-     "completeness", "activity", "state" ]
+     "completeness", "activity", "state", "mobile_friendly" ]
   end
   let(:api_resource_links) do
     [ "projects.workflows",

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::WorkflowsController, type: :controller do
     %w(id display_name tasks classifications_count subjects_count
     created_at updated_at first_task primary_language content_language
     version grouped prioritized pairwise retirement aggregation nero_config
-    active configuration finished_at public_gold_standard)
+    active mobile_friendly configuration finished_at public_gold_standard)
   end
   let(:api_resource_links)do
     %w(workflows.project workflows.subject_sets workflows.tutorial_subject


### PR DESCRIPTION
This lets the mobile app filter the projects listing to just projects that have been marked as mobile-friendly. This can be set by owners via the API since we don't want to have to manage this long-term. 

Short term we probably will be setting this ourselves without any UI, we'll think about adding it to the project builder at some point. 