### PR TITLE
add default configuration value to projects

### DIFF
--- a/db/migrate/20180207120238_add_default_project_config.rb
+++ b/db/migrate/20180207120238_add_default_project_config.rb
@@ -1,0 +1,18 @@
+class AddDefaultProjectConfig < ActiveRecord::Migration
+  def column_name
+    :configuration
+  end
+
+  def update_configuration_column(default, null)
+    change_column(:projects, column_name, :jsonb, default: default, null: null)
+  end
+
+  def up
+    Project.where(column_name => nil).update_all(column_name => {})
+    update_configuration_column({}, false)
+  end
+
+  def down
+    update_configuration_column(nil, true)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -889,7 +889,7 @@ CREATE TABLE projects (
     primary_language character varying,
     private boolean,
     lock_version integer DEFAULT 0,
-    configuration jsonb,
+    configuration jsonb DEFAULT '{}'::jsonb NOT NULL,
     live boolean DEFAULT false NOT NULL,
     urls jsonb DEFAULT '[]'::jsonb,
     migrated boolean DEFAULT false,
@@ -4053,4 +4053,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180110133833');
 INSERT INTO schema_migrations (version) VALUES ('20180115214144');
 
 INSERT INTO schema_migrations (version) VALUES ('20180122134607');
+
+INSERT INTO schema_migrations (version) VALUES ('20180207120238');
 


### PR DESCRIPTION
ensure the project configuration jsonb value exists for all projects, this will backfill missing data then update the default and null settings for the column.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
