### PR TITLE
Collection Default Subject updates

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::CollectionsController < Api::ApiController
   private
 
   def check_default_subject(collection)
-    collection.update({ default_subject: nil }) if collection.default_subject&.id.to_s == params["link_ids"]
+    collection.update({ default_subject: nil }) if params["link_ids"].split(",").include? collection.default_subject&.id.to_s
   end
 
   def filter_by_project_ids

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -19,6 +19,10 @@ class Api::V1::CollectionsController < Api::ApiController
     query.search_display_name(name.join(" "))
   end
 
+  def destroy_links
+    super { |collection| check_default_subject(collection) }
+  end
+
   protected
 
   def build_resource_for_create(create_params)
@@ -27,6 +31,10 @@ class Api::V1::CollectionsController < Api::ApiController
   end
 
   private
+
+  def check_default_subject(collection)
+    collection.update({ default_subject: nil }) if collection.default_subject&.id.to_s == params["link_ids"]
+  end
 
   def filter_by_project_ids
     if ids_string = (params.delete(:project_ids) || params.delete(:project_id)).try(:split, ',')

--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -25,9 +25,9 @@ class CollectionSerializer
 
   def default_subject_src
     if @model.default_subject
-      @model.default_subject&.locations&.first&.src
+      @model.default_subject&.locations&.first&.url_for_format(:get)
     else
-      @model.subjects.first&.locations&.first&.src
+      @model.subjects.first&.locations&.first&.url_for_format(:get)
     end
   end
 end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -190,4 +190,34 @@ describe Api::V1::CollectionsController, type: :controller do
 
     it_behaves_like "is destructable"
   end
+
+  describe '#destroy_links' do
+    context "removing the default subject from the collection" do
+      let(:default_subject) { collection.subjects.first }
+
+      def delete_default(ids)
+        delete :destroy_links,
+          collection_id: collection.id,
+          link_relation: :subjects,
+          link_ids: ids
+      end
+
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id
+        collection.update({default_subject: default_subject})
+      end
+
+      context "nulls the default subject relation" do
+        it "when there is a single subject given" do
+          delete_default(default_subject.id.to_s)
+          expect(collection.reload.default_subject).to be_nil
+        end
+
+        it "when there is an array of subjects given" do
+          delete_default(collection.subjects.pluck(:id).join(','))
+          expect(collection.reload.default_subject).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/serializers/collection_serializer_spec.rb
+++ b/spec/serializers/collection_serializer_spec.rb
@@ -59,7 +59,7 @@ describe CollectionSerializer do
     end
 
     it "includes the default subject's url" do
-      expect(serializer.default_subject_src).to eq(subject_with_media.locations.first.src)
+      expect(serializer.default_subject_src).to eq(subject_with_media.locations.first.url_for_format(:get))
     end
   end
 end


### PR DESCRIPTION
* Adds proper URL formatting to the default subject src URL returned from the collection serializer.
* If a subject is being unlinked from a collection, check to see if it's the current default. If it is, null the default subject before unlinking.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
