### PR TITLE
extend the default get / put presigned urls timeouts

### DIFF
--- a/spec/services/media_storage/aws_adapter_spec.rb
+++ b/spec/services/media_storage/aws_adapter_spec.rb
@@ -27,18 +27,19 @@ RSpec.describe MediaStorage::AwsAdapter do
     end
 
     describe "s3 client config" do
-      before do
-        expect(Aws::S3::Client)
-        .to receive(:new)
-        .with(s3_opts.except(:prefix, :bucket))
-        .and_call_original
-      end
-
       it 'should set the aws config through the s3 client ' do
+        expect(Aws::S3::Client)
+          .to receive(:new)
+          .with(s3_opts.except(:prefix, :bucket))
+          .and_call_original
         adapter
       end
 
       it 'should deafult to the us-east-1 region' do
+        expect(Aws::S3::Client)
+          .to receive(:new)
+          .with(s3_opts.except(:prefix, :bucket))
+          .and_call_original
         described_class.new(s3_opts.except(:region))
       end
     end

--- a/spec/services/media_storage/aws_adapter_spec.rb
+++ b/spec/services/media_storage/aws_adapter_spec.rb
@@ -18,20 +18,29 @@ RSpec.describe MediaStorage::AwsAdapter do
   let(:adapter) { described_class.new(s3_opts) }
   let(:uri_regex) { /\A#{URI::DEFAULT_PARSER.make_regexp}\z/ }
 
-  context 'when keys are passed to the initializer' do
-    let(:expectation) do
-      expect(Aws::S3::Client)
-      .to receive(:new)
-      .with(s3_opts.except(:prefix, :bucket))
-      .and_call_original
+  context 'when opts are passed to the initializer' do
+    it "should use default expiration values" do
+      adapter = described_class.new(s3_opts)
+      default = MediaStorage::AwsAdapter::DEFAULT_EXPIRES_IN
+      expect(adapter.get_expiration).to eq(default)
+      expect(adapter.put_expiration).to eq(default)
     end
 
-    it 'should set the aws config through the s3 client ' do
-      adapter
-    end
+    describe "s3 client config" do
+      before do
+        expect(Aws::S3::Client)
+        .to receive(:new)
+        .with(s3_opts.except(:prefix, :bucket))
+        .and_call_original
+      end
 
-    it 'should deafult to the us-east-1 region' do
-      described_class.new(s3_opts.except(:region))
+      it 'should set the aws config through the s3 client ' do
+        adapter
+      end
+
+      it 'should deafult to the us-east-1 region' do
+        described_class.new(s3_opts.except(:region))
+      end
     end
   end
 


### PR DESCRIPTION
give the clients more time to use the presigned URL’s by default, this options can still be overridden in the calling methods.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
