### PR TITLE
Fix email dump uploads

### DIFF
--- a/app/models/csv_dumps/direct_to_s3.rb
+++ b/app/models/csv_dumps/direct_to_s3.rb
@@ -34,7 +34,8 @@ module CsvDumps
       {
         private: true,
         compressed: true,
-        content_disposition: "attachment; filename=\"#{file_name}.csv\""
+        content_disposition: "attachment; filename=\"#{file_name}.csv\"",
+        signature_version: :v4
       }
     end
 

--- a/app/models/csv_dumps/full_email_list.rb
+++ b/app/models/csv_dumps/full_email_list.rb
@@ -1,7 +1,11 @@
 module CsvDumps
   class FullEmailList < DumpScope
-    EXPORT_FIELDS = {global: :global_email_communication,
-                     beta: :beta_email_communication}.freeze
+    attr_reader :type
+
+    EXPORT_FIELDS = {
+      global: :global_email_communication,
+      beta: :beta_email_communication
+    }.with_indifferent_access.freeze
 
     def initialize(type)
       @type = type
@@ -27,7 +31,7 @@ module CsvDumps
     end
 
     def export_field
-      EXPORT_FIELDS.fetch(@type)
+      EXPORT_FIELDS.fetch(type)
     end
   end
 end

--- a/app/services/media_storage/aws_adapter.rb
+++ b/app/services/media_storage/aws_adapter.rb
@@ -8,11 +8,7 @@ module MediaStorage
       @get_expiration = opts.dig(:expiration, :get) || 60
       @put_expiration = opts.dig(:expiration, :put) || 20
       keys = opts.slice(:access_key_id, :secret_access_key)
-      aws.config(keys) unless keys.empty?
-    end
-
-    def aws
-      AWS
+      AWS.config(keys) unless keys.empty?
     end
 
     def bucket
@@ -61,6 +57,9 @@ module MediaStorage
       upload_options[:content_encoding] = 'gzip' if opts[:compressed]
       if opts[:content_disposition]
         upload_options[:content_disposition] = opts[:content_disposition]
+      end
+      if opts[:signature_version]
+        upload_options[:signature_version] = opts[:signature_version]
       end
       object(path).write(**upload_options)
     end

--- a/spec/models/csv_dumps/direct_to_s3_spec.rb
+++ b/spec/models/csv_dumps/direct_to_s3_spec.rb
@@ -9,7 +9,8 @@ describe CsvDumps::DirectToS3 do
     {
       private: true,
       compressed: true,
-      content_disposition: "attachment; filename=\"full_email_list.csv\""
+      content_disposition: "attachment; filename=\"full_email_list.csv\"",
+      signature_version: :v4
     }
   end
   let(:file_path) { "/tmp/foobar" }

--- a/spec/models/csv_dumps/full_email_list_spec.rb
+++ b/spec/models/csv_dumps/full_email_list_spec.rb
@@ -17,4 +17,10 @@ describe CsvDumps::FullEmailList do
     list = described_class.new(:beta)
     expect { |b| list.each(&b) }.to yield_successive_args(*users)
   end
+
+  it 'should handle matching string args ala sidekiq' do
+    users = [all_email_user, global_email_user]
+    list = described_class.new("global")
+    expect { |b| list.each(&b) }.to yield_successive_args(*users)
+  end
 end

--- a/spec/services/media_storage/aws_adapter_spec.rb
+++ b/spec/services/media_storage/aws_adapter_spec.rb
@@ -53,19 +53,19 @@ RSpec.describe MediaStorage::AwsAdapter do
 
   describe "#get_path" do
     context "when the path is public" do
-      subject{ adapter.get_path("media.zooniverse.org/subject_locations/name.jpg") }
+      subject{ adapter.get_path("subject_locations/name.jpg") }
 
-      it { is_expected.to match(/\A#{URI::regexp}\z/) }
+      it { is_expected.to match(/\A#{URI.regexp}\z/) }
     end
 
     context "when the path is private" do
-      subject{ adapter.get_path("media.zooniverse.org/subject_locations/name.jpg", private: true) }
+      subject{ adapter.get_path("subject_locations/name.jpg", private: true) }
       it_behaves_like "signed s3 url"
     end
   end
 
   describe "#put_path" do
-    subject{ adapter.put_path("media.zooniverse.org/subject_locations/name.jpg") }
+    subject{ adapter.put_path("subject_locations/name.jpg") }
 
     it_behaves_like "signed s3 url"
   end
@@ -133,6 +133,23 @@ RSpec.describe MediaStorage::AwsAdapter do
             content_disposition: disposition
           )
         put_opts = { content_type: content_type, content_disposition: disposition }
+        adapter.put_file("src", file_path, put_opts)
+      end
+    end
+
+    context "when opts[:signature_version] is set" do
+      let(:signature_version) { :v4 }
+
+      it 'should call write with the signature_version set' do
+        expect(obj_double)
+          .to receive(:write)
+          .with(
+            file: file_path,
+            content_type: content_type,
+            acl: 'public-read',
+            signature_version: signature_version
+          )
+        put_opts = { content_type: content_type, signature_version: signature_version }
         adapter.put_file("src", file_path, put_opts)
       end
     end

--- a/spec/services/media_storage/aws_adapter_spec.rb
+++ b/spec/services/media_storage/aws_adapter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MediaStorage::AwsAdapter do
   let(:adapter) do
     described_class.new(prefix: prefix, bucket: bucket, access_key_id: 'fake', secret_access_key: 'keys')
   end
+  let(:uri_regex) { /\A#{URI::DEFAULT_PARSER.make_regexp}\z/ }
 
   context 'when keys are passed to the initializer' do
     it 'should set the aws config ' do
@@ -46,7 +47,7 @@ RSpec.describe MediaStorage::AwsAdapter do
   end
 
   shared_examples "signed s3 url" do
-    it { is_expected.to match(/\A#{URI::regexp}\z/) }
+    it { is_expected.to match(uri_regex) }
     it { is_expected.to match(/#{bucket}/) }
     it { is_expected.to match(/Expires=[0-9]+&Signature=[%A-z0-9]+/) }
   end
@@ -55,7 +56,7 @@ RSpec.describe MediaStorage::AwsAdapter do
     context "when the path is public" do
       subject{ adapter.get_path("subject_locations/name.jpg") }
 
-      it { is_expected.to match(/\A#{URI.regexp}\z/) }
+      it { is_expected.to match(uri_regex) }
     end
 
     context "when the path is private" do


### PR DESCRIPTION
Handle sidekiq params symbol -> string round trip lookups and ensure we use the correct s3 signature version for the emails bucket.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
