### PR TITLE
Process only undeleted workflows in cls exports

### DIFF
--- a/app/models/csv_dumps/classification_scope.rb
+++ b/app/models/csv_dumps/classification_scope.rb
@@ -34,7 +34,7 @@ module CsvDumps
     def completed_resource_classifications
       resource.classifications
         .complete
-        .joins(:workflow)
+        .joins(:workflow).where(workflows: {activated_state: "active"})
         .includes(:user, workflow: [:workflow_contents])
     end
 

--- a/spec/models/csv_dumps/classification_scope_spec.rb
+++ b/spec/models/csv_dumps/classification_scope_spec.rb
@@ -2,16 +2,18 @@ require 'spec_helper'
 
 describe CsvDumps::ClassificationScope do
   let(:workflow) { create(:workflow) }
+  let(:inactive_workflow) { create(:workflow, activated_state: "inactive") }
   let(:project) { workflow.project }
   let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
   let(:classifications) do
     create_list(:classification, 2, project: project, workflow: workflow, subjects: [subject])
   end
+  let!(:unincluded_classification) { create(:classification, project: project, workflow: inactive_workflow, subjects: [subject]) }
   let(:cache) { ClassificationDumpCache.new }
 
   let(:scope) { described_class.new(project, cache) }
 
-  it "should find all the classifications" do
+  it "should find all correctly scoped classifications" do
     expect { |b| scope.each(&b) }.to yield_successive_args(*classifications)
   end
 end


### PR DESCRIPTION
Classification dump workers should only export classifications from workflows that have not been deleted (via the Activatable module). That is, only workflows with `activated_state: "active"` should have their classifications included.

rationale: some deleted workflows have malformed tasks that occasionally cause exports to fail due to  an un-tracked-down PFE bug. This should be happening anyway, and will clean/speed up exports for researchers.

This should not be confused with `active`, which is a flag researchers can set. Those classifications are correctly included already.


Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
