### PR TITLE
Organization pages

### DIFF
--- a/app/controllers/api/v1/organization_pages_controller.rb
+++ b/app/controllers/api/v1/organization_pages_controller.rb
@@ -1,0 +1,33 @@
+class Api::V1::OrganizationPagesController < Api::ApiController
+  require_authentication :update, :create, :destroy, scopes: [:organization]
+
+  resource_actions :default
+
+  schema_type :strong_params
+
+  allowed_params :create, :url_key, :title, :content, :language
+  allowed_params :update, :url_key, :title, :content, :language
+
+  before_filter :set_language_from_header, only: [:index]
+
+  def controlled_resources
+    @controlled_resouces ||= super.where(organization: params[:organization_id])
+  end
+
+  protected
+
+  def build_resource_for_create(create_params)
+    create_params[:links] ||= {}
+    create_params[:links][:organization] = params[:organization_id]
+    super create_params
+  end
+
+  def link_header(resource)
+    resource = resource.first
+    send(:"api_#{ resource_name }_url", id: resource.id, organization_id: resource.organization_id)
+  end
+
+  def set_language_from_header
+    params[:language] = "en"
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,6 +13,7 @@ class Organization < ActiveRecord::Base
   has_one :avatar, -> { where(type: "organization_avatar") }, class_name: "Medium", as: :linked
   has_one :background, -> { where(type: "organization_background") }, class_name: "Medium", as: :linked
   has_many :organization_roles, -> { where.not(roles: []) }, class_name: "AccessControlList", as: :resource
+  has_many :pages, class_name: "OrganizationPage", dependent: :destroy
 
   accepts_nested_attributes_for :organization_contents
 

--- a/app/models/organization_page.rb
+++ b/app/models/organization_page.rb
@@ -1,0 +1,23 @@
+class OrganizationPage < ActiveRecord::Base
+  include Linkable
+  include RoleControl::ParentalControlled
+  include LanguageValidation
+
+  has_paper_trail ignore: [:language]
+
+  belongs_to :organization
+
+  can_through_parent :organization, :show, :index, :versions, :version
+
+  validates_uniqueness_of :url_key, scope: [:organization_id, :language]
+
+  def self.scope_for(action, user, opts={})
+    case action
+    when :show, :index
+      super
+    else
+      translatable = Organization.scope_for(:translate, user, opts)
+      joins(:organization).merge(translatable)
+    end
+  end
+end

--- a/app/serializers/organization_page_serializer.rb
+++ b/app/serializers/organization_page_serializer.rb
@@ -13,7 +13,7 @@ class OrganizationPageSerializer
 
     organization_id = options.filters.delete :organization_id
 
-    url = "#{self.href_prefix}/organizations/#{organization_id.try(:first)}/pages"
+    url = "#{href_prefix}/organizations/#{organization_id.try(:first)}/pages"
 
     params = []
     params << "page=#{page}" unless page == 1

--- a/app/serializers/organization_page_serializer.rb
+++ b/app/serializers/organization_page_serializer.rb
@@ -1,5 +1,5 @@
 class OrganizationPageSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :href, :created_at, :updated_at, :url_key, :title,

--- a/app/serializers/organization_page_serializer.rb
+++ b/app/serializers/organization_page_serializer.rb
@@ -1,0 +1,36 @@
+class OrganizationPageSerializer
+  include RestPack::Serializer
+  include CachedSerializer
+
+  attributes :id, :href, :created_at, :updated_at, :url_key, :title,
+    :language, :content, :type
+
+  can_include :organization
+  can_filter_by :url_key, :language
+
+  def self.page_href(page, options)
+    return nil unless page
+
+    organization_id = options.filters.delete :organization_id
+
+    url = "#{self.href_prefix}/organizations/#{organization_id.try(:first)}/pages"
+
+    params = []
+    params << "page=#{page}" unless page == 1
+    params << "page_size=#{options.page_size}" unless options.default_page_size?
+    params << "include=#{options.include.join(',')}" if options.include.any?
+    params << options.sorting_as_url_params if options.sorting.any?
+    params << options.filters_as_url_params if options.filters.any?
+
+    url += '?' + params.join('&') if params.any?
+    url
+  end
+
+  def type
+    "organization_pages"
+  end
+
+  def href
+    "/organizations/#{@model.organization_id}/pages/#{@model.id}"
+  end
+end

--- a/app/serializers/project_page_serializer.rb
+++ b/app/serializers/project_page_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectPageSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :href, :created_at, :updated_at, :url_key, :title,

--- a/app/serializers/project_page_serializer.rb
+++ b/app/serializers/project_page_serializer.rb
@@ -13,7 +13,7 @@ class ProjectPageSerializer
 
     project_id = options.filters.delete :project_id
 
-    url = "#{self.href_prefix}/projects/#{project_id.try(:first)}/pages"
+    url = "#{href_prefix}/projects/#{project_id.try(:first)}/pages"
 
     params = []
     params << "page=#{page}" unless page == 1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
       end
 
       json_api_resources :organizations, links: [:projects] do
+        json_api_resources :pages, controller: "organization_pages"
         media_resources :avatar, :background
       end
 

--- a/db/migrate/20170426162708_add_organization_pages.rb
+++ b/db/migrate/20170426162708_add_organization_pages.rb
@@ -1,0 +1,15 @@
+class AddOrganizationPages < ActiveRecord::Migration
+  def change
+    create_table :organization_pages do |t|
+      t.string :url_key
+      t.text :title
+      t.string :language
+      t.text :content
+      t.references :organization, index: true
+
+      t.timestamps null: false
+    end
+
+    add_index :organization_pages, :language
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -58,7 +58,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE access_control_lists (
@@ -92,7 +92,7 @@ ALTER SEQUENCE access_control_lists_id_seq OWNED BY access_control_lists.id;
 
 
 --
--- Name: aggregations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: aggregations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE aggregations (
@@ -125,7 +125,7 @@ ALTER SEQUENCE aggregations_id_seq OWNED BY aggregations.id;
 
 
 --
--- Name: authorizations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: authorizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE authorizations (
@@ -160,7 +160,7 @@ ALTER SEQUENCE authorizations_id_seq OWNED BY authorizations.id;
 
 
 --
--- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classification_subjects (
@@ -170,7 +170,7 @@ CREATE TABLE classification_subjects (
 
 
 --
--- Name: classifications; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: classifications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classifications (
@@ -212,7 +212,7 @@ ALTER SEQUENCE classifications_id_seq OWNED BY classifications.id;
 
 
 --
--- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE code_experiment_configs (
@@ -243,7 +243,7 @@ ALTER SEQUENCE code_experiment_configs_id_seq OWNED BY code_experiment_configs.i
 
 
 --
--- Name: collections; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: collections; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections (
@@ -282,7 +282,7 @@ ALTER SEQUENCE collections_id_seq OWNED BY collections.id;
 
 
 --
--- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections_subjects (
@@ -312,7 +312,7 @@ ALTER SEQUENCE collections_subjects_id_seq OWNED BY collections_subjects.id;
 
 
 --
--- Name: field_guides; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: field_guides; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE field_guides (
@@ -345,7 +345,7 @@ ALTER SEQUENCE field_guides_id_seq OWNED BY field_guides.id;
 
 
 --
--- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE flipper_features (
@@ -376,7 +376,7 @@ ALTER SEQUENCE flipper_features_id_seq OWNED BY flipper_features.id;
 
 
 --
--- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE flipper_gates (
@@ -409,7 +409,7 @@ ALTER SEQUENCE flipper_gates_id_seq OWNED BY flipper_gates.id;
 
 
 --
--- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE gold_standard_annotations (
@@ -446,7 +446,7 @@ ALTER SEQUENCE gold_standard_annotations_id_seq OWNED BY gold_standard_annotatio
 
 
 --
--- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE media (
@@ -488,7 +488,7 @@ ALTER SEQUENCE media_id_seq OWNED BY media.id;
 
 
 --
--- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE memberships (
@@ -523,7 +523,7 @@ ALTER SEQUENCE memberships_id_seq OWNED BY memberships.id;
 
 
 --
--- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_access_grants (
@@ -559,7 +559,7 @@ ALTER SEQUENCE oauth_access_grants_id_seq OWNED BY oauth_access_grants.id;
 
 
 --
--- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_access_tokens (
@@ -595,7 +595,7 @@ ALTER SEQUENCE oauth_access_tokens_id_seq OWNED BY oauth_access_tokens.id;
 
 
 --
--- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_applications (
@@ -634,7 +634,7 @@ ALTER SEQUENCE oauth_applications_id_seq OWNED BY oauth_applications.id;
 
 
 --
--- Name: organization_contents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: organization_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_contents (
@@ -670,7 +670,7 @@ ALTER SEQUENCE organization_contents_id_seq OWNED BY organization_contents.id;
 
 
 --
--- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_pages (
@@ -705,7 +705,7 @@ ALTER SEQUENCE organization_pages_id_seq OWNED BY organization_pages.id;
 
 
 --
--- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organizations (
@@ -741,7 +741,7 @@ ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
 
 
 --
--- Name: project_contents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: project_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_contents (
@@ -779,7 +779,7 @@ ALTER SEQUENCE project_contents_id_seq OWNED BY project_contents.id;
 
 
 --
--- Name: project_pages; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: project_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_pages (
@@ -814,7 +814,7 @@ ALTER SEQUENCE project_pages_id_seq OWNED BY project_pages.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE projects (
@@ -873,7 +873,7 @@ ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
 
 
 --
--- Name: recents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: recents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE recents (
@@ -909,7 +909,7 @@ ALTER SEQUENCE recents_id_seq OWNED BY recents.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE schema_migrations (
@@ -918,7 +918,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE set_member_subjects (
@@ -953,7 +953,7 @@ ALTER SEQUENCE set_member_subjects_id_seq OWNED BY set_member_subjects.id;
 
 
 --
--- Name: subject_queues; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subject_queues; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_queues (
@@ -988,7 +988,7 @@ ALTER SEQUENCE subject_queues_id_seq OWNED BY subject_queues.id;
 
 
 --
--- Name: subject_sets; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_sets (
@@ -1024,7 +1024,7 @@ ALTER SEQUENCE subject_sets_id_seq OWNED BY subject_sets.id;
 
 
 --
--- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_sets_workflows (
@@ -1054,7 +1054,7 @@ ALTER SEQUENCE subject_sets_workflows_id_seq OWNED BY subject_sets_workflows.id;
 
 
 --
--- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_workflow_counts (
@@ -1089,7 +1089,7 @@ ALTER SEQUENCE subject_workflow_counts_id_seq OWNED BY subject_workflow_counts.i
 
 
 --
--- Name: subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subjects (
@@ -1126,7 +1126,7 @@ ALTER SEQUENCE subjects_id_seq OWNED BY subjects.id;
 
 
 --
--- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tagged_resources (
@@ -1157,7 +1157,7 @@ ALTER SEQUENCE tagged_resources_id_seq OWNED BY tagged_resources.id;
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tags (
@@ -1189,7 +1189,7 @@ ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
--- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tutorials (
@@ -1224,7 +1224,7 @@ ALTER SEQUENCE tutorials_id_seq OWNED BY tutorials.id;
 
 
 --
--- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_collection_preferences (
@@ -1257,7 +1257,7 @@ ALTER SEQUENCE user_collection_preferences_id_seq OWNED BY user_collection_prefe
 
 
 --
--- Name: user_groups; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_groups (
@@ -1294,7 +1294,7 @@ ALTER SEQUENCE user_groups_id_seq OWNED BY user_groups.id;
 
 
 --
--- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_project_preferences (
@@ -1331,7 +1331,7 @@ ALTER SEQUENCE user_project_preferences_id_seq OWNED BY user_project_preferences
 
 
 --
--- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_seen_subjects (
@@ -1364,7 +1364,7 @@ ALTER SEQUENCE user_seen_subjects_id_seq OWNED BY user_seen_subjects.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE users (
@@ -1428,7 +1428,7 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE versions (
@@ -1463,7 +1463,7 @@ ALTER SEQUENCE versions_id_seq OWNED BY versions.id;
 
 
 --
--- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflow_contents (
@@ -1497,7 +1497,7 @@ ALTER SEQUENCE workflow_contents_id_seq OWNED BY workflow_contents.id;
 
 
 --
--- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflow_tutorials (
@@ -1527,7 +1527,7 @@ ALTER SEQUENCE workflow_tutorials_id_seq OWNED BY workflow_tutorials.id;
 
 
 --
--- Name: workflows; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflows (
@@ -1870,7 +1870,7 @@ ALTER TABLE ONLY workflows ALTER COLUMN id SET DEFAULT nextval('workflows_id_seq
 
 
 --
--- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY access_control_lists
@@ -1878,7 +1878,7 @@ ALTER TABLE ONLY access_control_lists
 
 
 --
--- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY aggregations
@@ -1886,7 +1886,7 @@ ALTER TABLE ONLY aggregations
 
 
 --
--- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY authorizations
@@ -1894,7 +1894,7 @@ ALTER TABLE ONLY authorizations
 
 
 --
--- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY classifications
@@ -1902,7 +1902,7 @@ ALTER TABLE ONLY classifications
 
 
 --
--- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY code_experiment_configs
@@ -1910,7 +1910,7 @@ ALTER TABLE ONLY code_experiment_configs
 
 
 --
--- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY collections
@@ -1918,7 +1918,7 @@ ALTER TABLE ONLY collections
 
 
 --
--- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY collections_subjects
@@ -1926,7 +1926,7 @@ ALTER TABLE ONLY collections_subjects
 
 
 --
--- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY field_guides
@@ -1934,7 +1934,7 @@ ALTER TABLE ONLY field_guides
 
 
 --
--- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY flipper_features
@@ -1942,7 +1942,7 @@ ALTER TABLE ONLY flipper_features
 
 
 --
--- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY flipper_gates
@@ -1950,7 +1950,7 @@ ALTER TABLE ONLY flipper_gates
 
 
 --
--- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -1958,7 +1958,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY media
@@ -1966,7 +1966,7 @@ ALTER TABLE ONLY media
 
 
 --
--- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY memberships
@@ -1974,7 +1974,7 @@ ALTER TABLE ONLY memberships
 
 
 --
--- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_access_grants
@@ -1982,7 +1982,7 @@ ALTER TABLE ONLY oauth_access_grants
 
 
 --
--- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_access_tokens
@@ -1990,7 +1990,7 @@ ALTER TABLE ONLY oauth_access_tokens
 
 
 --
--- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_applications
@@ -1998,7 +1998,7 @@ ALTER TABLE ONLY oauth_applications
 
 
 --
--- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_contents
@@ -2006,7 +2006,7 @@ ALTER TABLE ONLY organization_contents
 
 
 --
--- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_pages
@@ -2014,7 +2014,7 @@ ALTER TABLE ONLY organization_pages
 
 
 --
--- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organizations
@@ -2022,7 +2022,7 @@ ALTER TABLE ONLY organizations
 
 
 --
--- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_contents
@@ -2030,7 +2030,7 @@ ALTER TABLE ONLY project_contents
 
 
 --
--- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_pages
@@ -2038,7 +2038,7 @@ ALTER TABLE ONLY project_pages
 
 
 --
--- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY projects
@@ -2046,7 +2046,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY recents
@@ -2054,7 +2054,7 @@ ALTER TABLE ONLY recents
 
 
 --
--- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY set_member_subjects
@@ -2062,7 +2062,7 @@ ALTER TABLE ONLY set_member_subjects
 
 
 --
--- Name: subject_queues_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subject_queues_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_queues
@@ -2070,7 +2070,7 @@ ALTER TABLE ONLY subject_queues
 
 
 --
--- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_sets
@@ -2078,7 +2078,7 @@ ALTER TABLE ONLY subject_sets
 
 
 --
--- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_sets_workflows
@@ -2086,7 +2086,7 @@ ALTER TABLE ONLY subject_sets_workflows
 
 
 --
--- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_workflow_counts
@@ -2094,7 +2094,7 @@ ALTER TABLE ONLY subject_workflow_counts
 
 
 --
--- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subjects
@@ -2102,7 +2102,7 @@ ALTER TABLE ONLY subjects
 
 
 --
--- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tagged_resources
@@ -2110,7 +2110,7 @@ ALTER TABLE ONLY tagged_resources
 
 
 --
--- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tags
@@ -2118,7 +2118,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tutorials
@@ -2126,7 +2126,7 @@ ALTER TABLE ONLY tutorials
 
 
 --
--- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_collection_preferences
@@ -2134,7 +2134,7 @@ ALTER TABLE ONLY user_collection_preferences
 
 
 --
--- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_groups
@@ -2142,7 +2142,7 @@ ALTER TABLE ONLY user_groups
 
 
 --
--- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_project_preferences
@@ -2150,7 +2150,7 @@ ALTER TABLE ONLY user_project_preferences
 
 
 --
--- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_seen_subjects
@@ -2158,7 +2158,7 @@ ALTER TABLE ONLY user_seen_subjects
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -2166,7 +2166,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY versions
@@ -2174,7 +2174,7 @@ ALTER TABLE ONLY versions
 
 
 --
--- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflow_contents
@@ -2182,7 +2182,7 @@ ALTER TABLE ONLY workflow_contents
 
 
 --
--- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflow_tutorials
@@ -2190,7 +2190,7 @@ ALTER TABLE ONLY workflow_tutorials
 
 
 --
--- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflows
@@ -2198,903 +2198,903 @@ ALTER TABLE ONLY workflows
 
 
 --
--- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX classification_subjects_pk ON classification_subjects USING btree (classification_id, subject_id);
 
 
 --
--- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX idx_lower_email ON users USING btree (lower((email)::text));
 
 
 --
--- Name: idx_queues_on_ssid_wid_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: idx_queues_on_ssid_wid_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX idx_queues_on_ssid_wid_and_id ON subject_queues USING btree (subject_set_id, workflow_id, user_id);
 
 
 --
--- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_access_control_lists_on_resource_id_and_resource_type ON access_control_lists USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_access_control_lists_on_user_group_id ON access_control_lists USING btree (user_group_id);
 
 
 --
--- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_aggregations_on_subject_id_and_workflow_id ON aggregations USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_aggregations_on_workflow_id ON aggregations USING btree (workflow_id);
 
 
 --
--- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_authorizations_on_user_id ON authorizations USING btree (user_id);
 
 
 --
--- Name: index_classification_subjects_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classification_subjects_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_subjects_on_classification_id ON classification_subjects USING btree (classification_id);
 
 
 --
--- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_subjects_on_subject_id ON classification_subjects USING btree (subject_id);
 
 
 --
--- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_completed ON classifications USING btree (completed) WHERE (completed IS FALSE);
 
 
 --
--- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_created_at ON classifications USING btree (created_at);
 
 
 --
--- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_gold_standard ON classifications USING btree (gold_standard) WHERE (gold_standard IS TRUE);
 
 
 --
--- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_lifecycled_at ON classifications USING btree (lifecycled_at) WHERE (lifecycled_at IS NULL);
 
 
 --
--- Name: index_classifications_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_project_id ON classifications USING btree (project_id);
 
 
 --
--- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_user_id ON classifications USING btree (user_id);
 
 
 --
--- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_workflow_id ON classifications USING btree (workflow_id);
 
 
 --
--- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_code_experiment_configs_on_name ON code_experiment_configs USING btree (name);
 
 
 --
--- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_display_name_trgrm ON collections USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_activated_state ON collections USING btree (activated_state);
 
 
 --
--- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_display_name ON collections USING btree (display_name);
 
 
 --
--- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_favorite ON collections USING btree (favorite);
 
 
 --
--- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_private ON collections USING btree (private);
 
 
 --
--- Name: index_collections_on_project_ids; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_project_ids; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_project_ids ON collections USING gin (project_ids);
 
 
 --
--- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_slug ON collections USING btree (slug);
 
 
 --
--- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_collections_subjects_on_collection_id_and_subject_id ON collections_subjects USING btree (collection_id, subject_id);
 
 
 --
--- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_field_guides_on_language ON field_guides USING btree (language);
 
 
 --
--- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_field_guides_on_project_id ON field_guides USING btree (project_id);
 
 
 --
--- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_flipper_features_on_key ON flipper_features USING btree (key);
 
 
 --
--- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON flipper_gates USING btree (feature_key, key, value);
 
 
 --
--- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_gold_standard_annotations_on_subject_id ON gold_standard_annotations USING btree (subject_id);
 
 
 --
--- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_gold_standard_annotations_on_workflow_id ON gold_standard_annotations USING btree (workflow_id);
 
 
 --
--- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_media_on_linked_id_and_linked_type ON media USING btree (linked_id, linked_type);
 
 
 --
--- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_media_on_type ON media USING btree (type);
 
 
 --
--- Name: index_memberships_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_memberships_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_memberships_on_user_group_id ON memberships USING btree (user_group_id);
 
 
 --
--- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_memberships_on_user_group_id_and_user_id ON memberships USING btree (user_group_id, user_id);
 
 
 --
--- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_memberships_on_user_id ON memberships USING btree (user_id);
 
 
 --
--- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON oauth_access_grants USING btree (token);
 
 
 --
--- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_oauth_access_tokens_on_app_id_and_owner_id ON oauth_access_tokens USING btree (application_id, resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens USING btree (refresh_token);
 
 
 --
--- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON oauth_access_tokens USING btree (resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON oauth_access_tokens USING btree (token);
 
 
 --
--- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_applications_on_uid ON oauth_applications USING btree (uid);
 
 
 --
--- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organization_pages_on_language ON organization_pages USING btree (language);
 
 
 --
--- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organization_pages_on_organization_id ON organization_pages USING btree (organization_id);
 
 
 --
--- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_activated_state ON organizations USING btree (activated_state);
 
 
 --
--- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_display_name ON organizations USING btree (display_name);
 
 
 --
--- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_listed_at ON organizations USING btree (listed_at);
 
 
 --
--- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
 
 
 --
--- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_contents_on_project_id ON project_contents USING btree (project_id);
 
 
 --
--- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_pages_on_language ON project_pages USING btree (language);
 
 
 --
--- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_pages_on_project_id ON project_pages USING btree (project_id);
 
 
 --
--- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_display_name_trgrm ON projects USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_activated_state ON projects USING btree (activated_state);
 
 
 --
--- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_approved ON projects USING btree (beta_approved);
 
 
 --
--- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_requested ON projects USING btree (beta_requested) WHERE (beta_requested = true);
 
 
 --
--- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_row_order ON projects USING btree (beta_row_order);
 
 
 --
--- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launch_approved ON projects USING btree (launch_approved);
 
 
 --
--- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launch_requested ON projects USING btree (launch_requested) WHERE (launch_requested = true);
 
 
 --
--- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launched_row_order ON projects USING btree (launched_row_order);
 
 
 --
--- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_live ON projects USING btree (live);
 
 
 --
--- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_migrated ON projects USING btree (migrated) WHERE (migrated = true);
 
 
 --
--- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_mobile_friendly ON projects USING btree (mobile_friendly);
 
 
 --
--- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_organization_id ON projects USING btree (organization_id);
 
 
 --
--- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_private ON projects USING btree (private);
 
 
 --
--- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_slug ON projects USING btree (slug);
 
 
 --
--- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_state ON projects USING btree (state) WHERE (state IS NOT NULL);
 
 
 --
--- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_tsv ON projects USING gin (tsv);
 
 
 --
--- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_created_at ON recents USING btree (created_at);
 
 
 --
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
 
 
 --
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
 
 
 --
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
--- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_random ON set_member_subjects USING btree (random);
 
 
 --
--- Name: index_set_member_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_subject_id ON set_member_subjects USING btree (subject_id);
 
 
 --
--- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_set_member_subjects_on_subject_id_and_subject_set_id ON set_member_subjects USING btree (subject_id, subject_set_id);
 
 
 --
--- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_subject_set_id ON set_member_subjects USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_on_metadata ON subject_sets USING gin (metadata);
 
 
 --
--- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_on_project_id_and_display_name ON subject_sets USING btree (project_id, display_name);
 
 
 --
--- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_workflows_on_subject_set_id ON subject_sets_workflows USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_workflows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_workflows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_workflows_on_workflow_id ON subject_sets_workflows USING btree (workflow_id);
 
 
 --
--- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_subject_sets_workflows_on_workflow_id_and_subject_set_id ON subject_sets_workflows USING btree (workflow_id, subject_set_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_workflow_counts_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_workflow_counts_on_subject_id ON subject_workflow_counts USING btree (subject_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_subject_workflow_counts_on_subject_id_and_workflow_id ON subject_workflow_counts USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_workflow_counts_on_workflow_id ON subject_workflow_counts USING btree (workflow_id);
 
 
 --
--- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subjects_on_project_id ON subjects USING btree (project_id);
 
 
 --
--- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subjects_on_upload_user_id ON subjects USING btree (upload_user_id);
 
 
 --
--- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tagged_resources_on_resource_id_and_resource_type ON tagged_resources USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tagged_resources_on_tag_id ON tagged_resources USING btree (tag_id);
 
 
 --
--- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tags_name_trgrm ON tags USING gin ((COALESCE(name, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
 
 
 --
--- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_kind ON tutorials USING btree (kind);
 
 
 --
--- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_language ON tutorials USING btree (language);
 
 
 --
--- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_project_id ON tutorials USING btree (project_id);
 
 
 --
--- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_collection_preferences_on_collection_id ON user_collection_preferences USING btree (collection_id);
 
 
 --
--- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_collection_preferences_on_user_id ON user_collection_preferences USING btree (user_id);
 
 
 --
--- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_display_name_trgrm ON user_groups USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_on_activated_state ON user_groups USING btree (activated_state);
 
 
 --
--- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_user_groups_on_name ON user_groups USING btree (lower((name)::text));
 
 
 --
--- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_on_private ON user_groups USING btree (private);
 
 
 --
--- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_user_project_preferences_on_user_id_and_project_id ON user_project_preferences USING btree (user_id, project_id);
 
 
 --
--- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON user_seen_subjects USING btree (user_id, workflow_id);
 
 
 --
--- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_activated_state ON users USING btree (activated_state);
 
 
 --
--- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_beta_email_communication ON users USING btree (beta_email_communication) WHERE (beta_email_communication = true);
 
 
 --
--- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_display_name ON users USING btree (lower((display_name)::text));
 
 
 --
--- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
 
 
 --
--- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_global_email_communication ON users USING btree (global_email_communication) WHERE (global_email_communication = true);
 
 
 --
--- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_login ON users USING btree (lower((login)::text));
 
 
 --
--- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_login_with_case ON users USING btree (login);
 
 
 --
--- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_lower_names ON users USING btree (lower((login)::text) text_pattern_ops, lower((display_name)::text) text_pattern_ops);
 
 
 --
--- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_private_profile ON users USING btree (private_profile) WHERE (private_profile = false);
 
 
 --
--- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
 
 
 --
--- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_tsv ON users USING gin (tsv);
 
 
 --
--- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_unsubscribe_token ON users USING btree (unsubscribe_token);
 
 
 --
--- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_zooniverse_id ON users USING btree (zooniverse_id);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (item_type, item_id);
 
 
 --
--- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflow_contents_on_workflow_id ON workflow_contents USING btree (workflow_id);
 
 
 --
--- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflow_tutorials_on_tutorial_id ON workflow_tutorials USING btree (tutorial_id);
 
 
 --
--- Name: index_workflow_tutorials_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflow_tutorials_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflow_tutorials_on_workflow_id ON workflow_tutorials USING btree (workflow_id);
 
 
 --
--- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_workflow_tutorials_on_workflow_id_and_tutorial_id ON workflow_tutorials USING btree (workflow_id, tutorial_id);
 
 
 --
--- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_activated_state ON workflows USING btree (activated_state);
 
 
 --
--- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_aggregation ON workflows USING btree (((aggregation ->> 'public'::text)));
 
 
 --
--- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_display_order ON workflows USING btree (display_order);
 
 
 --
--- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_mobile_friendly ON workflows USING btree (mobile_friendly);
 
 
 --
--- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_project_id ON workflows USING btree (project_id);
 
 
 --
--- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_public_gold_standard ON workflows USING btree (public_gold_standard) WHERE (public_gold_standard IS TRUE);
 
 
 --
--- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tutorial_subject_id);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
 
 
 --
--- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX users_idx_trgm_login ON users USING gin ((COALESCE((login)::text, ''::text)) gin_trgm_ops);
@@ -3930,8 +3930,9 @@ INSERT INTO schema_migrations (version) VALUES ('20170325135953');
 
 INSERT INTO schema_migrations (version) VALUES ('20170403194826');
 
-INSERT INTO schema_migrations (version) VALUES ('20170426162708');
-
 INSERT INTO schema_migrations (version) VALUES ('20170420095703');
 
 INSERT INTO schema_migrations (version) VALUES ('20170425110939');
+
+INSERT INTO schema_migrations (version) VALUES ('20170426162708');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -670,6 +670,41 @@ ALTER SEQUENCE organization_contents_id_seq OWNED BY organization_contents.id;
 
 
 --
+-- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE organization_pages (
+    id integer NOT NULL,
+    url_key character varying,
+    title text,
+    language character varying,
+    content text,
+    organization_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: organization_pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE organization_pages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: organization_pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE organization_pages_id_seq OWNED BY organization_pages.id;
+
+
+--
 -- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1668,6 +1703,13 @@ ALTER TABLE ONLY organization_contents ALTER COLUMN id SET DEFAULT nextval('orga
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY organization_pages ALTER COLUMN id SET DEFAULT nextval('organization_pages_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organizations_id_seq'::regclass);
 
 
@@ -1959,6 +2001,14 @@ ALTER TABLE ONLY oauth_applications
 
 ALTER TABLE ONLY organization_contents
     ADD CONSTRAINT organization_contents_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY organization_pages
+    ADD CONSTRAINT organization_pages_pkey PRIMARY KEY (id);
 
 
 --
@@ -2444,6 +2494,20 @@ CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON oauth_access_tokens US
 --
 
 CREATE UNIQUE INDEX index_oauth_applications_on_uid ON oauth_applications USING btree (uid);
+
+
+--
+-- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_organization_pages_on_language ON organization_pages USING btree (language);
+
+
+--
+-- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_organization_pages_on_organization_id ON organization_pages USING btree (organization_id);
 
 
 --
@@ -3849,4 +3913,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170320203350');
 INSERT INTO schema_migrations (version) VALUES ('20170325135953');
 
 INSERT INTO schema_migrations (version) VALUES ('20170403194826');
+
+INSERT INTO schema_migrations (version) VALUES ('20170426162708');
 

--- a/spec/controllers/api/v1/organization_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_pages_controller_spec.rb
@@ -81,7 +81,7 @@ describe Api::V1::OrganizationPagesController, type: :controller do
       end
 
       it 'should use correct paging links' do
-        expect(json_response["meta"][api_resource_name]["first_href"]).to match(/organizations\/[0-9]+\/pages/)
+        expect(json_response["meta"][api_resource_name]["first_href"]).to match(%r{organizations/[0-9]+/pages})
       end
     end
   end
@@ -124,7 +124,7 @@ describe Api::V1::OrganizationPagesController, type: :controller do
       {
        organization_id: organization.id,
        organization_pages: {
-                       content: "dancer",
+                       content: "dancer"
                       }
       }
     end

--- a/spec/controllers/api/v1/organization_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_pages_controller_spec.rb
@@ -1,0 +1,140 @@
+require "spec_helper"
+
+describe Api::V1::OrganizationPagesController, type: :controller do
+  let(:organization) { create(:organization) }
+  let!(:pages) do
+    [create(:organization_page, organization: organization),
+     create(:organization_page, organization: organization, url_key: "faq"),
+     create(:organization_page, organization: organization, language: 'zh-tw'),
+     create(:organization_page)]
+  end
+
+  let(:scopes) { %w(public organization) }
+
+  let(:api_resource_name) { "organization_pages" }
+  let(:api_resource_attributes) do
+    ["title", "created_at", "updated_at", "type", "content", "language", "url_key"]
+  end
+
+  let(:api_resource_links) { ["organization_pages.organization"] }
+
+  let(:authorized_user) { organization.owner }
+
+  let(:resource) { pages.first }
+  let(:resource_class) { OrganizationPage }
+
+  describe "#index" do
+    let(:index_params) { {organization_id: organization.id} }
+    let(:n_visible) { 2 }
+
+    it_behaves_like "is indexable", false
+
+    describe "filter options" do
+      let(:filter_opts) { {} }
+      let(:headers) { {} }
+      before(:each) do
+        index_params.merge!(filter_opts)
+        default_request scopes: scopes, user_id: authorized_user.id
+        request.env.merge!(headers)
+        get :index, index_params
+      end
+
+      describe "filter by url_key" do
+        let(:filter_opts) { {url_key: "science_case"} }
+
+        it 'should return matching pages' do
+          expect(json_response[api_resource_name].map{ |p| p['url_key'] }).to all( eq("science_case") )
+        end
+      end
+
+      describe "filter by language", :disabled do
+        context "as a query param" do
+          let(:filter_opts) { {language: "zh-tw"} }
+
+          it 'should return matching pages' do
+            expect(json_response[api_resource_name].map{ |p| p['language'] }).to all( eq("zh-tw") )
+          end
+        end
+
+        context "using the Accept-Language Header" do
+          let(:headers) { {"HTTP_ACCEPT_LANGUAGE" => "zh-tw"} }
+
+          it 'should return matching pages' do
+            expect(json_response[api_resource_name].map{ |p| p['language'] }).to all( eq("zh-tw") )
+          end
+        end
+
+        context "when language is all" do
+          let(:filter_opts) { {language: "all" } }
+
+          it 'should not filter by language at all' do
+            expect(json_response[api_resource_name].length).to eq(3)
+          end
+        end
+      end
+    end
+
+    describe "paging" do
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id
+        get :index, index_params
+      end
+
+      it 'should use correct paging links' do
+        expect(json_response["meta"][api_resource_name]["first_href"]).to match(/organizations\/[0-9]+\/pages/)
+      end
+    end
+  end
+
+  describe "#show" do
+    let(:show_params) { {organization_id: organization.id} }
+
+    it_behaves_like "is showable"
+  end
+
+  describe "#create" do
+    let(:test_attr) { :content }
+    let(:test_attr_value) { "dancer" }
+    let(:resource_url) { "http://test.host/api/organizations/#{organization.id}/pages/#{created_id}"}
+    let(:create_params) do
+      {
+       organization_id: organization.id,
+       organization_pages: {
+                       content: "dancer",
+                       url_key: "whatevs",
+                       language: "en-CA",
+                       title: "Bester Pager"
+                      }
+      }
+    end
+
+    it_behaves_like "is creatable"
+
+    it 'should set organization from the organization_id param' do
+      default_request scopes: scopes, user_id: authorized_user.id
+      post :create, create_params
+      expect(json_response[api_resource_name][0]["links"]["organization"]).to eq(organization.id.to_s)
+    end
+  end
+
+  describe "#update" do
+    let(:test_attr) { :content }
+    let(:test_attr_value) { "dancer" }
+    let(:update_params) do
+      {
+       organization_id: organization.id,
+       organization_pages: {
+                       content: "dancer",
+                      }
+      }
+    end
+
+    it_behaves_like "is updatable"
+  end
+
+  describe "#destroy" do
+    let(:delete_params) { {organization_id: organization.id} }
+
+    it_behaves_like "is destructable"
+  end
+end

--- a/spec/controllers/api/v1/project_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/project_pages_controller_spec.rb
@@ -105,7 +105,7 @@ describe Api::V1::ProjectPagesController, type: :controller do
       end
 
       it 'should use correct paging links' do
-        expect(json_response["meta"][api_resource_name]["first_href"]).to match(/projects\/[0-9]+\/pages/)
+        expect(json_response["meta"][api_resource_name]["first_href"]).to match(%r{projects/[0-9]+/pages})
       end
     end
   end
@@ -148,7 +148,7 @@ describe Api::V1::ProjectPagesController, type: :controller do
       {
        project_id: project.id,
        project_pages: {
-                       content: "dancer",
+                       content: "dancer"
                       }
       }
     end

--- a/spec/factories/organization_pages.rb
+++ b/spec/factories/organization_pages.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :organization_page do
+    title "Science Case"
+    url_key "science_case"
+    language "en"
+    content "Crap about science"
+    organization
+  end
+end


### PR DESCRIPTION
Adds pages to organizations, just like projects. This is mostly duplicated code from the projects version of pages. I would like to extract it all out and DRY it all up, but with only these two uses it seems a bit like a waste of effort. This was everyone's take when orgs were first dropped in (new controller scheme aside) and it's still true. When something comes along that can make use of this code again, I think that'll be the time.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
