### PR TITLE
update retired counts and completeness metrics when linking new data sets

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -87,6 +87,7 @@ class Api::V1::WorkflowsController < Api::ApiController
           NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
         end
       when :subject_sets, 'subject_sets'
+        CalculateProjectCompletenessWorker.perform_async(workflow.project_id)
         NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)
       end
     end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -30,6 +30,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   def update_links
     super do |workflow|
       UnfinishWorkflowWorker.perform_async(workflow.id)
+      WorkflowRetiredCountWorker.perform_async(workflow.id)
       post_link_actions(workflow)
     end
   end
@@ -82,15 +83,12 @@ class Api::V1::WorkflowsController < Api::ApiController
     if workflow.set_member_subjects.exists?
       case relation
       when :retired_subjects, 'retired_subjects'
-        WorkflowRetiredCountWorker.perform_async(workflow.id)
-
         params[:retired_subjects].each do |subject_id|
           NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
         end
       when :subject_sets, 'subject_sets'
         NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)
       end
-
     end
   end
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -357,6 +357,12 @@ describe Api::V1::WorkflowsController, type: :controller do
               expect(UnfinishWorkflowWorker).to receive(:perform_async).with(resource.id)
             end
 
+            it 'should call the workflow retired counter worker' do
+              expect(WorkflowRetiredCountWorker)
+                .to receive(:perform_async)
+                .with(resource.id)
+            end
+
             it 'should notify the subject selector that the available subjects changed' do
               allow_any_instance_of(Workflow)
                 .to receive(:using_cellect?).and_return(true)

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -363,6 +363,12 @@ describe Api::V1::WorkflowsController, type: :controller do
                 .with(resource.id)
             end
 
+            it 'should call the project completeness worker' do
+              expect(CalculateProjectCompletenessWorker)
+                .to receive(:perform_async)
+                .with(resource.project_id)
+            end
+
             it 'should notify the subject selector that the available subjects changed' do
               allow_any_instance_of(Workflow)
                 .to receive(:using_cellect?).and_return(true)


### PR DESCRIPTION
closes #2201 - recount the retired currently linked subjects and recalculate the completeness metrics. This should ensure the stats are updated and the finished banner doesn't show when new data is uploaded after a project finished.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
