### PR TITLE
Clean old tmp files on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,13 @@ FROM ruby:2.4
 WORKDIR /rails_app
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git curl supervisor libpq-dev && \
+    apt-get install --no-install-recommends -y \
+        git \
+        curl \
+        supervisor \
+        libpq-dev \
+        tmpreaper \
+        && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir config && curl "https://ip-ranges.amazonaws.com/ip-ranges.json" > config/aws_ips.json

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -7,6 +7,8 @@ then
     ln -sf /rails_conf/* ./config/
 fi
 
+tmpreaper 7d /tmp/
+
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 


### PR DESCRIPTION
`/tmp` is now mounted from EFS to remove storage limits for exports. This means any orphaned files will persist indefinitely unless we remove them.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.