### PR TITLE
feature flag read recents from read replica

### DIFF
--- a/app/controllers/concerns/recents.rb
+++ b/app/controllers/concerns/recents.rb
@@ -2,10 +2,24 @@ module Recents
   def recents
     ps = params.dup
     ps.delete "#{resource_name}_id"
-    render json_api: RecentSerializer.page(
-      ps,
-      Recent.where(:"#{resource_name}_id" => resource_ids),
-      { url_prefix: "#{resource_sym.to_s.pluralize}/#{resource_ids}" }
-    )
+    read_recents_from_database do
+      render json_api: RecentSerializer.page(
+        ps,
+        Recent.where(:"#{resource_name}_id" => resource_ids),
+        { url_prefix: "#{resource_sym.to_s.pluralize}/#{resource_ids}" }
+      )
+    end
+  end
+
+  private
+
+  def read_recents_from_database
+    if Panoptes.flipper.enabled?("read_recents_from_read_slave")
+      Slavery.on_slave do
+        yield
+      end
+    else
+      yield
+    end
   end
 end

--- a/app/controllers/concerns/recents.rb
+++ b/app/controllers/concerns/recents.rb
@@ -2,24 +2,12 @@ module Recents
   def recents
     ps = params.dup
     ps.delete "#{resource_name}_id"
-    read_recents_from_database do
+    DatabaseReplica.read("read_recents_from_read_slave") do
       render json_api: RecentSerializer.page(
         ps,
         Recent.where(:"#{resource_name}_id" => resource_ids),
         { url_prefix: "#{resource_sym.to_s.pluralize}/#{resource_ids}" }
       )
-    end
-  end
-
-  private
-
-  def read_recents_from_database
-    if Panoptes.flipper.enabled?("read_recents_from_read_slave")
-      Slavery.on_slave do
-        yield
-      end
-    else
-      yield
     end
   end
 end

--- a/app/workers/concerns/dump_worker.rb
+++ b/app/workers/concerns/dump_worker.rb
@@ -128,13 +128,7 @@ module DumpWorker
     @resource_type.camelize.constantize.find(@resource_id)
   end
 
-  def read_from_database
-    if Panoptes.flipper.enabled?("dump_data_from_read_slave")
-      Slavery.on_slave do
-        yield
-      end
-    else
-      yield
-    end
+  def read_from_database(&block)
+    DatabaseReplica.read("dump_data_from_read_slave", &block)
   end
 end

--- a/lib/database_replica.rb
+++ b/lib/database_replica.rb
@@ -1,0 +1,11 @@
+class DatabaseReplica
+  def self.read(feature_flag_key)
+    if Panoptes.flipper.enabled?(feature_flag_key)
+      Slavery.on_slave do
+        yield
+      end
+    else
+      yield
+    end
+  end
+end


### PR DESCRIPTION
some of the recents queries can be costly as they invert the order on created at before selecting the first page. push this to the read replica where we can

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
