### PR TITLE
More robust classification lifecycling reflecting on the classification complete status

### DIFF
--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -27,6 +27,12 @@ class UserSeenSubject < ActiveRecord::Base
     scope.group(:workflow_id).sum("cardinality(subject_ids)").as_json
   end
 
+  def self.has_seen_subjects_for_workflow?(user, workflow, subject_ids)
+    where(user: user, workflow: workflow)
+    .where("subject_ids && ARRAY[?]::integer[]", subject_ids)
+    .exists?
+  end
+
   def subjects_seen?(ids)
     Array.wrap(ids).any? { |id| subject_ids.include?(id) }
   end

--- a/app/workers/classification_count_worker.rb
+++ b/app/workers/classification_count_worker.rb
@@ -3,7 +3,7 @@ class ClassificationCountWorker
 
   sidekiq_options queue: :data_medium
 
-  def perform(subject_id, workflow_id, was_update=false)
+  def perform(subject_id, workflow_id)
     workflow = Workflow.find(workflow_id)
 
     if workflow.project.live && Panoptes.flipper["classification_counters"].enabled?
@@ -11,7 +11,7 @@ class ClassificationCountWorker
 
       Workflow.transaction do
         count = SubjectWorkflowStatus.find_or_create_by!(subject_id: subject_id, workflow_id: workflow_id)
-        count.class.increment_counter(:classifications_count, count.id) unless was_update
+        count.class.increment_counter(:classifications_count, count.id)
       end
 
       SubjectWorkflowStatusCountWorker.perform_async(count.id)

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -23,7 +23,7 @@ class ClassificationLifecycle
   end
 
   def execute
-    return if create? && classification.lifecycled_at.present?
+    return if action == "create" && classification.lifecycled_at.present?
 
     Classification.transaction(requires_new: true) do
       update_classification_data
@@ -192,10 +192,6 @@ class ClassificationLifecycle
     else
       [nil]
     end
-  end
-
-  def create?
-    action == "create"
   end
 
   def update?

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -55,7 +55,7 @@ class ClassificationLifecycle
     return unless should_count_towards_retirement?
 
     classification.subject_ids.each do |sid|
-      ClassificationCountWorker.perform_async(sid, classification.workflow.id, update?)
+      ClassificationCountWorker.perform_async(sid, classification.workflow.id)
     end
   end
 
@@ -192,9 +192,5 @@ class ClassificationLifecycle
     else
       [nil]
     end
-  end
-
-  def update?
-    action == "update"
   end
 end

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -41,12 +41,14 @@ class ClassificationLifecycle
   end
 
   def update_classification_data
-    mark_expert_classifier
-    add_seen_before_for_user
-    add_project_live_state
-    add_user_groups
-    add_lifecycled_at
-    classification.save!
+    if classification.complete?
+      mark_expert_classifier
+      add_seen_before_for_user
+      add_project_live_state
+      add_user_groups
+      add_lifecycled_at
+      classification.save!
+    end
   end
 
   def update_counters

--- a/lib/classification_lifecycle.rb
+++ b/lib/classification_lifecycle.rb
@@ -66,7 +66,7 @@ class ClassificationLifecycle
   end
 
   def create_recent
-    return if classification.anonymous?
+    return unless completed_user_classification?
     return if subjects_are_seen_by_user?
 
     Recent.create_from_classification(classification)

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -496,9 +496,22 @@ describe ClassificationLifecycle do
 
   describe "#update_classification_data" do
     let(:update_classification_data) { subject.update_classification_data }
+    let(:update_methods) do
+      %i(
+        mark_expert_classifier
+        add_seen_before_for_user
+        add_project_live_state
+        add_user_groups
+        add_lifecycled_at
+      )
+    end
 
-    it "should wrap the calls in a transaction" do
-      expect(Classification).to receive(:transaction)
+    it "should not update any data if classification is incomplete" do
+      allow(classification).to receive(:complete?).and_return(false)
+      update_methods.each do |method|
+        expect(subject).not_to receive(method)
+      end
+      expect(classification).not_to receive(:save!)
       update_classification_data
     end
 

--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -230,8 +230,11 @@ describe ClassificationLifecycle do
       let(:subject_ids) { classification.subject_ids }
 
       it 'should call classification count worker' do
-        expect(ClassificationCountWorker).to receive(:perform_async).with(subject_ids[0], workflow.id, action == "update")
-        expect(ClassificationCountWorker).to receive(:perform_async).with(subject_ids[1], workflow.id, action == "update")
+        subject_ids.each do |subject_id|
+          expect(ClassificationCountWorker)
+            .to receive(:perform_async)
+            .with(subject_id, workflow.id)
+        end
         subject.execute
       end
 
@@ -250,8 +253,11 @@ describe ClassificationLifecycle do
         let(:classification) { create(:classification, user: nil) }
 
         it 'should call the classification count worker' do
-          expect(ClassificationCountWorker).to receive(:perform_async).with(subject_ids[0], workflow.id, action == "update")
-          expect(ClassificationCountWorker).to receive(:perform_async).with(subject_ids[1], workflow.id, action == "update")
+          subject_ids.each do |subject_id|
+            expect(ClassificationCountWorker)
+              .to receive(:perform_async)
+              .with(subject_id, workflow.id)
+          end
           subject.execute
         end
 
@@ -278,8 +284,11 @@ describe ClassificationLifecycle do
 
       context 'when classification is complete' do
         it 'should queue the count worker' do
-          expect(ClassificationCountWorker).to receive(:perform_async).with(subject_ids[0], workflow.id, action == "update")
-          expect(ClassificationCountWorker).to receive(:perform_async).with(subject_ids[1], workflow.id, action == "update")
+          subject_ids.each do |subject_id|
+            expect(ClassificationCountWorker)
+              .to receive(:perform_async)
+              .with(subject_id, workflow.id)
+          end
           subject.execute
         end
       end

--- a/spec/models/user_seen_subject_spec.rb
+++ b/spec/models/user_seen_subject_spec.rb
@@ -62,6 +62,38 @@ RSpec.describe UserSeenSubject, :type => :model do
     end
   end
 
+  describe '::has_seen_subjects_for_workflow?' do
+    let(:subject_ids) { [ 1 ] }
+    let(:user) { user_seen_subject.user }
+    let(:workflow) { user_seen_subject.workflow }
+
+    def run_seens_query
+      UserSeenSubject.has_seen_subjects_for_workflow?(
+        user,
+        workflow,
+        subject_ids
+      )
+    end
+
+    it 'should return false when no seen subject record exists' do
+      expect(run_seens_query).to eq(false)
+    end
+
+    context "when a user seen record exists" do
+
+      it 'should return false with no overlap in subject ids ' do
+        user_seen_subject.save
+        expect(run_seens_query).to eq(false)
+      end
+
+      it 'should return true with overlap in subject ids ' do
+        user_seen_subject.subject_ids = subject_ids
+        user_seen_subject.save
+        expect(run_seens_query).to eq(true)
+      end
+    end
+  end
+
   context "counting user activity" do
     let(:user_seen_subject) { create(:user_seen_subject) }
     let!(:another_uss) { create(:user_seen_subject, user: user_seen_subject.user) }


### PR DESCRIPTION
Classification lifecycling currently relies on the background worker being available (feature flagged but on by default). When redis drops / network error, etc the classification doesn't get scheduled to lifecycle but is saved in the db. We have a job to pick up non `lifecycled_at` classifications on a [schedule](https://github.com/zooniverse/Panoptes/blob/517e397c7aff4cd563ad06273d9b0fbac9a4eb99/app/workers/requeue_classifications_worker.rb#L7). All good you say, however we are currently adding `lifecycled_at` on create actions for incomplete classifications. Thus, any update classification (`complete: true`) that fails to schedule via redis can be left in limbo without creating recents, seens, counts, etc (all the good stuff users want us to do).

This PR modifies the state changes in the lifecycle reflecting on the `complete` flag on the classification. It now will only create a new `UserProjectPreference` on create when incomplete and rely on the next lifecycle where it's update and complete set to true to run the various actions.

I also attempted to simplify the boolean logic in this class, it could probably do with a refactor and I attempted this to split between complete / incomplete lifecycle strategies but it only saved the compete boolean test in the complete strategy so i aborted (it felt like too many changes for not much gain). 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
