### PR TITLE
Org serializer link update

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -45,6 +45,7 @@ class Medium < ActiveRecord::Base
   end
 
   def linked_resource_details
+    # field_guide has a _ in it so manually find it vs prefix_*
     details = /\A(?<resource>field_guide|[a-z]+)_(?<media_type>\w+)/i.match(type)
     [ details[:resource], details[:media_type] ]
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -15,7 +15,7 @@ class Organization < ActiveRecord::Base
   has_one :background, -> { where(type: "organization_background") }, class_name: "Medium", as: :linked
   has_many :organization_roles, -> { where.not(roles: []) }, class_name: "AccessControlList", as: :resource
   has_many :pages, class_name: "OrganizationPage", dependent: :destroy
-  has_many :attached_images, -> { where(type: "org_attached_image") }, class_name: "Medium",
+  has_many :attached_images, -> { where(type: "organization_attached_image") }, class_name: "Medium",
     as: :linked
   has_many :tagged_resources, as: :resource
   has_many :tags, through: :tagged_resources

--- a/db/migrate/20180115214144_add_announcement_to_organization_contents.rb
+++ b/db/migrate/20180115214144_add_announcement_to_organization_contents.rb
@@ -1,5 +1,6 @@
 class AddAnnouncementToOrganizationContents < ActiveRecord::Migration
   def change
     add_column :organization_contents, :announcement, :string, default: ""
+    Medium.where(type: "org_attached_image").update_all(type: "organization_attached_image")
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
       if env.build_media
         o.avatar = create(:medium, type: "organization_avatar", linked: o)
         o.background = create(:medium, type: "organization_background", linked: o)
-        o.attached_images << create(:medium, type: "org_attached_image", linked: o)
+        o.attached_images << create(:medium, type: "organization_attached_image", linked: o)
       end
     end
 

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
       if env.build_media
         o.avatar = create(:medium, type: "organization_avatar", linked: o)
         o.background = create(:medium, type: "organization_background", linked: o)
+        o.attached_images << create(:medium, type: "org_attached_image", linked: o)
       end
     end
 

--- a/spec/serializers/medium_serializer_spec.rb
+++ b/spec/serializers/medium_serializer_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe MediumSerializer do
+  let(:result) do
+    described_class.single({}, Medium.where(id: medium.id), {})
+  end
+
+  context "organization" do
+    describe "attached_images" do
+      let(:org) { create(:organization, build_media: true) }
+      let(:medium) { org.attached_images.first }
+      let(:medium_href) do
+        "/organizations/#{org.id}/attached_images/#{medium.id}"
+      end
+
+      it "should return the attached image href", :focus do
+        expect(result[:href]).to eq(medium_href)
+      end
+    end
+  end
+
+  context "field_guides" do
+    describe "attached_images" do
+      let(:field_guide) do
+        create(:field_guide) do |fg|
+          medium = create(:medium, type: "field_guide_attached_image", linked: fg)
+          fg.attached_images << medium
+        end
+      end
+      let(:medium) { field_guide.attached_images.first }
+      let(:medium_href) do
+        "/field_guides/#{field_guide.id}/attached_images/#{medium.id}"
+      end
+
+      it "should return the attached image href" do
+        expect(result[:href]).to eq(medium_href)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@camallen added the specs, I made "org" say "organization". This fixes the broken href in serialized orgs. 

Fixes https://github.com/zooniverse/Panoptes/issues/2586


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
