### PR TITLE
[WIP] Updatable resources should yield before they save

### DIFF
--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -16,8 +16,8 @@ module JsonApiController
 
       resource_class.transaction(requires_new: true) do
         controlled_resources.each do |resource|
-          yield resource if block_given?
           resource.save!
+          yield resource if block_given?
         end
       end
 


### PR DESCRIPTION
Race conditions can occur if the yield is to a sidekiq worker or something that pulls from the database before the following save! can commit its transaction. In lieu of a callback, this will at least wait until the save! call finishes (successfully or not) before the yield is attempted.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
