### PR TITLE
sync our sidekiq worker queues to the CI defaults

### DIFF
--- a/config/sidekiq.yml.hudson
+++ b/config/sidekiq.yml.hudson
@@ -13,7 +13,9 @@ production:
 # Set timeout to 8 on Heroku, longer if you manage your own systems.
 :timeout: 30
 :queues:
+  - really_high
   - high
-  - medium
+  - data_high
+  - data_medium
   - default
-  - low
+  - data_low


### PR DESCRIPTION
i use these queue lists for figure out what we have in the sidekiq options, without these listed here i need to look them up in a configuration file not in this repo.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
