### PR TITLE
Media resources scope fix

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -98,4 +98,14 @@ class Api::V1::MediaController < Api::ApiController
   def has_many_assocation?
     @has_many_assocation ||= association_reflection.macro == :has_many
   end
+
+  # locate the only the linked media type if it's supplied as a param (via routes)
+  def controlled_resources
+    @controlled_resources ||= if params[:media_name]
+                                linked_media_type = "#{polymorphic_klass_name}_#{params[:media_name]}"
+                                super.where(type: linked_media_type)
+                              else
+                                super
+                              end
+  end
 end

--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -102,10 +102,15 @@ class Api::V1::MediaController < Api::ApiController
   # locate the only the linked media type if it's supplied as a param (via routes)
   def controlled_resources
     @controlled_resources ||= if params[:media_name]
-                                linked_media_type = "#{polymorphic_klass_name}_#{params[:media_name]}"
-                                super.where(type: linked_media_type)
+                                super.where(type: singular_linked_media_type)
                               else
                                 super
                               end
+  end
+
+  # attached images have where(type: "tutorial_attached_image") } polymorphic scope
+  # so these has_many relatinos need to be singular types scopes
+  def singular_linked_media_type
+    "#{polymorphic_klass_name}_#{params[:media_name]}".singularize
   end
 end

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
 
         context "when another media type exits" do
           before do
-            create(:medium, linked: parent, type: "another_media_type", content_type: content_type)
+            create(:medium, linked: parent, type: "another_media_type", content_type: "image/jpeg")
             get_index
           end
 

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -172,10 +172,14 @@ RSpec.describe Api::V1::MediaController, type: :controller do
 
     if actions.include? :index
       describe "#index" do
+        let(:get_index) do
+          default_request user_id: authorized_user.id, scopes: scopes
+          get :index, :"#{parent_name}_id" => parent.id, :media_name => media_type
+        end
+
         context "when #{media_type} exists" do
           before(:each) do
-            default_request user_id: authorized_user.id, scopes: scopes
-            get :index, :"#{parent_name}_id" => parent.id, :media_name => media_type
+            get_index
           end
 
           it 'should return ok' do
@@ -192,8 +196,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
         context "when #{media_type} does not exist" do
           before(:each) do
             resource.destroy
-            default_request user_id: authorized_user.id, scopes: scopes
-            get :index, :"#{parent_name}_id" => parent.id, :media_name => media_type
+            get_index
           end
 
           it 'should return 404' do
@@ -203,6 +206,22 @@ RSpec.describe Api::V1::MediaController, type: :controller do
           it 'should return an error message' do
             msg = json_response['errors'][0]['message']
             expect(msg).to match(/No #{media_type} exists for #{parent_name} ##{parent.id}/)
+          end
+        end
+
+        context "when another media type exits" do
+          before do
+            create(:medium, linked: parent, type: "another_media_type", content_type: content_type)
+            get_index
+          end
+
+          it 'should return ok' do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'should include only the requested media type item' do
+            expect(json_response["media"].length).to eq(1)
+            expect(json_response["media"][0]["media_type"]).to eq("#{parent_name}_#{media_type}")
           end
         end
       end


### PR DESCRIPTION
Ensure the media resources restrict the media_type scope to the relevant route. 

E.g. get /projects/1/background should only return media resources with `type: 'project_background'`. fixes a bug reported in https://github.com/zooniverse/Panoptes-Front-End/pull/4142#issuecomment-344628072

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
