### PR TITLE
Update records before triggering sidekiq job

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -19,7 +19,8 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def update
-    super { |classification| lifecycle(:update, classification) }
+    super
+    controlled_resources.each { |resource| lifecycle(:update, resource) }
   end
 
   def gold_standard


### PR DESCRIPTION
When updating a classification to be complete, there is a race condition where the classification lifecycler sidekiq job is kiqed off before the update transaction completes, resulting in the job being run against the old data and not properly creating a Recent and a UserSeenSubject.

Subsequently incoming will be a new rake task to create recents for the classifications that slipped through the cracks.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
