### PR TITLE
user has finished a workflow if the workflow is finished

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,6 +236,8 @@ class User < ActiveRecord::Base
   end
 
   def has_finished?(workflow)
+    return true if workflow.finished?
+
     current_seen_count = SetMemberSubject
       .seen_for_user_by_workflow(self, workflow)
       .count

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -279,9 +279,9 @@ describe Api::V1::SubjectsController, type: :controller do
             get :index, request_params
           end
 
-          it 'should return user finished_workflow as false for each subject' do
+          it 'should return user finished_workflow as true for each subject' do
             seen_all = json_response["subjects"].map{ |s| s['finished_workflow']}
-            expect(seen_all).to all be(false)
+            expect(seen_all).to all be(true)
           end
 
           it 'should return all subjects as retired' do
@@ -461,9 +461,9 @@ describe Api::V1::SubjectsController, type: :controller do
             get :queued, request_params
           end
 
-          it 'should return user finished_workflow as false for each subject' do
+          it 'should return user finished_workflow as true for each subject' do
             seen_all = json_response["subjects"].map{ |s| s['finished_workflow']}
-            expect(seen_all).to all be(false)
+            expect(seen_all).to all be(true)
           end
 
           it 'should return all subjects as retired' do


### PR DESCRIPTION
closes #2197 - short circuit the check on seen linked counts vs linked counts. Only run this if the workflow isn't finished.

Also this flows into subject selection response context `finished_workflow` attribute. This now signals that a workflow is finished or the user has finished and can be used after each selection to determine if the client should prompt the user to choose a new worklfow and/or move to another project.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
