### PR TITLE
remove nero_config from workflows

### DIFF
--- a/app/schemas/workflow_create_schema.rb
+++ b/app/schemas/workflow_create_schema.rb
@@ -67,10 +67,6 @@ class WorkflowCreateSchema < JsonSchema
       type "object"
     end
 
-    property "nero_config" do
-      type "object"
-    end
-
     property "configuration" do
       type "object"
     end

--- a/app/schemas/workflow_update_schema.rb
+++ b/app/schemas/workflow_update_schema.rb
@@ -62,10 +62,6 @@ class WorkflowUpdateSchema < JsonSchema
       type "object"
     end
 
-    property "nero_config" do
-      type "object"
-    end
-
     property "configuration" do
       type "object"
     end

--- a/app/serializers/event_stream_serializers/workflow_serializer.rb
+++ b/app/serializers/event_stream_serializers/workflow_serializer.rb
@@ -1,5 +1,5 @@
 module EventStreamSerializers
   class WorkflowSerializer < ActiveModel::Serializer
-    attributes :id, :display_name, :retirement, :nero_config, :created_at, :updated_at
+    attributes :id, :display_name, :retirement, :created_at, :updated_at
   end
 end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -11,7 +11,7 @@ class WorkflowSerializer
              :created_at, :updated_at, :finished_at, :first_task, :primary_language,
              :version, :content_language, :prioritized, :grouped, :pairwise,
              :retirement, :retired_set_member_subjects_count, :href, :active, :mobile_friendly,
-             :aggregation, :nero_config, :configuration, :public_gold_standard, :completeness
+             :aggregation, :configuration, :public_gold_standard, :completeness
 
   can_include :project, :subject_sets, :tutorial_subject
 

--- a/db/migrate/20171214121332_remove_workflows_nero_config.rb
+++ b/db/migrate/20171214121332_remove_workflows_nero_config.rb
@@ -1,0 +1,5 @@
+class RemoveWorkflowsNeroConfig < ActiveRecord::Migration
+  def change
+    remove_column :workflows, :nero_config, :jsonb, default: {}
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1640,7 +1640,6 @@ CREATE TABLE workflows (
     current_version_number character varying,
     activated_state integer DEFAULT 0 NOT NULL,
     subject_selection_strategy integer DEFAULT 0,
-    nero_config jsonb DEFAULT '{}'::jsonb,
     mobile_friendly boolean DEFAULT false NOT NULL
 );
 
@@ -4085,4 +4084,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171019115705');
 INSERT INTO schema_migrations (version) VALUES ('20171120222438');
 
 INSERT INTO schema_migrations (version) VALUES ('20171121120455');
+
+INSERT INTO schema_migrations (version) VALUES ('20171214121332');
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -14,7 +14,7 @@ describe Api::V1::WorkflowsController, type: :controller do
   let(:api_resource_attributes) do
     %w(id display_name tasks classifications_count subjects_count
     created_at updated_at first_task primary_language content_language
-    version grouped prioritized pairwise retirement aggregation nero_config
+    version grouped prioritized pairwise retirement aggregation
     active mobile_friendly configuration finished_at public_gold_standard)
   end
   let(:api_resource_links)do
@@ -115,11 +115,6 @@ describe Api::V1::WorkflowsController, type: :controller do
           active: false,
           retirement: {criteria: "classification_count"},
           aggregation: {},
-          nero_config: {
-            extractors: {surv: {type: 'survey'}},
-            reducers: {custom: {type: 'external', url: 'https://example.org/reduce'}},
-            rules: [{if: ["const", true], then: [{action: 'retire_subject'}]}]
-          },
           configuration: {},
           public_gold_standard: true,
           tasks: {
@@ -524,11 +519,6 @@ describe Api::V1::WorkflowsController, type: :controller do
           active: true,
           retirement: {criteria: "classification_count"},
           aggregation: {public: true},
-          nero_config: {
-            extractors: {surv: {type: 'survey'}},
-            reducers: {custom: {type: 'external', url: 'https://example.org/reduce'}},
-            rules: [{if: ["const", true], then: [{action: 'retire_subject'}]}]
-          },
           configuration: {autoplay_subjects: true},
           public_gold_standard: true,
           tasks: create_task_params,


### PR DESCRIPTION
this configuration has moved into caesar itself

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
