### PR TITLE
[WIP] add code to correctly change a project owner

### DIFF
--- a/lib/role_control/owned.rb
+++ b/lib/role_control/owned.rb
@@ -30,6 +30,8 @@ module RoleControl
                        when UserGroup
                          o
                        end
+        # TODO: todo update an existing ACL if there is one
+        # on this resource instead of trying to build a new invalid one
         build_owner_control_list(user_group: owning_group, roles: ["owner"])
         super(owning_group)
       end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -10,10 +10,12 @@ describe Project, type: :model do
     let(:locked_update) { {display_name: "A Different Name"} }
   end
 
+context "test owner updates", :focus do
   it_behaves_like "is ownable" do
     let(:owned) { project }
     let(:not_owned) { build(:project, owner: nil) }
   end
+end
 
   it_behaves_like "has subject_count"
 

--- a/spec/support/ownable.rb
+++ b/spec/support/ownable.rb
@@ -26,4 +26,22 @@ shared_examples "is ownable" do
       expect(owned.owner?(not_the_owner)).to be_falsy
     end
   end
+
+  describe "#owner=" do
+    let(:new_owner) { create(:user) }
+    let!(:old_owner) { owned.owner }
+
+    it "should change the owner of a resource" do
+      owned.owner = new_owner
+      expect(owned.owner?(new_owner)).to be_truthy
+    end
+
+    it "should remove the old owner acl" do
+      owned.save
+      old_owner_acl = owned.owner_control_list
+      owned.owner = new_owner
+      expect(owned.owner?(@old_owner)).to be_falsy
+      expect{old_owner_acl.reload}.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end

--- a/spec/support/ownable.rb
+++ b/spec/support/ownable.rb
@@ -36,12 +36,22 @@ shared_examples "is ownable" do
       expect(owned.owner?(new_owner)).to be_truthy
     end
 
-    it "should remove the old owner acl" do
-      owned.save
-      old_owner_acl = owned.owner_control_list
-      owned.owner = new_owner
-      expect(owned.owner?(@old_owner)).to be_falsy
-      expect{old_owner_acl.reload}.to raise_error(ActiveRecord::RecordNotFound)
+    # it "should remove the old owner acl" do
+    #   owned.save
+    #   old_owner_acl = owned.owner_control_list
+    #   owned.owner = new_owner
+    #   expect(owned.owner?(@old_owner)).to be_falsy
+    #   expect{old_owner_acl.reload}.to raise_error(ActiveRecord::RecordNotFound)
+    # end
+
+    context "changing owner to an existing collaborator" do
+      it "should not fail to assign the new owner" do
+        owned.save
+        create(:access_control_list, resource: owned, user_group: new_owner.identity_group)
+        owned.owner = new_owner
+        binding.pry
+        expect(owned.reload.owner?(new_owner)).to be_truthy
+      end
     end
   end
 end

--- a/spec/support/ownable.rb
+++ b/spec/support/ownable.rb
@@ -45,12 +45,18 @@ shared_examples "is ownable" do
     # end
 
     context "changing owner to an existing collaborator" do
-      it "should not fail to assign the new owner" do
+      before do
         owned.save
         create(:access_control_list, resource: owned, user_group: new_owner.identity_group)
         owned.owner = new_owner
-        binding.pry
+      end
+
+      it "should assign the new owner" do
         expect(owned.reload.owner?(new_owner)).to be_truthy
+      end
+
+      it "should change the exising ACL from collab to owner" do
+        pending
       end
     end
   end


### PR DESCRIPTION
Make this an explicit method on project and a rake task that can be called. 

# Todo
- [ ] Add change_owner method to project.rb
- [ ] Add rake task AND/OR expose via admin only API

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
