### PR TITLE
Adds a description text field to collections

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::CollectionsController < Api::ApiController
   resource_actions :default
   schema_type :strong_params
 
-  allowed_params :create, :name, :display_name, :private, :favorite,
+  allowed_params :create, :name, :display_name, :private, :favorite, :description,
     links: [ :default_subject, :project, projects: [], subjects: [], owner: polymorphic ]
 
   allowed_params :update, :name, :display_name, :private, links: [ :default_subject, subjects: [] ]

--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -6,7 +6,7 @@ class CollectionSerializer
   include CachedSerializer
 
   attributes :id, :name, :display_name, :created_at, :updated_at,
-    :slug, :href, :favorite, :private, :default_subject_src
+    :slug, :href, :favorite, :private, :default_subject_src, :description
 
   # Do not include the BelongsToMany :projects relation
   # as this can't be preloaded (custom AR relation)

--- a/db/migrate/20170519181110_add_description_to_collections.rb
+++ b/db/migrate/20170519181110_add_description_to_collections.rb
@@ -1,6 +1,7 @@
 class AddDescriptionToCollections < ActiveRecord::Migration
   def change
-    add_column :collections, :description, :text, default: ""
-    Collection.update_all(display_name: "")
+    add_column :collections, :description, :text
+    Collection.update_all(description: "")
+    change_column_default(:collections, :description, "")
   end
 end

--- a/db/migrate/20170519181110_add_description_to_collections.rb
+++ b/db/migrate/20170519181110_add_description_to_collections.rb
@@ -1,0 +1,6 @@
+class AddDescriptionToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :description, :text, default: ""
+    Collection.update_all(display_name: "")
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -258,7 +258,8 @@ CREATE TABLE collections (
     slug character varying DEFAULT ''::character varying,
     favorite boolean DEFAULT false NOT NULL,
     project_ids integer[] DEFAULT '{}'::integer[],
-    default_subject_id integer
+    default_subject_id integer,
+    description text DEFAULT ''::text
 );
 
 
@@ -3935,4 +3936,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170420095703');
 INSERT INTO schema_migrations (version) VALUES ('20170425110939');
 
 INSERT INTO schema_migrations (version) VALUES ('20170426162708');
+
+INSERT INTO schema_migrations (version) VALUES ('20170519181110');
 

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -7,7 +7,7 @@ describe Api::V1::CollectionsController, type: :controller do
   let(:project) { collection.projects.sample }
   let(:api_resource_name) { 'collections' }
 
-  let(:api_resource_attributes) { %w(id name display_name created_at updated_at favorite private) }
+  let(:api_resource_attributes) { %w(id name display_name created_at updated_at favorite private description) }
   let(:api_resource_links) { %w(collections.projects collections.owner collections.collection_roles collections.subjects) }
 
   let(:scopes) { %w(public collection) }
@@ -153,6 +153,7 @@ describe Api::V1::CollectionsController, type: :controller do
                      name: 'test__collection',
                      display_name: 'Fancy name',
                      private: false,
+                     description: "Such a good collection, the best, amazing",
                      links: create_links
                     }
       }

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     end
     sequence(:name) { |n| "collection_name_#{ n }" }
     sequence(:display_name) { |n| "another name #{ n }" }
+    sequence(:description) { |n| "This collection is SO GOOD, it is #{ n } times better than any other" }
     activated_state :active
     private false
 


### PR DESCRIPTION
The only thing here is the `default: ""` and subsequent `Collection.update_all(display_name: "")`. There are 60k of them and so I think this should be fine, but if anyone's worried, maybe there's in a more forgiving way.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
