### PR TITLE
Saves all orgs to ensure non-blank slug attributes before adding unique index

### DIFF
--- a/db/migrate/20170524205300_add_index_to_organization_slug.rb
+++ b/db/migrate/20170524205300_add_index_to_organization_slug.rb
@@ -1,5 +1,7 @@
 class AddIndexToOrganizationSlug < ActiveRecord::Migration
   def change
+    # Ensure that all slugs are populated by acts_as_url callback
+    Organization.all.each(&:save)
     add_index :organizations, :slug, unique: true
   end
 end


### PR DESCRIPTION
I did this on the console to ensure that it would work, this will make sure that future from-scratch migrations won't have the same issue.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
