### PR TITLE
Always serialize updated_at if serializing created_at

### DIFF
--- a/app/serializers/classification_serializer.rb
+++ b/app/serializers/classification_serializer.rb
@@ -3,7 +3,7 @@ class ClassificationSerializer
   include NoCountSerializer
   include FilterHasMany
 
-  attributes :id, :annotations, :created_at, :metadata, :href
+  attributes :id, :annotations, :created_at, :updated_at, :metadata, :href
 
   can_include :project, :user, :user_group, :workflow
 

--- a/app/serializers/gold_standard_annotation_serializer.rb
+++ b/app/serializers/gold_standard_annotation_serializer.rb
@@ -3,7 +3,7 @@ class GoldStandardAnnotationSerializer
   include NoCountSerializer
   include CachedSerializer
 
-  attributes :id, :annotations, :created_at, :metadata
+  attributes :id, :annotations, :created_at, :updated_at, :metadata
 
   can_include :project, :user, :workflow
 

--- a/app/serializers/recent_serializer.rb
+++ b/app/serializers/recent_serializer.rb
@@ -2,7 +2,7 @@ class RecentSerializer
   include Serialization::PanoptesRestpack
   include CachedSerializer
 
-  attributes :id, :created_at, :locations, :href
+  attributes :id, :created_at, :updated_at, :locations, :href
   can_include :project, :workflow, :subject
   can_sort_by :created_at
 

--- a/app/serializers/subject_workflow_status_serializer.rb
+++ b/app/serializers/subject_workflow_status_serializer.rb
@@ -3,7 +3,7 @@ class SubjectWorkflowStatusSerializer
   include NoCountSerializer
 
   attributes :id, :classifications_count, :retired_at,
-    :retirement_reason, :updated_at, :created_at, :href
+    :retirement_reason, :created_at, :updated_at, :href
 
   can_include :subject, :workflow
 


### PR DESCRIPTION
We found that classifications weren't serializing the updated_at timestamp. This PR adds that in all instances.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
