### PR TITLE
allow text/plain media resources

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -10,8 +10,18 @@ class Medium < ActiveRecord::Base
 
   attr_writer :allow_any_content_type
 
-  ALLOWED_UPLOAD_CONTENT_TYPES = %w(image/jpeg image/png image/gif image/svg+xml audio/mpeg audio/mp3 audio/mp4 audio/x-m4a).freeze
-  ALLOWED_EXPORT_CONTENT_TYPES  = %w(text/csv).freeze
+  ALLOWED_UPLOAD_CONTENT_TYPES = %w(
+    image/jpeg
+    image/png
+    image/gif
+    image/svg+xml
+    audio/mpeg
+    audio/mp3
+    audio/mp4
+    audio/x-m4a
+    text/plain
+  ).freeze
+  ALLOWED_EXPORT_CONTENT_TYPES = %w(text/csv).freeze
 
   validate do |medium|
     if !allow_any_content_type && !allowed_content_types.include?(medium.content_type)

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -564,7 +564,7 @@ describe Api::V1::SubjectsController, type: :controller do
       end
 
       context "when the mime type is not allowed" do
-        let(:locations) { [ "text/plain" ] }
+        let(:locations) { [ "text/html" ] }
 
         it "should not overwrite existing locations" do
           loc_ids = resource.locations.map(&:id)

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Medium, :type => :model do
 
       it 'should be valid with both content_types' do
         aggregate_failures "content types" do
-          %w(text/plain video/mp4).each do |content_type|
+          %w(text/html video/mp4).each do |content_type|
             m = build(:medium, allow_any_content_type: true, content_type: content_type)
             expect(m).to be_valid
           end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Medium, :type => :model do
 
     it 'should be invalid with an disallowed content_types' do
       aggregate_failures "disallowed content types" do
-        %w(text/plain video/mp4).each do |content_type|
+        %w(text/html video/mp4).each do |content_type|
           m = build(:medium, content_type: content_type)
           expect(m).to_not be_valid
         end


### PR DESCRIPTION
plain text subjects can now be uploaded for use in projects

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
