### PR TITLE
Email export bucket and path locations

### DIFF
--- a/app/models/csv_dumps/direct_to_s3.rb
+++ b/app/models/csv_dumps/direct_to_s3.rb
@@ -42,9 +42,11 @@ module CsvDumps
       return @storage_adapter if @storage_adapter
       storage_config = Panoptes::StorageAdapter.configuration
       adapter = storage_config[:adapter]
-      storage_opts = { bucket: ENV["EMAIL_EXPORT_S3_BUCKET"] }
-      storage_opts = storage_opts.merge(storage_config.except(:adapter))
-      @storage_adapter = MediaStorage.send(:load_from_included, adapter).new(storage_opts)
+      storage_opts = {
+        bucket: ENV.fetch("EMAIL_EXPORT_S3_BUCKET", 'zooniverse-exports'),
+        prefix: ENV.fetch("EMAIL_EXPORT_S3_PREFIX", "emails/#{Rails.env}/")
+      }
+      @storage_adapter = MediaStorage.send(:load_adapter, adapter, storage_opts)
     end
   end
 end

--- a/spec/models/csv_dumps/direct_to_s3_spec.rb
+++ b/spec/models/csv_dumps/direct_to_s3_spec.rb
@@ -14,12 +14,17 @@ describe CsvDumps::DirectToS3 do
   end
   let(:file_path) { "/tmp/foobar" }
 
-  it "push the file to s3 the correct bucket location via a custom storage adapter" do
-    expect(adapter).to receive(:stored_path)
-                         .with("application/x-gzip", "email_exports")
-                         .and_call_original
-    expect(adapter).to receive(:put_file)
-                         .with(s3_path, an_instance_of(String), s3_opts)
+  it "should use a custom storage adapter" do
+    opts = {
+      bucket: 'zooniverse-exports',
+      prefix: "emails/#{Rails.env}/"
+    }
+    expect(MediaStorage)
+      .to receive(:load_adapter)
+      .with("test", opts)
+      .and_call_original
+    direct_to_s3.put_file(file_path)
+  end
 
   it "push the file to s3 the correct bucket location via a custom storage adapter" do
     expect(adapter)

--- a/spec/models/csv_dumps/direct_to_s3_spec.rb
+++ b/spec/models/csv_dumps/direct_to_s3_spec.rb
@@ -12,6 +12,7 @@ describe CsvDumps::DirectToS3 do
       content_disposition: "attachment; filename=\"full_email_list.csv\""
     }
   end
+  let(:file_path) { "/tmp/foobar" }
 
   it "push the file to s3 the correct bucket location via a custom storage adapter" do
     expect(adapter).to receive(:stored_path)
@@ -20,6 +21,14 @@ describe CsvDumps::DirectToS3 do
     expect(adapter).to receive(:put_file)
                          .with(s3_path, an_instance_of(String), s3_opts)
 
-    direct_to_s3.put_file("/tmp/foobar")
+  it "push the file to s3 the correct bucket location via a custom storage adapter" do
+    expect(adapter)
+      .to receive(:stored_path)
+      .with("application/x-gzip", "email_exports")
+      .and_call_original
+    expect(adapter)
+      .to receive(:put_file)
+      .with(s3_path, file_path, s3_opts)
+    direct_to_s3.put_file(file_path)
   end
 end


### PR DESCRIPTION
Ensure we write email exports to a special bucket path and not clobber files based on envs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
