### PR TITLE
optimise the subject workflow status by_set query

### DIFF
--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -22,7 +22,7 @@ class SubjectWorkflowStatus < ActiveRecord::Base
   # this is an optimized query to access the subject_id index on this table.
   # It uses an IN query with a CTE to create a subselect to access
   # the subject_id index as simple Joins do not use the index on this table
-  def self.by_set(subject_set_id)
+  def self.by_set(subject_set_ids)
     # create the CTE for reuse, e.g.
     # sws_by_set AS (
     #   SELECT set_member_subjects.subject_id
@@ -34,7 +34,7 @@ class SubjectWorkflowStatus < ActiveRecord::Base
     composed_cte = Arel::Nodes::As.new(
       cte_table,
       smses_arel.where(
-        smses_arel[:subject_set_id].eq(subject_set_id)
+        smses_arel[:subject_set_id].in(subject_set_ids)
       ).project(smses_arel[:subject_id])
     )
 

--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -40,14 +40,13 @@ class SubjectWorkflowStatus < ActiveRecord::Base
 
     # create the select from CTE, e.g
     # SELECT subject_id FROM sws_by_set
-    swses_arel = arel_table
     select_manager = Arel::SelectManager.new(cte_table.engine)
     select_manager.project(:subject_id)
     select_manager.from("sws_by_set")
 
     # create the where in clause matching the select from CTE, e.g.
     # subject_workflow_counts.subject_id IN (SELECT subject_id FROM sws_by_set)
-    subquery_where = swses_arel[:subject_id].in(select_manager)
+    subquery_where = arel_table[:subject_id].in(select_manager)
 
     # put it all together and combine the in clause with the CTE, e.g.
     # WITH sws_by_set AS (


### PR DESCRIPTION
avoid joins for this query as they do not use the subject_id index. Moving to a CTE that allows the sub-select to access the subject_id index. "CTEs can be thought of as defining temporary tables that exist just for one query" effectively exploding the find all subjects for this set to be used in a subquery IN operation. 

Benchmarking shows a massive improvement when accessing the index ~5-15x.

I've left in comments and example sql of the query for docs. happy to take this out / modify it.

Links on CTE and Arel query construction
https://www.postgresql.org/docs/9.4/static/queries-with.html
https://github.com/rails/arel#cte

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
