### PR TITLE
inject survey task descriptions and confusion strings

### DIFF
--- a/lib/tasks_visitors/inject_strings.rb
+++ b/lib/tasks_visitors/inject_strings.rb
@@ -10,9 +10,16 @@ module TasksVisitors
       @strings[n] || n
     end
 
+    def inject_nested_string(n, path=nil)
+      extracted_string_key = path.join(".")
+      @strings[extracted_string_key] || n
+    end
+
     alias :visit_instruction :inject_string
     alias :visit_question :inject_string
     alias :visit_label :inject_string
     alias :visit_help :inject_string
+    alias :visit_description :inject_string
+    alias :visit_confusions :inject_nested_string
   end
 end

--- a/spec/lib/tasks_visitors/inject_strings_spec.rb
+++ b/spec/lib/tasks_visitors/inject_strings_spec.rb
@@ -89,5 +89,37 @@ RSpec.describe TasksVisitors::InjectStrings do
     it 'should substitute a string at the correct index' do
       expect(task_hash[:interest][:question]).to eq("q1")
     end
+
+    context "with a survey task" do
+      let(:strings) do
+        {
+          "T1.choices.CVT.confusions" => {"GNT"=>"Okay these two actually are confusing, but genets are cuter and more weasel/cat like."},
+          "T1.choices.FR.description" => "It's a fire. Pretty sure you know what this looks like."
+        }
+      end
+      let(:task_hash) do
+        {
+          "T1"=>{
+            "type"=>"survey",
+            "images"=> {},
+            "choices"=>{
+              "FR"=>{
+                "description"=>"T1.choices.FR.description"
+              },
+              "CVT"=>{
+                "confusions"=>{"GNT"=>"T1.choices.CVT.confusions"}
+              }
+            }
+          }
+        }.with_indifferent_access
+      end
+
+      it 'should return the substituted strings' do
+        description = task_hash.dig(:T1, :choices, :FR, :description)
+        expect(description).to eq(strings["T1.choices.FR.description"])
+        confusions = task_hash.dig(:T1, :choices, :CVT, :confusions)
+        expect(confusions).to eq(strings["T1.choices.CVT.confusions"])
+      end
+    end
   end
 end


### PR DESCRIPTION
ensure descriptions and confusions have their extracted strings added to them. Added a new method to inject nested hash strings for confusions

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
