### PR TITLE
bump newrelic_rpm gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    newrelic_rpm (3.15.0.314)
+    newrelic_rpm (4.3.0.335)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     notiffany (0.1.1)


### PR DESCRIPTION
Attempting to fix no new relic staging data. Seems it may need the puma manual restart added back in, see https://github.com/zooniverse/Panoptes/pull/2358/commits/a940046c963c098ea7c283174c0ec86e81007fa7

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
