### PR TITLE
Add launch_approved to card fields

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -33,7 +33,8 @@ class Api::V1::ProjectsController < Api::ApiController
                  :redirect,
                  :avatar_src,
                  :classifications_count,
-                 :updated_at].freeze
+                 :updated_at,
+                 :launch_approved].freeze
 
   before_action :filter_by_tags, only: :index
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -109,7 +109,7 @@ describe Api::V1::ProjectsController, type: :controller do
         describe "cards only" do
           let(:index_options) { { cards: true } }
           let(:card_attrs) do
-            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at", "classifications_count"]
+            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at", "classifications_count", "launch_approved"]
           end
 
           it "should return only serialise the card data" do


### PR DESCRIPTION
`launch_approved` project boolean field added to the list of card fields in controller and spec.

Fixes https://github.com/zooniverse/Panoptes/issues/2483

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
