### PR TITLE
[WIP] Default organizations to public

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,6 +22,8 @@ class Organization < ActiveRecord::Base
 
   accepts_nested_attributes_for :organization_contents
 
+  validates_inclusion_of :private, in: [true, false], message: "must be true or false"
+
   can_by_role :destroy, :update, :update_links, :destroy_links, roles: [ :owner, :collaborator ]
 
   can_by_role :show, :index, :versions, :version, public: true,

--- a/db/migrate/20171212154401_add_private_to_organizations.rb
+++ b/db/migrate/20171212154401_add_private_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddPrivateToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :private, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -765,7 +765,8 @@ CREATE TABLE organizations (
     updated_at timestamp without time zone NOT NULL,
     urls jsonb DEFAULT '[]'::jsonb,
     listed boolean DEFAULT false NOT NULL,
-    categories character varying[] DEFAULT '{}'::character varying[]
+    categories character varying[] DEFAULT '{}'::character varying[],
+    private boolean DEFAULT false
 );
 
 
@@ -4085,4 +4086,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171019115705');
 INSERT INTO schema_migrations (version) VALUES ('20171120222438');
 
 INSERT INTO schema_migrations (version) VALUES ('20171121120455');
+
+INSERT INTO schema_migrations (version) VALUES ('20171212154401');
 

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     sequence(:display_name) { |n| "Test Organization #{ n }" }
     listed_at Time.now
     listed true
+    private false
     primary_language "en"
     urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
     categories %w(bugs fossils plants)

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -16,11 +16,15 @@ describe Organization, type: :model do
     let(:translatable) { create(:organization) }
     let(:translatable_without_content) { build(:organization, build_contents: false) }
     let(:primary_language_factory) { :organization }
-    let(:private_model) { create(:organization, listed_at: nil) }
+    let(:private_model) { create(:organization, private: true, listed_at: nil) }
   end
 
   it "should have a valid factory" do
     expect(organization).to be_valid
+  end
+
+  it 'should require a private field to be set' do
+    expect(build(:organization, private: nil)).to_not be_valid
   end
 
   it "should require a primary language field to be set" do


### PR DESCRIPTION
Closes #2573 - add a private field to organizations that will default to false (public) to fit into the default authorization lookups. 

Note the front end will have to set this on organization create (currently the lab does this for projects but default to true).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
