### PR TITLE
add subject_id index to collections_subjects

### DIFF
--- a/db/migrate/20170727142122_modify_collections_subjects_index.rb
+++ b/db/migrate/20170727142122_modify_collections_subjects_index.rb
@@ -1,0 +1,5 @@
+class ModifyCollectionsSubjectsIndex < ActiveRecord::Migration
+  def change
+    add_index :collections_subjects, :subject_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2375,6 +2375,13 @@ CREATE UNIQUE INDEX index_collections_subjects_on_collection_id_and_subject_id O
 
 
 --
+-- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_collections_subjects_on_subject_id ON collections_subjects USING btree (subject_id);
+
+
+--
 -- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3921,4 +3928,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170524205300');
 INSERT INTO schema_migrations (version) VALUES ('20170524210302');
 
 INSERT INTO schema_migrations (version) VALUES ('20170525151142');
+
+INSERT INTO schema_migrations (version) VALUES ('20170727142122');
 


### PR DESCRIPTION
final part and closes #2406 - avoid table scans when looking up what collections a subject belongs to

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
