### PR TITLE
Add categories to orgs

### DIFF
--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -9,7 +9,7 @@ module Organizations
     string :id
 
     def execute
-      Organization.transaction do
+      Organization.transaction(requires_new: true) do
         content_update = {}
         org_update = organization_params.dup
         Api::V1::OrganizationsController::CONTENT_FIELDS.each do |field|

--- a/app/schemas/organization_update_schema.rb
+++ b/app/schemas/organization_update_schema.rb
@@ -45,6 +45,13 @@ class OrganizationUpdateSchema < JsonSchema
       end
     end
 
+    property "categories" do
+      type "array"
+      items do
+        type "string"
+      end
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -7,7 +7,7 @@ class OrganizationSerializer
 
 
   attributes :id, :display_name, :description, :introduction, :title, :href,
-    :primary_language, :listed_at, :listed, :slug, :urls
+    :primary_language, :listed_at, :listed, :slug, :urls, :categories
   optional :avatar_src
   media_include :avatar, :background
   can_filter_by :display_name, :slug, :listed_at

--- a/db/migrate/20170824165411_add_categories_list_to_orgs.rb
+++ b/db/migrate/20170824165411_add_categories_list_to_orgs.rb
@@ -1,0 +1,5 @@
+class AddCategoriesListToOrgs < ActiveRecord::Migration
+  def change
+    add_column :organizations, :categories, :string, array: true, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -719,7 +719,8 @@ CREATE TABLE organizations (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     urls jsonb DEFAULT '[]'::jsonb,
-    listed boolean DEFAULT false NOT NULL
+    listed boolean DEFAULT false NOT NULL,
+    categories character varying[] DEFAULT '{}'::character varying[]
 );
 
 
@@ -1188,40 +1189,6 @@ CREATE SEQUENCE tags_id_seq
 --
 
 ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
-
-
---
--- Name: translations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE translations (
-    id integer NOT NULL,
-    translated_id integer,
-    translated_type character varying,
-    language character varying NOT NULL,
-    strings jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: translations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE translations_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: translations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE translations_id_seq OWNED BY translations.id;
 
 
 --
@@ -1839,13 +1806,6 @@ ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclas
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY translations ALTER COLUMN id SET DEFAULT nextval('translations_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY tutorials ALTER COLUMN id SET DEFAULT nextval('tutorials_id_seq'::regclass);
 
 
@@ -2158,14 +2118,6 @@ ALTER TABLE ONLY tagged_resources
 
 ALTER TABLE ONLY tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
-
-
---
--- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY translations
-    ADD CONSTRAINT translations_pkey PRIMARY KEY (id);
 
 
 --
@@ -2869,20 +2821,6 @@ CREATE INDEX index_tags_name_trgrm ON tags USING gin ((COALESCE(name, ''::text))
 --
 
 CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
-
-
---
--- Name: index_translations_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_translations_on_language ON translations USING btree (language);
-
-
---
--- Name: index_translations_on_translated_type_and_translated_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_translations_on_translated_type_and_translated_id ON translations USING btree (translated_type, translated_id);
 
 
 --
@@ -3995,4 +3933,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170525151142');
 INSERT INTO schema_migrations (version) VALUES ('20170727142122');
 
 INSERT INTO schema_migrations (version) VALUES ('20170808130619');
+
+INSERT INTO schema_migrations (version) VALUES ('20170824165411');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1192,6 +1192,40 @@ ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
+-- Name: translations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE translations (
+    id integer NOT NULL,
+    translated_id integer,
+    translated_type character varying,
+    language character varying NOT NULL,
+    strings jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: translations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE translations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: translations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE translations_id_seq OWNED BY translations.id;
+
+
+--
 -- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1806,6 +1840,13 @@ ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclas
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY translations ALTER COLUMN id SET DEFAULT nextval('translations_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY tutorials ALTER COLUMN id SET DEFAULT nextval('tutorials_id_seq'::regclass);
 
 
@@ -2118,6 +2159,14 @@ ALTER TABLE ONLY tagged_resources
 
 ALTER TABLE ONLY tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY translations
+    ADD CONSTRAINT translations_pkey PRIMARY KEY (id);
 
 
 --
@@ -2821,6 +2870,20 @@ CREATE INDEX index_tags_name_trgrm ON tags USING gin ((COALESCE(name, ''::text))
 --
 
 CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
+
+
+--
+-- Name: index_translations_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_translations_on_language ON translations USING btree (language);
+
+
+--
+-- Name: index_translations_on_translated_type_and_translated_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_translations_on_translated_type_and_translated_id ON translations USING btree (translated_type, translated_id);
 
 
 --

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -96,7 +96,8 @@ describe Api::V1::OrganizationsController, type: :controller do
             display_name: "The Illuminati",
             description: "This organization is the most organized organization to ever organize",
             urls: [{label: "Blog", url: "http://blogo.com/example"}],
-            primary_language: "zh-tw"
+            primary_language: "zh-tw",
+            categories: %w(stuff things moar)
           }
         }
       end
@@ -108,6 +109,23 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:api_resource_name) { "organizations" }
         let(:api_resource_attributes) { %w(id display_name) }
         let(:api_resource_links) { %w() }
+
+        context "a logged in user" do
+          before(:each) do
+            default_request scopes: scopes, user_id: authorized_user.id
+            post :create, create_params
+          end
+          let(:test_attr) { :categories }
+          let(:expected_categories) do
+            create_params.dig(:organizations, :categories)
+          end
+
+          # this should really be a spec on the operation to create orgs :sadpanda:
+          it 'should create the organization with the categories' do
+            categories = resource_class.find(created_id).send(test_attr)
+            expect(categories).to match_array(expected_categories)
+          end
+        end
       end
     end
 

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     listed true
     primary_language "en"
     urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
+    categories %w(bugs fossils plants)
 
     association :owner, factory: :user
 

--- a/spec/serializers/organization_serializer_spec.rb
+++ b/spec/serializers/organization_serializer_spec.rb
@@ -106,4 +106,17 @@ describe OrganizationSerializer do
       expect(result[:urls]).to match_array(result_urls)
     end
   end
+
+  describe "#categories" do
+    let(:result) do
+      OrganizationSerializer.single(
+        {},
+        Organization.where(id: organization.id),
+        {}
+      )
+    end
+    it "should return the categories by default" do
+      expect(result[:categories]).to match_array(organization.categories)
+    end
+  end
 end


### PR DESCRIPTION
Closes #2437 this adds categories attributes to organization model for use as org -> project tag filters.

There were no operation specs so i just tested in the controller actions, i'm happy to add these in and extract the controller specs but wanted to get something out when pairing with @mcbouslog .

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
