### PR TITLE
move workers outside of destroy transactions

### DIFF
--- a/app/controllers/api/v1/set_member_subjects_controller.rb
+++ b/app/controllers/api/v1/set_member_subjects_controller.rb
@@ -13,12 +13,11 @@ class Api::V1::SetMemberSubjectsController < Api::ApiController
   end
 
   def destroy
-    resource_class.transaction(requires_new: true) do
-      set_id = controlled_resource.subject_set_id
-      subject_id = controlled_resource.subject_id
-      super
-      update_set_counts(set_id)
-      SubjectRemovalWorker.perform_async(subject_id)
+    super
+    # use the memoized non-destroyed resource ids to setup a worker
+    controlled_resources.each do |sms|
+      update_set_counts(sms.subject_set_id)
+      SubjectRemovalWorker.perform_async(sms.subject_id)
     end
   end
 

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -32,14 +32,14 @@ class Api::V1::SubjectSetsController < Api::ApiController
   # avoid calling destroy_all on each controlled_resource
   # to optimize sets and linked relation cleanup
   def destroy
-    subject_ids = []
-    affected_workflow_ids = []
+    subject_ids = Set.new
+    affected_workflow_ids = Set.new
     resource_class.transaction(requires_new: true) do
       controlled_resources.each do |subject_set|
         smses = subject_set.set_member_subjects
-        subject_ids.concat(smses.map(&:subject_id))
+        subject_ids |= smses.map(&:subject_id)
         remove_linked_set_member_subjects(smses)
-        affected_workflow_ids.concat(controlled_resource.workflows.pluck(:id))
+        affected_workflow_ids |= controlled_resource.workflows.pluck(:id)
         controlled_resource.subject_sets_workflows.delete_all
         controlled_resource.delete
       end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
         smses = subject_set.set_member_subjects
         subject_ids |= smses.map(&:subject_id)
         remove_linked_set_member_subjects(smses)
-        affected_workflow_ids |= controlled_resource.workflows.pluck(:id)
+        affected_workflow_ids |= controlled_resource.workflow_ids
         controlled_resource.subject_sets_workflows.delete_all
         controlled_resource.delete
       end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -45,9 +45,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
       end
     end
 
-
     reset_workflow_retired_counts(affected_workflow_ids)
-
     subject_ids.each_with_index do |subject_id, index|
       SubjectRemovalWorker.perform_in(index.seconds, subject_id)
     end

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -39,12 +39,15 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def destroy
-    super do |subject|
-      begin
+    super
+
+    begin
+      # use the memoized non-destroyed resource ids to setup a worker
+      controlled_resources.each do |subject|
         SubjectRemovalWorker.perform_async(subject.id)
-      rescue Timeout::Error => e
-        Honeybadger.notify(e)
       end
+    rescue Timeout::Error => e
+      Honeybadger.notify(e)
     end
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -69,7 +69,8 @@ class Api::V1::UsersController < Api::ApiController
   def destroy
     sign_out_current_user!
     revoke_doorkeeper_request_token!
-    super { |user| UserInfoScrubber.scrub_personal_info!(user) }
+    UserInfoScrubber.scrub_personal_info!(user)
+    super
   end
 
   def build_update_hash(update_params, id)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -69,8 +69,7 @@ class Api::V1::UsersController < Api::ApiController
   def destroy
     sign_out_current_user!
     revoke_doorkeeper_request_token!
-    UserInfoScrubber.scrub_personal_info!(user)
-    super
+    super { |user| UserInfoScrubber.scrub_personal_info!(user) }
   end
 
   def build_update_hash(update_params, id)

--- a/lib/json_api_controller/deactivatable_resource.rb
+++ b/lib/json_api_controller/deactivatable_resource.rb
@@ -9,10 +9,12 @@ module JsonApiController
     end
 
     def destroy
-      Activation.disable_instances!(to_disable)
+      resource_class.transaction(requires_new: true) do
+        Activation.disable_instances!(to_disable)
 
-      to_disable.each do |resource|
-        yield resource if block_given?
+        to_disable.each do |resource|
+          yield resource if block_given?
+        end
       end
 
       deleted_resource_response

--- a/lib/json_api_controller/destructable_resource.rb
+++ b/lib/json_api_controller/destructable_resource.rb
@@ -10,7 +10,12 @@ module JsonApiController
     end
 
     def destroy
-      controlled_resources.destroy_all
+      resource_class.transaction(requires_new: true) do
+        controlled_resources.each do |resource|
+          yield resource if block_given?
+          resource.destroy
+        end
+      end
       deleted_resource_response
     end
 


### PR DESCRIPTION
add transactions to destroy actions and move the worker calls outside the transaction to ensure consistent state when they run and avoid race conditions.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
