### PR TITLE
allow admins to globally ban users

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,7 +11,8 @@ class Api::V1::UsersController < Api::ApiController
 
   allowed_params :update, :login, :display_name, :email, :credited_name,
    :global_email_communication, :project_email_communication,
-   :beta_email_communication, :languages, :subject_limit, :upload_whitelist
+   :beta_email_communication, :languages, :subject_limit, :upload_whitelist,
+   :banned
 
   alias_method :user, :controlled_resource
 
@@ -74,7 +75,7 @@ class Api::V1::UsersController < Api::ApiController
   end
 
   def build_update_hash(update_params, id)
-    admin_allowed(update_params, :subject_limit, :upload_whitelist)
+    admin_allowed(update_params, :subject_limit, :upload_whitelist, :banned)
     super
   end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -502,6 +502,11 @@ describe Api::V1::UsersController, type: :controller do
       it_behaves_like "admin only attribute", :upload_whitelist, true
     end
 
+    describe "upload_whitelist" do
+
+      it_behaves_like "admin only attribute", :banned, true
+    end
+
     context "when changing email" do
       let(:put_operations) { {users: {email: "test@example.com"}} }
 


### PR DESCRIPTION
provide api support for admins to ban users. 

A banned user cannot create content in the panoptes API, nor create content in talk-api. This does not apply to Ouroboros era, instead use the talk moderations page to ban a user, e.g. https://talk.penguinwatch.org/#/moderation

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
