### PR TITLE
Non content resource translations language filtering

### DIFF
--- a/app/controllers/api/v1/field_guides_controller.rb
+++ b/app/controllers/api/v1/field_guides_controller.rb
@@ -4,4 +4,12 @@ class Api::V1::FieldGuidesController < Api::ApiController
   resource_actions :default
 
   schema_type :json_schema
+
+  before_filter :set_language_if_missing, only: [:index]
+
+  private
+
+  def set_language_if_missing
+    params[:language] ||= "en"
+  end
 end

--- a/app/controllers/api/v1/tutorials_controller.rb
+++ b/app/controllers/api/v1/tutorials_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::TutorialsController < Api::ApiController
 
   schema_type :json_schema
 
-  before_filter :set_language_from_header, only: [:index]
+  before_filter :set_language_if_missing, only: [:index]
 
   protected
 
@@ -23,7 +23,7 @@ class Api::V1::TutorialsController < Api::ApiController
     @controlled_resources
   end
 
-  def set_language_from_header
-    params[:language] = "en"
+  def set_language_if_missing
+    params[:language] ||= "en"
   end
 end

--- a/app/controllers/concerns/pages.rb
+++ b/app/controllers/concerns/pages.rb
@@ -9,7 +9,7 @@ module Pages
     allowed_params :create, :url_key, :title, :content, :language
     allowed_params :update, :url_key, :title, :content, :language
 
-    before_filter :set_language_from_header, only: [:index]
+    before_filter :set_language_if_missing, only: [:index]
 
     # Methods defined here in order to avoid being overridden by resource modules
     define_method(:link_header) do |resource|
@@ -44,8 +44,8 @@ module Pages
 
   protected
 
-  def set_language_from_header
-    params[:language] = "en"
+  def set_language_if_missing
+    params[:language] ||= "en"
   end
 
   def serializer

--- a/app/serializers/field_guide_serializer.rb
+++ b/app/serializers/field_guide_serializer.rb
@@ -7,4 +7,5 @@ class FieldGuideSerializer
 
   can_include :project
   media_include :attached_images
+  can_filter_by :language
 end

--- a/app/serializers/field_guide_serializer.rb
+++ b/app/serializers/field_guide_serializer.rb
@@ -1,5 +1,5 @@
 class FieldGuideSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include MediaLinksSerializer
   include CachedSerializer
 

--- a/app/serializers/tutorial_serializer.rb
+++ b/app/serializers/tutorial_serializer.rb
@@ -1,5 +1,5 @@
 class TutorialSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include MediaLinksSerializer
   include CachedSerializer
 

--- a/app/serializers/tutorial_serializer.rb
+++ b/app/serializers/tutorial_serializer.rb
@@ -8,4 +8,5 @@ class TutorialSerializer
   can_include :project
   can_include :workflows
   media_include :attached_images
+  can_filter_by :language
 end

--- a/spec/controllers/api/v1/field_guides_controller_spec.rb
+++ b/spec/controllers/api/v1/field_guides_controller_spec.rb
@@ -24,7 +24,10 @@ describe Api::V1::FieldGuidesController, type: :controller do
     it_behaves_like "is indexable"
 
     describe "filter_params" do
+      let(:setup_field_guide) { }
+
       before(:each) do
+        setup_field_guide
         default_request user_id: authorized_user.id, scopes: scopes
         get :index, filter_params
       end
@@ -35,6 +38,28 @@ describe Api::V1::FieldGuidesController, type: :controller do
           aggregate_failures "project_id" do
             expect(json_response[api_resource_name].length).to eq(1)
             expect(created_instance_id(api_resource_name)).to eq(field_guides.first.id.to_s)
+          end
+        end
+      end
+
+      context "by language" do
+        let(:filter_params) { {language: "es-mx", project_id: project.id} }
+
+        context "with no field guide" do
+          it "should return not field guide" do
+            expect(json_response[api_resource_name].length).to eq(0)
+          end
+        end
+
+        context "with a field guide" do
+          let(:setup_field_guide) do
+            create(:field_guide, project: project, language: "es-mx")
+          end
+
+          it "should return field guide for es-mx" do
+            resources = json_response[api_resource_name]
+            expect(resources.length).to eq(1)
+            resources.first["language"] == "es-mx"
           end
         end
       end


### PR DESCRIPTION
partially address #1091 & #2348
closes #2405 

Allow query param language filtering for non _content translation resources: Field Guide, Project/Org pages, Tutorials. 

When no language query param is used it will default to "en" hard coded to match current behaviour. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
