### PR TITLE
avoid updating user on each subject upload

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -35,7 +35,6 @@ class Api::V1::SubjectsController < Api::ApiController
     super do |subject|
       user = subject.uploader
       user.increment_subjects_count_cache
-      user.touch
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
   include Activatable
   include Linkable
   include PgSearch
+  include ExtendedCacheKey
 
   ALLOWED_LOGIN_CHARACTERS = '[\w\-\.]'
   USER_LOGIN_REGEX = /\A#{ ALLOWED_LOGIN_CHARACTERS }+\z/
@@ -37,6 +38,8 @@ class User < ActiveRecord::Base
   has_many :subject_queues, dependent: :destroy
 
   belongs_to :signup_project, class_name: 'Project', foreign_key: "project_id"
+
+  cache_by_resource_method :uploaded_subjects_count
 
   before_validation :default_display_name, on: [:create, :update]
   before_validation :sync_identity_group, on: [:update]

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -614,7 +614,6 @@ describe Api::V1::SubjectsController, type: :controller do
 
     it "should incremement the user's subjects_count cache and touch the user" do
       expect_any_instance_of(User).to receive(:increment_subjects_count_cache)
-      expect_any_instance_of(User).to receive(:touch)
       default_request user_id: authorized_user.id, scopes: scopes
       post :create, create_params
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,14 @@ describe User, type: :model do
   it_behaves_like "activatable"
   it_behaves_like "is an owner"
 
+  context "with caching resource associations" do
+    let(:cached_resource) { user }
+
+    it_behaves_like "has an extended cache key" do
+      let(:methods) { %i(uploaded_subjects_count) }
+    end
+  end
+
   describe "links" do
     it "should allow membership links to any user" do
       expect(User).to link_to(Membership).with_scope(:all)


### PR DESCRIPTION
Partly addresses #2406 do not touch the user model on each upload (and stress the db), instead use the uploaded_subjects_count as part of the rails cache key to invalidated the serializer.

The only down side is without caching layers this can spam the db with subjects table counts for each user request. our setup has the caching layer so won't be impacted but i wanted to get this up for discussion.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
