### PR TITLE
Add param to include avatar in serializer context

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1068,7 +1068,6 @@ It has the following attributes:
 - beta
 - approved
 - live
-- avatar_src (optional)
 
 *id*, *created_at*, *updated_at*, *user_count*, and
 *classifications_count* are set by the API.
@@ -1079,7 +1078,6 @@ It has the following attributes:
   + approved (boolean) ... approved state filter
   + beta (boolean) ... beta state filter
   + live (boolean) ... live state filter
-  + avatar_src (boolean) ... include optional `avatar_src` attribute
 
 + Model
 
@@ -1130,7 +1128,6 @@ It has the following attributes:
                     }],
                     "science_case": "88mph + 1.21 GW = 1955",
                     "introduction": "asdfasdf",
-                    "avatar": "http://test.host/x02234.png",
                     "background_image": "http://test.host/12312asd.jp2",
                     "private": false,
                     "faq": "This project uses..",

--- a/apiary.apib
+++ b/apiary.apib
@@ -1068,6 +1068,7 @@ It has the following attributes:
 - beta
 - approved
 - live
+- avatar_src (optional)
 
 *id*, *created_at*, *updated_at*, *user_count*, and
 *classifications_count* are set by the API.
@@ -1078,6 +1079,7 @@ It has the following attributes:
   + approved (boolean) ... approved state filter
   + beta (boolean) ... beta state filter
   + live (boolean) ... live state filter
+  + avatar_src (boolean) ... include optional `avatar_src` attribute
 
 + Model
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -195,6 +195,8 @@ class Api::V1::ProjectsController < Api::ApiController
           context["include_#{k}?".to_sym] = false
         end
       end
+    elsif params[:avatar_src]
+      {include_avatar_src?: true}
     else
       super
     end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -32,6 +32,7 @@ class Api::V1::ProjectsController < Api::ApiController
                  :slug,
                  :redirect,
                  :avatar_src,
+                 :classifications_count,
                  :updated_at].freeze
 
   before_action :filter_by_tags, only: :index
@@ -195,8 +196,6 @@ class Api::V1::ProjectsController < Api::ApiController
           context["include_#{k}?".to_sym] = false
         end
       end
-    elsif params[:avatar_src]
-      {include_avatar_src?: true}
     else
       super
     end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -109,7 +109,7 @@ describe Api::V1::ProjectsController, type: :controller do
         describe "cards only" do
           let(:index_options) { { cards: true } }
           let(:card_attrs) do
-            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at"]
+            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at", "classifications_count"]
           end
 
           it "should return only serialise the card data" do


### PR DESCRIPTION
Avatar URL is an optional attribute on the project serializer. However, there was no way to indicate via param that it should be included. Now there is.

Sarah and I were working on reduxifying watch.zooniverse.org and we need the avatar--but we also need classification, which isn't included in the 'card' serialization method.

I thought about taking the opportunity to switch to PanoptesRestpack on the project serializer, but it occurred to me that I don't really know what the difference is supposed to be. This works with both.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
