### PR TITLE
add compound index for classifications by project and id

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -27,7 +27,10 @@ class Classification < ActiveRecord::Base
   scope :created_by, -> (user) { where(user_id: user.id) }
   scope :complete, -> { where(completed: true) }
   scope :gold_standard, -> { where("gold_standard IS TRUE") }
-  scope :after_id, -> (last_id) { where("classifications.id > ?", last_id) }
+  scope :after_id, lambda { |last_id|
+    where("classifications.id > ?", last_id)
+    .order("classifications.id")
+  }
 
   def self.scope_for(action, user, opts={})
     return all if user.is_admin? && action != :gold_standard

--- a/db/migrate/20171120222438_add_compound_project_last_id_index.rb
+++ b/db/migrate/20171120222438_add_compound_project_last_id_index.rb
@@ -1,0 +1,8 @@
+class AddCompoundProjectLastIdIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :classifications, %i(project_id id), algorithm: :concurrently
+    remove_index :classifications, column: :project_id
+  end
+end

--- a/db/migrate/20171121120455_rebuild_classification_indexes.rb
+++ b/db/migrate/20171121120455_rebuild_classification_indexes.rb
@@ -5,7 +5,7 @@ class RebuildClassificationIndexes < ActiveRecord::Migration
   def change
     reversible do |direction|
       direction.up do
-        rebuild_non_spare_indexes
+        rebuild_non_sparse_indexes
         rebuild_sparse_indexes
       end
     end
@@ -13,7 +13,7 @@ class RebuildClassificationIndexes < ActiveRecord::Migration
 
   private
 
-  def rebuild_non_spare_indexes
+  def rebuild_non_sparse_indexes
     index_cols.each do |column|
       rebuild_index(column) do
         add_index TABLE_NAME, column, algorithm: :concurrently

--- a/db/migrate/20171121120455_rebuild_classification_indexes.rb
+++ b/db/migrate/20171121120455_rebuild_classification_indexes.rb
@@ -1,0 +1,46 @@
+class RebuildClassificationIndexes < ActiveRecord::Migration
+  disable_ddl_transaction!
+  TABLE_NAME = :classifications
+
+  def change
+    index_cols.each do |column|
+      rebuild_index(column) do
+        add_index TABLE_NAME, column, algorithm: :concurrently
+      end
+    end
+
+    sparse_index_rebuilds.each do |column, clause|
+      rebuild_index(column) do
+        add_index TABLE_NAME, column, where: clause, algorithm: :concurrently
+      end
+    end
+  end
+
+  private
+
+  def rebuild_index(column)
+    renamed_index_name = to_delete_index_name(column)
+    rename_index TABLE_NAME, current_index_name(column), renamed_index_name
+    yield
+    remove_index TABLE_NAME, name: renamed_index_name
+  end
+
+  def index_cols
+    %i(created_at workflow_id user_id)
+  end
+
+  def sparse_index_rebuilds
+    {
+      gold_standard: "gold_standard IS TRUE",
+      lifecycled_at: "lifecycled_at IS NULL"
+    }
+  end
+
+  def current_index_name(column)
+    index_name(TABLE_NAME, column)
+  end
+
+  def to_delete_index_name(column)
+    "to_delete_#{column}_index"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2422,10 +2422,10 @@ CREATE INDEX index_classifications_on_lifecycled_at ON classifications USING btr
 
 
 --
--- Name: index_classifications_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_classifications_on_project_id ON classifications USING btree (project_id);
+CREATE INDEX index_classifications_on_project_id_and_id ON classifications USING btree (project_id, id);
 
 
 --
@@ -4081,4 +4081,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170808130619');
 INSERT INTO schema_migrations (version) VALUES ('20170824165411');
 
 INSERT INTO schema_migrations (version) VALUES ('20171019115705');
+
+INSERT INTO schema_migrations (version) VALUES ('20171120222438');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4084,3 +4084,5 @@ INSERT INTO schema_migrations (version) VALUES ('20171019115705');
 
 INSERT INTO schema_migrations (version) VALUES ('20171120222438');
 
+INSERT INTO schema_migrations (version) VALUES ('20171121120455');
+

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -227,7 +227,7 @@ describe Classification, :type => :model do
           expect(result).not_to include Classification.first
         end
 
-        it 'should order by id for determinisitc result sets' do
+        it 'should order by id for deterministic result sets' do
           expect(result.to_sql).to include("ORDER BY classifications.id")
         end
 

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -218,16 +218,24 @@ describe Classification, :type => :model do
 
       context "with last_id param provided" do
         let!(:classifications) { create_list(:classification, 2, project: project) }
+        let(:opts) { { last_id: Classification.first.id, project_id: project.id } }
+        let(:result) do
+          Classification.scope_for(:project, user, opts)
+        end
 
         it 'returns only the classifications after last_id if provided' do
-          result = Classification.scope_for(:project, user, {last_id: Classification.first.id, project_id: project.id})
           expect(result).not_to include Classification.first
         end
 
-        it 'raise MissingParameter if project_id is not also provided' do
-          expect {
-            Classification.scope_for(:project, user, {last_id: Classification.first.id})
-          }.to raise_error(Classification::MissingParameter)
+        it 'should order by id for determinisitc result sets' do
+          expect(result.to_sql).to include("ORDER BY classifications.id")
+        end
+
+        context "when project_id is not also provided" do
+          let(:opts) { { last_id: Classification.first.id } }
+          it 'raises MissingParameter' do
+            expect { result }.to raise_error(Classification::MissingParameter)
+          end
         end
       end
     end

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -38,10 +38,12 @@ describe ClassificationSerializer do
       end
       let(:prefix) { "/classifications?last_id=" }
       let(:suffix) { "&page_size=1&project_id=#{project.id}" }
+      let(:params) do
+        { project_id: project.id, last_id: last_id, page_size: 1 }
+      end
 
       it "should insert the highest page set id into the next_href" do
         second = create(:classification, project: project)
-        params = {project_id: project.id, last_id: last_id, page_size: 1}
         result = ClassificationSerializer.page(params, scope, {})
         meta = result[:meta][:classifications]
         expect(meta[:previous_href]).to eq("#{prefix}#{last_id}#{suffix}")
@@ -49,8 +51,8 @@ describe ClassificationSerializer do
       end
 
       it "should construct valid hrefs when there is no data" do
-        params = {project_id: project.id, last_id: last_id, page: 2, page_size: 1}
-        result = ClassificationSerializer.page(params, scope, {})
+        page2_params = params.merge({page: 2})
+        result = ClassificationSerializer.page(page2_params, scope, {})
         meta = result[:meta][:classifications]
         expect(meta[:previous_href]).to eq("#{prefix}#{last_id}#{suffix}")
         expect(meta[:next_href]).to be_nil

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -33,21 +33,26 @@ describe ClassificationSerializer do
     context "project context with last_id param present" do
       let(:project) { classification.project }
       let(:last_id) { classification.id }
+      let(:scope) do
+        Classification.where(project_id: project.id).after_id(last_id)
+      end
+      let(:prefix) { "/classifications?last_id=" }
+      let(:suffix) { "&page_size=1&project_id=#{project.id}" }
 
-      it "should insert the next hightest last_id into the next_href" do
+      it "should insert the highest page set id into the next_href" do
         second = create(:classification, project: project)
         params = {project_id: project.id, last_id: last_id, page_size: 1}
-        result = ClassificationSerializer.page(params, Classification.all, {})
+        result = ClassificationSerializer.page(params, scope, {})
         meta = result[:meta][:classifications]
-        expect(meta[:previous_href]).to eq("/classifications?last_id=#{last_id}&page_size=1&project_id=#{project.id}")
-        expect(meta[:next_href]).to eq("/classifications?last_id=#{second.id}&page_size=1&project_id=#{project.id}")
+        expect(meta[:previous_href]).to eq("#{prefix}#{last_id}#{suffix}")
+        expect(meta[:next_href]).to eq("#{prefix}#{second.id}#{suffix}")
       end
 
-      it "should constructu valid hrefs when there is no data" do
+      it "should construct valid hrefs when there is no data" do
         params = {project_id: project.id, last_id: last_id, page: 2, page_size: 1}
-        result = ClassificationSerializer.page(params, Classification.all, {})
+        result = ClassificationSerializer.page(params, scope, {})
         meta = result[:meta][:classifications]
-        expect(meta[:previous_href]).to eq("/classifications?last_id=#{last_id}&page_size=1&project_id=#{project.id}")
+        expect(meta[:previous_href]).to eq("#{prefix}#{last_id}#{suffix}")
         expect(meta[:next_href]).to be_nil
       end
     end


### PR DESCRIPTION
closes #2334 #2319

adds an index to filter by project_id and order by id at the same time e.g. 
`Classification.where(project_id: 1).where("id > ?", last_id).order(:id).limit(page_size)`

*Note: the rebuilt index is ~2x smaller than it was (4148 MB vs 1696 MB).* 

~I'm going to issue a new PR~ I've included a migration to concurrently rebuild and drop classifications table indexes. We should look at rebuilding the db / table indexes during downtimes or routinely rebuilding and dropping old ones to ensure we remove the index bloat. The code in the migration could be a nice target for extraction, i can do this if people think it'll be used more widely.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
