### PR TITLE
remove duplicate indexes

### DIFF
--- a/db/migrate/20170523135118_remove_dup_indexes_use_compounds.rb
+++ b/db/migrate/20170523135118_remove_dup_indexes_use_compounds.rb
@@ -1,0 +1,27 @@
+class RemoveDupIndexesUseCompounds < ActiveRecord::Migration
+  def change
+    if index_exists?(:classification_subjects, :classification_id)
+      remove_index :classification_subjects, column: :classification_id
+    end
+
+    if index_exists?(:memberships, :user_group_id)
+      remove_index :memberships, column: :user_group_id
+    end
+
+    if index_exists?(:set_member_subjects, :subject_id)
+      remove_index :set_member_subjects, column: :subject_id
+    end
+
+    if index_exists?(:subject_sets_workflows, :workflow_id)
+      remove_index :subject_sets_workflows, column: :workflow_id
+    end
+
+    if index_exists?(:subject_workflow_counts, :subject_id)
+      remove_index :subject_workflow_counts, column: :subject_id
+    end
+
+    if index_exists?(:workflow_tutorials, :workflow_id)
+      remove_index :workflow_tutorials, column: :workflow_id
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2254,13 +2254,6 @@ CREATE INDEX index_authorizations_on_user_id ON authorizations USING btree (user
 
 
 --
--- Name: index_classification_subjects_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_classification_subjects_on_classification_id ON classification_subjects USING btree (classification_id);
-
-
---
 -- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2433,13 +2426,6 @@ CREATE INDEX index_media_on_linked_id_and_linked_type ON media USING btree (link
 --
 
 CREATE INDEX index_media_on_type ON media USING btree (type);
-
-
---
--- Name: index_memberships_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_memberships_on_user_group_id ON memberships USING btree (user_group_id);
 
 
 --
@@ -2716,13 +2702,6 @@ CREATE INDEX index_set_member_subjects_on_random ON set_member_subjects USING bt
 
 
 --
--- Name: index_set_member_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_set_member_subjects_on_subject_id ON set_member_subjects USING btree (subject_id);
-
-
---
 -- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2758,24 +2737,10 @@ CREATE INDEX index_subject_sets_workflows_on_subject_set_id ON subject_sets_work
 
 
 --
--- Name: index_subject_sets_workflows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_subject_sets_workflows_on_workflow_id ON subject_sets_workflows USING btree (workflow_id);
-
-
---
 -- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_subject_sets_workflows_on_workflow_id_and_subject_set_id ON subject_sets_workflows USING btree (workflow_id, subject_set_id);
-
-
---
--- Name: index_subject_workflow_counts_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_subject_workflow_counts_on_subject_id ON subject_workflow_counts USING btree (subject_id);
 
 
 --
@@ -3021,13 +2986,6 @@ CREATE INDEX index_workflow_contents_on_workflow_id ON workflow_contents USING b
 --
 
 CREATE INDEX index_workflow_tutorials_on_tutorial_id ON workflow_tutorials USING btree (tutorial_id);
-
-
---
--- Name: index_workflow_tutorials_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_workflow_tutorials_on_workflow_id ON workflow_tutorials USING btree (workflow_id);
 
 
 --
@@ -3935,4 +3893,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170420095703');
 INSERT INTO schema_migrations (version) VALUES ('20170425110939');
 
 INSERT INTO schema_migrations (version) VALUES ('20170426162708');
+
+INSERT INTO schema_migrations (version) VALUES ('20170523135118');
 


### PR DESCRIPTION
use first col of compound indexes and remove the single column indexes where we can

I'd like to test this in staging and if you all feel strongly maybe against a production version with some timing tests. The query planner should be able to use the compound indexes if the first column is a match instead of the separate indexes. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
