### PR TITLE
Add unique db index and validation for translated resource languages

### DIFF
--- a/app/controllers/api/v1/translations_controller.rb
+++ b/app/controllers/api/v1/translations_controller.rb
@@ -9,6 +9,8 @@ class Api::V1::TranslationsController < Api::ApiController
 
   schema_type :json_schema
 
+  before_action :downcase_language_param, except: :create
+
   def create
     check_polymorphic_controller_resources
 
@@ -49,5 +51,9 @@ class Api::V1::TranslationsController < Api::ApiController
 
   def polymorphic_ids
     super("translated")
+  end
+
+  def downcase_language_param
+    params[:language] = params[:language]&.downcase
   end
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -3,8 +3,11 @@ class Translation < ActiveRecord::Base
   validate :validate_strings
   validates_presence_of :language
 
-  # TODO: add a unique validation for translated_type, id, language
   before_validation :downcase_language, on: :create
+
+  validates_uniqueness_of :language,
+    scope: %i(translated_type translated_id),
+    message: "translation already exists for this resource"
 
   # TODO: Look at adding in paper trail change tracking for laguage / strings here
 

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -4,12 +4,10 @@ class Translation < ActiveRecord::Base
   validates_presence_of :language
 
   # TODO: add a unique validation for translated_type, id, language
-  # and a unique index
+  before_validation :downcase_language, on: :create
 
   # TODO: Look at adding in paper trail change tracking for laguage / strings here
 
-  # TODO: these inverse relations need expanding to ensure the polymorphic
-  # links are correctly serialized
   def self.translated_model_names
     @translated_class_names ||= [].tap do |translated|
       ActiveRecord::Base.subclasses.each do |klass|
@@ -30,6 +28,12 @@ class Translation < ActiveRecord::Base
   def validate_strings
     unless strings.is_a?(Hash)
       errors.add(:strings, "must be present but can be empty")
+    end
+  end
+
+  def downcase_language
+    if language
+      self.language = language.downcase
     end
   end
 end

--- a/db/migrate/20171213144807_add_unique_translated_langauge_index.rb
+++ b/db/migrate/20171213144807_add_unique_translated_langauge_index.rb
@@ -2,8 +2,13 @@ class AddUniqueTranslatedLangaugeIndex < ActiveRecord::Migration
   def change
     table_name = :translations
     index_cols = %i(translated_type translated_id)
+
     if index_exists?(table_name, index_cols)
       remove_index table_name, column: index_cols
+    end
+
+    if index_exists?(table_name, :language)
+      remove_index table_name, column: :language
     end
 
     index_name = 'idx_translations_on_translated_type+id_and_language'

--- a/db/migrate/20171213144807_add_unique_translated_langauge_index.rb
+++ b/db/migrate/20171213144807_add_unique_translated_langauge_index.rb
@@ -1,0 +1,12 @@
+class AddUniqueTranslatedLangaugeIndex < ActiveRecord::Migration
+  def change
+    table_name = :translations
+    index_cols = %i(translated_type translated_id)
+    if index_exists?(table_name, index_cols)
+      remove_index table_name, column: index_cols
+    end
+
+    index_name = 'idx_translations_on_translated_type+id_and_language'
+    add_index table_name, index_cols | %i(language), unique: true, name: index_name
+  end
+end

--- a/db/migrate/20171213144807_add_unique_translated_langauge_index.rb
+++ b/db/migrate/20171213144807_add_unique_translated_langauge_index.rb
@@ -1,5 +1,7 @@
 class AddUniqueTranslatedLangaugeIndex < ActiveRecord::Migration
   def change
+    Translation.update_all("language = lower(language)")
+
     table_name = :translations
     index_cols = %i(translated_type translated_id)
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2284,13 +2284,6 @@ CREATE UNIQUE INDEX idx_lower_email ON users USING btree (lower((email)::text));
 
 
 --
--- Name: idx_queues_on_ssid_wid_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX idx_queues_on_ssid_wid_and_id ON subject_queues USING btree (subject_set_id, workflow_id, user_id);
-
-
---
 -- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4045,11 +4038,11 @@ INSERT INTO schema_migrations (version) VALUES ('20171120222438');
 
 INSERT INTO schema_migrations (version) VALUES ('20171121120455');
 
-INSERT INTO schema_migrations (version) VALUES ('20171213144807');
-
 INSERT INTO schema_migrations (version) VALUES ('20171208141841');
 
 INSERT INTO schema_migrations (version) VALUES ('20171208142645');
+
+INSERT INTO schema_migrations (version) VALUES ('20171213144807');
 
 INSERT INTO schema_migrations (version) VALUES ('20171214121332');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2284,6 +2284,20 @@ CREATE UNIQUE INDEX idx_lower_email ON users USING btree (lower((email)::text));
 
 
 --
+-- Name: idx_queues_on_ssid_wid_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX idx_queues_on_ssid_wid_and_id ON subject_queues USING btree (subject_set_id, workflow_id, user_id);
+
+
+--
+-- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX "idx_translations_on_translated_type+id_and_language" ON translations USING btree (translated_type, translated_id, language);
+
+
+--
 -- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2925,13 +2939,6 @@ CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
 --
 
 CREATE INDEX index_translations_on_language ON translations USING btree (language);
-
-
---
--- Name: index_translations_on_translated_type_and_translated_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_translations_on_translated_type_and_translated_id ON translations USING btree (translated_type, translated_id);
 
 
 --
@@ -4044,6 +4051,8 @@ INSERT INTO schema_migrations (version) VALUES ('20171019115705');
 INSERT INTO schema_migrations (version) VALUES ('20171120222438');
 
 INSERT INTO schema_migrations (version) VALUES ('20171121120455');
+
+INSERT INTO schema_migrations (version) VALUES ('20171213144807');
 
 INSERT INTO schema_migrations (version) VALUES ('20171208141841');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2935,13 +2935,6 @@ CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
 
 
 --
--- Name: index_translations_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_translations_on_language ON translations USING btree (language);
-
-
---
 -- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 

--- a/spec/controllers/api/v1/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/translations_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Api::V1::TranslationsController, type: :controller do
           translations: {
             strings: {
               title: "The frozen plant",
-              description: "Bro, how icy is this plant?",
+              description: "Burr, how icy is this plant?",
               introduction: "This project aims to find six of the coolest plants",
               workflow_description: "Is this field even used?",
               researcher_quote: "A really great project, you should help :)",

--- a/spec/controllers/api/v1/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/translations_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::TranslationsController, type: :controller do
     describe "#create" do
       let(:test_attr) { :language }
       let(:language) { "en-NZ" }
-      let(:test_attr_value)  { language }
+      let(:test_attr_value)  { language.downcase }
 
       let(:create_params) do
         {

--- a/spec/controllers/api/v1/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/translations_controller_spec.rb
@@ -34,19 +34,36 @@ RSpec.describe Api::V1::TranslationsController, type: :controller do
         end
 
         describe "filtering" do
-          let(:filter_params) do
-            { translated_id: resource.translated_id, translated_type: resource_type.to_s }
+          let(:non_filter_translation) do
+            create(:translation, language: "en-AU")
           end
 
           before(:each) do
+            non_filter_translation
             default_request scopes: scopes, user_id: authorized_user.id
             get :index, filter_params
           end
 
-          it "should filter the translated parent scope" do
-            create(:translation)
-            expect(json_response[api_resource_name].length).to eq(1)
-            expect(resource_ids).to match_array([resource.id])
+          describe "filtering on translation resources" do
+            let(:filter_params) do
+              { translated_id: resource.translated_id, translated_type: resource_type.to_s }
+            end
+
+            it "should return the filtered resource only" do
+              expect(json_response[api_resource_name].length).to eq(1)
+              expect(resource_ids).to match_array([resource.id])
+            end
+          end
+
+          describe "filtering on language code" do
+            let(:filter_params) do
+              { language: resource.language.upcase, translated_type: resource_type.to_s }
+            end
+
+            it "should return the filtered resource only" do
+              expect(json_response[api_resource_name].length).to eq(1)
+              expect(resource_ids).to match_array([resource.id])
+            end
           end
         end
       end

--- a/spec/factories/translations.rb
+++ b/spec/factories/translations.rb
@@ -22,16 +22,16 @@ FactoryGirl.define do
             type: 'drawing',
             question: "Draw a circle",
             help: "Duh?",
-            # the tool lables array might be best un-wound to avoid ambiguity
-            # "tool_lablel.2" => "Blue",
-            tool_labels: %w(Red Green Blue)
+            "tool_lablel.0" => "Red",
+            "tool_lablel.1" => "Green",
+            "tool_lablel.2" => "Blue"
           },
           shape: {
             question: "What shape is this galaxy",
             help: "Duh?",
-            # the answers array might be best un-wound to avoid ambiguity
-            # "answers.0" => "Smooth",
-            answers: ["Smooth", "Features", "Star or artifact"]
+            "answers.0" => "Smooth",
+            "answers.1" => "Features",
+            "answers.2" => "Star or artifact"
           }
         ]
       })

--- a/spec/factories/translations.rb
+++ b/spec/factories/translations.rb
@@ -22,9 +22,9 @@ FactoryGirl.define do
             type: 'drawing',
             question: "Draw a circle",
             help: "Duh?",
-            "tool_lablel.0" => "Red",
-            "tool_lablel.1" => "Green",
-            "tool_lablel.2" => "Blue"
+            "tool_label.0" => "Red",
+            "tool_label.1" => "Green",
+            "tool_label.2" => "Blue"
           },
           shape: {
             question: "What shape is this galaxy",

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe Translation, type: :model do
     translation.valid?
     expect(translation.language).to eq("en-gb")
   end
+
+  it 'should not allow duplicate translations for a resource' do
+    translation.save
+    dup_translation = build(:translation, translated: translation.translated)
+    expect(dup_translation).not_to be_valid
+    expected_errors = ["Language translation already exists for this resource"]
+    expect(dup_translation.errors).to match_array(expected_errors)
+  end
+
   it 'should not be valid without strings' do
     invalid_strings_msg = ["must be present but can be empty"]
     translation.strings = nil

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -1,12 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe Translation, type: :model do
-  let(:translation) { create(:translation) }
+  let(:translation) { build(:translation) }
 
   it 'should have a valid factory' do
     expect(translation).to be_valid
   end
 
+  it 'should downcase the language code before validation' do
+    expect(translation.language).to eq("en-GB")
+    translation.valid?
+    expect(translation.language).to eq("en-gb")
+  end
   it 'should not be valid without strings' do
     invalid_strings_msg = ["must be present but can be empty"]
     translation.strings = nil

--- a/spec/serializers/translation_serializer_spec.rb
+++ b/spec/serializers/translation_serializer_spec.rb
@@ -18,7 +18,7 @@ describe TranslationSerializer do
     let(:filtered_ids) { filtered_resources.map { |p| p[:id] } }
 
     context "language" do
-      let(:lang_code) { "en-AU"}
+      let(:lang_code) { "en-au"}
       let(:filtered_translation) { create(:translation, language: lang_code) }
       let(:filter) { { language: lang_code } }
 


### PR DESCRIPTION
Make sure we ever only save 1 language translation for a resource. this adds a unique compound db index that satisfies the validation query and our controller scope_for access queries. 

TODO
- [x] Add a rake task / migration step to downcase any existing language attributes.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
