### PR TITLE
pass the user has finished workflow context in to the subject selector serializer

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -124,6 +124,7 @@ class Api::V1::SubjectsController < Api::ApiController
         url_format: :get,
         favorite_subject_ids: FavoritesFinder.new(api_user.user, workflow.project, selected_subject_ids).find_favorites,
         retired_subject_ids: SubjectWorkflowRetirements.new(workflow, selected_subject_ids).find_retirees,
+        user_has_finished_workflow: api_user.user&.has_finished?(workflow),
         select_context: true
       }.compact
     end

--- a/app/serializers/subject_selector_serializer.rb
+++ b/app/serializers/subject_selector_serializer.rb
@@ -68,6 +68,6 @@ class SubjectSelectorSerializer
   end
 
   def finished_workflow
-    user&.has_finished?(workflow)
+    @context[:user_has_finished_workflow]
   end
 end

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -189,6 +189,7 @@ describe Api::V1::SubjectsController, type: :controller do
               favorite_subject_ids: [],
               retired_subject_ids: [],
               url_format: :get,
+              user_has_finished_workflow: false,
               select_context: true
             }
           end


### PR DESCRIPTION
avoid calling this method on for each subject. Instead just pass it in as it's static from the calling context.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
