### PR TITLE
ignore the project launch date when counting workflow retired subjects

### DIFF
--- a/app/counters/workflow_counter.rb
+++ b/app/counters/workflow_counter.rb
@@ -11,11 +11,7 @@ class WorkflowCounter
   end
 
   def retired_subjects
-    retired = linked_subject_workflow_status.retired
-    if launch_date
-      retired = retired.where("subject_workflow_counts.retired_at >= ?", launch_date)
-    end
-    retired.count
+    linked_subject_workflow_status.retired.count
   end
 
   private

--- a/spec/counters/workflow_counter_spec.rb
+++ b/spec/counters/workflow_counter_spec.rb
@@ -54,9 +54,9 @@ describe WorkflowCounter do
         expect(counter.retired_subjects).to eq(2)
       end
 
-      it "should respect the project launch date" do
+      it "should ignore the project launch date" do
         workflow.project.update_column(:launch_date, DateTime.now + 1.day)
-        expect(counter.retired_subjects).to eq(0)
+        expect(counter.retired_subjects).to eq(2)
       end
 
       it "should return 0 when a subject set was unlinked" do


### PR DESCRIPTION
count all the retired subjects as some projects launch with their beta sets still linked. Allow the retirement counter to decide which classifications count towards retirement and respect project launch date there instead of here.

Note, some subjects that are beta tested and make it through to launch without retirement will ignore any classifications prior to launch. 

The best way to avoid this situation is to beta test with a sample of your data in a different subject set and upload and link new data for the launch. All launches should be on a clean slate of data. Failing that we should look at specifying when a project records classifications from de-coupled from the launch data.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
