### PR TITLE
[WIP] Add bootsnap gem for faster(?) boots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'flipper-active_record'
 gem 'flipper-ui'
 gem 'panoptes-client'
 gem 'dalli-elasticache'
+gem 'bootsnap', require: false
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.1.2)
+      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (8.2.2)
     cellect-client (3.0.1)
@@ -239,6 +241,7 @@ GEM
     mock_redis (0.17.2)
     modware (0.1.3)
       key_struct (~> 0.4)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -445,6 +448,7 @@ DEPENDENCIES
   active_record_union (~> 1.2.0)
   activerecord-import (~> 0.19)
   aws-sdk-v1 (~> 1.67)
+  bootsnap
   cellect-client (~> 3.0.1)
   dalli-elasticache
   database_cleaner (~> 1.3.0)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,6 +2,7 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'bootsnap/setup'
 begin
   require "fig_rake/rails"
 rescue LoadError => e

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,7 +2,25 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-require 'bootsnap/setup'
+
+# require 'bootsnap/setup'
+# vs https://github.com/Shopify/bootsnap/wiki/Bootlib::Require
+require_relative '../lib/bootlib_require'
+BootLib::Require.from_gem('bootsnap', 'bootsnap')
+
+env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV']
+development_mode = ['', nil, 'development'].include?(env)
+
+Bootsnap.setup(
+  cache_dir:            'tmp/cache',      # Path to your cache
+  development_mode:     development_mode, # Current working environment, e.g. RACK_ENV, RAILS_ENV, etc
+  load_path_cache:      true,             # Optimize the LOAD_PATH with a cache
+  autoload_paths_cache: true,             # Optimize ActiveSupport autoloads with cache
+  disable_trace:        true,             # (Alpha) Set `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
+  compile_cache_iseq:   development_mode, # Compile Ruby code into ISeq cache, breaks coverage reporting.
+  compile_cache_yaml:   development_mode  # Compile YAML into a cache
+)
+
 begin
   require "fig_rake/rails"
 rescue LoadError => e

--- a/lib/bootlib_require.rb
+++ b/lib/bootlib_require.rb
@@ -1,0 +1,37 @@
+module BootLib
+  module Require
+    ARCHDIR    = RbConfig::CONFIG['archdir']
+    RUBYLIBDIR = RbConfig::CONFIG['rubylibdir']
+    DLEXT      = RbConfig::CONFIG['DLEXT']
+
+    def self.from_archdir(feature)
+      require(File.join(ARCHDIR, "#{feature}.#{DLEXT}"))
+    end
+
+    def self.from_rubylibdir(feature)
+      require(File.join(RUBYLIBDIR, "#{feature}.rb"))
+    end
+
+    def self.from_gem(gem, feature)
+      match = $LOAD_PATH
+        .select { |e| e.match(gem_pattern(gem)) }
+        .map    { |e| File.join(e, feature) }
+        .detect { |e| File.exist?(e) }
+      if match
+        require(match)
+      else
+        puts "[BootLib::Require warning] couldn't locate #{feature}"
+        require(feature)
+      end
+    end
+
+    def self.gem_pattern(gem)
+      %r{
+        /
+        (gems|extensions/[^/]+/[^/]+)          # "gems" or "extensions/x64_64-darwin16/2.3.0"
+        /
+        #{Regexp.escape(gem)}-(\h{12}|(\d+\.)) # msgpack-1.2.3 or msgpack-1234567890ab
+      }x
+    end
+  end
+end


### PR DESCRIPTION
Rails now includes this gem in default Gemfile. Added and played around with boot times but doesn't gain much on my laptop using the cmd, `time DISABLE_SPRING=true rails r 'puts "loaded"'`.

I didn't test the code caching speed up in dev mode but in theory the load times should have been helped with the load paths caching. Happy to close this without a merge but thought i'd share the results. 

Current
--------
|run 1|run 2|run 3|
|---- |---- |----|
|real	0m5.429s|real	0m4.727s|real	0m4.762s|
|user	0m3.561s|user	0m3.462s|user	0m3.499s|
|sys	0m1.214s|sys	0m1.048s|sys	0m1.062s|

Bootsnap - load paths only
--------
|run 1|run 2|run 3|
|---- |---- |----|
|real	0m5.291s|real	0m5.165s|real	0m4.499s|
|user	0m4.018s|user	0m4.202s|user	0m3.919s|
|sys	0m0.605s|sys	0m0.466s|sys	0m0.345s|

Bootsnap - load paths plus ruby & yaml cache
--------
|run 1|run 2|run 3|
|---- |---- |----|
|real	0m8.529s|real	0m4.286s|real	0m4.246s|
|user	0m5.651s|user	0m3.537s|user	0m3.736s|
|sys	0m1.456s|sys	0m0.373s|sys	0m0.323s|

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
