### PR TITLE
update workflow retirement configuration docs

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2010,15 +2010,20 @@ link to a *project*. Can optionally set cellect parameters *grouped*,
 A SubjectSet that already belongs to another workflow will be
 duplicated when it is linked.
 
-A Workflow may also include a _retirement_ object with a
-_criteria_ key and an _options_ key. _criteria_ describes the strategy
-Panoptes will use to decide when to retire subjects. Currently, this
-may only be 'classification\_count' which retires subjects after a
-target number of classifications are reached. _options_ describes the
-parameters for the strategy. The 'classification\_count' strategy
-accepts _count_ as an option with an integer number of classifications
-for each subject. If _retirement_ is left blank Panoptes defaults to
-the 'classification\_count' strategy with 15 classifications per subject.
+A Workflow may also include a _retirement_ object with a _criteria_
+key and an _options_ key. _criteria_ describes the strategy Panoptes
+will use to decide when to retire subjects while _options_ configures
+the strategy. There are 2 valid criteria:
+ 1. `classification_count` will retire subjects after a target number
+ of classifications are reached. You must supply an `options` hash
+ with an integer `count` to specify the minimum number of classifications.
+   + `{"criteria": "classification_count", "options": {"count": 15} }`
+ 2. `never_retire` will never retire subjects and requires an empty
+ `options` hash.
+   + `{"criteria": "never_retire "options": {} }`
+
+If retirement is left blank Panoptes defaults to the `classification_count`
+strategy with 15 classifications per subject.
 
 + Request
 


### PR DESCRIPTION
linked to #2591 - update the docs for the allowed strategy configuration for workflow retirement via the API.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
