### PR TITLE
Better subject classification counts used for reporting & retirement.

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -55,8 +55,8 @@ class Api::V1::ClassificationsController < Api::ApiController
 
   def resources_completed?
     Classification.created_by(api_user.user)
-      .merge(Classification.complete)
-      .exists?(id: resource_ids)
+    .complete
+    .exists?(id: resource_ids)
   end
 
   def build_resource_for_create(create_params)

--- a/app/counters/subject_workflow_counter.rb
+++ b/app/counters/subject_workflow_counter.rb
@@ -12,6 +12,7 @@ class SubjectWorkflowCounter
       .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
       .where("cs.subject_id = ?", swc.subject_id)
       .where("gold_standard IS NOT TRUE")
+      .where.not("metadata ? 'seen_before'")
       .complete
 
     if launch_date = swc.project.launch_date

--- a/app/counters/subject_workflow_counter.rb
+++ b/app/counters/subject_workflow_counter.rb
@@ -11,6 +11,7 @@ class SubjectWorkflowCounter
       .where(workflow: swc.workflow_id)
       .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
       .where("cs.subject_id = ?", swc.subject_id)
+      .complete
     if launch_date = swc.project.launch_date
       scope = scope.where("classifications.created_at >= ?", launch_date)
     end

--- a/app/counters/subject_workflow_counter.rb
+++ b/app/counters/subject_workflow_counter.rb
@@ -11,7 +11,9 @@ class SubjectWorkflowCounter
       .where(workflow: swc.workflow_id)
       .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
       .where("cs.subject_id = ?", swc.subject_id)
+      .where("gold_standard IS NOT TRUE")
       .complete
+
     if launch_date = swc.project.launch_date
       scope = scope.where("classifications.created_at >= ?", launch_date)
     end

--- a/app/counters/subject_workflow_counter.rb
+++ b/app/counters/subject_workflow_counter.rb
@@ -7,14 +7,39 @@ class SubjectWorkflowCounter
   end
 
   def classifications
-    scope = Classification
-      .where(workflow: swc.workflow_id)
-      .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
-      .where("cs.subject_id = ?", swc.subject_id)
-      .where("gold_standard IS NOT TRUE")
-      .where.not("metadata ? 'seen_before'")
-      .complete
+    experiment_name = "subject_workflow_counter_skip_gs_and_seen_before"
+    CodeExperiment.run(experiment_name) do |e|
+      e.run_if { Panoptes.flipper[experiment_name].enabled? }
 
+      e.use do
+        scope = Classification
+          .where(workflow: swc.workflow_id)
+          .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
+          .where("cs.subject_id = ?", swc.subject_id)
+
+        count_classifications(scope)
+      end
+
+      e.try do
+        scope = Classification
+          .where(workflow: swc.workflow_id)
+          .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
+          .where("cs.subject_id = ?", swc.subject_id)
+          .where("gold_standard IS NOT TRUE")
+          .where.not("metadata ? 'seen_before'")
+          .complete
+
+        count_classifications(scope)
+      end
+
+      # skip the mismatch reporting...we just want perf metrics
+      e.ignore { true }
+    end
+  end
+
+  private
+
+  def count_classifications(scope)
     if launch_date = swc.project.launch_date
       scope = scope.where("classifications.created_at >= ?", launch_date)
     end

--- a/spec/counters/subject_workflow_counter_spec.rb
+++ b/spec/counters/subject_workflow_counter_spec.rb
@@ -40,7 +40,7 @@ describe SubjectWorkflowCounter do
         expect(counter.classifications).to eq(2)
       end
 
-      context "with classifications that do not count" do
+      context "with classifications that do not count", :disabled do
         let(:default_attrs) do
           {
             subject_ids: [sws.subject_id],

--- a/spec/counters/subject_workflow_counter_spec.rb
+++ b/spec/counters/subject_workflow_counter_spec.rb
@@ -18,7 +18,11 @@ describe SubjectWorkflowCounter do
     context "with classifications" do
       before do
         2.times do
-          create(:classification,  subject_ids: [sws.subject_id], project: project, workflow: workflow)
+          create(:classification,
+            subject_ids: [sws.subject_id],
+            project: project,
+            workflow: workflow
+          )
         end
       end
 
@@ -30,6 +34,16 @@ describe SubjectWorkflowCounter do
         allow(project).to receive(:launch_date).and_return(now)
         expect(counter.classifications).to eq(0)
         allow(project).to receive(:launch_date).and_return(now-1.day)
+        expect(counter.classifications).to eq(2)
+      end
+
+      it "should ignore any incomplete classifications" do
+        incomplete = create(:classification,
+          subject_ids: [sws.subject_id],
+          project: project,
+          workflow: workflow,
+          completed: false
+        )
         expect(counter.classifications).to eq(2)
       end
 

--- a/spec/counters/subject_workflow_counter_spec.rb
+++ b/spec/counters/subject_workflow_counter_spec.rb
@@ -37,14 +37,28 @@ describe SubjectWorkflowCounter do
         expect(counter.classifications).to eq(2)
       end
 
-      it "should ignore any incomplete classifications" do
-        incomplete = create(:classification,
-          subject_ids: [sws.subject_id],
-          project: project,
-          workflow: workflow,
-          completed: false
-        )
-        expect(counter.classifications).to eq(2)
+      context "with classifications that do not count" do
+        let(:default_attrs) do
+          {
+            subject_ids: [sws.subject_id],
+            project: project,
+            workflow: workflow,
+            user: project.owner
+          }
+        end
+        def create_non_counting_classification(attrs)
+          create(:classification, default_attrs.merge(attrs))
+        end
+
+        it "should ignore any incomplete classifications" do
+          create_non_counting_classification(completed: false)
+          expect(counter.classifications).to eq(2)
+        end
+
+        it "should ignore any gold standard classifications" do
+          create_non_counting_classification(gold_standard: true)
+          expect(counter.classifications).to eq(2)
+        end
       end
 
       context "when the subject is classified for other workflows" do

--- a/spec/counters/subject_workflow_counter_spec.rb
+++ b/spec/counters/subject_workflow_counter_spec.rb
@@ -16,14 +16,17 @@ describe SubjectWorkflowCounter do
     end
 
     context "with classifications" do
+      let(:classifications) do
+        create_list(
+          :classification,
+          2,
+          subject_ids: [sws.subject_id],
+          project: project,
+          workflow: workflow
+        )
+      end
       before do
-        2.times do
-          create(:classification,
-            subject_ids: [sws.subject_id],
-            project: project,
-            workflow: workflow
-          )
-        end
+        classifications
       end
 
       it "should return 2" do
@@ -57,6 +60,13 @@ describe SubjectWorkflowCounter do
 
         it "should ignore any gold standard classifications" do
           create_non_counting_classification(gold_standard: true)
+          expect(counter.classifications).to eq(2)
+        end
+
+        it "should ignore any already seens classifications" do
+          metadata = classifications.first.metadata
+          metadata[:seen_before] = true
+          create_non_counting_classification(metadata: metadata)
           expect(counter.classifications).to eq(2)
         end
       end


### PR DESCRIPTION
Fixes #2471, closed #1956 and resolves #2394

Ignore incomplete, gold_standard and user has seen before classifications in counts, specifically for retirement.

Making a note that  https://github.com/zooniverse/Panoptes/blob/fbb0d47e9d4a6b3e5d603d734b27bb66c69c60df/app/models/classification.rb#L28

Is currently a seq scan...it's only used with other more specific scopes
so it's a filter when walking the index but this is still row lookup (not pure index query), note: the below is a warm cache query.
>"Nested Loop  (cost=1.14..573.03 rows=2 width=4) (actual time=0.085..0.431 rows=10 loops=1)"
"  Output: classifications.id"
"  ->  Index Scan using index_classification_subjects_on_subject_id on public.classification_subjects cs  (cost=0.57..74.08 rows=58 width=4) (actual time=0.050..0.148 rows=10 loops=1)"
"        Output: cs.classification_id, cs.subject_id"
"        Index Cond: (cs.subject_id = 17083694)"
"  ->  Index Scan using classifications_pkey on public.classifications  (cost=0.57..8.59 rows=1 width=4) (actual time=0.027..0.027 rows=1 loops=10)"
"        Output: classifications.id"
"        Index Cond: (classifications.id = cs.classification_id)"
"        Filter: (classifications.completed AND (classifications.gold_standard IS NOT TRUE) AND (NOT (classifications.metadata ? 'seen_before'::text)) AND (classifications.workflow_id = 1737))"
"Planning time: 0.296 ms"
"Execution time: 0.455 ms"

Noting that the impact of this filter lookup on the counter queries is negligible in query analysis. ~Should we just bite the bullet and flip field from a sparse index to a full btree?~ Looking at the join query i don't think a non-sparse index would be used in this case anyway as the join finds the linked classification ids and walks the index applying the filter on row lookup. We'd have to have a compound id, X index to use this on the join we have. I'm not bothering about this as testing on queries look ok. We can revisit if the performance is impacted (also happy to add an feature flag experiment here if you want).

# TODO
- [x] Don't count already seens
- [x] Figure out what to do about gold standard
- [x] Decide what todo with completed sparse index

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
