### PR TITLE
Fix renamed classes in migrations

### DIFF
--- a/db/migrate/20150427171257_create_subject_workflow_counts.rb
+++ b/db/migrate/20150427171257_create_subject_workflow_counts.rb
@@ -10,7 +10,7 @@ class CreateSubjectWorkflowCounts < ActiveRecord::Migration
 
     SetMemberSubject.find_each do |sms|
       (sms.subject_set.try(:workflows) || []).each do |w|
-        SubjectWorkflowCount.create!(set_member_subject: sms, workflow: w, classifications_count: sms.classification_count)
+        SubjectWorkflowStatus.create!(set_member_subject: sms, workflow: w, classifications_count: sms.classification_count)
       end
     end
 

--- a/db/migrate/20160613075003_foreign_keys_workflows.rb
+++ b/db/migrate/20160613075003_foreign_keys_workflows.rb
@@ -1,7 +1,7 @@
 class ForeignKeysWorkflows < ActiveRecord::Migration
   def change
     workflow_ids = Workflow.joins("LEFT OUTER JOIN projects ON projects.id = workflows.project_id").where("workflows.project_id IS NOT NULL AND projects.id IS NULL").pluck("workflows.id")
-    SubjectWorkflowCount.where(workflow_id: workflow_ids).delete_all
+    SubjectWorkflowStatus.where(workflow_id: workflow_ids).delete_all
     Workflow.where(id: workflow_ids).delete_all
     add_foreign_key :workflows, :projects, on_update: :cascade, on_delete: :restrict
     add_foreign_key :workflows, :subjects, column: :tutorial_subject_id, on_update: :cascade, on_delete: :restrict

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1104,7 +1104,7 @@ CREATE TABLE subjects (
     migrated boolean,
     lock_version integer DEFAULT 0,
     upload_user_id integer,
-    activated_state integer DEFAULT 0
+    activated_state integer DEFAULT 0 NOT NULL
 );
 
 
@@ -3910,13 +3910,13 @@ INSERT INTO schema_migrations (version) VALUES ('20170425110939');
 
 INSERT INTO schema_migrations (version) VALUES ('20170426162708');
 
-INSERT INTO schema_migrations (version) VALUES ('20170519181110');
-
-INSERT INTO schema_migrations (version) VALUES ('20170523135118');
-
 INSERT INTO schema_migrations (version) VALUES ('20170524205300');
 
+INSERT INTO schema_migrations (version) VALUES ('20170519181110');
+
 INSERT INTO schema_migrations (version) VALUES ('20170524210302');
+
+INSERT INTO schema_migrations (version) VALUES ('20170523135118');
 
 INSERT INTO schema_migrations (version) VALUES ('20170525151142');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1104,7 +1104,7 @@ CREATE TABLE subjects (
     migrated boolean,
     lock_version integer DEFAULT 0,
     upload_user_id integer,
-    activated_state integer DEFAULT 0 NOT NULL
+    activated_state integer DEFAULT 0
 );
 
 
@@ -3910,13 +3910,13 @@ INSERT INTO schema_migrations (version) VALUES ('20170425110939');
 
 INSERT INTO schema_migrations (version) VALUES ('20170426162708');
 
-INSERT INTO schema_migrations (version) VALUES ('20170524205300');
-
 INSERT INTO schema_migrations (version) VALUES ('20170519181110');
 
-INSERT INTO schema_migrations (version) VALUES ('20170524210302');
-
 INSERT INTO schema_migrations (version) VALUES ('20170523135118');
+
+INSERT INTO schema_migrations (version) VALUES ('20170524205300');
+
+INSERT INTO schema_migrations (version) VALUES ('20170524210302');
 
 INSERT INTO schema_migrations (version) VALUES ('20170525151142');
 


### PR DESCRIPTION
Migrations via `db:migrate` (rather than `db:setup`, which pulls directly from structure.rb) were broken because of the renaming of `SubjectWorkflowCount` to `SubjectWorkflowStatus`. 

Renamed!

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
