### PR TITLE
queue remove subjects in a realistic time frame

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
       super
 
       subject_ids.each_with_index do |subject_id, index|
-        SubjectRemovalWorker.perform_in(index.minute, subject_id)
+        SubjectRemovalWorker.perform_in(index.seconds, subject_id)
       end
     end
   end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -342,7 +342,9 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
     it 'should call the subject removal worker' do
       subject_set.subjects.each_with_index do |s, index|
-        expect(SubjectRemovalWorker).to receive(:perform_in).with(index.minute, s.id)
+        expect(SubjectRemovalWorker)
+          .to receive(:perform_in)
+          .with(index.seconds, s.id)
       end
       delete_resources
     end


### PR DESCRIPTION
don’t just have these sitting in redis taking up memory, schedule them in seconds not minutes to clear this queue.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
