### PR TITLE
Add mime-types as explicit dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'dalli-elasticache'
 gem 'slavery'
 gem 'graphql'
 gem 'graphiql-rails'
+gem 'mime-types'
 
 group :production, :staging do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,6 +471,7 @@ DEPENDENCIES
   json-schema (~> 2.8)
   librato-metrics (~> 2.1.2)
   logstasher (~> 1.2)
+  mime-types
   mock_redis
   newrelic_rpm
   oauth2


### PR DESCRIPTION
Rails 5 upgrade drops this in favour of `mini-mime`. For now, let's just add this explicitly.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
