### PR TITLE
remove unused header for response mime type

### DIFF
--- a/app/services/media_storage/aws_adapter.rb
+++ b/app/services/media_storage/aws_adapter.rb
@@ -48,7 +48,6 @@ module MediaStorage
         :put,
         content_type: content_type,
         expires_in: expires,
-        response_content_type: content_type,
         acl: opts[:private] ? 'private' : 'public-read'
       ).to_s
     end

--- a/spec/services/media_storage/aws_adapter_spec.rb
+++ b/spec/services/media_storage/aws_adapter_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe MediaStorage::AwsAdapter do
   end
 
   describe "#put_path" do
-    subject{ adapter.put_path("subject_locations/name.jpg") }
+    let(:opts) { { private: false, content_type: "image/jpeg" } }
+    subject{ adapter.put_path("subject_locations/name.jpg", opts) }
 
     it_behaves_like "signed s3 url"
   end


### PR DESCRIPTION
v1 url_for accepted this header, v2 presigned_url does not. the client was ignoring this header anyway as it was supplying the known mime type during PUT to the presigned URL so it’s not needed.

For ref, I've tested this manually on the console and that gave me the way to create the failing spec.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
