### PR TITLE
count things less and space them out more

### DIFF
--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -6,14 +6,14 @@ class ProjectClassificationsCountWorker
   sidekiq_options congestion: {
     interval: 60,
     max_in_interval: 1,
-    min_delay: 10,
+    min_delay: 60,
     reject_with: :reschedule,
     key: ->(project_id) {
       "project_#{project_id}_classifications_count_worker"
     }
   }
 
-  sidekiq_options unique: :until_executing
+  sidekiq_options unique: :until_executed
 
   def perform(project_id)
     project = Project.find(project_id)

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -3,15 +3,22 @@ class RetirementWorker
 
   sidekiq_options queue: :high
 
-  def perform(count_id)
-    count = SubjectWorkflowStatus.find(count_id)
-    if count.retire?
-      count.retire!("classification_count")
+  def perform(status_id)
+    status = load_subject_workflow_status(status_id)
+    if status&.retire?
+      status.retire!("classification_count")
 
-      workflow = count.workflow
-      WorkflowRetiredCountWorker.perform_async(workflow.id)
-      PublishRetirementEventWorker.perform_async(workflow.id)
-      NotifySubjectSelectorOfRetirementWorker.perform_async(count.subject_id, workflow.id)
+      workflow_id = status.workflow_id
+      WorkflowRetiredCountWorker.perform_async(workflow_id)
+      PublishRetirementEventWorker.perform_async(workflow_id)
+      NotifySubjectSelectorOfRetirementWorker
+        .perform_async(status.subject_id, workflow_id)
     end
+  end
+
+  private
+
+  def load_subject_workflow_status(status_id)
+    SubjectWorkflowStatus.where(id: status_id).eager_load(:workflow).first
   end
 end

--- a/app/workers/workflow_classifications_count_worker.rb
+++ b/app/workers/workflow_classifications_count_worker.rb
@@ -6,14 +6,14 @@ class WorkflowClassificationsCountWorker
   sidekiq_options congestion: {
     interval: 60,
     max_in_interval: 1,
-    min_delay: 10,
+    min_delay: 60,
     reject_with: :reschedule,
     key: ->(workflow_id) {
       "workflow_#{workflow_id}_classifications_count_worker"
     }
   }
 
-  sidekiq_options unique: :until_executing
+  sidekiq_options unique: :until_executed
 
   def perform(workflow_id)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/workflow_retired_count_worker.rb
+++ b/app/workers/workflow_retired_count_worker.rb
@@ -11,7 +11,7 @@ class WorkflowRetiredCountWorker
     key: ->(workflow_id) { "workflow_#{workflow_id}_retired_count_worker" }
   }
 
-  sidekiq_options unique: :until_executing
+  sidekiq_options unique: :until_executed
 
   def perform(workflow_id)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/workflow_retired_count_worker.rb
+++ b/app/workers/workflow_retired_count_worker.rb
@@ -6,7 +6,7 @@ class WorkflowRetiredCountWorker
   sidekiq_options congestion: {
     interval: 10,
     max_in_interval: 1,
-    min_delay: 0,
+    min_delay: 10,
     reject_with: :reschedule,
     key: ->(workflow_id) { "workflow_#{workflow_id}_retired_count_worker" }
   }

--- a/spec/workers/project_classifications_count_worker_spec.rb
+++ b/spec/workers/project_classifications_count_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProjectClassificationsCountWorker do
     opts = worker.class.get_sidekiq_options['congestion']
     expect(opts[:interval]).to eq(60)
     expect(opts[:max_in_interval]).to eq(1)
-    expect(opts[:min_delay]).to eq(10)
+    expect(opts[:min_delay]).to eq(60)
     expect(opts[:reject_with]).to eq(:reschedule)
   end
 

--- a/spec/workers/workflow_classifications_count_worker_spec.rb
+++ b/spec/workers/workflow_classifications_count_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe WorkflowClassificationsCountWorker do
     opts = worker.class.get_sidekiq_options['congestion']
     expect(opts[:interval]).to eq(60)
     expect(opts[:max_in_interval]).to eq(1)
-    expect(opts[:min_delay]).to eq(10)
+    expect(opts[:min_delay]).to eq(60)
     expect(opts[:reject_with]).to eq(:reschedule)
   end
 


### PR DESCRIPTION
do not allow duplicate count jobs to start, drop any new ones until the current one has finished and then fallback to congestion control.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
