### PR TITLE
Sync translated resource strings to translations data model

### DIFF
--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -11,6 +11,24 @@ class TranslationStrings
 
   private
 
+  # def visitor_extract_strings
+  #   if content_model_resource?
+  #     attrs
+  #   else
+  #     # this doesn't seem to be used in pandora
+  #     # looks like pandora will iterate over the list of
+  #     # translated resources and extract the attributes in visit_question
+  #     visitor = TasksVisitors::ExtractStrings.new
+  #     stripped_items = visitor.visit(attrs[*translatable_attributes])
+  #     extracted_strings = visitor.collector
+  #   end
+  # end
+  #
+  # CONTENT_MODELS = %w(project workflow).freeze
+  # def content_model_resource?
+  #   CONTENT_MODELS.include?(resource.model_name.singular)
+  # end
+
   def resource_attributes
     attrs = resource.attributes.dup.except(:id)
     attrs.merge(primary_content_attributes).with_indifferent_access

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -17,6 +17,8 @@ class TranslationStrings
   end
 
   def primary_content_attributes
+    return {} unless resource.class.respond_to?(:content_association)
+
     content_assocation = resource.class.content_association
     resource
       .send(content_assocation)

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -73,7 +73,7 @@ class TranslationStrings
 
   # field guide item has icon attributes that should not be translated
   def transform_field_guide_attributes(nested_key="items")
-    attributes[nested_key] = removed_nested_attributes(%i(title content), nested_key)
+    attributes[nested_key] = extract_nested_attributes(%i(title content), nested_key)
   end
 
   # pandora app uses the tasks key to find the tasks strings
@@ -82,10 +82,10 @@ class TranslationStrings
   end
 
   def transform_tutorial_attributes(nested_key="steps")
-    attributes[nested_key] = removed_nested_attributes(%i(content), nested_key)
+    attributes[nested_key] = extract_nested_attributes(%i(content), nested_key)
   end
 
-  def removed_nested_attributes(attributes_to_slice, key)
+  def extract_nested_attributes(attributes_to_slice, key)
     attributes[key.to_sym].map do |nested_object|
       nested_object.slice(*attributes_to_slice)
     end

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -37,30 +37,26 @@ class TranslationStrings
   end
 
   def workflow_attributes
-    {}
-  end
-
-  def organization_attributes
-    {}
+    raise NotImplementedError
   end
 
   def tutorial_attributes
-    {}
+    raise NotImplementedError
   end
 
   def field_guide_attributes
-    {}
+    raise NotImplementedError
   end
 
   def project_page_attributes
-    {}
+    raise NotImplementedError
   end
 
   def organization_attributes
-    {}
+    raise NotImplementedError
   end
 
   def organization_page_attributes
-    {}
+    nil
   end
 end

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -33,14 +33,11 @@ class TranslationStrings
   end
 
   def project_attributes
-    %i(title description workflow_description introduction researcher_quote url_labels)
+    %i(display_name title description workflow_description introduction researcher_quote url_labels)
   end
 
   def workflow_attributes
-    # display_name == title in this case,
-    # something to ensure is fixed for all
-    # resources that have these confused attributes
-    %i(title strings)
+    %i(display_name strings)
   end
 
   def tutorial_attributes

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -71,7 +71,7 @@ class TranslationStrings
   end
 
   def organization_attributes
-    raise NotImplementedError.new("Org")
+    %i(display_name title description introduction url_labels)
   end
 
   def organization_page_attributes

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -44,22 +44,22 @@ class TranslationStrings
   end
 
   def tutorial_attributes
-    raise NotImplementedError
+    raise NotImplementedError.new("Tutorial")
   end
 
   def field_guide_attributes
-    raise NotImplementedError
+    raise NotImplementedError.new("FieldGuide")
   end
 
   def project_page_attributes
-    raise NotImplementedError
+    raise NotImplementedError.new("ProjectPage")
   end
 
   def organization_attributes
-    raise NotImplementedError
+    raise NotImplementedError.new("Org")
   end
 
   def organization_page_attributes
-    nil
+    raise NotImplementedError.new("OrgPage")
   end
 end

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -75,6 +75,6 @@ class TranslationStrings
   end
 
   def organization_page_attributes
-    raise NotImplementedError.new("OrgPage")
+    %i(title content)
   end
 end

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -37,7 +37,10 @@ class TranslationStrings
   end
 
   def workflow_attributes
-    raise NotImplementedError
+    # display_name == title in this case,
+    # something to ensure is fixed for all
+    # resources that have these confused attributes
+    %i(title strings)
   end
 
   def tutorial_attributes

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -1,0 +1,36 @@
+class TranslationStrings
+  attr_reader :resource
+
+  def initialize(resource)
+    @resource = resource
+  end
+
+  def extract
+    resource_attributes.slice(*translatable_attributes)
+  end
+
+  private
+
+  def resource_attributes
+    attrs = resource.attributes.dup.except(:id)
+    attrs.merge(primary_content_attributes).with_indifferent_access
+  end
+
+  def primary_content_attributes
+    content_assocation = resource.class.content_association
+    resource
+      .send(content_assocation)
+      .find_by(language: resource.primary_language)
+      .attributes
+      .dup
+      .except(:id)
+  end
+
+  def translatable_attributes
+    send("#{resource.model_name.singular}_attributes")
+  end
+
+  def project_attributes
+    %i(title description workflow_description introduction researcher_quote url_labels)
+  end
+end

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -35,4 +35,32 @@ class TranslationStrings
   def project_attributes
     %i(title description workflow_description introduction researcher_quote url_labels)
   end
+
+  def workflow_attributes
+    {}
+  end
+
+  def organization_attributes
+    {}
+  end
+
+  def tutorial_attributes
+    {}
+  end
+
+  def field_guide_attributes
+    {}
+  end
+
+  def project_page_attributes
+    {}
+  end
+
+  def organization_attributes
+    {}
+  end
+
+  def organization_page_attributes
+    {}
+  end
 end

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -25,24 +25,6 @@ class TranslationStrings
     TRANSFORM_RESOURCES.include?(resource_name)
   end
 
-  # def visitor_extract_strings
-  #   if content_model_resource?
-  #     attrs
-  #   else
-  #     # this doesn't seem to be used in pandora
-  #     # looks like pandora will iterate over the list of
-  #     # translated resources and extract the attributes in visit_question
-  #     visitor = TasksVisitors::ExtractStrings.new
-  #     stripped_items = visitor.visit(attrs[*translatable_attributes])
-  #     extracted_strings = visitor.collector
-  #   end
-  # end
-  #
-  # CONTENT_MODELS = %w(project workflow).freeze
-  # def content_model_resource?
-  #   CONTENT_MODELS.include?(resource_name)
-  # end
-
   def resource_attributes
     attrs = resource.attributes.dup.except(:id)
     attrs.merge(primary_content_attributes).with_indifferent_access

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -67,7 +67,7 @@ class TranslationStrings
   end
 
   def project_page_attributes
-    raise NotImplementedError.new("ProjectPage")
+    %i(title content)
   end
 
   def organization_attributes

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -45,7 +45,7 @@ class TranslationStrings
   end
 
   def field_guide_attributes
-    raise NotImplementedError.new("FieldGuide")
+    %i(items)
   end
 
   def project_page_attributes

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -59,7 +59,7 @@ class TranslationStrings
   end
 
   def tutorial_attributes
-    raise NotImplementedError.new("Tutorial")
+    %i(display_name steps)
   end
 
   def field_guide_attributes

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -4,9 +4,12 @@ class Translation < ActiveRecord::Base
   validates_presence_of :language
 
   # TODO: add a unique validation for translated_type, id, language
+  # and a unique index
 
   # TODO: Look at adding in paper trail change tracking for laguage / strings here
 
+  # TODO: these inverse relations need expanding to ensure the polymorphic
+  # links are correctly serialized
   def self.translated_model_names
     @translated_class_names ||= [].tap do |translated|
       ActiveRecord::Base.subclasses.each do |klass|

--- a/lib/tasks/translations.rake
+++ b/lib/tasks/translations.rake
@@ -1,0 +1,51 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+namespace :translations do
+
+  def create_or_update_translation_strings(resource, language)
+    translation = Translation.find_or_initialize_by(translated: resource, language: language)
+    translated_strings = TranslationStrings.new(resource).extract
+    translation.strings = translated_strings
+    translation.save!
+  end
+
+  desc "Sync existing translatable resources with new translations data model"
+  task :sync_resource_strings, [:project_id] => [:environment] do |task, args|
+    project = Project.find(args[:project_id])
+    language = project.primary_language
+
+    puts "Syncing project - #{project.id} strings to translations"
+    create_or_update_translation_strings(project, language)
+
+    puts "Syncing all project workflow strings to translations"
+    project.workflows.each do |workflow|
+      create_or_update_translation_strings(workflow, language)
+    end
+
+    puts "Syncing all project field guide strings to translations"
+    project.field_guides.each do |field_guide|
+      create_or_update_translation_strings(field_guide, language)
+    end
+
+    puts "Syncing all project tutorial strings to translations"
+    project.tutorials.each do |tutorial|
+      create_or_update_translation_strings(tutorial, language)
+    end
+
+    puts "Syncing all project page strings to translations"
+    project.pages.each do |page|
+      create_or_update_translation_strings(page, language)
+    end
+
+    if organization = project.organization
+      puts "Syncing project organization strings to translations"
+      create_or_update_translation_strings(organization, language)
+
+      puts "Syncing project organization page strings to translations"
+      organization.pages.each do |page|
+        create_or_update_translation_strings(page, language)
+      end
+    end
+  end
+end

--- a/spec/factories/organization_contents.rb
+++ b/spec/factories/organization_contents.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
     title "Test Organization"
     introduction "This is the intro for an Organization"
     language "en"
+    url_labels({"0.label" => "Blog", "1.label" => "Twitter"})
   end
 end

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe TranslationStrings do
   def project_strings
     {
+      "display_name" => "A Test Project",
       "title" => "A Test Project",
       "description" => "Some Lorem Ipsum",
       "workflow_description" => "Go outside",
@@ -17,7 +18,21 @@ describe TranslationStrings do
   end
 
   def workflow_strings
-    {}
+    {
+      "display_name" => "A Workflow",
+      "strings" => {
+        "interest.question" => "Draw a circle",
+        "interest.help" => "Duh?",
+        "interest.tools.0.label" => "Red",
+        "interest.tools.1.label" => "Green",
+        "interest.tools.2.label" => "Blue",
+        "shape.question" => "What shape is this galaxy",
+        "shape.help" => "Duh?",
+        "shape.answers.0.label" => "Smooth",
+        "shape.answers.1.label" => "Features",
+        "shape.answers.2.label" => "Star or artifact"
+      }
+    }
   end
 
   def tutorial_strings

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -95,11 +95,10 @@ describe TranslationStrings do
     }
   end
 
-  # %i(project workflow field_guide organization_page organization project_page)
-  %i(tutorial).each do |resource_type|
+  %i(project workflow field_guide organization_page organization project_page tutorial).each do |resource_type|
 
     describe "#extract" do
-      it "should extract all the available content to a strings hash", :focus do
+      it "should extract all the available content to a strings hash" do
         resource = create(resource_type)
         subject = TranslationStrings.new(resource)
         expect(subject.extract).to eq(send("#{resource_type}_strings"))

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -32,11 +32,15 @@ describe TranslationStrings do
     {}
   end
 
+  def organization_strings
+    {}
+  end
+
   def organization_page_strings
     {}
   end
 
-  %i(project workflow tutorial field_guide project_page organization_page).each do |resource_type|
+  %i(project workflow tutorial field_guide project_page organization organization_page).each do |resource_type|
 
     describe "#extract" do
       it "should extract all the available content to a strings hash", :focus do

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe TranslationStrings do
-  def project_strings
+  def project_strings(resource)
     {
-      "display_name" => "A Test Project",
+      "display_name" => resource.display_name,
       "title" => "A Test Project",
       "description" => "Some Lorem Ipsum",
       "workflow_description" => "Go outside",
@@ -17,7 +17,7 @@ describe TranslationStrings do
     }
   end
 
-  def workflow_strings
+  def workflow_strings(resource)
     {
       "display_name" => "A Workflow",
       "tasks" => {
@@ -35,7 +35,7 @@ describe TranslationStrings do
     }
   end
 
-  def tutorial_strings
+  def tutorial_strings(resource)
     {
       "display_name" => "A Tutorial",
       "steps" =>
@@ -52,7 +52,7 @@ describe TranslationStrings do
     }
   end
 
-  def field_guide_strings
+  def field_guide_strings(resource)
     {
       "items" =>
       [
@@ -68,16 +68,16 @@ describe TranslationStrings do
      }
   end
 
-  def project_page_strings
+  def project_page_strings(resource)
     {
       "title" => "Science Case",
       "content" => "Crap about science"
     }
   end
 
-  def organization_strings
+  def organization_strings(resource)
     {
-      "display_name" => "Test Organization 1",
+      "display_name" => resource.display_name,
       "title" => "Test Organization",
       "description" => "This is the description for an Organization",
       "introduction" => "This is the intro for an Organization",
@@ -88,7 +88,7 @@ describe TranslationStrings do
     }
   end
 
-  def organization_page_strings
+  def organization_page_strings(resource)
     {
       "title" => "Science Case",
       "content" => "Crap about science"
@@ -96,12 +96,11 @@ describe TranslationStrings do
   end
 
   %i(project workflow field_guide organization_page organization project_page tutorial).each do |resource_type|
-
     describe "#extract" do
       it "should extract all the available content to a strings hash" do
         resource = create(resource_type)
         subject = TranslationStrings.new(resource)
-        expect(subject.extract).to eq(send("#{resource_type}_strings"))
+        expect(subject.extract).to eq(send("#{resource_type}_strings", resource))
       end
     end
   end

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -45,12 +45,11 @@ describe TranslationStrings do
       [
         {
           "title" => "Page 1",
-          "content" => "stuff and things",
-          "icon" => "123456"
-        }, {
+          "content" => "stuff and things"
+        },
+        {
           "title" => "Other guide",
-          "content" => "animals & such",
-          "icon" => "654321"
+          "content" => "animals & such"
         }
       ]
      }

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -61,7 +61,16 @@ describe TranslationStrings do
   end
 
   def organization_strings
-    {}
+    {
+      "display_name" => "Test Organization 1",
+      "title" => "Test Organization",
+      "description" => "This is the description for an Organization",
+      "introduction" => "This is the intro for an Organization",
+      "url_labels" => {
+        "0.label" => "Blog",
+        "1.label" => "Twitter"
+      }
+    }
   end
 
   def organization_page_strings

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -56,7 +56,10 @@ describe TranslationStrings do
   end
 
   def project_page_strings
-    {}
+    {
+      "title" => "Science Case",
+      "content" => "Crap about science"
+    }
   end
 
   def organization_strings
@@ -79,8 +82,8 @@ describe TranslationStrings do
     }
   end
 
-  # %i(project workflow field_guide organization_page organization)
-  %i(tutorial project_page).each do |resource_type|
+  # %i(project workflow field_guide organization_page organization project_page)
+  %i(tutorial).each do |resource_type|
 
     describe "#extract" do
       it "should extract all the available content to a strings hash", :focus do

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -79,8 +79,8 @@ describe TranslationStrings do
     }
   end
 
-  # %i(project workflow field_guide)
-  %i(tutorial project_page organization organization_page).each do |resource_type|
+  # %i(project workflow field_guide organization_page organization)
+  %i(tutorial project_page).each do |resource_type|
 
     describe "#extract" do
       it "should extract all the available content to a strings hash", :focus do

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -9,62 +9,42 @@ describe TranslationStrings do
       "workflow_description" => "Go outside",
       "introduction" => "MORE IPSUM",
       "researcher_quote" => "This is my favorite project",
-      "url_labels" => {
-        "0.label"=>"Blog",
-        "1.label"=>"Twitter",
-        "2.label"=>"Science Case"
-      }
+      "url_labels.0.label"=>"Blog",
+      "url_labels.1.label"=>"Twitter",
+      "url_labels.2.label"=>"Science Case"
     }
   end
 
   def workflow_strings(resource)
     {
       "display_name" => "A Workflow",
-      "tasks" => {
-        "interest.question" => "Draw a circle",
-        "interest.help" => "Duh?",
-        "interest.tools.0.label" => "Red",
-        "interest.tools.1.label" => "Green",
-        "interest.tools.2.label" => "Blue",
-        "shape.question" => "What shape is this galaxy",
-        "shape.help" => "Duh?",
-        "shape.answers.0.label" => "Smooth",
-        "shape.answers.1.label" => "Features",
-        "shape.answers.2.label" => "Star or artifact"
-      }
+      "tasks.interest.question" => "Draw a circle",
+      "tasks.interest.help" => "Duh?",
+      "tasks.interest.tools.0.label" => "Red",
+      "tasks.interest.tools.1.label" => "Green",
+      "tasks.interest.tools.2.label" => "Blue",
+      "tasks.shape.question" => "What shape is this galaxy",
+      "tasks.shape.help" => "Duh?",
+      "tasks.shape.answers.0.label" => "Smooth",
+      "tasks.shape.answers.1.label" => "Features",
+      "tasks.shape.answers.2.label" => "Star or artifact"
     }
   end
 
   def tutorial_strings(resource)
     {
       "display_name" => "A Tutorial",
-      "steps" =>
-      [
-        {
-          "media" => "asdfasdf",
-          "content" => "asdfkajlsdf;"
-        },
-        {
-          "media" => "asdfasdf",
-          "content" => "asdkfljds;lj"
-        }
-      ]
+      "steps.0.content" => "asdfkajlsdf;",
+      "steps.1.content" => "asdkfljds;lj"
     }
   end
 
   def field_guide_strings(resource)
     {
-      "items" =>
-      [
-        {
-          "title" => "Page 1",
-          "content" => "stuff and things"
-        },
-        {
-          "title" => "Other guide",
-          "content" => "animals & such"
-        }
-      ]
+      "items.0.title" => "Page 1",
+      "items.0.content" => "stuff and things",
+      "items.1.title" => "Other guide",
+      "items.1.content" => "animals & such"
      }
   end
 
@@ -81,10 +61,8 @@ describe TranslationStrings do
       "title" => "Test Organization",
       "description" => "This is the description for an Organization",
       "introduction" => "This is the intro for an Organization",
-      "url_labels" => {
-        "0.label" => "Blog",
-        "1.label" => "Twitter"
-      }
+      "url_labels.0.label" => "Blog",
+      "url_labels.1.label" => "Twitter"
     }
   end
 
@@ -95,8 +73,9 @@ describe TranslationStrings do
     }
   end
 
-  %i(project workflow field_guide organization_page organization project_page tutorial).each do |resource_type|
-    describe "#extract" do
+  # %i(project workflow field_guide organization_page organization project_page tutorial).each do |resource_type|
+  %i(project).each do |resource_type|
+    describe "#extract", :focus do
       it "should extract all the available content to a strings hash" do
         resource = create(resource_type)
         subject = TranslationStrings.new(resource)

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -36,7 +36,20 @@ describe TranslationStrings do
   end
 
   def tutorial_strings
-    {}
+    {
+      "display_name" => "A Tutorial",
+      "steps" =>
+      [
+        {
+          "media" => "asdfasdf",
+          "content" => "asdfkajlsdf;"
+        },
+        {
+          "media" => "asdfasdf",
+          "content" => "asdkfljds;lj"
+        }
+      ]
+    }
   end
 
   def field_guide_strings

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -73,9 +73,8 @@ describe TranslationStrings do
     }
   end
 
-  # %i(project workflow field_guide organization_page organization project_page tutorial).each do |resource_type|
-  %i(project).each do |resource_type|
-    describe "#extract", :focus do
+  %i(project workflow field_guide organization_page organization project_page tutorial).each do |resource_type|
+    describe "#extract" do
       it "should extract all the available content to a strings hash" do
         resource = create(resource_type)
         subject = TranslationStrings.new(resource)

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -68,7 +68,8 @@ describe TranslationStrings do
     {}
   end
 
-  %i(project workflow tutorial field_guide project_page organization organization_page).each do |resource_type|
+  # %i(project workflow field_guide)
+  %i(tutorial field_guide project_page organization organization_page).each do |resource_type|
 
     describe "#extract" do
       it "should extract all the available content to a strings hash", :focus do

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -65,11 +65,14 @@ describe TranslationStrings do
   end
 
   def organization_page_strings
-    {}
+    {
+      "title" => "Science Case",
+      "content" => "Crap about science"
+    }
   end
 
   # %i(project workflow field_guide)
-  %i(tutorial field_guide project_page organization organization_page).each do |resource_type|
+  %i(tutorial project_page organization organization_page).each do |resource_type|
 
     describe "#extract" do
       it "should extract all the available content to a strings hash", :focus do

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe TranslationStrings do
+  def project_strings
+    {
+      "title" => "A Test Project",
+      "description" => "Some Lorem Ipsum",
+      "workflow_description" => "Go outside",
+      "introduction" => "MORE IPSUM",
+      "researcher_quote" => "This is my favorite project",
+      "url_labels" =>{
+        "0.label"=>"Blog",
+        "1.label"=>"Twitter",
+        "2.label"=>"Science Case"
+      }
+    }
+  end
+
+  def workflow_strings
+    {}
+  end
+
+  def tutorial_strings
+    {}
+  end
+
+  def field_guide_strings
+    {}
+  end
+
+  def project_page_strings
+    {}
+  end
+
+  def organization_page_strings
+    {}
+  end
+
+  %i(project workflow tutorial field_guide project_page organization_page).each do |resource_type|
+
+    describe "#extract" do
+      it "should extract all the available content to a strings hash", :focus do
+        resource = create(resource_type)
+        subject = TranslationStrings.new(resource)
+        expect(subject.extract).to eq(send("#{resource_type}_strings"))
+      end
+    end
+  end
+end

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -9,7 +9,7 @@ describe TranslationStrings do
       "workflow_description" => "Go outside",
       "introduction" => "MORE IPSUM",
       "researcher_quote" => "This is my favorite project",
-      "url_labels" =>{
+      "url_labels" => {
         "0.label"=>"Blog",
         "1.label"=>"Twitter",
         "2.label"=>"Science Case"

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -20,7 +20,7 @@ describe TranslationStrings do
   def workflow_strings
     {
       "display_name" => "A Workflow",
-      "strings" => {
+      "tasks" => {
         "interest.question" => "Draw a circle",
         "interest.help" => "Duh?",
         "interest.tools.0.label" => "Red",

--- a/spec/models/concerns/translation_strings_spec.rb
+++ b/spec/models/concerns/translation_strings_spec.rb
@@ -40,7 +40,20 @@ describe TranslationStrings do
   end
 
   def field_guide_strings
-    {}
+    {
+      "items" =>
+      [
+        {
+          "title" => "Page 1",
+          "content" => "stuff and things",
+          "icon" => "123456"
+        }, {
+          "title" => "Other guide",
+          "content" => "animals & such",
+          "icon" => "654321"
+        }
+      ]
+     }
   end
 
   def project_page_strings


### PR DESCRIPTION
Batch process to seed the conversion of translatable resources to new translations data model. This will be run in a rake task to initially seed the data / iron out schema bugs. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
