### PR TITLE
remove code experiment on subject workflow counters

### DIFF
--- a/app/counters/subject_workflow_counter.rb
+++ b/app/counters/subject_workflow_counter.rb
@@ -7,42 +7,18 @@ class SubjectWorkflowCounter
   end
 
   def classifications
-    experiment_name = "subject_workflow_counter_skip_gs_and_seen_before"
-    CodeExperiment.run(experiment_name) do |e|
-      e.run_if { Panoptes.flipper[experiment_name].enabled? }
+    scope = Classification
+      .where(workflow: swc.workflow_id)
+      .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
+      .where("cs.subject_id = ?", swc.subject_id)
+      .where("gold_standard IS NOT TRUE")
+      .where.not("metadata ? 'seen_before'")
+      .complete
 
-      e.use do
-        scope = Classification
-          .where(workflow: swc.workflow_id)
-          .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
-          .where("cs.subject_id = ?", swc.subject_id)
-
-        count_classifications(scope)
-      end
-
-      e.try do
-        scope = Classification
-          .where(workflow: swc.workflow_id)
-          .joins("INNER JOIN classification_subjects cs ON cs.classification_id = classifications.id")
-          .where("cs.subject_id = ?", swc.subject_id)
-          .where("gold_standard IS NOT TRUE")
-          .where.not("metadata ? 'seen_before'")
-          .complete
-
-        count_classifications(scope)
-      end
-
-      # skip the mismatch reporting...we just want perf metrics
-      e.ignore { true }
-    end
-  end
-
-  private
-
-  def count_classifications(scope)
     if launch_date = swc.project.launch_date
       scope = scope.where("classifications.created_at >= ?", launch_date)
     end
+
     scope.count
   end
 end

--- a/spec/counters/subject_workflow_counter_spec.rb
+++ b/spec/counters/subject_workflow_counter_spec.rb
@@ -40,7 +40,7 @@ describe SubjectWorkflowCounter do
         expect(counter.classifications).to eq(2)
       end
 
-      context "with classifications that do not count", :disabled do
+      context "with classifications that do not count" do
         let(:default_attrs) do
           {
             subject_ids: [sws.subject_id],


### PR DESCRIPTION
switch to the proposed filtering on classification index scopes to avoid counting duplicate, incomplete and gold standard data.

Note: linked to code experiment in #2636 - If the code experiment proves to have little impact then this filtering technique can proceed as planned. Failing that we will have to look at different index access patterns to speed up this count. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
