### PR TITLE
construct valid refs when there is no page data for classification last_id queries

### DIFF
--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -30,8 +30,8 @@ class ClassificationSerializer
       href_key_ids = { next_href: next_last_id, previous_href: params[:last_id] }
       href_key_ids.map do |href_key, next_id|
         href = page[:meta][:classifications][href_key]
-        updated_last_id_href = href.gsub(/page=\d+/, "last_id=#{next_id}")
-        page[:meta][:classifications][href_key] = updated_last_id_href
+        next unless href
+        page[:meta][:classifications][href_key] = updated_last_id_href(href, next_id)
       end
     end
     page
@@ -54,5 +54,13 @@ class ClassificationSerializer
       href: "/subjects/{#{key}.subjects}"
     }
     links
+  end
+
+  def self.updated_last_id_href(href, next_id)
+    parsed_uri = URI::parse(href)
+    path = parsed_uri.path
+    uri_params = Rack::Utils.parse_nested_query(parsed_uri.query)
+    no_page_href = uri_params.except("page").merge("last_id" => next_id)
+    "#{path}?#{no_page_href.to_query}"
   end
 end

--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -57,7 +57,7 @@ class ClassificationSerializer
   end
 
   def self.updated_last_id_href(href, next_id)
-    parsed_uri = URI::parse(href)
+    parsed_uri = URI.parse(href)
     path = parsed_uri.path
     uri_params = Rack::Utils.parse_nested_query(parsed_uri.query)
     no_page_href = uri_params.except("page").merge("last_id" => next_id)

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -32,15 +32,23 @@ describe ClassificationSerializer do
 
     context "project context with last_id param present" do
       let(:project) { classification.project }
+      let(:last_id) { classification.id }
 
       it "should insert the next hightest last_id into the next_href" do
         second = create(:classification, project: project)
-        last_id = classification.id
         params = {project_id: project.id, last_id: last_id, page_size: 1}
         result = ClassificationSerializer.page(params, Classification.all, {})
         meta = result[:meta][:classifications]
         expect(meta[:previous_href]).to eq("/classifications?last_id=#{last_id}&page_size=1&project_id=#{project.id}")
         expect(meta[:next_href]).to eq("/classifications?last_id=#{second.id}&page_size=1&project_id=#{project.id}")
+      end
+
+      it "should constructu valid hrefs when there is no data" do
+        params = {project_id: project.id, last_id: last_id, page: 2, page_size: 1}
+        result = ClassificationSerializer.page(params, Classification.all, {})
+        meta = result[:meta][:classifications]
+        expect(meta[:previous_href]).to eq("/classifications?last_id=#{last_id}&page_size=1&project_id=#{project.id}")
+        expect(meta[:next_href]).to be_nil
       end
     end
   end


### PR DESCRIPTION
This fixes an error when accessing project classification data using the last_id offset. It now will handle empty pages of data and construct the last_id href without string manipulations.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
