### PR TITLE
add cache_total_count dsl to panoptes restpack

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -18,6 +18,8 @@ class UserSerializer
 
   preload :avatar
 
+  cache_total_count true
+
   def admin
     !!@model.admin
   end
@@ -57,10 +59,5 @@ class UserSerializer
 
   def add_links(model, data)
     data[:links] = {}
-  end
-
-  def self.serialize_meta(page, options)
-    page = Serialization::PageWithCachedMetadata.new(page)
-    super(page, options)
   end
 end

--- a/lib/serialization/page_with_cached_metadata.rb
+++ b/lib/serialization/page_with_cached_metadata.rb
@@ -8,8 +8,9 @@ module Serialization
         super
       end
 
-      # Make sure to fill instance variable cache in object, so that other methods
-      # can use it.
+      # Ensure setting the instance variable cache in delegated monkey patched
+      # AR object (kaminari), as other page count calculation methods
+      # use it in serialize_meta restpack paging method
       __getobj__.instance_variable_set(:@total_count, @total_count)
     end
   end

--- a/lib/serialization/panoptes_restpack.rb
+++ b/lib/serialization/panoptes_restpack.rb
@@ -16,6 +16,14 @@ module Serialization
       def preloads
         @preloads || []
       end
+
+      def cache_total_count(cache_setting)
+        @cache_total_count ||= !!cache_setting
+      end
+
+      def cache_total_count_on
+        @cache_total_count || false
+      end
     end
 
     module ClassMethodOverrides
@@ -62,6 +70,14 @@ module Serialization
         else
           "#{href_prefix}/#{key}"
         end
+      end
+
+      def serialize_meta(page, options)
+        if cache_total_count_on
+          page = Serialization::PageWithCachedMetadata.new(page)
+        end
+
+        super(page, options)
       end
     end
   end


### PR DESCRIPTION
closes #2472 allow any panoptes restpack serializer to cache the total count value via a DSL option

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
