### PR TITLE
sync to the prod db schema dump of PostgreSQL 9.4.9

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,17 +2,12 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.6
--- Dumped by pg_dump version 9.6.6
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -63,7 +58,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -
+-- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE access_control_lists (
@@ -97,7 +92,7 @@ ALTER SEQUENCE access_control_lists_id_seq OWNED BY access_control_lists.id;
 
 
 --
--- Name: aggregations; Type: TABLE; Schema: public; Owner: -
+-- Name: aggregations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE aggregations (
@@ -130,7 +125,7 @@ ALTER SEQUENCE aggregations_id_seq OWNED BY aggregations.id;
 
 
 --
--- Name: authorizations; Type: TABLE; Schema: public; Owner: -
+-- Name: authorizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE authorizations (
@@ -165,7 +160,7 @@ ALTER SEQUENCE authorizations_id_seq OWNED BY authorizations.id;
 
 
 --
--- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -
+-- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classification_export_rows (
@@ -210,7 +205,7 @@ ALTER SEQUENCE classification_export_rows_id_seq OWNED BY classification_export_
 
 
 --
--- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -
+-- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classification_subjects (
@@ -220,7 +215,7 @@ CREATE TABLE classification_subjects (
 
 
 --
--- Name: classifications; Type: TABLE; Schema: public; Owner: -
+-- Name: classifications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classifications (
@@ -262,7 +257,7 @@ ALTER SEQUENCE classifications_id_seq OWNED BY classifications.id;
 
 
 --
--- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -
+-- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE code_experiment_configs (
@@ -293,7 +288,7 @@ ALTER SEQUENCE code_experiment_configs_id_seq OWNED BY code_experiment_configs.i
 
 
 --
--- Name: collections; Type: TABLE; Schema: public; Owner: -
+-- Name: collections; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections (
@@ -333,7 +328,7 @@ ALTER SEQUENCE collections_id_seq OWNED BY collections.id;
 
 
 --
--- Name: collections_projects; Type: TABLE; Schema: public; Owner: -
+-- Name: collections_projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections_projects (
@@ -343,7 +338,7 @@ CREATE TABLE collections_projects (
 
 
 --
--- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -
+-- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections_subjects (
@@ -373,7 +368,7 @@ ALTER SEQUENCE collections_subjects_id_seq OWNED BY collections_subjects.id;
 
 
 --
--- Name: field_guides; Type: TABLE; Schema: public; Owner: -
+-- Name: field_guides; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE field_guides (
@@ -406,7 +401,7 @@ ALTER SEQUENCE field_guides_id_seq OWNED BY field_guides.id;
 
 
 --
--- Name: flipper_features; Type: TABLE; Schema: public; Owner: -
+-- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE flipper_features (
@@ -437,7 +432,7 @@ ALTER SEQUENCE flipper_features_id_seq OWNED BY flipper_features.id;
 
 
 --
--- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -
+-- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE flipper_gates (
@@ -470,7 +465,7 @@ ALTER SEQUENCE flipper_gates_id_seq OWNED BY flipper_gates.id;
 
 
 --
--- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -
+-- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE gold_standard_annotations (
@@ -507,7 +502,7 @@ ALTER SEQUENCE gold_standard_annotations_id_seq OWNED BY gold_standard_annotatio
 
 
 --
--- Name: media; Type: TABLE; Schema: public; Owner: -
+-- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE media (
@@ -549,7 +544,7 @@ ALTER SEQUENCE media_id_seq OWNED BY media.id;
 
 
 --
--- Name: memberships; Type: TABLE; Schema: public; Owner: -
+-- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE memberships (
@@ -584,7 +579,7 @@ ALTER SEQUENCE memberships_id_seq OWNED BY memberships.id;
 
 
 --
--- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -
+-- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_access_grants (
@@ -620,7 +615,7 @@ ALTER SEQUENCE oauth_access_grants_id_seq OWNED BY oauth_access_grants.id;
 
 
 --
--- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -
+-- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_access_tokens (
@@ -656,7 +651,7 @@ ALTER SEQUENCE oauth_access_tokens_id_seq OWNED BY oauth_access_tokens.id;
 
 
 --
--- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -
+-- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_applications (
@@ -695,7 +690,7 @@ ALTER SEQUENCE oauth_applications_id_seq OWNED BY oauth_applications.id;
 
 
 --
--- Name: organization_contents; Type: TABLE; Schema: public; Owner: -
+-- Name: organization_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_contents (
@@ -731,7 +726,7 @@ ALTER SEQUENCE organization_contents_id_seq OWNED BY organization_contents.id;
 
 
 --
--- Name: organization_pages; Type: TABLE; Schema: public; Owner: -
+-- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_pages (
@@ -766,7 +761,7 @@ ALTER SEQUENCE organization_pages_id_seq OWNED BY organization_pages.id;
 
 
 --
--- Name: organizations; Type: TABLE; Schema: public; Owner: -
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organizations (
@@ -804,7 +799,7 @@ ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
 
 
 --
--- Name: project_contents; Type: TABLE; Schema: public; Owner: -
+-- Name: project_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_contents (
@@ -842,7 +837,7 @@ ALTER SEQUENCE project_contents_id_seq OWNED BY project_contents.id;
 
 
 --
--- Name: project_pages; Type: TABLE; Schema: public; Owner: -
+-- Name: project_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_pages (
@@ -877,7 +872,7 @@ ALTER SEQUENCE project_pages_id_seq OWNED BY project_pages.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -
+-- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE projects (
@@ -937,7 +932,7 @@ ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
 
 
 --
--- Name: recents; Type: TABLE; Schema: public; Owner: -
+-- Name: recents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE recents (
@@ -973,7 +968,7 @@ ALTER SEQUENCE recents_id_seq OWNED BY recents.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE schema_migrations (
@@ -982,7 +977,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -
+-- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE set_member_subjects (
@@ -1017,7 +1012,7 @@ ALTER SEQUENCE set_member_subjects_id_seq OWNED BY set_member_subjects.id;
 
 
 --
--- Name: subject_sets; Type: TABLE; Schema: public; Owner: -
+-- Name: subject_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_sets (
@@ -1053,7 +1048,7 @@ ALTER SEQUENCE subject_sets_id_seq OWNED BY subject_sets.id;
 
 
 --
--- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -
+-- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_sets_workflows (
@@ -1083,7 +1078,7 @@ ALTER SEQUENCE subject_sets_workflows_id_seq OWNED BY subject_sets_workflows.id;
 
 
 --
--- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -
+-- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_workflow_counts (
@@ -1118,7 +1113,7 @@ ALTER SEQUENCE subject_workflow_counts_id_seq OWNED BY subject_workflow_counts.i
 
 
 --
--- Name: subjects; Type: TABLE; Schema: public; Owner: -
+-- Name: subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subjects (
@@ -1155,7 +1150,7 @@ ALTER SEQUENCE subjects_id_seq OWNED BY subjects.id;
 
 
 --
--- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -
+-- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tagged_resources (
@@ -1186,7 +1181,7 @@ ALTER SEQUENCE tagged_resources_id_seq OWNED BY tagged_resources.id;
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -
+-- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tags (
@@ -1218,7 +1213,7 @@ ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
--- Name: translations; Type: TABLE; Schema: public; Owner: -
+-- Name: translations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE translations (
@@ -1252,7 +1247,7 @@ ALTER SEQUENCE translations_id_seq OWNED BY translations.id;
 
 
 --
--- Name: tutorials; Type: TABLE; Schema: public; Owner: -
+-- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tutorials (
@@ -1287,7 +1282,7 @@ ALTER SEQUENCE tutorials_id_seq OWNED BY tutorials.id;
 
 
 --
--- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -
+-- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_collection_preferences (
@@ -1320,7 +1315,7 @@ ALTER SEQUENCE user_collection_preferences_id_seq OWNED BY user_collection_prefe
 
 
 --
--- Name: user_groups; Type: TABLE; Schema: public; Owner: -
+-- Name: user_groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_groups (
@@ -1357,7 +1352,7 @@ ALTER SEQUENCE user_groups_id_seq OWNED BY user_groups.id;
 
 
 --
--- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -
+-- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_project_preferences (
@@ -1394,7 +1389,7 @@ ALTER SEQUENCE user_project_preferences_id_seq OWNED BY user_project_preferences
 
 
 --
--- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -
+-- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_seen_subjects (
@@ -1427,7 +1422,7 @@ ALTER SEQUENCE user_seen_subjects_id_seq OWNED BY user_seen_subjects.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE users (
@@ -1491,7 +1486,7 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -
+-- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE versions (
@@ -1526,7 +1521,7 @@ ALTER SEQUENCE versions_id_seq OWNED BY versions.id;
 
 
 --
--- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -
+-- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflow_contents (
@@ -1560,7 +1555,7 @@ ALTER SEQUENCE workflow_contents_id_seq OWNED BY workflow_contents.id;
 
 
 --
--- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -
+-- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflow_tutorials (
@@ -1590,7 +1585,7 @@ ALTER SEQUENCE workflow_tutorials_id_seq OWNED BY workflow_tutorials.id;
 
 
 --
--- Name: workflows; Type: TABLE; Schema: public; Owner: -
+-- Name: workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflows (
@@ -1645,301 +1640,301 @@ ALTER SEQUENCE workflows_id_seq OWNED BY workflows.id;
 
 
 --
--- Name: access_control_lists id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY access_control_lists ALTER COLUMN id SET DEFAULT nextval('access_control_lists_id_seq'::regclass);
 
 
 --
--- Name: aggregations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY aggregations ALTER COLUMN id SET DEFAULT nextval('aggregations_id_seq'::regclass);
 
 
 --
--- Name: authorizations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY authorizations ALTER COLUMN id SET DEFAULT nextval('authorizations_id_seq'::regclass);
 
 
 --
--- Name: classification_export_rows id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY classification_export_rows ALTER COLUMN id SET DEFAULT nextval('classification_export_rows_id_seq'::regclass);
 
 
 --
--- Name: classifications id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY classifications ALTER COLUMN id SET DEFAULT nextval('classifications_id_seq'::regclass);
 
 
 --
--- Name: code_experiment_configs id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY code_experiment_configs ALTER COLUMN id SET DEFAULT nextval('code_experiment_configs_id_seq'::regclass);
 
 
 --
--- Name: collections id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY collections ALTER COLUMN id SET DEFAULT nextval('collections_id_seq'::regclass);
 
 
 --
--- Name: collections_subjects id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY collections_subjects ALTER COLUMN id SET DEFAULT nextval('collections_subjects_id_seq'::regclass);
 
 
 --
--- Name: field_guides id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY field_guides ALTER COLUMN id SET DEFAULT nextval('field_guides_id_seq'::regclass);
 
 
 --
--- Name: flipper_features id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY flipper_features ALTER COLUMN id SET DEFAULT nextval('flipper_features_id_seq'::regclass);
 
 
 --
--- Name: flipper_gates id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY flipper_gates ALTER COLUMN id SET DEFAULT nextval('flipper_gates_id_seq'::regclass);
 
 
 --
--- Name: gold_standard_annotations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY gold_standard_annotations ALTER COLUMN id SET DEFAULT nextval('gold_standard_annotations_id_seq'::regclass);
 
 
 --
--- Name: media id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY media ALTER COLUMN id SET DEFAULT nextval('media_id_seq'::regclass);
 
 
 --
--- Name: memberships id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY memberships ALTER COLUMN id SET DEFAULT nextval('memberships_id_seq'::regclass);
 
 
 --
--- Name: oauth_access_grants id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_access_grants ALTER COLUMN id SET DEFAULT nextval('oauth_access_grants_id_seq'::regclass);
 
 
 --
--- Name: oauth_access_tokens id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_access_tokens ALTER COLUMN id SET DEFAULT nextval('oauth_access_tokens_id_seq'::regclass);
 
 
 --
--- Name: oauth_applications id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_applications ALTER COLUMN id SET DEFAULT nextval('oauth_applications_id_seq'::regclass);
 
 
 --
--- Name: organization_contents id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organization_contents ALTER COLUMN id SET DEFAULT nextval('organization_contents_id_seq'::regclass);
 
 
 --
--- Name: organization_pages id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organization_pages ALTER COLUMN id SET DEFAULT nextval('organization_pages_id_seq'::regclass);
 
 
 --
--- Name: organizations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organizations_id_seq'::regclass);
 
 
 --
--- Name: project_contents id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_contents ALTER COLUMN id SET DEFAULT nextval('project_contents_id_seq'::regclass);
 
 
 --
--- Name: project_pages id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_pages ALTER COLUMN id SET DEFAULT nextval('project_pages_id_seq'::regclass);
 
 
 --
--- Name: projects id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects ALTER COLUMN id SET DEFAULT nextval('projects_id_seq'::regclass);
 
 
 --
--- Name: recents id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY recents ALTER COLUMN id SET DEFAULT nextval('recents_id_seq'::regclass);
 
 
 --
--- Name: set_member_subjects id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY set_member_subjects ALTER COLUMN id SET DEFAULT nextval('set_member_subjects_id_seq'::regclass);
 
 
 --
--- Name: subject_sets id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_sets ALTER COLUMN id SET DEFAULT nextval('subject_sets_id_seq'::regclass);
 
 
 --
--- Name: subject_sets_workflows id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_sets_workflows ALTER COLUMN id SET DEFAULT nextval('subject_sets_workflows_id_seq'::regclass);
 
 
 --
--- Name: subject_workflow_counts id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_workflow_counts ALTER COLUMN id SET DEFAULT nextval('subject_workflow_counts_id_seq'::regclass);
 
 
 --
--- Name: subjects id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subjects ALTER COLUMN id SET DEFAULT nextval('subjects_id_seq'::regclass);
 
 
 --
--- Name: tagged_resources id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tagged_resources ALTER COLUMN id SET DEFAULT nextval('tagged_resources_id_seq'::regclass);
 
 
 --
--- Name: tags id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
 
 
 --
--- Name: translations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY translations ALTER COLUMN id SET DEFAULT nextval('translations_id_seq'::regclass);
 
 
 --
--- Name: tutorials id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tutorials ALTER COLUMN id SET DEFAULT nextval('tutorials_id_seq'::regclass);
 
 
 --
--- Name: user_collection_preferences id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_collection_preferences ALTER COLUMN id SET DEFAULT nextval('user_collection_preferences_id_seq'::regclass);
 
 
 --
--- Name: user_groups id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_groups ALTER COLUMN id SET DEFAULT nextval('user_groups_id_seq'::regclass);
 
 
 --
--- Name: user_project_preferences id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_project_preferences ALTER COLUMN id SET DEFAULT nextval('user_project_preferences_id_seq'::regclass);
 
 
 --
--- Name: user_seen_subjects id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_seen_subjects ALTER COLUMN id SET DEFAULT nextval('user_seen_subjects_id_seq'::regclass);
 
 
 --
--- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: versions id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq'::regclass);
 
 
 --
--- Name: workflow_contents id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflow_contents ALTER COLUMN id SET DEFAULT nextval('workflow_contents_id_seq'::regclass);
 
 
 --
--- Name: workflow_tutorials id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflow_tutorials ALTER COLUMN id SET DEFAULT nextval('workflow_tutorials_id_seq'::regclass);
 
 
 --
--- Name: workflows id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflows ALTER COLUMN id SET DEFAULT nextval('workflows_id_seq'::regclass);
 
 
 --
--- Name: access_control_lists access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY access_control_lists
@@ -1947,7 +1942,7 @@ ALTER TABLE ONLY access_control_lists
 
 
 --
--- Name: aggregations aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY aggregations
@@ -1955,7 +1950,7 @@ ALTER TABLE ONLY aggregations
 
 
 --
--- Name: authorizations authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY authorizations
@@ -1963,7 +1958,7 @@ ALTER TABLE ONLY authorizations
 
 
 --
--- Name: classification_export_rows classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY classification_export_rows
@@ -1971,7 +1966,7 @@ ALTER TABLE ONLY classification_export_rows
 
 
 --
--- Name: classifications classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY classifications
@@ -1979,7 +1974,7 @@ ALTER TABLE ONLY classifications
 
 
 --
--- Name: code_experiment_configs code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY code_experiment_configs
@@ -1987,7 +1982,7 @@ ALTER TABLE ONLY code_experiment_configs
 
 
 --
--- Name: collections collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY collections
@@ -1995,7 +1990,7 @@ ALTER TABLE ONLY collections
 
 
 --
--- Name: collections_subjects collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY collections_subjects
@@ -2003,7 +1998,7 @@ ALTER TABLE ONLY collections_subjects
 
 
 --
--- Name: field_guides field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY field_guides
@@ -2011,7 +2006,7 @@ ALTER TABLE ONLY field_guides
 
 
 --
--- Name: flipper_features flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY flipper_features
@@ -2019,7 +2014,7 @@ ALTER TABLE ONLY flipper_features
 
 
 --
--- Name: flipper_gates flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY flipper_gates
@@ -2027,7 +2022,7 @@ ALTER TABLE ONLY flipper_gates
 
 
 --
--- Name: gold_standard_annotations gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -2035,7 +2030,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: media media_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY media
@@ -2043,7 +2038,7 @@ ALTER TABLE ONLY media
 
 
 --
--- Name: memberships memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY memberships
@@ -2051,7 +2046,7 @@ ALTER TABLE ONLY memberships
 
 
 --
--- Name: oauth_access_grants oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_access_grants
@@ -2059,7 +2054,7 @@ ALTER TABLE ONLY oauth_access_grants
 
 
 --
--- Name: oauth_access_tokens oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_access_tokens
@@ -2067,7 +2062,7 @@ ALTER TABLE ONLY oauth_access_tokens
 
 
 --
--- Name: oauth_applications oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_applications
@@ -2075,7 +2070,7 @@ ALTER TABLE ONLY oauth_applications
 
 
 --
--- Name: organization_contents organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_contents
@@ -2083,7 +2078,7 @@ ALTER TABLE ONLY organization_contents
 
 
 --
--- Name: organization_pages organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_pages
@@ -2091,7 +2086,7 @@ ALTER TABLE ONLY organization_pages
 
 
 --
--- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organizations
@@ -2099,7 +2094,7 @@ ALTER TABLE ONLY organizations
 
 
 --
--- Name: project_contents project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_contents
@@ -2107,7 +2102,7 @@ ALTER TABLE ONLY project_contents
 
 
 --
--- Name: project_pages project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_pages
@@ -2115,7 +2110,7 @@ ALTER TABLE ONLY project_pages
 
 
 --
--- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY projects
@@ -2123,7 +2118,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: recents recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY recents
@@ -2131,7 +2126,7 @@ ALTER TABLE ONLY recents
 
 
 --
--- Name: set_member_subjects set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY set_member_subjects
@@ -2139,7 +2134,7 @@ ALTER TABLE ONLY set_member_subjects
 
 
 --
--- Name: subject_sets subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_sets
@@ -2147,7 +2142,7 @@ ALTER TABLE ONLY subject_sets
 
 
 --
--- Name: subject_sets_workflows subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_sets_workflows
@@ -2155,7 +2150,7 @@ ALTER TABLE ONLY subject_sets_workflows
 
 
 --
--- Name: subject_workflow_counts subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_workflow_counts
@@ -2163,7 +2158,7 @@ ALTER TABLE ONLY subject_workflow_counts
 
 
 --
--- Name: subjects subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subjects
@@ -2171,7 +2166,7 @@ ALTER TABLE ONLY subjects
 
 
 --
--- Name: tagged_resources tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tagged_resources
@@ -2179,7 +2174,7 @@ ALTER TABLE ONLY tagged_resources
 
 
 --
--- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tags
@@ -2187,7 +2182,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- Name: translations translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY translations
@@ -2195,7 +2190,7 @@ ALTER TABLE ONLY translations
 
 
 --
--- Name: tutorials tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tutorials
@@ -2203,7 +2198,7 @@ ALTER TABLE ONLY tutorials
 
 
 --
--- Name: user_collection_preferences user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_collection_preferences
@@ -2211,7 +2206,7 @@ ALTER TABLE ONLY user_collection_preferences
 
 
 --
--- Name: user_groups user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_groups
@@ -2219,7 +2214,7 @@ ALTER TABLE ONLY user_groups
 
 
 --
--- Name: user_project_preferences user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_project_preferences
@@ -2227,7 +2222,7 @@ ALTER TABLE ONLY user_project_preferences
 
 
 --
--- Name: user_seen_subjects user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_seen_subjects
@@ -2235,7 +2230,7 @@ ALTER TABLE ONLY user_seen_subjects
 
 
 --
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -2243,7 +2238,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: versions versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY versions
@@ -2251,7 +2246,7 @@ ALTER TABLE ONLY versions
 
 
 --
--- Name: workflow_contents workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflow_contents
@@ -2259,7 +2254,7 @@ ALTER TABLE ONLY workflow_contents
 
 
 --
--- Name: workflow_tutorials workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflow_tutorials
@@ -2267,7 +2262,7 @@ ALTER TABLE ONLY workflow_tutorials
 
 
 --
--- Name: workflows workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflows
@@ -2275,945 +2270,945 @@ ALTER TABLE ONLY workflows
 
 
 --
--- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -
+-- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX classification_subjects_pk ON classification_subjects USING btree (classification_id, subject_id);
 
 
 --
--- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX idx_lower_email ON users USING btree (lower((email)::text));
 
 
 --
--- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -
+-- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_access_control_lists_on_resource_id_and_resource_type ON access_control_lists USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_access_control_lists_on_user_group_id ON access_control_lists USING btree (user_group_id);
 
 
 --
--- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_aggregations_on_subject_id_and_workflow_id ON aggregations USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_aggregations_on_workflow_id ON aggregations USING btree (workflow_id);
 
 
 --
--- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_authorizations_on_user_id ON authorizations USING btree (user_id);
 
 
 --
--- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_classification_export_rows_on_classification_id ON classification_export_rows USING btree (classification_id);
 
 
 --
--- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_export_rows_on_project_id ON classification_export_rows USING btree (project_id);
 
 
 --
--- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_export_rows_on_workflow_id ON classification_export_rows USING btree (workflow_id);
 
 
 --
--- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_subjects_on_subject_id ON classification_subjects USING btree (subject_id);
 
 
 --
--- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_completed ON classifications USING btree (completed) WHERE (completed IS FALSE);
 
 
 --
--- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_created_at ON classifications USING btree (created_at);
 
 
 --
--- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_gold_standard ON classifications USING btree (gold_standard) WHERE (gold_standard IS TRUE);
 
 
 --
--- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_lifecycled_at ON classifications USING btree (lifecycled_at) WHERE (lifecycled_at IS NULL);
 
 
 --
--- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_project_id_and_id ON classifications USING btree (project_id, id);
 
 
 --
--- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_user_id ON classifications USING btree (user_id);
 
 
 --
--- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_workflow_id ON classifications USING btree (workflow_id);
 
 
 --
--- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -
+-- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_code_experiment_configs_on_name ON code_experiment_configs USING btree (name);
 
 
 --
--- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_display_name_trgrm ON collections USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_activated_state ON collections USING btree (activated_state);
 
 
 --
--- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_display_name ON collections USING btree (display_name);
 
 
 --
--- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_favorite ON collections USING btree (favorite);
 
 
 --
--- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_private ON collections USING btree (private);
 
 
 --
--- Name: index_collections_on_project_ids; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_on_project_ids; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_project_ids ON collections USING gin (project_ids);
 
 
 --
--- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_slug ON collections USING btree (slug);
 
 
 --
--- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_projects_on_collection_id ON collections_projects USING btree (collection_id);
 
 
 --
--- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_collections_subjects_on_collection_id_and_subject_id ON collections_subjects USING btree (collection_id, subject_id);
 
 
 --
--- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_subjects_on_subject_id ON collections_subjects USING btree (subject_id);
 
 
 --
--- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -
+-- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_field_guides_on_language ON field_guides USING btree (language);
 
 
 --
--- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_field_guides_on_project_id ON field_guides USING btree (project_id);
 
 
 --
--- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -
+-- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_flipper_features_on_key ON flipper_features USING btree (key);
 
 
 --
--- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -
+-- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON flipper_gates USING btree (feature_key, key, value);
 
 
 --
--- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_gold_standard_annotations_on_subject_id ON gold_standard_annotations USING btree (subject_id);
 
 
 --
--- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_gold_standard_annotations_on_workflow_id ON gold_standard_annotations USING btree (workflow_id);
 
 
 --
--- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -
+-- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_media_on_linked_id_and_linked_type ON media USING btree (linked_id, linked_type);
 
 
 --
--- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -
+-- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_media_on_type ON media USING btree (type);
 
 
 --
--- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_memberships_on_user_group_id_and_user_id ON memberships USING btree (user_group_id, user_id);
 
 
 --
--- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_memberships_on_user_id ON memberships USING btree (user_id);
 
 
 --
--- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -
+-- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON oauth_access_grants USING btree (token);
 
 
 --
--- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_oauth_access_tokens_on_app_id_and_owner_id ON oauth_access_tokens USING btree (application_id, resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -
+-- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens USING btree (refresh_token);
 
 
 --
--- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON oauth_access_tokens USING btree (resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -
+-- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON oauth_access_tokens USING btree (token);
 
 
 --
--- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -
+-- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_applications_on_uid ON oauth_applications USING btree (uid);
 
 
 --
--- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organization_pages_on_language ON organization_pages USING btree (language);
 
 
 --
--- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organization_pages_on_organization_id ON organization_pages USING btree (organization_id);
 
 
 --
--- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_activated_state ON organizations USING btree (activated_state);
 
 
 --
--- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_display_name ON organizations USING btree (display_name);
 
 
 --
--- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_listed ON organizations USING btree (listed);
 
 
 --
--- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_listed_at ON organizations USING btree (listed_at);
 
 
 --
--- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_organizations_on_slug ON organizations USING btree (slug);
 
 
 --
--- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
 
 
 --
--- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_contents_on_project_id ON project_contents USING btree (project_id);
 
 
 --
--- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -
+-- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_pages_on_language ON project_pages USING btree (language);
 
 
 --
--- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_pages_on_project_id ON project_pages USING btree (project_id);
 
 
 --
--- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_display_name_trgrm ON projects USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_activated_state ON projects USING btree (activated_state);
 
 
 --
--- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_approved ON projects USING btree (beta_approved);
 
 
 --
--- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_requested ON projects USING btree (beta_requested) WHERE (beta_requested = true);
 
 
 --
--- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_row_order ON projects USING btree (beta_row_order);
 
 
 --
--- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_featured ON projects USING btree (featured);
 
 
 --
--- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launch_approved ON projects USING btree (launch_approved);
 
 
 --
--- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launch_requested ON projects USING btree (launch_requested) WHERE (launch_requested = true);
 
 
 --
--- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launched_row_order ON projects USING btree (launched_row_order);
 
 
 --
--- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_live ON projects USING btree (live);
 
 
 --
--- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_migrated ON projects USING btree (migrated) WHERE (migrated = true);
 
 
 --
--- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_mobile_friendly ON projects USING btree (mobile_friendly);
 
 
 --
--- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_organization_id ON projects USING btree (organization_id);
 
 
 --
--- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_private ON projects USING btree (private);
 
 
 --
--- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_slug ON projects USING btree (slug);
 
 
 --
--- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_state ON projects USING btree (state) WHERE (state IS NOT NULL);
 
 
 --
--- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_tsv ON projects USING gin (tsv);
 
 
 --
--- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_created_at ON recents USING btree (created_at);
 
 
 --
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
 
 
 --
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
 
 
 --
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
--- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -
+-- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_random ON set_member_subjects USING btree (random);
 
 
 --
--- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_set_member_subjects_on_subject_id_and_subject_set_id ON set_member_subjects USING btree (subject_id, subject_set_id);
 
 
 --
--- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_subject_set_id ON set_member_subjects USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_on_metadata ON subject_sets USING gin (metadata);
 
 
 --
--- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_on_project_id_and_display_name ON subject_sets USING btree (project_id, display_name);
 
 
 --
--- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_workflows_on_subject_set_id ON subject_sets_workflows USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_subject_sets_workflows_on_workflow_id_and_subject_set_id ON subject_sets_workflows USING btree (workflow_id, subject_set_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_subject_workflow_counts_on_subject_id_and_workflow_id ON subject_workflow_counts USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_workflow_counts_on_workflow_id ON subject_workflow_counts USING btree (workflow_id);
 
 
 --
--- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subjects_on_project_id ON subjects USING btree (project_id);
 
 
 --
--- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subjects_on_upload_user_id ON subjects USING btree (upload_user_id);
 
 
 --
--- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -
+-- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tagged_resources_on_resource_id_and_resource_type ON tagged_resources USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tagged_resources_on_tag_id ON tagged_resources USING btree (tag_id);
 
 
 --
--- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -
+-- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tags_name_trgrm ON tags USING gin ((COALESCE(name, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -
+-- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
 
 
 --
--- Name: index_translations_on_language; Type: INDEX; Schema: public; Owner: -
+-- Name: index_translations_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_translations_on_language ON translations USING btree (language);
 
 
 --
--- Name: index_translations_on_translated_type_and_translated_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_translations_on_translated_type_and_translated_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_translations_on_translated_type_and_translated_id ON translations USING btree (translated_type, translated_id);
 
 
 --
--- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -
+-- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_kind ON tutorials USING btree (kind);
 
 
 --
--- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -
+-- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_language ON tutorials USING btree (language);
 
 
 --
--- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_project_id ON tutorials USING btree (project_id);
 
 
 --
--- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_collection_preferences_on_collection_id ON user_collection_preferences USING btree (collection_id);
 
 
 --
--- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_collection_preferences_on_user_id ON user_collection_preferences USING btree (user_id);
 
 
 --
--- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_display_name_trgrm ON user_groups USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_on_activated_state ON user_groups USING btree (activated_state);
 
 
 --
--- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_user_groups_on_name ON user_groups USING btree (lower((name)::text));
 
 
 --
--- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_on_private ON user_groups USING btree (private);
 
 
 --
--- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_user_project_preferences_on_user_id_and_project_id ON user_project_preferences USING btree (user_id, project_id);
 
 
 --
--- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON user_seen_subjects USING btree (user_id, workflow_id);
 
 
 --
--- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_activated_state ON users USING btree (activated_state);
 
 
 --
--- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_beta_email_communication ON users USING btree (beta_email_communication) WHERE (beta_email_communication = true);
 
 
 --
--- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_display_name ON users USING btree (lower((display_name)::text));
 
 
 --
--- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
 
 
 --
--- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_global_email_communication ON users USING btree (global_email_communication) WHERE (global_email_communication = true);
 
 
 --
--- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_login ON users USING btree (lower((login)::text));
 
 
 --
--- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_login_with_case ON users USING btree (login);
 
 
 --
--- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_lower_names ON users USING btree (lower((login)::text) text_pattern_ops, lower((display_name)::text) text_pattern_ops);
 
 
 --
--- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_private_profile ON users USING btree (private_profile) WHERE (private_profile = false);
 
 
 --
--- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
 
 
 --
--- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_tsv ON users USING gin (tsv);
 
 
 --
--- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_unsubscribe_token ON users USING btree (unsubscribe_token);
 
 
 --
--- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_zooniverse_id ON users USING btree (zooniverse_id);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (item_type, item_id);
 
 
 --
--- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflow_contents_on_workflow_id ON workflow_contents USING btree (workflow_id);
 
 
 --
--- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflow_tutorials_on_tutorial_id ON workflow_tutorials USING btree (tutorial_id);
 
 
 --
--- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_workflow_tutorials_on_workflow_id_and_tutorial_id ON workflow_tutorials USING btree (workflow_id, tutorial_id);
 
 
 --
--- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_activated_state ON workflows USING btree (activated_state);
 
 
 --
--- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_aggregation ON workflows USING btree (((aggregation ->> 'public'::text)));
 
 
 --
--- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_display_order ON workflows USING btree (display_order);
 
 
 --
--- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_mobile_friendly ON workflows USING btree (mobile_friendly);
 
 
 --
--- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_project_id ON workflows USING btree (project_id);
 
 
 --
--- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_public_gold_standard ON workflows USING btree (public_gold_standard) WHERE (public_gold_standard IS TRUE);
 
 
 --
--- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tutorial_subject_id);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
 
 
 --
--- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -
+-- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX users_idx_trgm_login ON users USING gin ((COALESCE((login)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: projects tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
+-- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'display_name');
 
 
 --
--- Name: users tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
+-- Name: tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('tsv', 'pg_catalog.english', 'login');
 
 
 --
--- Name: user_collection_preferences fk_rails_02f2e5d7ed; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_02f2e5d7ed; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_collection_preferences
@@ -3221,7 +3216,7 @@ ALTER TABLE ONLY user_collection_preferences
 
 
 --
--- Name: subject_sets_workflows fk_rails_038f6f9f13; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_038f6f9f13; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_sets_workflows
@@ -3229,7 +3224,7 @@ ALTER TABLE ONLY subject_sets_workflows
 
 
 --
--- Name: gold_standard_annotations fk_rails_06fc22e4c3; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_06fc22e4c3; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -3237,7 +3232,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: gold_standard_annotations fk_rails_082b4f1af7; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_082b4f1af7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -3245,7 +3240,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: access_control_lists fk_rails_0be1922a0e; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_0be1922a0e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY access_control_lists
@@ -3253,7 +3248,7 @@ ALTER TABLE ONLY access_control_lists
 
 
 --
--- Name: workflow_tutorials fk_rails_0ca158de43; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_0ca158de43; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflow_tutorials
@@ -3261,7 +3256,7 @@ ALTER TABLE ONLY workflow_tutorials
 
 
 --
--- Name: gold_standard_annotations fk_rails_0e782fcb3c; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_0e782fcb3c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -3269,7 +3264,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: workflow_contents fk_rails_107209726e; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_107209726e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflow_contents
@@ -3277,7 +3272,7 @@ ALTER TABLE ONLY workflow_contents
 
 
 --
--- Name: collections_projects fk_rails_1be0872ee9; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_1be0872ee9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY collections_projects
@@ -3285,7 +3280,7 @@ ALTER TABLE ONLY collections_projects
 
 
 --
--- Name: gold_standard_annotations fk_rails_1d218ca624; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_1d218ca624; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -3293,7 +3288,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: recents fk_rails_1e54468460; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_1e54468460; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY recents
@@ -3301,7 +3296,7 @@ ALTER TABLE ONLY recents
 
 
 --
--- Name: subject_workflow_counts fk_rails_2001a01c81; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_2001a01c81; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_workflow_counts
@@ -3309,7 +3304,7 @@ ALTER TABLE ONLY subject_workflow_counts
 
 
 --
--- Name: aggregations fk_rails_27ae8e8a0d; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_27ae8e8a0d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY aggregations
@@ -3317,7 +3312,7 @@ ALTER TABLE ONLY aggregations
 
 
 --
--- Name: aggregations fk_rails_28a7ada458; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_28a7ada458; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY aggregations
@@ -3325,7 +3320,7 @@ ALTER TABLE ONLY aggregations
 
 
 --
--- Name: project_contents fk_rails_305e6d8bf1; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_305e6d8bf1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_contents
@@ -3333,7 +3328,7 @@ ALTER TABLE ONLY project_contents
 
 
 --
--- Name: oauth_access_grants fk_rails_330c32d8d9; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_330c32d8d9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_access_grants
@@ -3341,7 +3336,7 @@ ALTER TABLE ONLY oauth_access_grants
 
 
 --
--- Name: workflows fk_rails_382d2c48c7; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_382d2c48c7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflows
@@ -3349,7 +3344,7 @@ ALTER TABLE ONLY workflows
 
 
 --
--- Name: project_pages fk_rails_489b3ea925; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_489b3ea925; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_pages
@@ -3357,7 +3352,7 @@ ALTER TABLE ONLY project_pages
 
 
 --
--- Name: subject_workflow_counts fk_rails_4a73c0f7f5; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_4a73c0f7f5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_workflow_counts
@@ -3365,7 +3360,7 @@ ALTER TABLE ONLY subject_workflow_counts
 
 
 --
--- Name: user_project_preferences fk_rails_4da2a0f9d6; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_4da2a0f9d6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_project_preferences
@@ -3373,7 +3368,7 @@ ALTER TABLE ONLY user_project_preferences
 
 
 --
--- Name: user_project_preferences fk_rails_4e8620169e; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_4e8620169e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_project_preferences
@@ -3381,7 +3376,7 @@ ALTER TABLE ONLY user_project_preferences
 
 
 --
--- Name: authorizations fk_rails_4ecef5b8c5; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_4ecef5b8c5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY authorizations
@@ -3389,7 +3384,7 @@ ALTER TABLE ONLY authorizations
 
 
 --
--- Name: recents fk_rails_5244e2cc55; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_5244e2cc55; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY recents
@@ -3397,7 +3392,7 @@ ALTER TABLE ONLY recents
 
 
 --
--- Name: user_collection_preferences fk_rails_670188dbc7; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_670188dbc7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_collection_preferences
@@ -3405,7 +3400,7 @@ ALTER TABLE ONLY user_collection_preferences
 
 
 --
--- Name: oauth_access_tokens fk_rails_732cb83ab7; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_732cb83ab7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_access_tokens
@@ -3413,7 +3408,7 @@ ALTER TABLE ONLY oauth_access_tokens
 
 
 --
--- Name: classification_subjects fk_rails_7c8fb1018a; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_7c8fb1018a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY classification_subjects
@@ -3421,7 +3416,7 @@ ALTER TABLE ONLY classification_subjects
 
 
 --
--- Name: tutorials fk_rails_82e4d0479b; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_82e4d0479b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tutorials
@@ -3429,7 +3424,7 @@ ALTER TABLE ONLY tutorials
 
 
 --
--- Name: collections_projects fk_rails_895b025564; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_895b025564; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY collections_projects
@@ -3437,7 +3432,7 @@ ALTER TABLE ONLY collections_projects
 
 
 --
--- Name: set_member_subjects fk_rails_93073bf3b1; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_93073bf3b1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY set_member_subjects
@@ -3445,7 +3440,7 @@ ALTER TABLE ONLY set_member_subjects
 
 
 --
--- Name: gold_standard_annotations fk_rails_937b47dc37; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_937b47dc37; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -3453,7 +3448,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: subject_sets fk_rails_960d10a3c6; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_960d10a3c6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_sets
@@ -3461,7 +3456,7 @@ ALTER TABLE ONLY subject_sets
 
 
 --
--- Name: collections fk_rails_991d5ad7ab; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_991d5ad7ab; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY collections
@@ -3469,7 +3464,7 @@ ALTER TABLE ONLY collections
 
 
 --
--- Name: memberships fk_rails_99326fb65d; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_99326fb65d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY memberships
@@ -3477,7 +3472,7 @@ ALTER TABLE ONLY memberships
 
 
 --
--- Name: projects fk_rails_9aee26923d; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_9aee26923d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects
@@ -3485,7 +3480,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: user_seen_subjects fk_rails_9c86377aa8; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_9c86377aa8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_seen_subjects
@@ -3493,7 +3488,7 @@ ALTER TABLE ONLY user_seen_subjects
 
 
 --
--- Name: memberships fk_rails_9dd81aaaa3; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_9dd81aaaa3; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY memberships
@@ -3501,7 +3496,7 @@ ALTER TABLE ONLY memberships
 
 
 --
--- Name: field_guides fk_rails_a1b35288b8; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_a1b35288b8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY field_guides
@@ -3509,7 +3504,7 @@ ALTER TABLE ONLY field_guides
 
 
 --
--- Name: workflows fk_rails_b029d72783; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_b029d72783; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflows
@@ -3517,7 +3512,7 @@ ALTER TABLE ONLY workflows
 
 
 --
--- Name: subject_sets_workflows fk_rails_b08d342668; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_b08d342668; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subject_sets_workflows
@@ -3525,7 +3520,7 @@ ALTER TABLE ONLY subject_sets_workflows
 
 
 --
--- Name: oauth_access_grants fk_rails_b4b53e07b8; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_b4b53e07b8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_access_grants
@@ -3533,7 +3528,7 @@ ALTER TABLE ONLY oauth_access_grants
 
 
 --
--- Name: set_member_subjects fk_rails_bbb4bf5489; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_bbb4bf5489; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY set_member_subjects
@@ -3541,7 +3536,7 @@ ALTER TABLE ONLY set_member_subjects
 
 
 --
--- Name: workflow_tutorials fk_rails_bcabfcd540; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_bcabfcd540; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY workflow_tutorials
@@ -3549,7 +3544,7 @@ ALTER TABLE ONLY workflow_tutorials
 
 
 --
--- Name: tagged_resources fk_rails_d6fe15ec78; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_d6fe15ec78; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tagged_resources
@@ -3557,7 +3552,7 @@ ALTER TABLE ONLY tagged_resources
 
 
 --
--- Name: organization_contents fk_rails_d80672ecd1; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_d80672ecd1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organization_contents
@@ -3565,7 +3560,7 @@ ALTER TABLE ONLY organization_contents
 
 
 --
--- Name: collections_subjects fk_rails_dff7cd1e07; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_dff7cd1e07; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY collections_subjects
@@ -3573,7 +3568,7 @@ ALTER TABLE ONLY collections_subjects
 
 
 --
--- Name: user_seen_subjects fk_rails_e881fca299; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_e881fca299; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_seen_subjects
@@ -3581,7 +3576,7 @@ ALTER TABLE ONLY user_seen_subjects
 
 
 --
--- Name: collections_subjects fk_rails_e9323f2e30; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_e9323f2e30; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY collections_subjects
@@ -3589,7 +3584,7 @@ ALTER TABLE ONLY collections_subjects
 
 
 --
--- Name: oauth_access_tokens fk_rails_ee63f25419; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_ee63f25419; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY oauth_access_tokens
@@ -3597,7 +3592,7 @@ ALTER TABLE ONLY oauth_access_tokens
 
 
 --
--- Name: subjects fk_rails_f1e22b77bf; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_f1e22b77bf; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subjects
@@ -3605,7 +3600,7 @@ ALTER TABLE ONLY subjects
 
 
 --
--- Name: subjects fk_rails_f26c409132; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_f26c409132; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subjects
@@ -3613,7 +3608,7 @@ ALTER TABLE ONLY subjects
 
 
 --
--- Name: classification_subjects fk_rails_fc0cd14ebe; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_fc0cd14ebe; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY classification_subjects
@@ -3621,7 +3616,7 @@ ALTER TABLE ONLY classification_subjects
 
 
 --
--- Name: users fk_rails_fedc809cf8; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_fedc809cf8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -3632,7 +3627,7 @@ ALTER TABLE ONLY users
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user", public;
+SET search_path TO "$user",public;
 
 INSERT INTO schema_migrations (version) VALUES ('20150210025312');
 


### PR DESCRIPTION
the structure got updated from a local 9.6 pg server dump and it's incompatible with 9.4. this will remove warnings when loading a new db from structure.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
