### PR TITLE
add urls to organisation serialiser

### DIFF
--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -6,7 +6,8 @@ class OrganizationSerializer
   include CachedSerializer
 
 
-  attributes :id, :display_name, :description, :introduction, :title, :href, :primary_language, :listed_at, :listed, :slug
+  attributes :id, :display_name, :description, :introduction, :title, :href,
+    :primary_language, :listed_at, :listed, :slug, :urls
   optional :avatar_src
   media_include :avatar, :background
   can_filter_by :display_name, :slug, :listed_at

--- a/spec/serializers/organization_serializer_spec.rb
+++ b/spec/serializers/organization_serializer_spec.rb
@@ -88,4 +88,22 @@ describe OrganizationSerializer do
       end
     end
   end
+
+  describe "#urls" do
+    let(:result) do
+      OrganizationSerializer.single({}, Organization.where(id: organization.id), {})
+    end
+    let(:result_urls) do
+      organization.urls.map do |url|
+        {
+          url: url["url"],
+          label: url["label"]
+        }
+      end
+    end
+
+    it "should return url attribute" do
+      expect(result[:urls]).to match_array(result_urls)
+    end
+  end
 end


### PR DESCRIPTION
closes #2397 allow the orgs to get access to their external URL's

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
