### PR TITLE
Remove not-null for Doorkeeper previous_token migration

### DIFF
--- a/db/migrate/20180122134607_add_previous_refresh_token_to_access_tokens.rb
+++ b/db/migrate/20180122134607_add_previous_refresh_token_to_access_tokens.rb
@@ -4,8 +4,7 @@ class AddPreviousRefreshTokenToAccessTokens < ActiveRecord::Migration
       :oauth_access_tokens,
       :previous_refresh_token,
       :string,
-      default: "",
-      null: false
+      default: ""
     )
   end
 end

--- a/db/migrate/20180122134607_add_previous_refresh_token_to_access_tokens.rb
+++ b/db/migrate/20180122134607_add_previous_refresh_token_to_access_tokens.rb
@@ -3,8 +3,7 @@ class AddPreviousRefreshTokenToAccessTokens < ActiveRecord::Migration
     add_column(
       :oauth_access_tokens,
       :previous_refresh_token,
-      :string,
-      default: ""
+      :string
     )
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -628,7 +628,7 @@ CREATE TABLE oauth_access_tokens (
     revoked_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
     scopes character varying,
-    previous_refresh_token character varying DEFAULT ''::character varying NOT NULL
+    previous_refresh_token character varying DEFAULT ''::character varying
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -628,7 +628,7 @@ CREATE TABLE oauth_access_tokens (
     revoked_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
     scopes character varying,
-    previous_refresh_token character varying DEFAULT ''::character varying
+    previous_refresh_token character varying
 );
 
 


### PR DESCRIPTION

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
