### PR TITLE
remove old indexes from structure.sql 

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -58,7 +58,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE access_control_lists (
@@ -92,7 +92,7 @@ ALTER SEQUENCE access_control_lists_id_seq OWNED BY access_control_lists.id;
 
 
 --
--- Name: aggregations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: aggregations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE aggregations (
@@ -125,7 +125,7 @@ ALTER SEQUENCE aggregations_id_seq OWNED BY aggregations.id;
 
 
 --
--- Name: authorizations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: authorizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE authorizations (
@@ -160,7 +160,7 @@ ALTER SEQUENCE authorizations_id_seq OWNED BY authorizations.id;
 
 
 --
--- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classification_export_rows (
@@ -205,7 +205,7 @@ ALTER SEQUENCE classification_export_rows_id_seq OWNED BY classification_export_
 
 
 --
--- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classification_subjects (
@@ -215,7 +215,7 @@ CREATE TABLE classification_subjects (
 
 
 --
--- Name: classifications; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: classifications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE classifications (
@@ -257,7 +257,7 @@ ALTER SEQUENCE classifications_id_seq OWNED BY classifications.id;
 
 
 --
--- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE code_experiment_configs (
@@ -288,7 +288,7 @@ ALTER SEQUENCE code_experiment_configs_id_seq OWNED BY code_experiment_configs.i
 
 
 --
--- Name: collections; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: collections; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections (
@@ -328,7 +328,7 @@ ALTER SEQUENCE collections_id_seq OWNED BY collections.id;
 
 
 --
--- Name: collections_projects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: collections_projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections_projects (
@@ -338,7 +338,7 @@ CREATE TABLE collections_projects (
 
 
 --
--- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE collections_subjects (
@@ -368,7 +368,7 @@ ALTER SEQUENCE collections_subjects_id_seq OWNED BY collections_subjects.id;
 
 
 --
--- Name: field_guides; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: field_guides; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE field_guides (
@@ -401,7 +401,7 @@ ALTER SEQUENCE field_guides_id_seq OWNED BY field_guides.id;
 
 
 --
--- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE flipper_features (
@@ -432,7 +432,7 @@ ALTER SEQUENCE flipper_features_id_seq OWNED BY flipper_features.id;
 
 
 --
--- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE flipper_gates (
@@ -465,7 +465,7 @@ ALTER SEQUENCE flipper_gates_id_seq OWNED BY flipper_gates.id;
 
 
 --
--- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE gold_standard_annotations (
@@ -502,7 +502,7 @@ ALTER SEQUENCE gold_standard_annotations_id_seq OWNED BY gold_standard_annotatio
 
 
 --
--- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE media (
@@ -544,7 +544,7 @@ ALTER SEQUENCE media_id_seq OWNED BY media.id;
 
 
 --
--- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE memberships (
@@ -579,7 +579,7 @@ ALTER SEQUENCE memberships_id_seq OWNED BY memberships.id;
 
 
 --
--- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_access_grants (
@@ -615,7 +615,7 @@ ALTER SEQUENCE oauth_access_grants_id_seq OWNED BY oauth_access_grants.id;
 
 
 --
--- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_access_tokens (
@@ -651,7 +651,7 @@ ALTER SEQUENCE oauth_access_tokens_id_seq OWNED BY oauth_access_tokens.id;
 
 
 --
--- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE oauth_applications (
@@ -690,7 +690,7 @@ ALTER SEQUENCE oauth_applications_id_seq OWNED BY oauth_applications.id;
 
 
 --
--- Name: organization_contents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: organization_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_contents (
@@ -727,7 +727,7 @@ ALTER SEQUENCE organization_contents_id_seq OWNED BY organization_contents.id;
 
 
 --
--- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_pages (
@@ -762,7 +762,7 @@ ALTER SEQUENCE organization_pages_id_seq OWNED BY organization_pages.id;
 
 
 --
--- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organizations (
@@ -800,7 +800,7 @@ ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
 
 
 --
--- Name: project_contents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: project_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_contents (
@@ -838,7 +838,7 @@ ALTER SEQUENCE project_contents_id_seq OWNED BY project_contents.id;
 
 
 --
--- Name: project_pages; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: project_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_pages (
@@ -873,7 +873,7 @@ ALTER SEQUENCE project_pages_id_seq OWNED BY project_pages.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE projects (
@@ -933,7 +933,7 @@ ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
 
 
 --
--- Name: recents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: recents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE recents (
@@ -969,7 +969,7 @@ ALTER SEQUENCE recents_id_seq OWNED BY recents.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE schema_migrations (
@@ -978,7 +978,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE set_member_subjects (
@@ -1013,7 +1013,7 @@ ALTER SEQUENCE set_member_subjects_id_seq OWNED BY set_member_subjects.id;
 
 
 --
--- Name: subject_sets; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_sets (
@@ -1049,7 +1049,7 @@ ALTER SEQUENCE subject_sets_id_seq OWNED BY subject_sets.id;
 
 
 --
--- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_sets_workflows (
@@ -1079,7 +1079,7 @@ ALTER SEQUENCE subject_sets_workflows_id_seq OWNED BY subject_sets_workflows.id;
 
 
 --
--- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subject_workflow_counts (
@@ -1114,7 +1114,7 @@ ALTER SEQUENCE subject_workflow_counts_id_seq OWNED BY subject_workflow_counts.i
 
 
 --
--- Name: subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE subjects (
@@ -1151,7 +1151,7 @@ ALTER SEQUENCE subjects_id_seq OWNED BY subjects.id;
 
 
 --
--- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tagged_resources (
@@ -1182,7 +1182,7 @@ ALTER SEQUENCE tagged_resources_id_seq OWNED BY tagged_resources.id;
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tags (
@@ -1214,7 +1214,7 @@ ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
--- Name: translations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: translations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE translations (
@@ -1248,7 +1248,7 @@ ALTER SEQUENCE translations_id_seq OWNED BY translations.id;
 
 
 --
--- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tutorials (
@@ -1283,7 +1283,7 @@ ALTER SEQUENCE tutorials_id_seq OWNED BY tutorials.id;
 
 
 --
--- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_collection_preferences (
@@ -1316,7 +1316,7 @@ ALTER SEQUENCE user_collection_preferences_id_seq OWNED BY user_collection_prefe
 
 
 --
--- Name: user_groups; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_groups (
@@ -1353,7 +1353,7 @@ ALTER SEQUENCE user_groups_id_seq OWNED BY user_groups.id;
 
 
 --
--- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_project_preferences (
@@ -1390,7 +1390,7 @@ ALTER SEQUENCE user_project_preferences_id_seq OWNED BY user_project_preferences
 
 
 --
--- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_seen_subjects (
@@ -1423,7 +1423,7 @@ ALTER SEQUENCE user_seen_subjects_id_seq OWNED BY user_seen_subjects.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE users (
@@ -1487,7 +1487,7 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE versions (
@@ -1522,7 +1522,7 @@ ALTER SEQUENCE versions_id_seq OWNED BY versions.id;
 
 
 --
--- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflow_contents (
@@ -1556,7 +1556,7 @@ ALTER SEQUENCE workflow_contents_id_seq OWNED BY workflow_contents.id;
 
 
 --
--- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflow_tutorials (
@@ -1586,7 +1586,7 @@ ALTER SEQUENCE workflow_tutorials_id_seq OWNED BY workflow_tutorials.id;
 
 
 --
--- Name: workflows; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE workflows (
@@ -1935,7 +1935,7 @@ ALTER TABLE ONLY workflows ALTER COLUMN id SET DEFAULT nextval('workflows_id_seq
 
 
 --
--- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY access_control_lists
@@ -1943,7 +1943,7 @@ ALTER TABLE ONLY access_control_lists
 
 
 --
--- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY aggregations
@@ -1951,7 +1951,7 @@ ALTER TABLE ONLY aggregations
 
 
 --
--- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY authorizations
@@ -1959,7 +1959,7 @@ ALTER TABLE ONLY authorizations
 
 
 --
--- Name: classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY classification_export_rows
@@ -1967,7 +1967,7 @@ ALTER TABLE ONLY classification_export_rows
 
 
 --
--- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY classifications
@@ -1975,7 +1975,7 @@ ALTER TABLE ONLY classifications
 
 
 --
--- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY code_experiment_configs
@@ -1983,7 +1983,7 @@ ALTER TABLE ONLY code_experiment_configs
 
 
 --
--- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY collections
@@ -1991,7 +1991,7 @@ ALTER TABLE ONLY collections
 
 
 --
--- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY collections_subjects
@@ -1999,7 +1999,7 @@ ALTER TABLE ONLY collections_subjects
 
 
 --
--- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY field_guides
@@ -2007,7 +2007,7 @@ ALTER TABLE ONLY field_guides
 
 
 --
--- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY flipper_features
@@ -2015,7 +2015,7 @@ ALTER TABLE ONLY flipper_features
 
 
 --
--- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY flipper_gates
@@ -2023,7 +2023,7 @@ ALTER TABLE ONLY flipper_gates
 
 
 --
--- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY gold_standard_annotations
@@ -2031,7 +2031,7 @@ ALTER TABLE ONLY gold_standard_annotations
 
 
 --
--- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY media
@@ -2039,7 +2039,7 @@ ALTER TABLE ONLY media
 
 
 --
--- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY memberships
@@ -2047,7 +2047,7 @@ ALTER TABLE ONLY memberships
 
 
 --
--- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_access_grants
@@ -2055,7 +2055,7 @@ ALTER TABLE ONLY oauth_access_grants
 
 
 --
--- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_access_tokens
@@ -2063,7 +2063,7 @@ ALTER TABLE ONLY oauth_access_tokens
 
 
 --
--- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY oauth_applications
@@ -2071,7 +2071,7 @@ ALTER TABLE ONLY oauth_applications
 
 
 --
--- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_contents
@@ -2079,7 +2079,7 @@ ALTER TABLE ONLY organization_contents
 
 
 --
--- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_pages
@@ -2087,7 +2087,7 @@ ALTER TABLE ONLY organization_pages
 
 
 --
--- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organizations
@@ -2095,7 +2095,7 @@ ALTER TABLE ONLY organizations
 
 
 --
--- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_contents
@@ -2103,7 +2103,7 @@ ALTER TABLE ONLY project_contents
 
 
 --
--- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_pages
@@ -2111,7 +2111,7 @@ ALTER TABLE ONLY project_pages
 
 
 --
--- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY projects
@@ -2119,7 +2119,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY recents
@@ -2127,7 +2127,7 @@ ALTER TABLE ONLY recents
 
 
 --
--- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY set_member_subjects
@@ -2135,7 +2135,7 @@ ALTER TABLE ONLY set_member_subjects
 
 
 --
--- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_sets
@@ -2143,7 +2143,7 @@ ALTER TABLE ONLY subject_sets
 
 
 --
--- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_sets_workflows
@@ -2151,7 +2151,7 @@ ALTER TABLE ONLY subject_sets_workflows
 
 
 --
--- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subject_workflow_counts
@@ -2159,7 +2159,7 @@ ALTER TABLE ONLY subject_workflow_counts
 
 
 --
--- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY subjects
@@ -2167,7 +2167,7 @@ ALTER TABLE ONLY subjects
 
 
 --
--- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tagged_resources
@@ -2175,7 +2175,7 @@ ALTER TABLE ONLY tagged_resources
 
 
 --
--- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tags
@@ -2183,7 +2183,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY translations
@@ -2191,7 +2191,7 @@ ALTER TABLE ONLY translations
 
 
 --
--- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY tutorials
@@ -2199,7 +2199,7 @@ ALTER TABLE ONLY tutorials
 
 
 --
--- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_collection_preferences
@@ -2207,7 +2207,7 @@ ALTER TABLE ONLY user_collection_preferences
 
 
 --
--- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_groups
@@ -2215,7 +2215,7 @@ ALTER TABLE ONLY user_groups
 
 
 --
--- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_project_preferences
@@ -2223,7 +2223,7 @@ ALTER TABLE ONLY user_project_preferences
 
 
 --
--- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_seen_subjects
@@ -2231,7 +2231,7 @@ ALTER TABLE ONLY user_seen_subjects
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -2239,7 +2239,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY versions
@@ -2247,7 +2247,7 @@ ALTER TABLE ONLY versions
 
 
 --
--- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflow_contents
@@ -2255,7 +2255,7 @@ ALTER TABLE ONLY workflow_contents
 
 
 --
--- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflow_tutorials
@@ -2263,7 +2263,7 @@ ALTER TABLE ONLY workflow_tutorials
 
 
 --
--- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY workflows
@@ -2271,658 +2271,658 @@ ALTER TABLE ONLY workflows
 
 
 --
--- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX classification_subjects_pk ON classification_subjects USING btree (classification_id, subject_id);
 
 
 --
--- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX idx_lower_email ON users USING btree (lower((email)::text));
 
 
 --
--- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX "idx_translations_on_translated_type+id_and_language" ON translations USING btree (translated_type, translated_id, language);
 
 
 --
--- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_access_control_lists_on_resource_id_and_resource_type ON access_control_lists USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_access_control_lists_on_user_group_id ON access_control_lists USING btree (user_group_id);
 
 
 --
--- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_aggregations_on_subject_id_and_workflow_id ON aggregations USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_aggregations_on_workflow_id ON aggregations USING btree (workflow_id);
 
 
 --
--- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_authorizations_on_user_id ON authorizations USING btree (user_id);
 
 
 --
--- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_classification_export_rows_on_classification_id ON classification_export_rows USING btree (classification_id);
 
 
 --
--- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_export_rows_on_project_id ON classification_export_rows USING btree (project_id);
 
 
 --
--- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_export_rows_on_workflow_id ON classification_export_rows USING btree (workflow_id);
 
 
 --
--- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classification_subjects_on_subject_id ON classification_subjects USING btree (subject_id);
 
 
 --
--- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_completed ON classifications USING btree (completed) WHERE (completed IS FALSE);
 
 
 --
--- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_created_at ON classifications USING btree (created_at);
 
 
 --
--- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_gold_standard ON classifications USING btree (gold_standard) WHERE (gold_standard IS TRUE);
 
 
 --
--- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_lifecycled_at ON classifications USING btree (lifecycled_at) WHERE (lifecycled_at IS NULL);
 
 
 --
--- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_project_id_and_id ON classifications USING btree (project_id, id);
 
 
 --
--- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_user_id ON classifications USING btree (user_id);
 
 
 --
--- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_classifications_on_workflow_id ON classifications USING btree (workflow_id);
 
 
 --
--- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_code_experiment_configs_on_name ON code_experiment_configs USING btree (name);
 
 
 --
--- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_display_name_trgrm ON collections USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_activated_state ON collections USING btree (activated_state);
 
 
 --
--- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_display_name ON collections USING btree (display_name);
 
 
 --
--- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_favorite ON collections USING btree (favorite);
 
 
 --
--- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_private ON collections USING btree (private);
 
 
 --
--- Name: index_collections_on_project_ids; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_project_ids; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_project_ids ON collections USING gin (project_ids);
 
 
 --
--- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_on_slug ON collections USING btree (slug);
 
 
 --
--- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_projects_on_collection_id ON collections_projects USING btree (collection_id);
 
 
 --
--- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_collections_subjects_on_collection_id_and_subject_id ON collections_subjects USING btree (collection_id, subject_id);
 
 
 --
--- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_collections_subjects_on_subject_id ON collections_subjects USING btree (subject_id);
 
 
 --
--- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_field_guides_on_language ON field_guides USING btree (language);
 
 
 --
--- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_field_guides_on_project_id ON field_guides USING btree (project_id);
 
 
 --
--- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_flipper_features_on_key ON flipper_features USING btree (key);
 
 
 --
--- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON flipper_gates USING btree (feature_key, key, value);
 
 
 --
--- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_gold_standard_annotations_on_subject_id ON gold_standard_annotations USING btree (subject_id);
 
 
 --
--- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_gold_standard_annotations_on_workflow_id ON gold_standard_annotations USING btree (workflow_id);
 
 
 --
--- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_media_on_linked_id_and_linked_type ON media USING btree (linked_id, linked_type);
 
 
 --
--- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_media_on_type ON media USING btree (type);
 
 
 --
--- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_memberships_on_user_group_id_and_user_id ON memberships USING btree (user_group_id, user_id);
 
 
 --
--- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_memberships_on_user_id ON memberships USING btree (user_id);
 
 
 --
--- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON oauth_access_grants USING btree (token);
 
 
 --
--- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_oauth_access_tokens_on_app_id_and_owner_id ON oauth_access_tokens USING btree (application_id, resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens USING btree (refresh_token);
 
 
 --
--- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON oauth_access_tokens USING btree (resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON oauth_access_tokens USING btree (token);
 
 
 --
--- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_oauth_applications_on_uid ON oauth_applications USING btree (uid);
 
 
 --
--- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organization_pages_on_language ON organization_pages USING btree (language);
 
 
 --
--- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organization_pages_on_organization_id ON organization_pages USING btree (organization_id);
 
 
 --
--- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_activated_state ON organizations USING btree (activated_state);
 
 
 --
--- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_display_name ON organizations USING btree (display_name);
 
 
 --
--- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_listed ON organizations USING btree (listed);
 
 
 --
--- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_listed_at ON organizations USING btree (listed_at);
 
 
 --
--- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_organizations_on_slug ON organizations USING btree (slug);
 
 
 --
--- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
 
 
 --
--- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_contents_on_project_id ON project_contents USING btree (project_id);
 
 
 --
--- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_pages_on_language ON project_pages USING btree (language);
 
 
 --
--- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_project_pages_on_project_id ON project_pages USING btree (project_id);
 
 
 --
--- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_display_name_trgrm ON projects USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_activated_state ON projects USING btree (activated_state);
 
 
 --
--- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_approved ON projects USING btree (beta_approved);
 
 
 --
--- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_requested ON projects USING btree (beta_requested) WHERE (beta_requested = true);
 
 
 --
--- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_beta_row_order ON projects USING btree (beta_row_order);
 
 
 --
--- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_featured ON projects USING btree (featured);
 
 
 --
--- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launch_approved ON projects USING btree (launch_approved);
 
 
 --
--- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launch_requested ON projects USING btree (launch_requested) WHERE (launch_requested = true);
 
 
 --
--- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_launched_row_order ON projects USING btree (launched_row_order);
 
 
 --
--- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_live ON projects USING btree (live);
 
 
 --
--- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_migrated ON projects USING btree (migrated) WHERE (migrated = true);
 
 
 --
--- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_mobile_friendly ON projects USING btree (mobile_friendly);
 
 
 --
--- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_organization_id ON projects USING btree (organization_id);
 
 
 --
--- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_private ON projects USING btree (private);
 
 
 --
--- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_slug ON projects USING btree (slug);
 
 
 --
--- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_state ON projects USING btree (state) WHERE (state IS NOT NULL);
 
 
 --
--- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_projects_on_tsv ON projects USING gin (tsv);
 
 
 --
--- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_created_at ON recents USING btree (created_at);
 
 
 --
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_project_id ON recents USING btree (project_id);
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_subject_id ON recents USING btree (subject_id);
 
 
 --
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_user_id ON recents USING btree (user_id);
 
 
 --
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_recents_on_workflow_id ON recents USING btree (workflow_id);
 
 
 --
--- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_random ON set_member_subjects USING btree (random);
 
 
 --
--- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_set_member_subjects_on_subject_id_and_subject_set_id ON set_member_subjects USING btree (subject_id, subject_set_id);
 
 
 --
--- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_set_member_subjects_on_subject_set_id ON set_member_subjects USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_on_metadata ON subject_sets USING gin (metadata);
 
 
 --
--- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_on_project_id_and_display_name ON subject_sets USING btree (project_id, display_name);
 
 
 --
--- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_sets_workflows_on_subject_set_id ON subject_sets_workflows USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_subject_sets_workflows_on_workflow_id_and_subject_set_id ON subject_sets_workflows USING btree (workflow_id, subject_set_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_subject_workflow_counts_on_subject_id_and_workflow_id ON subject_workflow_counts USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subject_workflow_counts_on_workflow_id ON subject_workflow_counts USING btree (workflow_id);
 
 
 --
--- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subjects_on_project_id ON subjects USING btree (project_id);
 
 
 --
--- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_subjects_on_upload_user_id ON subjects USING btree (upload_user_id);
 
 
 --
--- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tagged_resources_on_resource_id_and_resource_type ON tagged_resources USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tagged_resources_on_tag_id ON tagged_resources USING btree (tag_id);
 
 
 --
--- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tags_name_trgrm ON tags USING gin ((COALESCE(name, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
@@ -2936,252 +2936,252 @@ CREATE INDEX index_tutorials_on_kind ON tutorials USING btree (kind);
 
 
 --
--- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_language ON tutorials USING btree (language);
 
 
 --
--- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_project_id ON tutorials USING btree (project_id);
 
 
 --
--- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_collection_preferences_on_collection_id ON user_collection_preferences USING btree (collection_id);
 
 
 --
--- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_collection_preferences_on_user_id ON user_collection_preferences USING btree (user_id);
 
 
 --
--- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_display_name_trgrm ON user_groups USING gin ((COALESCE((display_name)::text, ''::text)) gin_trgm_ops);
 
 
 --
--- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_on_activated_state ON user_groups USING btree (activated_state);
 
 
 --
--- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_user_groups_on_name ON user_groups USING btree (lower((name)::text));
 
 
 --
--- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_groups_on_private ON user_groups USING btree (private);
 
 
 --
--- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_user_project_preferences_on_user_id_and_project_id ON user_project_preferences USING btree (user_id, project_id);
 
 
 --
--- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON user_seen_subjects USING btree (user_id, workflow_id);
 
 
 --
--- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_activated_state ON users USING btree (activated_state);
 
 
 --
--- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_beta_email_communication ON users USING btree (beta_email_communication) WHERE (beta_email_communication = true);
 
 
 --
--- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_display_name ON users USING btree (lower((display_name)::text));
 
 
 --
--- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
 
 
 --
--- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_global_email_communication ON users USING btree (global_email_communication) WHERE (global_email_communication = true);
 
 
 --
--- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_login ON users USING btree (lower((login)::text));
 
 
 --
--- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_login_with_case ON users USING btree (login);
 
 
 --
--- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_lower_names ON users USING btree (lower((login)::text) text_pattern_ops, lower((display_name)::text) text_pattern_ops);
 
 
 --
--- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_private_profile ON users USING btree (private_profile) WHERE (private_profile = false);
 
 
 --
--- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
 
 
 --
--- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_users_on_tsv ON users USING gin (tsv);
 
 
 --
--- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_unsubscribe_token ON users USING btree (unsubscribe_token);
 
 
 --
--- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_zooniverse_id ON users USING btree (zooniverse_id);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (item_type, item_id);
 
 
 --
--- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflow_contents_on_workflow_id ON workflow_contents USING btree (workflow_id);
 
 
 --
--- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflow_tutorials_on_tutorial_id ON workflow_tutorials USING btree (tutorial_id);
 
 
 --
--- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_workflow_tutorials_on_workflow_id_and_tutorial_id ON workflow_tutorials USING btree (workflow_id, tutorial_id);
 
 
 --
--- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_activated_state ON workflows USING btree (activated_state);
 
 
 --
--- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_aggregation ON workflows USING btree (((aggregation ->> 'public'::text)));
 
 
 --
--- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_display_order ON workflows USING btree (display_order);
 
 
 --
--- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_mobile_friendly ON workflows USING btree (mobile_friendly);
 
 
 --
--- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_project_id ON workflows USING btree (project_id);
 
 
 --
--- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_public_gold_standard ON workflows USING btree (public_gold_standard) WHERE (public_gold_standard IS TRUE);
 
 
 --
--- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_workflows_on_tutorial_subject_id ON workflows USING btree (tutorial_subject_id);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
 
 
 --
--- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX users_idx_trgm_login ON users USING gin ((COALESCE((login)::text, ''::text)) gin_trgm_ops);

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2929,21 +2929,7 @@ CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
 
 
 --
--- Name: index_translations_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace:
---
-
-CREATE INDEX index_translations_on_language ON translations USING btree (language);
-
-
---
--- Name: index_translations_on_translated_type_and_translated_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
---
-
-CREATE INDEX index_translations_on_translated_type_and_translated_id ON translations USING btree (translated_type, translated_id);
-
-
---
--- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_tutorials_on_kind ON tutorials USING btree (kind);


### PR DESCRIPTION
Old indexes crept into the structure from #2611 and due to whitespace formatting, the diff was large so didn't show in the PR by default. We should either leave the whitespace as is output from the `rake db:migrate` task or all strip whitespace on this file for any PR. I vote leave whitespace as it is the easiest to avoid messing up. 

Either way we need to ensure we see the diffs on this file and they do what we expect.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
