### PR TITLE
do not memoize data between runs

### DIFF
--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -86,5 +86,23 @@ RSpec.describe Formatter::Csv::Subject do
         expect(result).to match_array(expected)
       end
     end
+
+    describe "on reuse of the formatter for the next subject" do
+      let(:next_subject) do
+        create(:subject, :with_mediums, project: project, uploader: project.owner)
+      end
+      let(:formatter) { described_class.new(project) }
+
+      before do
+        create(:set_member_subject, subject_set: subject_set, subject: next_subject)
+      end
+
+      it "should not memoize any data and have 0 counts on the second run" do
+        first_result = formatter.to_rows(subject)
+        second_result = formatter.to_rows(next_subject)
+        classification_counts = second_result.map { |result| result[6] }
+        expect(classification_counts).to match_array([0,0])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes a bug reported by @CKrawczyk for incorrect data in subject exports. Reset the memoized subject workflow status lookup for each subject, do not reuse old data.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
