### PR TITLE
Reactivate existing membership on create

### DIFF
--- a/app/operations/memberships/create.rb
+++ b/app/operations/memberships/create.rb
@@ -12,7 +12,10 @@ module Memberships
       raise Unauthorized unless user_group.verify_join_token(join_token)
       raise Unauthorized unless user.id == api_user.id
 
-      Membership.create! user: api_user.user, user_group: user_group, state: :active
+      membership = Membership.find_or_initialize_by(user: api_user.user, user_group: user_group)
+      membership.state = :active
+      membership.save!
+
     end
 
     def user

--- a/app/operations/memberships/create.rb
+++ b/app/operations/memberships/create.rb
@@ -15,7 +15,6 @@ module Memberships
       membership = Membership.find_or_initialize_by(user: api_user.user, user_group: user_group)
       membership.state = :active
       membership.tap(&:save!)
-
     end
 
     def user

--- a/app/operations/memberships/create.rb
+++ b/app/operations/memberships/create.rb
@@ -14,7 +14,7 @@ module Memberships
 
       membership = Membership.find_or_initialize_by(user: api_user.user, user_group: user_group)
       membership.state = :active
-      membership.save!
+      membership.tap(&:save!)
 
     end
 

--- a/spec/operations/memberships/create_spec.rb
+++ b/spec/operations/memberships/create_spec.rb
@@ -39,5 +39,17 @@ describe Memberships::Create do
         operation.run links: {user: you.id, user_group: 0}, join_token: 'wrong_token'
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    describe 'user group exists' do
+      let(:membership) { create(:membership, user: you, state: Membership.states[:inactive], roles: ["group_admin"], user_group: user_group) }
+
+      it 'finds an existing deactivated membership and reactivates' do
+        membership
+        result = operation.run links: {user: you.id, user_group: user_group.id}, join_token: user_group.join_token
+        expect(result).to be_valid
+        expect(user_group.users).to include(you)
+        expect(membership.reload.state).to eq("active")
+      end
+    end
   end
 end


### PR DESCRIPTION
When a user tries to re-join a user group they had been deleted from, the existing, inactive membership causes an error on `Membership.create!`. Now, memberships are either created or reactivated on a successfully validated create request.

Primary use for this is adding/removing users from Education classrooms, which correspond directly to Panoptes user groups.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
