### PR TITLE
Convert version numbers to ints in specs

### DIFF
--- a/spec/models/workflow_content_spec.rb
+++ b/spec/models/workflow_content_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe WorkflowContent, :type => :model do
     end
 
     it 'caches the new version number', :aggregate_failures do
-      previous_number = subject.current_version_number
+      previous_number = subject.current_version_number.to_i
       subject.update!(strings: new_strings)
-      expect(subject.current_version_number).to eq(previous_number + 1)
-      expect(subject.current_version_number).to eq(ModelVersion.version_number(subject))
+      expect(subject.current_version_number.to_i).to eq(previous_number + 1)
+      expect(subject.current_version_number.to_i).to eq(ModelVersion.version_number(subject))
     end
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -116,10 +116,10 @@ describe Workflow, type: :model do
     end
 
     it 'caches the new version number', :aggregate_failures do
-      previous_number = workflow.current_version_number
+      previous_number = workflow.current_version_number.to_i
       workflow.update!(tasks: {blha: 'asdfasd', quera: "asdfas"})
-      expect(workflow.current_version_number).to eq(previous_number + 1)
-      expect(workflow.current_version_number).to eq(ModelVersion.version_number(workflow))
+      expect(workflow.current_version_number.to_i).to eq(previous_number + 1)
+      expect(workflow.current_version_number.to_i).to eq(ModelVersion.version_number(workflow))
     end
   end
 


### PR DESCRIPTION
Don't ask me why. Especially don't get me started on the naming of a `varchar` column called `current_version_number`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
