### PR TITLE
read from slave for dump workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'flipper-active_record'
 gem 'flipper-ui'
 gem 'panoptes-client'
 gem 'dalli-elasticache'
+gem 'slavery'
 
 group :production, :staging do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,8 @@ GEM
       celluloid (>= 0.17.3)
       ice_cube (~> 0.14.0)
       sidekiq (>= 4.1.0)
+    slavery (2.1.1)
+      activerecord (>= 3.0.0)
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -499,6 +501,7 @@ DEPENDENCIES
   sidekiq-congestion (~> 0.1.0)
   sidekiq-unique-jobs
   sidetiq (~> 0.7)
+  slavery
   spring
   spring-commands-rspec
   stringex (~> 2.7)
@@ -508,4 +511,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0.1)
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -12,11 +12,14 @@ class ClassificationsDumpWorker
     CSV.open(csv_file_path, 'wb') do |csv|
       formatter = Formatter::Csv::Classification.new(cache)
       csv << formatter.class.headers
-      completed_resource_classifications.find_in_batches do |batch|
-        subject_ids = setup_subjects_cache(batch)
-        setup_retirement_cache(batch, subject_ids)
-        batch.each do |classification|
-          csv << formatter.to_array(classification)
+
+      read_from_slave do
+        completed_resource_classifications.find_in_batches do |batch|
+          subject_ids = setup_subjects_cache(batch)
+          setup_retirement_cache(batch, subject_ids)
+          batch.each do |classification|
+            csv << formatter.to_array(classification)
+          end
         end
       end
     end

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -13,7 +13,7 @@ class ClassificationsDumpWorker
       formatter = Formatter::Csv::Classification.new(cache)
       csv << formatter.class.headers
 
-      read_from_slave do
+      Slavery.on_slave do
         completed_resource_classifications.find_in_batches do |batch|
           subject_ids = setup_subjects_cache(batch)
           setup_retirement_cache(batch, subject_ids)

--- a/app/workers/concerns/dump_worker.rb
+++ b/app/workers/concerns/dump_worker.rb
@@ -127,13 +127,4 @@ module DumpWorker
   def get_resource
     @resource_type.camelize.constantize.find(@resource_id)
   end
-
-  def read_from_slave
-    original_connection = ActiveRecord::Base.remove_connection
-    slave_connection_config = ActiveRecord::Base.configurations["#{ Rails.env }_read_slave"]
-    ActiveRecord::Base.establish_connection(slave_connection_config)
-    yield
-  ensure
-    ActiveRecord::Base.establish_connection(original_connection)
-  end
 end

--- a/app/workers/concerns/dump_worker.rb
+++ b/app/workers/concerns/dump_worker.rb
@@ -127,4 +127,13 @@ module DumpWorker
   def get_resource
     @resource_type.camelize.constantize.find(@resource_id)
   end
+
+  def read_from_slave
+    original_connection = ActiveRecord::Base.remove_connection
+    slave_connection_config = ActiveRecord::Base.configurations["#{ Rails.env }_read_slave"]
+    ActiveRecord::Base.establish_connection(slave_connection_config)
+    yield
+  ensure
+    ActiveRecord::Base.establish_connection(original_connection)
+  end
 end

--- a/app/workers/subjects_dump_worker.rb
+++ b/app/workers/subjects_dump_worker.rb
@@ -12,10 +12,9 @@ class SubjectsDumpWorker
     raise ApiErrors::FeatureDisabled unless Panoptes.flipper[:dump_worker_exports].enabled?
     CSV.open(csv_file_path, 'wb') do |csv|
       headers = Formatter::Csv::Subject.headers
-
       csv << headers
 
-      read_from_slave do
+      Slavery.on_slave do
         project_subjects.find_each do |subject|
           Formatter::Csv::Subject.new(resource, subject).to_rows.each do |hash|
             csv << hash.values_at(*headers)

--- a/app/workers/subjects_dump_worker.rb
+++ b/app/workers/subjects_dump_worker.rb
@@ -15,9 +15,11 @@ class SubjectsDumpWorker
 
       csv << headers
 
-      project_subjects.find_each do |subject|
-        Formatter::Csv::Subject.new(resource, subject).to_rows.each do |hash|
-          csv << hash.values_at(*headers)
+      read_from_slave do
+        project_subjects.find_each do |subject|
+          Formatter::Csv::Subject.new(resource, subject).to_rows.each do |hash|
+            csv << hash.values_at(*headers)
+          end
         end
       end
     end

--- a/app/workers/workflow_contents_dump_worker.rb
+++ b/app/workers/workflow_contents_dump_worker.rb
@@ -14,7 +14,7 @@ class WorkflowContentsDumpWorker
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers
 
-      read_from_slave do
+      Slavery.on_slave do
         resource.workflows.each do |workflow|
           workflow.workflow_contents.find_each do |wc|
             csv << csv_formatter.to_array(wc)

--- a/app/workers/workflow_contents_dump_worker.rb
+++ b/app/workers/workflow_contents_dump_worker.rb
@@ -13,11 +13,14 @@ class WorkflowContentsDumpWorker
     csv_formatter = Formatter::Csv::WorkflowContent.new
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers
-      resource.workflows.each do |workflow|
-        workflow.workflow_contents.find_each do |wc|
-          csv << csv_formatter.to_array(wc)
-          while wc = wc.previous_version
+
+      read_from_slave do
+        resource.workflows.each do |workflow|
+          workflow.workflow_contents.find_each do |wc|
             csv << csv_formatter.to_array(wc)
+            while wc = wc.previous_version
+              csv << csv_formatter.to_array(wc)
+            end
           end
         end
       end

--- a/app/workers/workflows_dump_worker.rb
+++ b/app/workers/workflows_dump_worker.rb
@@ -14,7 +14,7 @@ class WorkflowsDumpWorker
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers
 
-      read_from_slave do
+      Slavery.on_slave do
         resource.workflows.find_each do |workflow|
           csv << csv_formatter.to_array(workflow)
           while workflow = workflow.previous_version

--- a/app/workers/workflows_dump_worker.rb
+++ b/app/workers/workflows_dump_worker.rb
@@ -13,10 +13,13 @@ class WorkflowsDumpWorker
     csv_formatter = Formatter::Csv::Workflow.new
     CSV.open(csv_file_path, 'wb') do |csv|
       csv << csv_formatter.class.headers
-      resource.workflows.find_each do |workflow|
-        csv << csv_formatter.to_array(workflow)
-        while workflow = workflow.previous_version
+
+      read_from_slave do
+        resource.workflows.find_each do |workflow|
           csv << csv_formatter.to_array(workflow)
+          while workflow = workflow.previous_version
+            csv << csv_formatter.to_array(workflow)
+          end
         end
       end
     end

--- a/config/database.yml.hudson
+++ b/config/database.yml.hudson
@@ -12,7 +12,7 @@ development:
   <<: *default
   database: panoptes_development
 
-development_read_slave:
+development_slave:
   <<: *default
   database: panoptes_development
 
@@ -20,6 +20,6 @@ test:
   <<: *default
   database: panoptes_test
 
-test_read_slave:
+test_slave:
   <<: *default
   database: panoptes_test

--- a/config/database.yml.hudson
+++ b/config/database.yml.hudson
@@ -12,6 +12,14 @@ development:
   <<: *default
   database: panoptes_development
 
+development_read_slave:
+  <<: *default
+  database: panoptes_development
+
 test:
+  <<: *default
+  database: panoptes_test
+
+test_read_slave:
   <<: *default
   database: panoptes_test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,9 @@ RSpec.configure do |config|
 
   Devise.mailer = Devise::Mailer
 
+  # disable slave reads to deal with testing transaction isolation
+  Slavery.disabled = true
+
   # work around https://github.com/celluloid/celluloid/issues/696
   Celluloid.shutdown_timeout = 1
 
@@ -45,9 +48,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do |example|
-    # use truncation to handle distinct read_slave db connection
-    # revert back to :transaction (faster) when the read slave requirement is removed
-    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,9 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do |example|
-    DatabaseCleaner.strategy = :transaction
+    # use truncation to handle distinct read_slave db connection
+    # revert back to :transaction (faster) when the read slave requirement is removed
+    DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
 


### PR DESCRIPTION
Use Slavery Gem https://github.com/kenn/slavery to read from slave db for data dump workers

possibly supersedes #2494 - and will need a `_slave` entry in the database.yml before merging. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
