### PR TITLE
serialise the tag names array in project tags attribute

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -115,7 +115,7 @@ class ProjectSerializer
     if @model.tags.loaded?
       @model.tags.map(&:name)
     else
-      @model.tags.pluck(&:name)
+      @model.tags.pluck(:name)
     end
   end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -153,4 +153,19 @@ describe ProjectSerializer do
       expect(serialized[:projects][0][:links][:active_workflows]).to contain_exactly(active_workflow.id.to_s)
     end
   end
+
+  describe "tags" do
+    let(:tag) { create(:tag) }
+    let(:project) { tag.tagged_resources.first.resource }
+    let(:tag_names){ [ tag.name ]}
+
+    it "should only return the tag strings array" do
+      expect(serializer.tags).to eq(tag_names)
+    end
+
+    it "should only return the tag strings array when preloaded" do
+      project.tags
+      expect(serializer.tags).to eq(tag_names)
+    end
+  end
 end


### PR DESCRIPTION
fixes #2375 - serializer the tag names only in the project tags attribute.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
