### PR TITLE
Etag on create

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::ProjectsController < Api::ApiController
   include Versioned
   include UrlLabels
   include ContentFromParams
+  include MediumResponse
 
   require_authentication :update, :create, :destroy, :create_classifications_export,
     :create_subjects_export, :create_aggregations_export,
@@ -125,12 +126,6 @@ class Api::V1::ProjectsController < Api::ApiController
       @controlled_resources = controlled_resources
       .joins(:tags).where(tags: {name: tags})
     end
-  end
-
-  def medium_response(medium)
-    headers['Location'] = "#{request.protocol}#{request.host_with_port}/api#{medium.location}"
-    headers['Last-Modified'] = medium.updated_at.httpdate
-    json_api_render(:created, MediumSerializer.resource({}, Medium.where(id: medium.id)))
   end
 
   def create_response(projects)

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -3,6 +3,7 @@ require 'model_version'
 class Api::V1::WorkflowsController < Api::ApiController
   include Versioned
   include TranslatableResource
+  include MediumResponse
 
   require_authentication :update, :create, :destroy, :retire_subjects, :create_classifications_export, scopes: [:project]
 
@@ -194,11 +195,5 @@ class Api::V1::WorkflowsController < Api::ApiController
     else
       super
     end
-  end
-
-  def medium_response(medium)
-    headers['Location'] = "#{request.protocol}#{request.host_with_port}/api#{medium.location}"
-    headers['Last-Modified'] = medium.updated_at.httpdate
-    json_api_render(:created, MediumSerializer.resource({}, Medium.where(id: medium.id)))
   end
 end

--- a/app/controllers/concerns/json_api_responses.rb
+++ b/app/controllers/concerns/json_api_responses.rb
@@ -3,6 +3,7 @@ module JSONApiResponses
 
   def created_resource_response(resources)
     scope = resource_scope(resources)
+    response.headers['ETag'] = gen_etag(scope)
     response.headers['Last-Modified'] = scope.maximum(:updated_at).httpdate
     json_api_render(:created,
                     create_response(scope),

--- a/app/controllers/concerns/medium_response.rb
+++ b/app/controllers/concerns/medium_response.rb
@@ -1,0 +1,9 @@
+module MediumResponse
+  def medium_response(medium)
+    scope = Medium.where(id: medium)
+    headers['ETag'] = gen_etag(scope)
+    headers['Location'] = "#{request.protocol}#{request.host_with_port}/api#{medium.location}"
+    headers['Last-Modified'] = medium.updated_at.httpdate
+    json_api_render(:created, MediumSerializer.resource({}, scope))
+  end
+end

--- a/spec/support/creatable.rb
+++ b/spec/support/creatable.rb
@@ -11,6 +11,10 @@ shared_examples "is creatable" do |action=:create|
       expect(response).to have_http_status(:created)
     end
 
+    it 'should have an ETag header' do
+      expect(response.headers.key?('ETag')).to eq(true)
+    end
+
     it 'should create the new resource' do
       field = resource_class.find(created_id).send(test_attr)
 

--- a/spec/support/showable.rb
+++ b/spec/support/showable.rb
@@ -12,6 +12,10 @@ RSpec.shared_examples "is showable" do
     expect(response.status).to eq 200
   end
 
+  it 'should have an ETag header' do
+    expect(response.headers.key?('ETag')).to eq(true)
+  end
+
   it 'should return the requested resource' do
     expect(json_response[api_resource_name].length).to eq 1
     expect(json_response[api_resource_name][0]['id']).to eq(resource.id.to_s)


### PR DESCRIPTION
linked to #https://github.com/zooniverse/panoptes-python-client/issues/83

add the resource etag on create actions to avoid an extra lookup to manipulate the resource. This etag should be the same as a subsequent get etag as long as the cache key hasn't changed.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
