### PR TITLE
Allow admins to look up users by email

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -61,7 +61,7 @@ class Api::V1::UsersController < Api::ApiController
 
   def index
     if api_user.is_admin? and emails = params.delete(:email).try(:split, ',').try(:map, &:downcase)
-      @controlled_resources = controlled_resources.where(User.arel_table[:email].lower.in(logins))
+      @controlled_resources = controlled_resources.where(User.arel_table[:email].lower.in(emails))
     elsif logins = params.delete(:login).try(:split, ',').try(:map, &:downcase)
       @controlled_resources = controlled_resources.where(User.arel_table[:login].lower.in(logins))
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -60,10 +60,14 @@ class Api::V1::UsersController < Api::ApiController
   end
 
   def index
-    if api_user.is_admin? && emails = params.delete(:email).try(:split, ',').try(:map, &:downcase)
-      @controlled_resources = controlled_resources.where(User.arel_table[:email].lower.in(emails))
-    elsif logins = params.delete(:login).try(:split, ',').try(:map, &:downcase)
-      @controlled_resources = controlled_resources.where(User.arel_table[:login].lower.in(logins))
+    if api_user.is_admin? && downcased_emails = downcase_filter_params(:email)
+      @controlled_resources = controlled_resources.where(
+        User.arel_table[:email].lower.in(downcased_emails)
+      )
+    elsif downcased_login = downcase_filter_params(:login)
+      @controlled_resources = controlled_resources.where(
+        User.arel_table[:login].lower.in(downcased_login)
+      )
     end
     super
   end
@@ -107,5 +111,11 @@ class Api::V1::UsersController < Api::ApiController
     UserProjectPreference
      .where(user_id: user.id)
      .update_all(email_communication: false)
+  end
+
+  def downcase_filter_params(key)
+    if param_value = params.delete(key)
+      param_value.split(',').map(&:downcase)
+    end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -60,7 +60,9 @@ class Api::V1::UsersController < Api::ApiController
   end
 
   def index
-    if logins = params.delete(:login).try(:split, ',').try(:map, &:downcase)
+    if api_user.is_admin? and emails = params.delete(:email).try(:split, ',').try(:map, &:downcase)
+      @controlled_resources = controlled_resources.where(User.arel_table[:email].lower.in(logins))
+    elsif logins = params.delete(:login).try(:split, ',').try(:map, &:downcase)
       @controlled_resources = controlled_resources.where(User.arel_table[:login].lower.in(logins))
     end
     super

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::UsersController < Api::ApiController
   end
 
   def index
-    if api_user.is_admin? and emails = params.delete(:email).try(:split, ',').try(:map, &:downcase)
+    if api_user.is_admin? && emails = params.delete(:email).try(:split, ',').try(:map, &:downcase)
       @controlled_resources = controlled_resources.where(User.arel_table[:email].lower.in(emails))
     elsif logins = params.delete(:login).try(:split, ',').try(:map, &:downcase)
       @controlled_resources = controlled_resources.where(User.arel_table[:login].lower.in(logins))

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -192,6 +192,30 @@ describe Api::V1::UsersController, type: :controller do
         end
       end
 
+      describe "filter by email" do
+        let(:index_options) { { login: user.email} }
+
+        it "should respond with 1 item" do
+          expect(json_response[api_resource_name].length).to eq(1)
+        end
+
+        it "should respond with the correct item" do
+          expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+        end
+      end
+
+      describe "filter by case insensitive email" do
+        let(:index_options) { { login: user.email.upcase } }
+
+        it "should respond with 1 item" do
+          expect(json_response[api_resource_name].length).to eq(1)
+        end
+
+        it "should respond with the correct item" do
+          expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+        end
+      end
+
       describe "include avatars" do
         let(:index_options) { { include: 'avatar' } }
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -193,7 +193,7 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       describe "filter by email" do
-        let(:index_options) { { login: user.email} }
+        let(:index_options) { { email: user.email} }
 
         it "should respond with 1 item" do
           expect(json_response[api_resource_name].length).to eq(1)
@@ -205,7 +205,7 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       describe "filter by case insensitive email" do
-        let(:index_options) { { login: user.email.upcase } }
+        let(:index_options) { { email: user.email.upcase } }
 
         it "should respond with 1 item" do
           expect(json_response[api_resource_name].length).to eq(1)

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -192,27 +192,47 @@ describe Api::V1::UsersController, type: :controller do
         end
       end
 
-      describe "filter by email" do
+      describe "filter by email (non-admin)" do
         let(:index_options) { { email: user.email} }
 
-        it "should respond with 1 item" do
-          expect(json_response[api_resource_name].length).to eq(1)
-        end
-
-        it "should respond with the correct item" do
-          expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+        it "should respond with 2 items" do
+          expect(json_response[api_resource_name].length).to eq(2)
         end
       end
 
-      describe "filter by case insensitive email" do
+      describe "filter by case insensitive email (non-admin)" do
         let(:index_options) { { email: user.email.upcase } }
 
-        it "should respond with 1 item" do
-          expect(json_response[api_resource_name].length).to eq(1)
+        it "should respond with 2 items" do
+          expect(json_response[api_resource_name].length).to eq(2)
+        end
+      end
+
+      context "as an admin user" do
+        let(:user) { create(:user, admin: true) }
+
+        describe "filter by email" do
+          let(:index_options) { { email: user.email, admin: true} }
+
+          it "should respond with 1 item" do
+            expect(json_response[api_resource_name].length).to eq(1)
+          end
+
+          it "should respond with the correct item" do
+            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+          end
         end
 
-        it "should respond with the correct item" do
-          expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+        describe "filter by case insensitive email" do
+          let(:index_options) { { email: user.email.upcase, admin: true } }
+
+          it "should respond with 1 item" do
+            expect(json_response[api_resource_name].length).to eq(1)
+          end
+
+          it "should respond with the correct item" do
+            expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
+          end
         end
       end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -163,6 +163,7 @@ describe Api::V1::UsersController, type: :controller do
       let(:resource) { user }
 
       before(:each) do
+        default_request(scopes: scopes, user_id: user.id)
         get :index, index_options
       end
 
@@ -209,8 +210,10 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       context "as an admin user" do
-        let(:index_options) { { email: user.email, admin: true} }
         let(:user) { create(:user, admin: true) }
+        let(:index_options) do
+          { email: user.email, admin: true}
+        end
 
         describe "filter by email" do
           it "should respond with 1 item" do

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -211,8 +211,9 @@ describe Api::V1::UsersController, type: :controller do
 
       context "as an admin user" do
         let(:user) { create(:user, admin: true) }
+        let(:email) { user.email }
         let(:index_options) do
-          { email: user.email, admin: true}
+          { email: email, admin: true}
         end
 
         describe "filter by email" do
@@ -226,6 +227,8 @@ describe Api::V1::UsersController, type: :controller do
         end
 
         describe "filter by case insensitive email" do
+          let(:email) { user.email.upcase }
+
           it "should respond with 1 item" do
             expect(json_response[api_resource_name].length).to eq(1)
           end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -209,11 +209,10 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       context "as an admin user" do
+        let(:index_options) { { email: user.email, admin: true} }
         let(:user) { create(:user, admin: true) }
 
         describe "filter by email" do
-          let(:index_options) { { email: user.email, admin: true} }
-
           it "should respond with 1 item" do
             expect(json_response[api_resource_name].length).to eq(1)
           end
@@ -224,8 +223,6 @@ describe Api::V1::UsersController, type: :controller do
         end
 
         describe "filter by case insensitive email" do
-          let(:index_options) { { email: user.email.upcase, admin: true } }
-
           it "should respond with 1 item" do
             expect(json_response[api_resource_name].length).to eq(1)
           end


### PR DESCRIPTION
When handling spam complaints we only have the user's email address, so I need to be able to use that to look up the user. This looks for an `email` param and splits it on commas in the same way as `login`.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.