### PR TITLE
[WIP] Stdout logging for graylog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'slavery'
 gem 'graphql'
 gem 'graphiql-rails'
 gem 'mime-types'
+gem "lograge" # this can be moved to staging / prod group after testing
 
 group :production, :staging do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.8.0)
+      actionpack (>= 4, < 5.2)
+      activesupport (>= 4, < 5.2)
+      railties (>= 4, < 5.2)
+      request_store (~> 1.0)
     logstash-event (1.2.02)
     logstasher (1.2.2)
       activesupport (>= 4.0)
@@ -470,6 +475,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3)
   json-schema (~> 2.8)
   librato-metrics (~> 2.1.2)
+  lograge
   logstasher (~> 1.2)
   mime-types
   mock_redis

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,5 +42,9 @@ Rails.application.configure do
     config.lograge.enabled = true
     config.lograge.log_format = :graylog2
     config.logger = GELF::Logger.new(*Logging::GraylogDefaults.config)
+  else
+    # Use default logging formatter so that PID and timestamp are
+    # included in default rails logs
+    config.log_formatter = ::Logger::Formatter.new
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,4 +37,10 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  if ENV.fetch("LOG_TO_GRAYLOG", false)
+    config.lograge.enabled = true
+    config.lograge.log_format = :graylog2
+    config.logger = GELF::Logger.new(*Logging::GraylogDefaults.config)
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -90,4 +90,10 @@ Rails.application.configure do
   config.logstasher.enabled = true
   # Enable logging of controller params
   config.logstasher.log_controller_parameters = true
+
+  if ENV.fetch("LOG_TO_GRAYLOG", true)
+    config.lograge.enabled = true
+    config.lograge.log_format = :graylog2
+    config.logger = GELF::Logger.new(*Logging::GraylogDefaults.config)
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -80,20 +80,20 @@ Rails.application.configure do
   # Disable automatic flushing of the log to improve performance.
   # config.autoflush_log = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Enable the logstasher logs for the current environment
-  config.logstasher.enabled = true
-  # Enable logging of controller params
-  config.logstasher.log_controller_parameters = true
 
   if ENV.fetch("LOG_TO_GRAYLOG", true)
     config.lograge.enabled = true
     config.lograge.log_format = :graylog2
     config.logger = GELF::Logger.new(*Logging::GraylogDefaults.config)
+  else
+    # Use default logging formatter so that PID and timestamp are
+    # included in default rails logs
+    config.log_formatter = ::Logger::Formatter.new
+    # Enable the logstasher logs for the current environment
+    config.logstasher.enabled = true
+    # Enable logging of controller params
+    config.logstasher.log_controller_parameters = true
   end
 end

--- a/lib/logging/graylog_defaults.rb
+++ b/lib/logging/graylog_defaults.rb
@@ -1,0 +1,30 @@
+module Logging
+  module GraylogDefaults
+    def self.config
+      [
+        ENV.fetch("GRAYLOG_HOST_NAME", "graylog.zooniverse.org"),
+        ENV.fetch("GRAYLOG_HOST_PORT", 12201),
+        ENV.fetch("GRAYLOG_UPD_CHUNK_CONFIG", "WAN"),
+        { host: app_source_name }
+      ]
+    end
+
+    # the source name that appears in graylog UI
+    def self.app_source_name
+      suffix = if !Rails.env.production?
+                "rails"
+               else
+                "#{Rails.env}-rails"
+               end
+      ENV.fetch("GRAYLOG_SOURCE_NAME", "panoptes-api-#{suffix}")
+    end
+
+    # TODO: add sidekiq logger for gelf / or just drop it and
+    # and keep them in stdout
+    # https://github.com/mperham/sidekiq/wiki/Logging#customize-logger
+    # also https://github.com/layervault/sidekiq-gelf-rb
+    # but that hooks into job middleware and should be thread safe
+    # i'd prefer to use a single instance vs one for each job that runs
+    # but maybe that won't scale out
+  end
+end


### PR DESCRIPTION
Staging env (and opt in dev) defaults to graylog message forwarding now by default. This may need some tweaking on the log format but it looks ok (different from the logstasher format). 

Also sidekiq will need its own logger pushing to graylog. i've left a note on how to do this. If we're happy with how this is working out we can move away from logstasher as it was writing duplicate formatted files for gelfcat too. 

We could also log to stdout and let gelfcat still work and that might help sidekiq too. that's another option available instead of using the ruby gelf gem and one i'm actually leaning towards. @astopy reasons we shouldn't use file redirection > stdout and gelfcat -> graylog?

# TODO

- [ ] Get this logging to graylog to see what the message payload looks like and see if we can get extractors working for this. 
- [ ] Test stdout logging with gelfcat docker plugin on a formatted json payload to see how that works with graylog

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
