### PR TITLE
fix intermittent spec failure matching date time strings

### DIFF
--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -98,8 +98,9 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
       run_update
       updated_upp = json_response[api_resource_name].first
       expect(updated_upp).not_to be_empty
-      modified = upp.updated_at.httpdate
-      expect(response.headers).to include('Last-Modified' => modified)
+      modified_dt = upp.updated_at.httpdate.to_datetime
+      response_dt = response.headers['Last-Modified'].to_datetime
+      expect(response_dt).to be_within(1.second).of(modified_dt)
     end
 
     it "updates the UPP settings attribute" do


### PR DESCRIPTION
Trying my best to avoid intermittent spec errors in our CI tools, this will convert the date time strings to time and allow a delta of 1 second difference between the two

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
