### PR TITLE
Unsubscribe all project email preferences when user unsets project_email_communication

### DIFF
--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -624,6 +624,38 @@ describe Api::V1::UsersController, type: :controller do
         expect(user.reload.project_id).to eq(prev_project_id)
       end
     end
+
+    context "when unsubscribing from project emails" do
+      let(:project_email_comms) { false }
+      let(:put_operations) do
+        { users: { project_email_communication: project_email_comms } }
+      end
+      let(:user_project_preferences) do
+        create(:user_project_preference, user: user)
+      end
+
+      it "should unsubscribe all the user project emails prefs when false" do
+        user_project_preferences
+        expect {
+          update_request
+        }.to change {
+          user_project_preferences.reload.email_communication
+        }.from(true).to(false)
+      end
+
+      context "when the unsubscribe email prefs is true" do
+        let(:project_email_comms) { true }
+
+        it "should not unsubscribe all the user project emails prefs when false" do
+          user_project_preferences
+          expect {
+            update_request
+          }.not_to change {
+            user_project_preferences.reload.email_communication
+          }
+        end
+      end
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
Linked to https://github.com/zooniverse/Panoptes-Front-End/issues/4220#issuecomment-361304385 and https://github.com/zooniverse/Panoptes-Front-End/pull/4229

When a user sets `project_email_communication` to false it should unsubscribe all their user project preferences.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
