### PR TITLE
Add tags to Organizations

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::OrganizationsController < Api::ApiController
   include FilterByOwner
   include FilterByCurrentUserRoles
   include IndexSearch
+  include FilterByTags
   include AdminAllowed
   include Slug
 

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::OrganizationsController < Api::ApiController
                     :url_labels].freeze
 
   def create
-    organizations = Organization.transaction do
+    organizations = Organization.transaction(requires_new: true) do
       Array.wrap(params[:organizations]).map do |organization_params|
         Organizations::Create.with(api_user: api_user).run!(organization_params)
       end
@@ -33,7 +33,7 @@ class Api::V1::OrganizationsController < Api::ApiController
   end
 
   def update
-    Organization.transaction do
+    Organization.transaction(requires_new: true) do
       Array.wrap(resource_ids).zip(Array.wrap(params[:organizations])).map do |organization_id, organization_params|
         wrapper = { organization_params: organization_params }
         Organizations::Update.with(api_user: api_user, id: organization_id).run!(wrapper)
@@ -44,7 +44,7 @@ class Api::V1::OrganizationsController < Api::ApiController
   end
 
   def destroy
-    Organization.transaction do
+    Organization.transaction(requires_new: true) do
       Array.wrap(resource_ids).zip(Array.wrap(params[:organizations])).map do |organization_id, organization_params|
         Organizations::Destroy.with(api_user: api_user, id: organization_id).run!
       end

--- a/app/controllers/concerns/filter_by_tags.rb
+++ b/app/controllers/concerns/filter_by_tags.rb
@@ -1,0 +1,22 @@
+module FilterByTags
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :filter_by_tags, only: :index
+
+    search_by do |name, query|
+      query.search_display_name(name.join(" "))
+    end
+
+    search_by :tag do |name, query|
+      query.joins(:tags).merge(Tag.search_tags(name.first))
+    end
+  end
+
+  def filter_by_tags
+    if tags = params.delete(:tags).try(:split, ",").try(:map, &:downcase)
+      @controlled_resources = controlled_resources
+      .joins(:tags).where(tags: {name: tags})
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -15,6 +15,8 @@ class Organization < ActiveRecord::Base
   has_one :background, -> { where(type: "organization_background") }, class_name: "Medium", as: :linked
   has_many :organization_roles, -> { where.not(roles: []) }, class_name: "AccessControlList", as: :resource
   has_many :pages, class_name: "OrganizationPage", dependent: :destroy
+  has_many :tagged_resources, as: :resource
+  has_many :tags, through: :tagged_resources
 
   accepts_nested_attributes_for :organization_contents
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,6 +2,7 @@ class Tag < ActiveRecord::Base
   include PgSearch
   has_many :tagged_resources
   has_many :projects, through: :tagged_resources, source: :resource, source_type: "Project"
+  has_many :organizations, through: :tagged_resources, source: :resource, source_type: "Organization"
 
   validates :name, uniqueness: { case_sensitive: false }, presence: true
 

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -18,8 +18,8 @@ module Organizations
         organization = build_organization
         organization.organization_contents.build(organization_contents_params)
 
-        tags = Tags::BuildTags.run!(api_user: api_user, tag_array: tags) if tags
-        organization.tags = tags unless tags.nil?
+        tag_objects = Tags::BuildTags.run!(api_user: api_user, tag_array: tags) if tags
+        organization.tags = tag_objects unless tags.nil?
 
         organization.save!
         organization

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -11,11 +11,16 @@ module Organizations
     string :introduction, default: ''
     array :urls, default: []
     array :categories, default: []
+    array :tags, default: []
 
     def execute
       Organization.transaction(requires_new: true) do
         organization = build_organization
         organization.organization_contents.build(organization_contents_params)
+
+        tags = Tags::BuildTags.run!(api_user: api_user, tag_array: tags) if tags
+        organization.tags = tags unless tags.nil?
+
         organization.save!
         organization
       end

--- a/app/operations/organizations/destroy.rb
+++ b/app/operations/organizations/destroy.rb
@@ -3,7 +3,7 @@ module Organizations
     integer :id
 
     def execute
-      Organization.transaction do
+      Organization.transaction(requires_new: true) do
         organization = Organization.find(id)
         Activation.disable_instances!([organization])
       end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -18,6 +18,13 @@ module Organizations
             org_update.delete(field)
           end
         end
+
+        if org_update.key?(:tags)
+          tags = Tags::BuildTags.run!(api_user: api_user, tag_array: org_update[:tags])
+          organization.tags = tags unless tags.nil?
+          org_update.delete(:tags)
+        end
+
         organization.update!(org_update.symbolize_keys)
         organization.organization_contents.find_or_initialize_by(language: language).tap do |content|
           results = content_from_params(inputs[:organization_params], Api::V1::OrganizationsController::CONTENT_FIELDS) do |ps|
@@ -27,6 +34,7 @@ module Organizations
           content.update! content_update.symbolize_keys
         end
         org_update[:listed] == true ? organization.touch(:listed_at) : organization[:listed_at] = nil
+
         organization.save!
       end
     end

--- a/app/operations/tags/build_tags.rb
+++ b/app/operations/tags/build_tags.rb
@@ -4,7 +4,7 @@ module Tags
     array :tag_array
 
     def execute
-      tags = tag_array.try(:map) do |tag|
+      tags = tag_array.map do |tag|
         name = tag.downcase
         Tag.where(name: name).first_or_create
       end

--- a/app/operations/tags/build_tags.rb
+++ b/app/operations/tags/build_tags.rb
@@ -6,7 +6,7 @@ module Tags
     def execute
       tags = tag_array.try(:map) do |tag|
         name = tag.downcase
-        Tag.find_or_initialize_by(name: name)
+        Tag.where(name: name).first_or_create
       end
       tags
     end

--- a/app/operations/tags/build_tags.rb
+++ b/app/operations/tags/build_tags.rb
@@ -1,0 +1,14 @@
+module Tags
+  class BuildTags < Operation
+
+    array :tag_array
+
+    def execute
+      tags = tag_array.try(:map) do |tag|
+        name = tag.downcase
+        Tag.find_or_initialize_by(name: name)
+      end
+      tags
+    end
+  end
+end

--- a/app/schemas/organization_update_schema.rb
+++ b/app/schemas/organization_update_schema.rb
@@ -52,6 +52,13 @@ class OrganizationUpdateSchema < JsonSchema
       end
     end
 
+    property "tags" do
+      type "array"
+      items do
+        type "string"
+      end
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Api::V1::OrganizationsController, type: :controller do
   let(:authorized_user) { create(:user) }
+  let(:api_resource_name) { "organizations" }
   let(:organization) { build(:organization, listed_at: Time.now, owner: authorized_user) }
   let(:unlisted_organization) { build(:unlisted_organization) }
   let(:owned_unlisted_organization) { build(:unlisted_organization, owner: authorized_user) }
@@ -63,6 +64,11 @@ describe Api::V1::OrganizationsController, type: :controller do
           get :index
           expect(json_response["organizations"]).to be_empty
         end
+      end
+
+      it_behaves_like "taggable" do
+        let(:resource) { organization }
+        let(:second_resource) { build(:organization, listed_at: Time.now, owner: authorized_user) }
       end
 
       describe "filtering by slug" do

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -66,7 +66,7 @@ describe Api::V1::OrganizationsController, type: :controller do
         end
       end
 
-      it_behaves_like "taggable" do
+      it_behaves_like "indexable by tag" do
         let(:resource) { organization }
         let(:second_resource) { build(:organization, listed_at: Time.now, owner: authorized_user) }
       end
@@ -155,6 +155,14 @@ describe Api::V1::OrganizationsController, type: :controller do
         end
         let(:test_attr) { :display_name }
         let(:test_attr_value) { "Def Not Illuminati" }
+      end
+
+      it_behaves_like "has updatable tags" do
+        let(:resource) { create(:organization, owner: authorized_user) }
+        let(:tag_array) { ["astro", "gastro"] }
+        let(:tag_params) do
+          { organizations: { tags: tag_array }, id: resource.id }
+        end
       end
 
       context "includes exceptional parameters" do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -119,7 +119,7 @@ describe Api::V1::ProjectsController, type: :controller do
           end
         end
 
-        it_behaves_like "taggable" do
+        it_behaves_like "indexable by tag" do
           let(:resource) { new_project }
           let(:second_resource) { beta_resource }
         end
@@ -605,35 +605,10 @@ describe Api::V1::ProjectsController, type: :controller do
     end
 
     it_behaves_like "is updatable"
-
-    describe "update tags" do
-      let(:tags) { ["astro", "gastro"] }
+    it_behaves_like "has updatable tags" do
+      let(:tag_array) { ["astro", "gastro"] }
       let(:tag_params) do
-        { projects: { tags: tags }, id: resource.id }
-      end
-
-      def tag_update
-        default_request scopes: scopes, user_id: authorized_user.id
-        put :update, tag_params
-      end
-
-      it 'should remove all previous tags' do
-        create(:tag, name: "GONE", resource: resource)
-        tag_update
-        resource.reload
-        expect(resource.tags.pluck(:name)).to_not include("GONE")
-      end
-
-      it 'should update with new tags' do
-        tag_update
-        resource.reload
-        expect(resource.tags.pluck(:name)).to match_array(tags)
-      end
-
-      it "should touch the project resource to modify the cache_key / etag" do
-        expect {
-          tag_update
-        }.to change { resource.reload.updated_at }
+        { projects: { tags: tag_array }, id: resource.id }
       end
     end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -119,60 +119,9 @@ describe Api::V1::ProjectsController, type: :controller do
           end
         end
 
-        describe "tag filters" do
-          let!(:tags) do
-            [create(:tag, name: "youreit", resource: new_project),
-             create(:tag, name: "youreout", resource: beta_resource)]
-          end
-          let(:tag) { tags.first }
-
-          before do
-            index_request
-          end
-
-          describe "fuzzy filter by tag name" do
-            context "with full tag" do
-              let(:index_options) { { search: "tag:#{tag.name}" } }
-
-              it 'should return a project with the tag' do
-                expect(json_response[api_resource_name][0]["id"]).to eq(new_project.id.to_s)
-              end
-            end
-
-            context "partial tag" do
-              let(:index_options) { { search: "tag:#{tag.name[0..-4]}" } }
-
-              it 'should fuzzymatch' do
-                expect(json_response[api_resource_name].map{ |p| p["id"]}).to match_array([new_project.id.to_s, beta_resource.id.to_s])
-              end
-            end
-          end
-
-          describe "strict filter by tag" do
-            context "with full tag" do
-              let(:index_options) { { tags: tag.name } }
-
-              it 'should return a project with the tag' do
-                expect(json_response[api_resource_name][0]["id"]).to eq(new_project.id.to_s)
-              end
-            end
-
-            context "case insensitive" do
-              let(:index_options) { { tags: tag.name.upcase } }
-
-              it 'should return a project with the tag' do
-                expect(json_response[api_resource_name][0]["id"]).to eq(new_project.id.to_s)
-              end
-            end
-
-            context "partial tag" do
-              let(:index_options) { { tags: tag.name[0..-4] } }
-
-              it 'should return nothing' do
-                expect(json_response[api_resource_name]).to be_empty
-              end
-            end
-          end
+        it_behaves_like "taggable" do
+          let(:resource) { new_project }
+          let(:second_resource) { beta_resource }
         end
 
         describe "filtering" do

--- a/spec/operations/tags/build_tags_spec.rb
+++ b/spec/operations/tags/build_tags_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Tags::BuildTags do
+
+  let(:api_user) { ApiUser.new(build_stubbed(:user)) }
+  let(:operation) { described_class.with(api_user: api_user) }
+  let(:resource) { create(:project) }
+  let!(:tag) { create(:tag, name: "waycool", resource: resource) }
+
+  it "requires an array of tags" do
+    expect{operation.run! tag_array: "uhoh" }.to raise_error(ActiveInteraction::InvalidInteractionError)
+  end
+
+  it "finds existing tags" do
+    tags = ['waycool']
+    expect{operation.run! tag_array: tags}.not_to change{Tag.count}
+  end
+
+  it "creates non-existant tags" do
+    tags = ['new', 'tag']
+    expect{operation.run! tag_array: tags}.to change{Tag.count}.by(2)
+  end
+
+  it "returns an array of Tag objects" do
+    tags = ['new', 'tag']
+    result = operation.run! tag_array: tags
+    expect(result).to eq([Tag.find_by_name('new'), Tag.find_by_name('tag')])
+  end
+end

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -1,0 +1,57 @@
+shared_examples "taggable" do
+  describe "tag filters" do
+    let!(:tags) do
+      [create(:tag, name: "youreit", resource: resource),
+       create(:tag, name: "youreout", resource: second_resource)]
+    end
+    let(:tag) { tags.first }
+
+    before do
+      get :index, index_options
+    end
+
+    describe "fuzzy filter by tag name" do
+      context "with full tag" do
+        let(:index_options) { { search: "tag:#{tag.name}" } }
+
+        it 'should return a project with the tag' do
+          expect(json_response[api_resource_name][0]["id"]).to eq(resource.id.to_s)
+        end
+      end
+
+      context "partial tag" do
+        let(:index_options) { { search: "tag:#{tag.name[0..-4]}" } }
+
+        it 'should fuzzymatch' do
+          expect(json_response[api_resource_name].map{ |p| p["id"]}).to match_array([resource.id.to_s, second_resource.id.to_s])
+        end
+      end
+    end
+
+    describe "strict filter by tag" do
+      context "with full tag" do
+        let(:index_options) { { tags: tag.name } }
+
+        it 'should return a project with the tag' do
+          expect(json_response[api_resource_name][0]["id"]).to eq(resource.id.to_s)
+        end
+      end
+
+      context "case insensitive" do
+        let(:index_options) { { tags: tag.name.upcase } }
+
+        it 'should return a project with the tag' do
+          expect(json_response[api_resource_name][0]["id"]).to eq(resource.id.to_s)
+        end
+      end
+
+      context "partial tag" do
+        let(:index_options) { { tags: tag.name[0..-4] } }
+
+        it 'should return nothing' do
+          expect(json_response[api_resource_name]).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -81,5 +81,12 @@ shared_context "has updatable tags" do
         tag_update
       }.to change { resource.reload.updated_at }
     end
+
+    it "error response is returned if tag is invalid" do
+      borked_params = { organizations: { tags: "bork" }, id: resource.id }
+      default_request scopes: scopes, user_id: authorized_user.id
+      put :update, borked_params
+      expect(response.status).to eq(422)
+    end
   end
 end


### PR DESCRIPTION
Adds tag resource to organizations. Extracts tag logic into concerns and support specs and adds filtering via query params on index methods.

Tags are now built (find or init) in a little service object that's used by the project and organization update and create methods/ops.

Bonus: should make it easy to add tags to other things. Lookin' at you, collections.

Fixes #2436 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
