### PR TITLE
remove collection belongs_to_many project_ids col & index

### DIFF
--- a/db/migrate/20180119110708_drop_collection_project_ids_column.rb
+++ b/db/migrate/20180119110708_drop_collection_project_ids_column.rb
@@ -1,0 +1,6 @@
+class DropCollectionProjectIdsColumn < ActiveRecord::Migration
+  def change
+    remove_index  :collections, column: :project_ids
+    remove_column :collections, :project_ids, :integer, array: true, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -302,7 +302,6 @@ CREATE TABLE collections (
     lock_version integer DEFAULT 0,
     slug character varying DEFAULT ''::character varying,
     favorite boolean DEFAULT false NOT NULL,
-    project_ids integer[] DEFAULT '{}'::integer[],
     default_subject_id integer,
     description text DEFAULT ''::text
 );
@@ -2447,13 +2446,6 @@ CREATE INDEX index_collections_on_private ON collections USING btree (private);
 
 
 --
--- Name: index_collections_on_project_ids; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_collections_on_project_ids ON collections USING gin (project_ids);
-
-
---
 -- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4051,6 +4043,8 @@ INSERT INTO schema_migrations (version) VALUES ('20171214121332');
 INSERT INTO schema_migrations (version) VALUES ('20180110133833');
 
 INSERT INTO schema_migrations (version) VALUES ('20180115214144');
+
+INSERT INTO schema_migrations (version) VALUES ('20180119110708');
 
 INSERT INTO schema_migrations (version) VALUES ('20180122134607');
 


### PR DESCRIPTION
Related to #2606 - if we are happy that the HABTM collection -> projects relation is working as expected then this will clean up the unused `project_ids` collections column and associated GIN index. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
