### PR TITLE
Override nonstandard mimetypes on subject upload

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -98,6 +98,8 @@ class Api::V1::SubjectsController < Api::ApiController
   def location_params(locations)
     (locations || []).map.with_index do |loc, i|
       location_params = case loc
+                        when *Subject.nonstandard_mimetypes.keys
+                          { content_type: Subject.nonstandard_mimetypes[loc] }
                         when String
                           { content_type: loc }
                         when Hash

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -98,10 +98,8 @@ class Api::V1::SubjectsController < Api::ApiController
   def location_params(locations)
     (locations || []).map.with_index do |loc, i|
       location_params = case loc
-                        when *Subject.nonstandard_mimetypes.keys
-                          { content_type: Subject.nonstandard_mimetypes[loc] }
                         when String
-                          { content_type: loc }
+                          { content_type: Subject.nonstandard_mimetypes[loc] || loc }
                         when Hash
                           {
                             content_type: loc.keys.first,

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -30,6 +30,13 @@ class Subject < ActiveRecord::Base
   can_through_parent :project, :update, :index, :show, :destroy, :update_links,
                      :destroy_links, :versions, :version
 
+  def self.nonstandard_mimetypes
+    {
+      "audio/mp3" => "audio/mpeg",
+      "audio/x-wav" => "audio/mpeg",
+    }
+  end
+
   def migrated_subject?
     !!migrated
   end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -33,7 +33,7 @@ class Subject < ActiveRecord::Base
   def self.nonstandard_mimetypes
     {
       "audio/mp3" => "audio/mpeg",
-      "audio/x-wav" => "audio/mpeg",
+      "audio/x-wav" => "audio/mpeg"
     }
   end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -626,6 +626,14 @@ describe Api::V1::SubjectsController, type: :controller do
       expect(locations).to eq(["image/jpeg", "image/jpeg", "image/png"])
     end
 
+    it "should replace non-standard mimetypes" do
+      create_params[:subjects][:locations] = ["audio/mp3", "audio/x-wav"]
+      default_request user_id: authorized_user.id, scopes: scopes
+      post :create, create_params
+      locations = json_response[api_resource_name][0]["locations"].flat_map(&:keys)
+      expect(locations).to eq(["audio/mpeg", "audio/mpeg"])
+    end
+
     it 'should create externally linked media resources' do
       default_request user_id: authorized_user.id, scopes: scopes
       external_locs = [{"image/jpeg" => "http://example.com/1.jpg"}, {"image/jpeg" => "http://example.com/2.jpg"}]
@@ -668,7 +676,6 @@ describe Api::V1::SubjectsController, type: :controller do
         end
 
         context "when uploading restricted content_types" do
-
           it 'should return the created status' do
             create_params.deep_merge!({ subjects: { locations: [ "video/mp4" ] } })
             upload_subjects
@@ -700,7 +707,6 @@ describe Api::V1::SubjectsController, type: :controller do
       end
 
       context "when the user is an admin" do
-
         it 'should return the created status' do
           allow_any_instance_of(ApiUser).to receive(:is_admin?).and_return(true)
           upload_subjects
@@ -709,7 +715,6 @@ describe Api::V1::SubjectsController, type: :controller do
       end
 
       context "when the user is whitelisted to upload" do
-
         it 'should return the created status' do
           allow_any_instance_of(User).to receive(:upload_whitelist).and_return(true)
           upload_subjects


### PR DESCRIPTION
I put the mimetype map right in the Subject model cause that's where it seemed like it should go. Can be generalized into a global constant via initializer or similar if you'd prefer.

These are the only two nonstandard MIME types that I remember facing outside of one weird instance from the Python client that might have been a bug. Were there more?

Resolves #2458 and https://github.com/zooniverse/Panoptes-Front-End/issues/4029

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
