### PR TITLE
add project metadata config option to restrict self service data access

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -17,7 +17,8 @@ module Api
       Subjects::Selector::MissingSubjectSet,
       Subjects::Selector::MissingSubjects,                 with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
-    rescue_from Api::LiveProjectChanges,                   with: :forbidden
+    rescue_from Api::LiveProjectChanges,
+      Api::DisabledDataExport,                             with: :forbidden
     rescue_from Api::NotLoggedIn,
       Api::UnauthorizedTokenError,
       Operation::Unauthenticated,                          with: :not_authenticated

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -185,7 +185,7 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def available_to_export
-    if controlled_resource.disabled_data_export?
+    if controlled_resource.keep_data_in_panoptes_only?
       raise Api::DisabledDataExport.new(
         "Data exports are disabled for this project"
       )

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::ProjectsController < Api::ApiController
     only: [:create, :update, :destroy, :create_classifications_export,
     :create_subjects_export, :create_workflows_export, :create_workflow_contents_export]
 
-  prepend_before_action :available_to_export, only: :create_classifications_export
+  before_action :available_to_export, only: :create_classifications_export
 
   def index
     unless params.has_key?(:sort)

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -40,6 +40,8 @@ class Api::V1::ProjectsController < Api::ApiController
     only: [:create, :update, :destroy, :create_classifications_export,
     :create_subjects_export, :create_workflows_export, :create_workflow_contents_export]
 
+  prepend_before_action :available_to_export, only: :create_classifications_export
+
   def index
     unless params.has_key?(:sort)
       @controlled_resources = case
@@ -179,6 +181,14 @@ class Api::V1::ProjectsController < Api::ApiController
   def primary_content_attributes(content_attributes)
     content_from_params(content_attributes.dup, CONTENT_FIELDS) do |ps|
       ps[:title] = ps[:display_name]
+    end
+  end
+
+  def available_to_export
+    if controlled_resource.disabled_data_export?
+      raise Api::DisabledDataExport.new(
+        "Data exports are disabled for this project"
+      )
     end
   end
 end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   schema_type :json_schema
 
   prepend_before_action :require_login, only: [:create, :update, :destroy, :create_classifications_export]
+  prepend_before_action :available_to_export, only: :create_classifications_export
 
   def index
     unless params.has_key?(:sort)
@@ -194,6 +195,14 @@ class Api::V1::WorkflowsController < Api::ApiController
       SubjectWorkflowStatus
     else
       super
+    end
+  end
+
+  def available_to_export
+    if controlled_resource.project.disabled_data_export?
+      raise Api::DisabledDataExport.new(
+        "Data exports are disabled for this project"
+      )
     end
   end
 end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   schema_type :json_schema
 
   prepend_before_action :require_login, only: [:create, :update, :destroy, :create_classifications_export]
-  prepend_before_action :available_to_export, only: :create_classifications_export
+  before_action :available_to_export, only: :create_classifications_export
 
   def index
     unless params.has_key?(:sort)

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -199,7 +199,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def available_to_export
-    if controlled_resource.project.disabled_data_export?
+    if controlled_resource.project.keep_data_in_panoptes_only?
       raise Api::DisabledDataExport.new(
         "Data exports are disabled for this project"
       )

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -8,6 +8,7 @@ module ApiErrors
   class NoUserError < PanoptesApiError; end
   class UnpermittedParameter < PanoptesApiError; end
   class LiveProjectChanges < PanoptesApiError; end
+  class DisabledDataExport < PanoptesApiError; end
   class Unauthorized < PanoptesApiError; end
   class NoMediaError < PanoptesApiError
     def initialize(media_type, parent, parent_id, media_id=nil)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -33,8 +33,11 @@ class Classification < ActiveRecord::Base
   }
 
   def self.scope_for(action, user, opts={})
-    return all if user.is_admin? && action != :gold_standard
-    case action
+    if user.is_admin? && action != :gold_standard
+      return all
+    end
+
+    scope = case action
     when :index
       complete.merge(created_by(user))
     when :show
@@ -50,6 +53,19 @@ class Classification < ActiveRecord::Base
     else
       none
     end
+
+    # Tested on prod all projects table scan:
+    # "Seq Scan on public.projects  (cost=0.00..1097.20 rows=6 width=4) (actual time=16.918..16.918 rows=0 loops=1)"
+    # "  Output: id"
+    # "  Filter: (projects.configuration ? 'keep_data_in_panoptes_only'::text)"
+    # "  Rows Removed by Filter: 5776"
+    # "Planning time: 0.101 ms"
+    # "Execution time: 23.301 ms
+
+    # this seems to add a small overhead to the query, it should be
+    # removed once the panoptes only data project has finished
+    forbidden_project_ids = Project.where("configuration ? 'keep_data_in_panoptes_only'").select(:id)
+    exportable_scope = scope.where.not(project_id: forbidden_project_ids)
   end
 
   def self.joins_classification_subjects
@@ -77,11 +93,16 @@ class Classification < ActiveRecord::Base
     if opts[:last_id] && !opts[:project_id]
       raise Classification::MissingParameter.new("Project ID required if last_id is included")
     end
-    projects = Project.scope_for(:update, user)
-    projects = projects.where(id: opts[:project_id]) if opts[:project_id]
-    scope = where(project_id: projects.select(:id))
+    user_project_ids = user_projects(user,opts).select(:id)
+    scope = where(project_id: user_project_ids)
     scope = scope.after_id(opts[:last_id]) if opts[:last_id]
     scope
+  end
+
+  def self.user_projects(user, opts)
+    projects = Project.scope_for(:update, user)
+    projects = projects.where(id: opts[:project_id]) if opts[:project_id]
+    projects
   end
 
   def created_and_incomplete?(actor)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -167,7 +167,7 @@ class Project < ActiveRecord::Base
     end
   end
 
-  def disabled_data_export?
-    !!configuration.fetch("private_data", false)
+  def keep_data_in_panoptes_only?
+    !!configuration.fetch("keep_data_in_panoptes_only", false)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -166,4 +166,8 @@ class Project < ActiveRecord::Base
       live ? "live" : "development"
     end
   end
+
+  def disabled_data_export?
+    !!configuration.fetch("private_data", false)
+  end
 end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -77,8 +77,7 @@ class ClassificationLifecycle
   def publish_data
     return unless classification.complete?
 
-    private_data = !!project.configuration.fetch("private_data", false)
-    unless private_data
+    unless project.disabled_data_export?
       PublishClassificationWorker.perform_async(classification.id)
     end
   end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -77,8 +77,8 @@ class ClassificationLifecycle
   def publish_data
     return unless classification.complete?
 
-    allow_in_stream = !!project.configuration.fetch("allow_in_stream", true)
-    if allow_in_stream
+    private_data = !!project.configuration.fetch("private_data", false)
+    unless private_data
       PublishClassificationWorker.perform_async(classification.id)
     end
   end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -77,7 +77,10 @@ class ClassificationLifecycle
   def publish_data
     return unless classification.complete?
 
-    PublishClassificationWorker.perform_async(classification.id)
+    allow_in_stream = !!project.configuration.fetch("allow_in_stream", true)
+    if allow_in_stream
+      PublishClassificationWorker.perform_async(classification.id)
+    end
   end
 
   def notify_subject_selector

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -77,7 +77,7 @@ class ClassificationLifecycle
   def publish_data
     return unless classification.complete?
 
-    unless project.disabled_data_export?
+    unless project.keep_data_in_panoptes_only?
       PublishClassificationWorker.perform_async(classification.id)
     end
   end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -6,7 +6,6 @@ describe Api::V1::ProjectsController, type: :controller do
     create_list(:project_with_contents, 2, owner: user)
   end
   let(:project) { create(:project_with_contents, owner: user, state: "paused") }
-  let(:authorized_user) { user }
 
   let(:api_resource_name) { "projects" }
   let(:api_resource_attributes) do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -801,6 +801,8 @@ describe Api::V1::ProjectsController, type: :controller do
       let(:test_attr_value) { "project_classifications_export" }
 
       it_behaves_like "is creatable", :create_classifications_export
+
+      it_behaves_like "it forbids data exports"
     end
 
     describe "#create_subjects_export" do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -676,5 +676,21 @@ describe Api::V1::WorkflowsController, type: :controller do
     end
 
     it_behaves_like "is creatable", :create_classifications_export
+
+    context "when the project has exports disabled" do
+      let(:project) { workflow.project }
+      before do
+        private_data_config = project.configuration.merge("private_data" => true)
+        project.update_column(:configuration, private_data_config)
+      end
+
+      it 'throws a forbidden error with a useful message' do
+        default_request scopes: scopes, user_id: authorized_user.id
+        post :create_classifications_export, create_params
+        expect(json_response['errors'][0]['message'])
+          .to eq("Data exports are disabled for this project")
+        expect(response.status).to eq(403)
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -677,19 +677,9 @@ describe Api::V1::WorkflowsController, type: :controller do
 
     it_behaves_like "is creatable", :create_classifications_export
 
-    context "when the project has exports disabled" do
-      let(:project) { workflow.project }
-      before do
-        private_data_config = project.configuration.merge("private_data" => true)
-        project.update_column(:configuration, private_data_config)
-      end
-
-      it 'throws a forbidden error with a useful message' do
-        default_request scopes: scopes, user_id: authorized_user.id
-        post :create_classifications_export, create_params
-        expect(json_response['errors'][0]['message'])
-          .to eq("Data exports are disabled for this project")
-        expect(response.status).to eq(403)
+    describe "dsakjhfkjd", :focus do
+      it_behaves_like "it forbids data exports" do
+        let(:project) { workflow.project }
       end
     end
   end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -677,10 +677,8 @@ describe Api::V1::WorkflowsController, type: :controller do
 
     it_behaves_like "is creatable", :create_classifications_export
 
-    describe "dsakjhfkjd", :focus do
-      it_behaves_like "it forbids data exports" do
-        let(:project) { workflow.project }
-      end
+    it_behaves_like "it forbids data exports" do
+      let(:project) { workflow.project }
     end
   end
 end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -345,7 +345,7 @@ describe ClassificationLifecycle do
       end
     end
 
-    describe "allow_in_stream project configuation" do
+    describe "no_public_data project configuation" do
       let(:classification) { build(:classification) }
 
       it 'should call the publish classification worker when configuration is missing' do
@@ -357,16 +357,16 @@ describe ClassificationLifecycle do
           classification
             .project
             .configuration
-            .merge!("allow_in_stream" => allow)
+            .merge!("private_data" => allow)
         end
 
-        it 'should call the publish classification worker when it is allowed' do
-          update_stream_metadata(true)
+        it 'should call the publish classification worker when public' do
+          update_stream_metadata(false)
           expect(PublishClassificationWorker).to receive(:perform_async)
         end
 
-        it 'should not call the publish classification worker when it is not allowed' do
-          update_stream_metadata(false)
+        it 'should not call the publish classification worker when private' do
+          update_stream_metadata(true)
           expect(PublishClassificationWorker).not_to receive(:perform_async)
         end
       end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -345,7 +345,7 @@ describe ClassificationLifecycle do
       end
     end
 
-    describe "no_public_data project configuation" do
+    describe "keep_data_in_panoptes_only project configuation" do
       let(:classification) { build(:classification) }
 
       it 'should call the publish classification worker when configuration is missing' do
@@ -353,20 +353,20 @@ describe ClassificationLifecycle do
       end
 
       context "with non-default configuration" do
-        def update_stream_metadata(allow)
+        def update_project_metadata(allow)
           classification
             .project
             .configuration
-            .merge!("private_data" => allow)
+            .merge!("keep_data_in_panoptes_only" => allow)
         end
 
         it 'should call the publish classification worker when public' do
-          update_stream_metadata(false)
+          update_project_metadata(false)
           expect(PublishClassificationWorker).to receive(:perform_async)
         end
 
         it 'should not call the publish classification worker when private' do
-          update_stream_metadata(true)
+          update_project_metadata(true)
           expect(PublishClassificationWorker).not_to receive(:perform_async)
         end
       end

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -344,6 +344,33 @@ describe ClassificationLifecycle do
         expect(PublishClassificationWorker).not_to receive(:perform_async)
       end
     end
+
+    describe "allow_in_stream project configuation" do
+      let(:classification) { build(:classification) }
+
+      it 'should call the publish classification worker when configuration is missing' do
+        expect(PublishClassificationWorker).to receive(:perform_async)
+      end
+
+      context "with non-default configuration" do
+        def update_stream_metadata(allow)
+          classification
+            .project
+            .configuration
+            .merge!("allow_in_stream" => allow)
+        end
+
+        it 'should call the publish classification worker when it is allowed' do
+          update_stream_metadata(true)
+          expect(PublishClassificationWorker).to receive(:perform_async)
+        end
+
+        it 'should not call the publish classification worker when it is not allowed' do
+          update_stream_metadata(false)
+          expect(PublishClassificationWorker).not_to receive(:perform_async)
+        end
+      end
+    end
   end
 
   describe "#create_project_preference" do

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -143,6 +143,17 @@ describe Classification, :type => :model do
         user_group: user_group, state: :active)
     end
 
+    it "should return empty set when project#keep_data_in_panoptes_only is true" do
+      only_panoptes_config = project.configuration.merge(
+        "keep_data_in_panoptes_only" => true
+      )
+      project.update_column(:configuration, only_panoptes_config)
+      classification = create(:classification, user: user.owner, project_id: project.id)
+      %i(index show update destroy incomplete project gold_standard).each do |action|
+        expect(Classification.scope_for(action, user)).to be_empty
+      end
+    end
+
     describe "#show/index" do
       it 'should return an ActiveRecord::Relation' do
         expect(Classification.scope_for(:index, user)).to be_a(ActiveRecord::Relation)
@@ -249,7 +260,8 @@ describe Classification, :type => :model do
 
     describe "#gold_standard" do
       it 'should return all gold_standard project data' do
-        gsa = create(:gold_standard_annotation,
+        gsa = create(
+          :gold_standard_annotation,
           project: project, user: project.owner
         )
         gsa.workflow.update_column(:public_gold_standard, true)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -505,19 +505,23 @@ describe Project, type: :model do
     end
   end
 
-  describe "#disabled_data_export?" do
+  describe "#keep_data_in_panoptes_only?" do
     it "should not return true when no private config" do
-      expect(project.disabled_data_export?).to eq(false)
+      expect(project.keep_data_in_panoptes_only?).to eq(false)
     end
 
     it "should not return true when private config is false" do
-      project.configuration = project.configuration.merge("private_data" => false)
-      expect(project.disabled_data_export?).to eq(false)
+      project.configuration = project.configuration.merge(
+        "keep_data_in_panoptes_only" => false
+      )
+      expect(project.keep_data_in_panoptes_only?).to eq(false)
     end
 
     it "should not return true when private config is true" do
-      project.configuration = project.configuration.merge("private_data" => true)
-      expect(project.disabled_data_export?).to eq(true)
+      project.configuration = project.configuration.merge(
+        "keep_data_in_panoptes_only" => true
+      )
+      expect(project.keep_data_in_panoptes_only?).to eq(true)
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -504,4 +504,20 @@ describe Project, type: :model do
       end
     end
   end
+
+  describe "#disabled_data_export?" do
+    it "should not return true when no private config" do
+      expect(project.disabled_data_export?).to eq(false)
+    end
+
+    it "should not return true when private config is false" do
+      project.configuration = project.configuration.merge("private_data" => false)
+      expect(project.disabled_data_export?).to eq(false)
+    end
+
+    it "should not return true when private config is true" do
+      project.configuration = project.configuration.merge("private_data" => true)
+      expect(project.disabled_data_export?).to eq(true)
+    end
+  end
 end

--- a/spec/support/disabled_exports.rb
+++ b/spec/support/disabled_exports.rb
@@ -1,0 +1,16 @@
+shared_examples "it forbids data exports" do
+  context "when the project resource has exports disabled" do
+    before do
+      private_data_config = project.configuration.merge("private_data" => true)
+      project.update_column(:configuration, private_data_config)
+    end
+
+    it 'throws a forbidden error with a useful message' do
+      default_request scopes: scopes, user_id: authorized_user.id
+      post :create_classifications_export, create_params
+      expect(json_response['errors'][0]['message'])
+        .to eq("Data exports are disabled for this project")
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/support/disabled_exports.rb
+++ b/spec/support/disabled_exports.rb
@@ -1,7 +1,9 @@
 shared_examples "it forbids data exports" do
-  context "when the project resource has exports disabled" do
+  context "when the project resource has internal data only flag enabled" do
     before do
-      private_data_config = project.configuration.merge("private_data" => true)
+      private_data_config = project.configuration.merge(
+        "keep_data_in_panoptes_only" => true
+      )
       project.update_column(:configuration, private_data_config)
     end
 


### PR DESCRIPTION
some projects may contain sensitive data that we need to control access to. this is a first step to avoid leaking that data to the stream and associated services. If this becomes widely needed it should be a column on the project with an index.

# TODO:

- [x] Add in restrictions on classification (subjects?) dumps for this project at the API level so there are decent error messages in the UI
- [x] Add in restrictions on classification api end points for all users (admin included)
- [ ] Test this on staging / prod to ensure no data is published to the stream and classification exports cannot be requested via the api.
# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
