### PR TITLE
do not modify any user project email prefs

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -44,10 +44,6 @@ class Api::V1::UsersController < Api::ApiController
     [].tap do |update_email_user_ids|
 
       super do |user|
-        unless user.project_email_communication
-          unsubscribe_all_project_emails(user)
-        end
-
         if user.email_changed?
           update_email_user_ids << user.id
         end
@@ -99,11 +95,5 @@ class Api::V1::UsersController < Api::ApiController
   def revoke_doorkeeper_request_token!
     token = Doorkeeper.authenticate(request)
     token.revoke
-  end
-
-  def unsubscribe_all_project_emails(user)
-    UserProjectPreference
-     .where(user_id: user.id)
-     .update_all(email_communication: false)
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -631,34 +631,20 @@ describe Api::V1::UsersController, type: :controller do
     end
 
     context "when unsubscribing from project emails" do
-      let(:project_email_comms) { false }
       let(:put_operations) do
-        { users: { project_email_communication: project_email_comms } }
+        { users: { project_email_communication: false } }
       end
       let(:user_project_preferences) do
         create(:user_project_preference, user: user)
       end
 
-      it "should unsubscribe all the user project emails prefs when false" do
+      it "should not modify any of the user project emails prefs" do
         user_project_preferences
         expect {
           update_request
-        }.to change {
+        }.not_to change {
           user_project_preferences.reload.email_communication
-        }.from(true).to(false)
-      end
-
-      context "when the unsubscribe email prefs is true" do
-        let(:project_email_comms) { true }
-
-        it "should not unsubscribe all the user project emails prefs when false" do
-          user_project_preferences
-          expect {
-            update_request
-          }.not_to change {
-            user_project_preferences.reload.email_communication
-          }
-        end
+        }
       end
     end
   end


### PR DESCRIPTION
reverts the unsubscribe behaviour added in #2644. 

Use the project_email_communication field as a state to copy to new project prefs when users first classify. The UI will now offer a button to unset all project email prefs and allow the user to modify the state this way.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
