### PR TITLE
rebuild the oauth access token index

### DIFF
--- a/db/migrate/20170525151142_rebuild_oauth_token_index.rb
+++ b/db/migrate/20170525151142_rebuild_oauth_token_index.rb
@@ -1,0 +1,8 @@
+class RebuildOauthTokenIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    remove_index :oauth_access_tokens, column: :token, unique: true
+    add_index :oauth_access_tokens, :token, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3898,3 +3898,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170426162708');
 INSERT INTO schema_migrations (version) VALUES ('20170519181110');
 
 INSERT INTO schema_migrations (version) VALUES ('20170523135118');
+
+INSERT INTO schema_migrations (version) VALUES ('20170525151142');
+


### PR DESCRIPTION
ensure this is run after cleaning up the table so the index can build quickly.

Only merge / deploy this after #2329 has been deployed and taken effect to cleanup the table space. Check the index size after cleanup and see how it looks.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
