### PR TITLE
Allow description in collections update

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::CollectionsController < Api::ApiController
   allowed_params :create, :name, :display_name, :private, :favorite, :description,
     links: [ :default_subject, :project, projects: [], subjects: [], owner: polymorphic ]
 
-  allowed_params :update, :name, :display_name, :private, links: [ :default_subject, subjects: [] ]
+  allowed_params :update, :name, :display_name, :private, :description, links: [ :default_subject, subjects: [] ]
 
   search_by do |name, query|
     query.search_display_name(name.join(" "))

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -98,6 +98,7 @@ describe Api::V1::CollectionsController, type: :controller do
       {
        collections: {
                      display_name: "Tested Collection",
+                     description: "Super tested collection of subjects, very good very nice",
                      private: false,
                      links: {
                              subjects: subjects.map(&:id).map(&:to_s)


### PR DESCRIPTION
Was in the `allowed_params` for create but not for update. Also added it to the test object.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
