### PR TITLE
Optionally include Pages in serialized organizations

### DIFF
--- a/app/controllers/api/v1/organization_pages_controller.rb
+++ b/app/controllers/api/v1/organization_pages_controller.rb
@@ -1,17 +1,4 @@
 class Api::V1::OrganizationPagesController < Api::ApiController
+  PARENT_RESOURCE = :organization
   include Pages
-
-  require_authentication :update, :create, :destroy, scopes: [:organization]
-
-  def parent_resource
-    :organization
-  end
-
-  def resource_id
-    params[:organization_id]
-  end
-
-  def resource_name
-    "organization_page"
-  end
 end

--- a/app/controllers/api/v1/organization_pages_controller.rb
+++ b/app/controllers/api/v1/organization_pages_controller.rb
@@ -1,4 +1,4 @@
 class Api::V1::OrganizationPagesController < Api::ApiController
-  PARENT_RESOURCE = :organization.freeze
+  PARENT_RESOURCE = :organization
   include Pages
 end

--- a/app/controllers/api/v1/organization_pages_controller.rb
+++ b/app/controllers/api/v1/organization_pages_controller.rb
@@ -1,4 +1,4 @@
 class Api::V1::OrganizationPagesController < Api::ApiController
-  PARENT_RESOURCE = :organization
+  PARENT_RESOURCE = :organization.freeze
   include Pages
 end

--- a/app/controllers/api/v1/organization_pages_controller.rb
+++ b/app/controllers/api/v1/organization_pages_controller.rb
@@ -1,33 +1,17 @@
 class Api::V1::OrganizationPagesController < Api::ApiController
+  include Pages
+
   require_authentication :update, :create, :destroy, scopes: [:organization]
 
-  resource_actions :default
-
-  schema_type :strong_params
-
-  allowed_params :create, :url_key, :title, :content, :language
-  allowed_params :update, :url_key, :title, :content, :language
-
-  before_filter :set_language_from_header, only: [:index]
-
-  def controlled_resources
-    @controlled_resouces ||= super.where(organization: params[:organization_id])
+  def parent_resource
+    :organization
   end
 
-  protected
-
-  def build_resource_for_create(create_params)
-    create_params[:links] ||= {}
-    create_params[:links][:organization] = params[:organization_id]
-    super create_params
+  def resource_id
+    params[:organization_id]
   end
 
-  def link_header(resource)
-    resource = resource.first
-    send(:"api_#{ resource_name }_url", id: resource.id, organization_id: resource.organization_id)
-  end
-
-  def set_language_from_header
-    params[:language] = "en"
+  def resource_name
+    "organization_page"
   end
 end

--- a/app/controllers/api/v1/project_pages_controller.rb
+++ b/app/controllers/api/v1/project_pages_controller.rb
@@ -1,17 +1,4 @@
 class Api::V1::ProjectPagesController < Api::ApiController
+  PARENT_RESOURCE = :project
   include Pages
-
-  require_authentication :update, :create, :destroy, scopes: [:project]
-
-  def parent_resource
-    :project
-  end
-
-  def resource_id
-    params[:project_id]
-  end
-
-  def resource_name
-    "project_page"
-  end
 end

--- a/app/controllers/api/v1/project_pages_controller.rb
+++ b/app/controllers/api/v1/project_pages_controller.rb
@@ -1,4 +1,4 @@
 class Api::V1::ProjectPagesController < Api::ApiController
-  PARENT_RESOURCE = :project.freeze
+  PARENT_RESOURCE = :project
   include Pages
 end

--- a/app/controllers/api/v1/project_pages_controller.rb
+++ b/app/controllers/api/v1/project_pages_controller.rb
@@ -1,4 +1,4 @@
 class Api::V1::ProjectPagesController < Api::ApiController
-  PARENT_RESOURCE = :project
+  PARENT_RESOURCE = :project.freeze
   include Pages
 end

--- a/app/controllers/api/v1/project_pages_controller.rb
+++ b/app/controllers/api/v1/project_pages_controller.rb
@@ -1,33 +1,17 @@
 class Api::V1::ProjectPagesController < Api::ApiController
+  include Pages
+
   require_authentication :update, :create, :destroy, scopes: [:project]
 
-  resource_actions :default
-
-  schema_type :strong_params
-
-  allowed_params :create, :url_key, :title, :content, :language
-  allowed_params :update, :url_key, :title, :content, :language
-
-  before_filter :set_language_from_header, only: [:index]
-
-  def controlled_resources
-    @controlled_resouces ||= super.where(project: params[:project_id])
+  def parent_resource
+    :project
   end
 
-  protected
-
-  def build_resource_for_create(create_params)
-    create_params[:links] ||= {}
-    create_params[:links][:project] = params[:project_id]
-    super create_params
+  def resource_id
+    params[:project_id]
   end
 
-  def link_header(resource)
-    resource = resource.first
-    send(:"api_#{ resource_name }_url", id: resource.id, project_id: resource.project_id)
-  end
-
-  def set_language_from_header
-    params[:language] = "en"
+  def resource_name
+    "project_page"
   end
 end

--- a/app/controllers/concerns/pages.rb
+++ b/app/controllers/concerns/pages.rb
@@ -11,6 +11,7 @@ module Pages
 
     before_filter :set_language_from_header, only: [:index]
 
+    # Methods defined here in order to avoid being overridden by resource modules
     define_method(:link_header) do |resource|
       resource = resource.first
       send(:"api_#{ resource_name }_url", id: resource.id, "#{parent_resource}_id": resource_id)
@@ -21,10 +22,24 @@ module Pages
       create_params[:links][parent_resource] = resource_id
       super create_params
     end
+
+    require_authentication :update, :create, :destroy, scopes: [:"#{self::PARENT_RESOURCE}"]
   end
 
   def controlled_resources
     @controlled_resouces ||= super.where("#{parent_resource}": resource_id)
+  end
+
+  def parent_resource
+    self.class::PARENT_RESOURCE
+  end
+
+  def resource_name
+    @resource_name ||= controller_name.singularize
+  end
+
+  def resource_id
+    params[:"#{parent_resource}_id"]
   end
 
   protected

--- a/app/controllers/concerns/pages.rb
+++ b/app/controllers/concerns/pages.rb
@@ -1,0 +1,43 @@
+module Pages
+  extend ActiveSupport::Concern
+
+  included do
+    resource_actions :default
+
+    schema_type :strong_params
+
+    allowed_params :create, :url_key, :title, :content, :language
+    allowed_params :update, :url_key, :title, :content, :language
+
+    before_filter :set_language_from_header, only: [:index]
+
+    define_method(:link_header) do |resource|
+      resource = resource.first
+      send(:"api_#{ resource_name }_url", id: resource.id, "#{parent_resource}_id": resource_id)
+    end
+
+    define_method(:build_resource_for_create) do |create_params|
+      create_params[:links] ||= {}
+      create_params[:links][parent_resource] = resource_id
+      super create_params
+    end
+  end
+
+  def serializer
+    @serializer ||= "#{resource_name.camelize}Serializer".constantize
+  end
+
+  def controlled_resources
+    @controlled_resouces ||= super.where("#{parent_resource}": resource_id)
+  end
+
+  protected
+
+  def set_language_from_header
+    params[:language] = "en"
+  end
+
+  def serializer
+    @serializer ||= "#{resource_name.camelize}Serializer".constantize
+  end
+end

--- a/app/controllers/concerns/pages.rb
+++ b/app/controllers/concerns/pages.rb
@@ -23,10 +23,6 @@ module Pages
     end
   end
 
-  def serializer
-    @serializer ||= "#{resource_name.camelize}Serializer".constantize
-  end
-
   def controlled_resources
     @controlled_resouces ||= super.where("#{parent_resource}": resource_id)
   end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -8,7 +8,7 @@ class OrganizationSerializer
   attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language, :listed_at
   optional :avatar_src
   media_include :avatar, :background
-  can_include :organization_contents, :organization_roles, :projects, :owners
+  can_include :organization_contents, :organization_roles, :projects, :owners, :pages
   can_sort_by :display_name, :updated_at, :listed_at
 
   def title
@@ -37,5 +37,14 @@ class OrganizationSerializer
 
   def fields
     %i(title description introduction)
+  end
+
+  def self.links
+    links = super
+    links["organizations.pages"] = {
+                               href: "/organizations/{organizations.id}/pages",
+                               type: "organization_pages"
+                              }
+    links
   end
 end


### PR DESCRIPTION
Reference: #2318 

Just stuck pages into the org serializer's can_include. Index methods aren't authenticated and therefore won't show you pages from private projects or orgs.

EXTRA CREDIT: I took the opportunity to actually extract out the page controller stuff from the org and project controllers into it's own concern. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
