### PR TITLE
Fix unicode regex warning

### DIFF
--- a/spec/models/csv_dumps/finds_medium_spec.rb
+++ b/spec/models/csv_dumps/finds_medium_spec.rb
@@ -56,7 +56,7 @@ describe CsvDumps::FindsMedium do
       finder.medium
       medium.reload
       name = resource.slug.split("/")[1]
-      type = medium.type.match(/\project_(\w+)_export\z/)[1]
+      type = medium.type.match(/\Aproject_(\w+)_export\z/)[1]
       ext = MIME::Types[medium.content_type].first.extensions.first
       file_name = "#{name}-#{type}.#{ext}"
       expect(medium.content_disposition).to eq("attachment; filename=\"#{file_name}\"")


### PR DESCRIPTION
remove warning by replacing escape \p`warning: invalid Unicode Property \p: /\project_(\w+)_export\z/`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
