### PR TITLE
lock sidekiq at 5.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'schema_plus_pg_indexes', '~> 0.1'
 gem 'scientist', '~> 1.1.0'
 gem 'sdoc', '~> 0.4.2', group: :doc
 gem 'semantic_logger', '~> 4.2.0'
-gem 'sidekiq', '~> 5.1'
+gem 'sidekiq', '~> 5.0.5'
 gem 'sidekiq-congestion', '~> 0.1.0'
 gem 'sidekiq-unique-jobs'
 gem 'sidetiq', '~> 0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,7 +385,7 @@ GEM
     semantic_logger (4.2.0)
       concurrent-ruby (~> 1.0)
     shellany (0.0.1)
-    sidekiq (5.1.0)
+    sidekiq (5.0.5)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
@@ -427,7 +427,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
     versionist (1.7.0)
       activesupport (>= 3)
       railties (>= 3)
@@ -499,7 +499,7 @@ DEPENDENCIES
   scientist (~> 1.1.0)
   sdoc (~> 0.4.2)
   semantic_logger (~> 4.2.0)
-  sidekiq (~> 5.1)
+  sidekiq (~> 5.0.5)
   sidekiq-congestion (~> 0.1.0)
   sidekiq-unique-jobs
   sidetiq (~> 0.7)
@@ -513,4 +513,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0.1)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
sidekiq 5.1 require redis 4 gem but attention relies on redis 3. Attention redis dep needs to bump to 4

Note: the failure is only in the sidekiq web UI and should be fixed by a manual redis bump to 4. Also i've issued a PR to sidekiq to fix this, https://github.com/mperham/sidekiq/pull/3748

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
