### PR TITLE
Communications role for projects

### DIFF
--- a/app/controllers/api/v1/project_roles_controller.rb
+++ b/app/controllers/api/v1/project_roles_controller.rb
@@ -11,12 +11,24 @@ class Api::V1::ProjectRolesController < Api::ApiController
 
   def update
     super
-    UserAddedToProjectMailerWorker.perform_async(acl_user_id, controlled_resource.resource.id, roles) if new_roles_present?(roles)
+    if new_roles_present?(roles)
+      UserAddedToProjectMailerWorker.perform_async(
+        acl_user_id,
+        controlled_resource.resource.id,
+        roles
+      )
+    end
   end
 
   def create
     super
-    UserAddedToProjectMailerWorker.perform_async(new_user_id, project_id, roles) if new_roles_present?(roles)
+    if new_roles_present?(roles)
+      UserAddedToProjectMailerWorker.perform_async(
+        new_user_id,
+        project_id,
+        roles
+      )
+    end
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -111,9 +111,7 @@ class Project < ActiveRecord::Base
   end
 
   def owners_and_collaborators
-    User.joins(user_groups: :access_control_lists)
-      .merge(acls.where.overlap(roles: %w(owner collaborator)))
-      .select(:id)
+    users_with_project_roles(%w(owner collaborator)).select(:id)
   end
 
   def create_talk_admin(client)
@@ -167,10 +165,13 @@ class Project < ActiveRecord::Base
     end
   end
 
-  def communication_emails
+  def users_with_project_roles(roles)
     User.joins(user_groups: :access_control_lists)
-    .merge(acls.where.overlap(roles: %w(owner communications)))
-    .pluck(:email)
+    .merge(acls.where.overlap(roles: roles))
+  end
+
+  def communication_emails
+    users_with_project_roles(%w(owner communications)).pluck(:email)
   end
 
   def keep_data_in_panoptes_only?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -167,6 +167,12 @@ class Project < ActiveRecord::Base
     end
   end
 
+  def communication_emails
+    User.joins(user_groups: :access_control_lists)
+    .merge(acls.where.overlap(roles: %w(owner communications)))
+    .pluck(:email)
+  end
+
   def keep_data_in_panoptes_only?
     !!configuration.fetch("keep_data_in_panoptes_only", false)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -166,8 +166,11 @@ class Project < ActiveRecord::Base
   end
 
   def users_with_project_roles(roles)
-    User.joins(user_groups: :access_control_lists)
-    .merge(acls.where.overlap(roles: roles))
+    project_roles = acls.where(
+      "access_control_lists.roles && ARRAY[?]::varchar[]",
+      roles
+    )
+    User.joins(user_groups: :access_control_lists).merge(project_roles)
   end
 
   def communication_emails

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -56,6 +56,7 @@ class Workflow < ActiveRecord::Base
   ranks :display_order, with_same: :project_id
 
   delegate :owner, to: :project
+  delegate :communication_emails, to: :project
 
   def self.same_project?(subject_set)
     where(project: subject_set.project)

--- a/app/workers/concerns/dump_mailer_worker.rb
+++ b/app/workers/concerns/dump_mailer_worker.rb
@@ -15,8 +15,8 @@ module DumpMailerWorker
   end
 
   def emails
-    recipients = medium&.metadata.dig("recipients")
-    if recipients
+    metadata = medium&.metadata
+    if recipients = metadata&.dig("recipients")
       User.where(id: recipients).pluck(:email)
     else
       resource_comms_emails

--- a/app/workers/concerns/dump_mailer_worker.rb
+++ b/app/workers/concerns/dump_mailer_worker.rb
@@ -15,14 +15,21 @@ module DumpMailerWorker
   end
 
   def emails
-    if recipients = medium.try(:metadata).try(:[], "recipients")
+    recipients = medium&.metadata.dig("recipients")
+    if recipients
       User.where(id: recipients).pluck(:email)
     else
-      [resource.owner.email]
+      resource_comms_emails
     end
   end
 
   def media_get_url(expires=24*60)
     medium.get_url(get_expires: expires)
+  end
+
+  private
+
+  def resource_comms_emails
+    resource.communication_emails
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -524,7 +524,7 @@ describe Project, type: :model do
         )
       end
 
-      it 'should return the owner by default' do
+      it 'should return the owner and comms roles emails' do
         expect(project.communication_emails).to match_array([owner_email, comms_user.email])
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -505,6 +505,31 @@ describe Project, type: :model do
     end
   end
 
+  describe "#communication_emails" do
+    let(:project) { create(:project) }
+    let(:owner_email) { project.owner.email }
+
+    it 'should return the owner by default' do
+      expect(project.communication_emails).to match_array([owner_email])
+    end
+
+    context "with communication project roles" do
+      let(:comms_user) { create(:user) }
+      before do
+        create(
+          :access_control_list,
+          user_group: comms_user.identity_group,
+          resource: project,
+          roles: ["communications"]
+        )
+      end
+
+      it 'should return the owner by default' do
+        expect(project.communication_emails).to match_array([owner_email, comms_user.email])
+      end
+    end
+  end
+
   describe "#keep_data_in_panoptes_only?" do
     it "should not return true when no private config" do
       expect(project.keep_data_in_panoptes_only?).to eq(false)

--- a/spec/workers/concerns/dump_mailer_worker_spec.rb
+++ b/spec/workers/concerns/dump_mailer_worker_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 describe DumpMailerWorker do
-  let(:resource) { double(id: 1, class: Workflow) }
   let(:users) { create_list(:user, 2) }
+  let(:owner) { users.sample }
+  let(:resource) do
+    double(id: 1, class: Workflow, communication_emails: [owner.email])
+  end
   let(:metadata) { {"recipients" => users.map(&:id) } }
   let(:medium) {double(id: 2, get_url: nil, metadata: metadata) }
   let(:worker_class) do
@@ -25,22 +28,38 @@ describe DumpMailerWorker do
 
   describe 'queueing notification emails' do
     let(:worker) { worker_class.new(resource, medium) }
+    let(:expected_emails) { users.map(&:email) }
+
+    before do
+      expect(worker.mailer)
+      .to receive(:perform_async)
+      .with(resource.id, "workflow", nil, expected_emails)
+      .once
+      .and_call_original
+    end
 
     it 'queues up an email job' do
-      expect(worker.mailer)
-        .to receive(:perform_async)
-        .with(resource.id, "workflow", nil, users.map(&:email))
-        .once
-        .and_call_original
       worker.send_email
     end
 
-    context "with no recipients" do
-      let(:users) { [] }
+    context "with no specified recipients" do
+      let(:metadata) { { } }
 
-      it 'does not queue an email job' do
-        expect(worker.mailer).to receive(:perform_async).never
-        worker.send_email
+      context "a normal project" do
+        let(:expected_emails) { [ resource.owner.email ] }
+
+        it 'queues an email to the owner' do
+          worker.send_email
+        end
+      end
+
+      context "when the project is internal panoptes only" do
+        let(:metadata) { { } }
+        let(:expected_emails) { [ resource.owner.email ] }
+
+        it 'queues an email to the owner', :focus do
+          worker.send_email
+        end
       end
     end
   end

--- a/spec/workers/concerns/dump_mailer_worker_spec.rb
+++ b/spec/workers/concerns/dump_mailer_worker_spec.rb
@@ -44,22 +44,10 @@ describe DumpMailerWorker do
 
     context "with no specified recipients" do
       let(:metadata) { { } }
+      let(:expected_emails) { [ owner.email ] }
 
-      context "a normal project" do
-        let(:expected_emails) { [ resource.owner.email ] }
-
-        it 'queues an email to the owner' do
-          worker.send_email
-        end
-      end
-
-      context "when the project is internal panoptes only" do
-        let(:metadata) { { } }
-        let(:expected_emails) { [ resource.owner.email ] }
-
-        it 'queues an email to the owner', :focus do
-          worker.send_email
-        end
+      it 'queues an email to the owner' do
+        worker.send_email
       end
     end
   end


### PR DESCRIPTION
Fixes #2524 and closes https://github.com/zooniverse/Panoptes-Front-End/issues/1703

Add communications email list for projects that includes the owner by default and any user with the communications role. Dumps will use this as a fallback when there is no requesting user.

# TODO:
- [x] figure out how @mrniaboc get the project communication emails and link into this owner & comms work / automate the creation of these lists for him.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
