### PR TITLE
only match integers in route ids

### DIFF
--- a/lib/routes/json_api_routes.rb
+++ b/lib/routes/json_api_routes.rb
@@ -1,6 +1,6 @@
 module Routes
   module JsonApiRoutes
-    VALID_IDS = /[0-9]*/
+    VALID_IDS = /[0-9]+/
 
     def id_constraint(path)
       { :"#{ path.to_s.singularize }_id" => VALID_IDS }

--- a/spec/routes/constraints/translations_spec.rb
+++ b/spec/routes/constraints/translations_spec.rb
@@ -23,7 +23,7 @@ describe Routes::Constraints::Translations do
 
         it 'should not match when id is invalid and translated_type is a project' do
           request = double(params: { id: "nan", translated_type: translated_type})
-          expect(subject.matches?(request)).to be true
+          expect(subject.matches?(request)).to be false
         end
       end
     end


### PR DESCRIPTION
Only allow integers for route ids. Note: this would have to change if we move to UUID, etc but for now this is what we need.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
