### PR TITLE
Set organization title by display_name param

### DIFF
--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -7,7 +7,6 @@ module Organizations
     string :primary_language
 
     # Organization Contents Fields
-    string :title
     string :description
     string :introduction, default: ''
     array :urls, default: []
@@ -15,7 +14,7 @@ module Organizations
     def execute
       Organization.transaction do
         organization = Organization.new owner: api_user.user, display_name: display_name, primary_language: primary_language
-        param_hash = { title: title, description: description, introduction: introduction }
+        param_hash = { title: display_name, description: description, introduction: introduction }
         param_hash.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
         organization.organization_contents.build param_hash
         organization.save!

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -19,8 +19,11 @@ module Organizations
           end
         end
         organization.update!(org_update.symbolize_keys)
-        organization.organization_contents.find_or_initialize_by(language: language) do |content|
-          content_update.merge! content_from_params(inputs, Api::V1::OrganizationsController::CONTENT_FIELDS)
+        organization.organization_contents.find_or_initialize_by(language: language).tap do |content|
+          results = content_from_params(inputs[:organization_params], Api::V1::OrganizationsController::CONTENT_FIELDS) do |ps|
+            ps["title"] = ps["display_name"]
+          end
+          content_update.merge! results
           content.update! content_update.symbolize_keys
         end
         organization.save!

--- a/app/schemas/organization_update_schema.rb
+++ b/app/schemas/organization_update_schema.rb
@@ -14,11 +14,6 @@ class OrganizationUpdateSchema < JsonSchema
       description "Two character ISO 639 language code, optionally include two character ISO 3166-1 alpha-2 country code seperated by a hyphen for specific locale. ie 'en', 'zh-tw', 'es_MX'"
     end
 
-    property "title" do
-      type "string"
-      description "Translatable name for the project"
-    end
-
     property "description" do
       type "string"
     end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -5,7 +5,7 @@ class OrganizationSerializer
   include MediaLinksSerializer
   include CachedSerializer
 
-  attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language
+  attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language, :listed_at
   optional :avatar_src
   media_include :avatar, :background
   can_include :organization_contents, :organization_roles, :projects, :owners

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -82,7 +82,6 @@ describe Api::V1::OrganizationsController, type: :controller do
         {
           organizations: {
             display_name: "The Illuminati",
-            title: "Come join us",
             description: "This organization is the most organized organization to ever organize",
             urls: [{label: "Blog", url: "http://blogo.com/example"}],
             primary_language: "zh-tw"
@@ -105,14 +104,13 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:resource) { create(:organization, owner: authorized_user) }
         let(:resource_class) { Organization }
         let(:api_resource_name) { "organizations" }
-        let(:api_resource_attributes) { ["display_name", "title", "description"] }
+        let(:api_resource_attributes) { ["display_name", "description"] }
         let(:api_resource_links) { [] }
         let(:update_params) do
           {
             organizations: {
               primary_language: "tw",
               display_name: "Def Not Illuminati",
-              title: "Totally Harmless",
               description: "This Organization is not affiliated with the Illuminati, absolutely not no way",
               urls: [{label: "Blog", url: "http://blogo.com/example"}],
               introduction: "Hello and welcome to Illuminati Headquarters oh wait damn"
@@ -156,6 +154,14 @@ describe Api::V1::OrganizationsController, type: :controller do
           ]
           put :update, params
         end
+      end
+
+      it "updates the title to match the display name" do
+        default_request scopes: scopes, user_id: authorized_user.id
+        organization.save!
+        params = { organizations: { display_name: "Also a title"}, id: organization.id }
+        put :update, params
+        expect(json_response["organizations"].first['title']).to eq("Also a title")
       end
     end
 


### PR DESCRIPTION
Title is no longer a required param for create and is removed from the update schema. It is set to the display name for the content's language.

listed_at is now serialized


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
