### PR TITLE
handle invalid combo task annotations in csv formatter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -212,3 +212,9 @@ Style/FrozenStringLiteralComment:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
   Enabled: false
+Style/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'test/**/*.rb'
+    - 'spec/**/*.rb'

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -68,7 +68,7 @@ module Formatter
           new_anno['task'] = annotation['task']
           new_anno['task_label'] = nil
           new_anno['value'] ||= []
-          annotation['value'].each do |subtask|
+          Array.wrap(annotation['value']).each do |subtask|
             @current = subtask
             task_info = get_task_info(subtask)
             new_anno['value'].push case task_info['type']
@@ -181,6 +181,8 @@ module Formatter
         workflow_at_version.tasks.find do |key, task|
          key == subtask["task"]
         end.try(:last) || {}
+      rescue
+        {}
       end
 
       def task

--- a/spec/factories/workflow_contents.rb
+++ b/spec/factories/workflow_contents.rb
@@ -58,5 +58,17 @@ FactoryGirl.define do
         "T1.help"=>"this is a survey",
       })
     end
+
+    trait :combo_task do
+      strings({
+        "T1.help"=>"Just pick a fruit already",
+        "T1.instruction"=>"Tell me a secret.",
+        "T2.help"=>"Help is needed here I see",
+        "T2.question"=>"Choose one of the labels",
+        "T2.answers.0.label"=>"I'm positive.",
+        "T2.answers.1.label"=>"Well now I'm second guessing myself",
+        "T2.answers.2.label"=>"Has to be the correct one, for sure...right"
+      })
+    end
   end
 end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -220,6 +220,32 @@ FactoryGirl.define do
         })
     end
 
+    trait :combo_task do
+      display_name "Combo Task Workflow"
+      first_task "T3"
+      tasks ({
+        "T1"=>{
+          "help"=>"T1.help",
+          "type"=>"text",
+          "instruction"=>"T1.instruction"
+        },
+        "T2"=>{
+          "help"=>"T2.help",
+          "type"=>"multiple",
+          "answers"=>[
+            {"label"=>"T2.answers.0.label"},
+            {"label"=>"T2.answers.1.label"},
+            {"label"=>"T2.answers.2.label"}
+          ],
+          "question"=>"T2.question"
+        },
+        "T3"=>{
+          "type"=>"combo",
+          "tasks"=>["T1", "T2"]
+        }
+      })
+    end
+
     trait :shortcut do
       tasks (
         {

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -157,11 +157,10 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
                 {"task"=>"T2", "value"=>[1]},
                 {"task"=>"T6", "value"=>"no secrets between us, panoptes. you see all."},
                 {"task"=>"T7", "value"=>[
-                    {"value"=>"c6e0d98477ec8", "option"=>true},
-                    {"value"=>"fb39ba165bfd4", "option"=>true},
-                    {"value"=>"81a10debaa648", "option"=>true}
-                  ]
-                }
+                  {"value"=>"c6e0d98477ec8", "option"=>true},
+                  {"value"=>"fb39ba165bfd4", "option"=>true},
+                  {"value"=>"81a10debaa648", "option"=>true}
+                ]}
               ]
             }]
           end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -145,8 +145,10 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         let(:combo_annotation) { new_classification.annotations.first }
 
         context "with a valid annotation" do
-          let(:combo_workflow) { build(:workflow, :complex_task) }
-          let(:combo_contents) { create(:workflow_content, :complex_task, workflow: combo_workflow) }
+          let(:complex_with_combo_workflow) { build(:workflow, :complex_task) }
+          let(:combo_contents) do
+            create(:workflow_content, :complex_task, workflow: complex_with_combo_workflow)
+          end
           let(:annotations) do
             [{
               "task"=>"T3",

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
 
         context "with a valid annotation" do
           let(:complex_with_combo_workflow) { build(:workflow, :complex_task) }
+          let(:combo_workflow) { complex_with_combo_workflow }
           let(:combo_contents) do
             create(:workflow_content, :complex_task, workflow: complex_with_combo_workflow)
           end


### PR DESCRIPTION
some combo task annotations are malformed and do not embed as the annotation values in the expected format (see specs).

Now the code will report an error in the output file and move on instead of failing.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
