### PR TITLE
Adds boolean to Organizations that touches/nulls listed_at on update

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -5,8 +5,8 @@ class Organization < ActiveRecord::Base
   include Linkable
   include Translatable
 
-  scope :public_scope, -> { where.not(listed_at: nil) }
-  scope :private_scope, -> { where(listed_at: nil) }
+  scope :public_scope, -> { where(listed: true) }
+  scope :private_scope, -> { where(listed: false) }
 
   has_many :projects
   has_many :acls, class_name: "AccessControlList", as: :resource, dependent: :destroy

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -26,7 +26,7 @@ module Organizations
           content_update.merge! results
           content.update! content_update.symbolize_keys
         end
-        organization.listed ? organization.touch(:listed_at) : organization[:listed_at] = nil
+        org_update[:listed] == true ? organization.touch(:listed_at) : organization[:listed_at] = nil
         organization.save!
       end
     end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -26,6 +26,7 @@ module Organizations
           content_update.merge! results
           content.update! content_update.symbolize_keys
         end
+        organization.listed ? organization.touch(:listed_at) : organization[:listed_at] = nil
         organization.save!
       end
     end

--- a/app/schemas/organization_update_schema.rb
+++ b/app/schemas/organization_update_schema.rb
@@ -26,6 +26,10 @@ class OrganizationUpdateSchema < JsonSchema
        type "string"
     end
 
+    property "listed" do
+      type "boolean"
+    end
+
     property "urls" do
       type "array"
       items do

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -5,11 +5,11 @@ class OrganizationSerializer
   include MediaLinksSerializer
   include CachedSerializer
 
-  attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language, :listed_at
+  attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language, :listed_at, :listed
   optional :avatar_src
   media_include :avatar, :background
   can_include :organization_contents, :organization_roles, :projects, :owners
-  can_sort_by :display_name, :updated_at, :listed_at
+  can_sort_by :display_name, :updated_at, :listed
 
   def title
     content[:title]

--- a/db/migrate/20170524210302_add_listed_boolean_to_organizations.rb
+++ b/db/migrate/20170524210302_add_listed_boolean_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddListedBooleanToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :listed, :boolean, index: true, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -717,7 +717,8 @@ CREATE TABLE organizations (
     activated_state integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    urls jsonb DEFAULT '[]'::jsonb
+    urls jsonb DEFAULT '[]'::jsonb,
+    listed boolean DEFAULT false NOT NULL
 );
 
 
@@ -2513,6 +2514,13 @@ CREATE INDEX index_organizations_on_display_name ON organizations USING btree (d
 
 
 --
+-- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_organizations_on_listed ON organizations USING btree (listed);
+
+
+--
 -- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3895,4 +3903,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170425110939');
 INSERT INTO schema_migrations (version) VALUES ('20170426162708');
 
 INSERT INTO schema_migrations (version) VALUES ('20170523135118');
+
+INSERT INTO schema_migrations (version) VALUES ('20170524210302');
 

--- a/spec/controllers/api/v1/organization_contents_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_contents_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::OrganizationContentsController, type: :controller do
     let(:acl_roles) { %w(collaborator) }
 
     let!(:private_resource) do
-      create(:organization, listed_at: nil).organization_contents.first
+      create(:unlisted_organization).organization_contents.first
     end
 
     before { acl }

--- a/spec/controllers/api/v1/organization_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_roles_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::V1::OrganizationRolesController, type: :controller do
   let(:resource_class) { AccessControlList }
 
   describe "#index" do
-    let!(:private_resource) { create(:access_control_list, resource: create(:organization, listed_at: nil)) }
+    let!(:private_resource) { create(:access_control_list, resource: create(:unlisted_organization)) }
     let(:n_visible) { 3 }
 
     it_behaves_like "it has custom owner links"

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Api::V1::OrganizationsController, type: :controller do
   let(:authorized_user) { create(:user) }
   let(:organization) { build(:organization, listed_at: Time.now, owner: authorized_user) }
-  let(:unlisted_organization) { build(:organization, listed_at: nil) }
-  let(:owned_unlisted_organization) { build(:organization, listed_at: nil, owner: authorized_user) }
+  let(:unlisted_organization) { build(:unlisted_organization) }
+  let(:owned_unlisted_organization) { build(:unlisted_organization, owner: authorized_user) }
 
   let(:scopes) { %w(public organization) }
 
@@ -162,6 +162,22 @@ describe Api::V1::OrganizationsController, type: :controller do
         params = { organizations: { display_name: "Also a title"}, id: organization.id }
         put :update, params
         expect(json_response["organizations"].first['title']).to eq("Also a title")
+      end
+
+      it "touches listed_at if listed is true" do
+        default_request scopes: scopes, user_id: authorized_user.id
+        organization.update_attributes({listed: false, listed_at: nil})
+        params = { organizations: { listed: true }, id: organization.id }
+        put :update, params
+        expect(json_response["organizations"].first['listed_at']).to be_truthy
+      end
+
+      it "nulls listed_at if listed is false" do
+        default_request scopes: scopes, user_id: authorized_user.id
+        organization.update_attributes({listed: true, listed_at: Time.now })
+        params = { organizations: { listed: false }, id: organization.id }
+        put :update, params
+        expect(json_response["organizations"].first['listed_at']).to be_nil
       end
     end
 

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
 
     sequence(:display_name) { |n| "Test Organization #{ n }" }
     listed_at Time.now
+    listed true
     primary_language "en"
     urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
 
@@ -22,6 +23,11 @@ FactoryGirl.define do
         o.avatar = create(:medium, type: "organization_avatar", linked: o)
         o.background = create(:medium, type: "organization_background", linked: o)
       end
+    end
+
+    factory :unlisted_organization do
+      listed_at nil
+      listed false
     end
   end
 end


### PR DESCRIPTION
Having a timestamp field for public/private seemed like a good idea, but Restpack isn't having it. You can't filter by anything you can't put after an equals sign. So I added a `listed` boolean to Organizations and set up the controller to touch the `listed_at` timestamp on update when `listed` is present in the params and true and nil it when false.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
