### PR TITLE
fix typo and comment wording for media controller scopes

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -108,8 +108,8 @@ class Api::V1::MediaController < Api::ApiController
                               end
   end
 
-  # attached images have where(type: "tutorial_attached_image") } polymorphic scope
-  # so these has_many relatinos need to be singular types scopes
+  # attached images have where(type: "tutorial_attached_image") } filters
+  # so these has_many relations need to be singular types
   def singular_linked_media_type
     "#{polymorphic_klass_name}_#{params[:media_name]}".singularize
   end


### PR DESCRIPTION
Fix typo and make comment wording clearer.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
