### PR TITLE
add bundle gem cache volume for panoptes docker dev env

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,7 +22,6 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-RUN bundle install
 
 ADD supervisord.conf.dev /etc/supervisor/conf.d/panoptes.conf
 ADD ./ /rails_app

--- a/Gemfile
+++ b/Gemfile
@@ -58,10 +58,6 @@ group :production, :staging do
   gem 'newrelic_rpm'
 end
 
-group :development do
-  gem 'fig_rake', '~> 0.9.3'
-end
-
 group :development, :test do
   gem 'foreman'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,6 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.18)
-    fig_rake (0.9.3)
     flipper (0.9.2)
     flipper-active_record (0.9.2)
       activerecord (>= 3.2, < 6)
@@ -452,7 +451,6 @@ DEPENDENCIES
   faraday (~> 0.9)
   faraday-http-cache (~> 2.0)
   faraday_middleware (~> 0.12)
-  fig_rake (~> 0.9.3)
   flipper
   flipper-active_record
   flipper-ui

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ There are multiple options for setting up a testing environment:
 0. Assuming you have the correct Ruby environment already setup:
 
     1. Run `bundle install`
-    0. Start the docker Postgres container by running `docker-compose run -d --name postgres --service-ports postgres`
-      + You can run your own postgres server instead.
+    0. Start the docker Postgres container by running `docker-compose run -d --name postgres --service-ports postgres` or run your own
     0. Modify your `config/database.yml` test env to point to the running Postgres server, e.g. `host: localhost`
     0. Setup the testing database if you haven't already, by running `RAILS_ENV=test rake db:setup`
     0. Finally, run rspec with `RAILS_ENV=test rspec`

--- a/README.md
+++ b/README.md
@@ -70,11 +70,15 @@ Once all the above steps complete you will have a working copy of the checked ou
 
 There are multiple options for setting up a testing environment:
 
-0. Run it entirely from within docker-compose:
+1. Run it entirely from within docker-compose:
 
-    0. Create config files if you don't already have them, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake configure:local" panoptes`
-    0. To create the testing database, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" panoptes`.
-    0. Run the full spec suite `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes`. Note: this will be slow. Use rspec focus set or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
+  1. Run `docker-compose build` to build the panoptes container.
+  0. Install the gem dependencies for the application
+    + Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
+  0. Create config files if you don't already have them, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake configure:local" panoptes`
+  0. To create the testing database, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" panoptes`
+  0. Run the full spec suite `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes` noting that running all tests is slow.
+    + Use rspec focus keyword in your specs or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
 
 0. Use parts of docker-compose manually and wire them up manually to create a testing environment.
 
@@ -83,11 +87,12 @@ There are multiple options for setting up a testing environment:
     docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes
     ```
 
-0. Assuming you have a Ruby environment already setup:
+0. Assuming you have the correct Ruby environment already setup:
 
-    0. Run `bundle install`
+    1. Run `bundle install`
     0. Start the docker Postgres container by running `docker-compose run -d --name postgres --service-ports postgres`
-    0. Modify your `config/database.yml` test env to point to the running Postgres container, e.g. `host: localhost`
+      + You can run your own postgres server instead.
+    0. Modify your `config/database.yml` test env to point to the running Postgres server, e.g. `host: localhost`
     0. Setup the testing database if you haven't already, by running `RAILS_ENV=test rake db:setup`
     0. Finally, run rspec with `RAILS_ENV=test rspec`
 

--- a/README.md
+++ b/README.md
@@ -39,36 +39,32 @@ It's possible to run Panoptes only having to install the `fig_rake` gem. Alterna
 
 #### Usage
 
-0. Clone the repository `git clone https://github.com/zooniverse/Panoptes`.
-
-0. `cd` into the cloned folder.
-
-0. Setup the configuration files via a rake task
-  + Run: `rake configure:local`
-
-  Or manually copy the example configuration files and setup the doorkeeper keys.
-  + Run: `find config/*.yml.hudson -exec bash -c 'for x; do x=${x#./}; cp -i "$x" "${x/.hudson/}"; done' _ {} +`
-  + Run: `rake configure:doorkeeper_keys`
+1. Clone the repository `git clone https://github.com/zooniverse/Panoptes`.
 
 0. Install Docker from the appropriate link above.
 
-0.  + **If you have an existing Panoptes Docker container or if your Dockerfile.dev has changed,** run `docker-compose build` to rebuild the containers.
-    + Otherwise, create and run the application containers by running `docker-compose up`
+0. `cd` into the cloned folder.
 
-0. After step 5 finishes (most likely with a missing db error), open a new terminal and run `docker-compose run --rm --entrypoint="bundle exec rake db:setup" panoptes` to setup the database. This will launch a new Docker container, run the rake DB setup task, and then clean up the container.
+0. Run `docker-compose build` to build the containers Panoptes API container. You will need to re-run this command on any changes to `Dockerfile.dev`
+
+0. Install the gem dependencies for the application
+  + Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
+
+0. Setup the configuration files via a rake task
+  + Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:local" panoptes`
+  + Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:doorkeeper_keys" panoptes`
+  + Alternatively, manually copy the example configuration files and setup the doorkeeper keys.
+    + Run: `find config/*.yml.hudson -exec bash -c 'for x; do x=${x#./}; cp -i "$x" "${x/.hudson/}"; done' _ {} +`
+
+0. Create and run the application containers with `docker-compose up`
+
+0. If the above step reports a missing database error, kill the docker-compose process or open a new terminal window in the current directory and then run `docker-compose run --rm --entrypoint="bundle exec rake db:setup" panoptes` to setup the database. This command will launch a new Docker container, run the rake DB setup task, and then clean up the container.
 
 0. To seed the development database with an Admin user and a Doorkeeper client application for API access run `docker-compose run --rm --entrypoint="bundle exec rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb" panoptes`
 
-0. Open up the application in your browser:
-  + It should be running on http://localhost:3000
-  + If it's not and you're on a Mac, run `docker ps`, and find the IP address where the `panoptes_panoptes` image is running. E.g.: 0.0.0.0:3000->3000/tcp means running on localhost at port 3000.
+0. Open up the application in your browser at http://localhost:3000
 
-     ```
-CONTAINER ID        IMAGE                         COMMAND                  CREATED             STATUS              PORTS                            NAMES
-1f98164914be        panoptes_panoptes             "/bin/sh -c /rails_ap"   16 minutes ago      Up 16 minutes       80/tcp, **0.0.0.0:3000->3000/tcp**   panoptes_panoptes_1
-     ```
-
-This will get you a working copy of the checked out code base. Keep your code up to date and rebuild the image if needed!
+Once all the above steps complete you will have a working copy of the checked out code base. Keep your code up to date and rebuild the image on any code or configuration changes.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ It's possible to run Panoptes only having to install the `fig_rake` gem. Alterna
 
 0. Install Docker from the appropriate link above.
 
-0.  + **If you have an existing Panoptes Docker container, or if your Gemfile or Ruby version has changed,** run `docker-compose build` to rebuild the containers.
+0.  + **If you have an existing Panoptes Docker container or if your Dockerfile.dev has changed,** run `docker-compose build` to rebuild the containers.
     + Otherwise, create and run the application containers by running `docker-compose up`
 
-0. After step 5 finishes, open a new terminal and run `docker-compose run --rm --entrypoint=rake panoptes db:setup` to setup the database. This will launch a new Docker container, run the rake DB setup task, and then clean up the container.
+0. After step 5 finishes (most likely with a missing db error), open a new terminal and run `docker-compose run --rm --entrypoint="bundle exec rake db:setup" panoptes` to setup the database. This will launch a new Docker container, run the rake DB setup task, and then clean up the container.
 
-0. To seed the development database with an Admin user and a Doorkeeper client application for API access run `docker-compose run --rm --entrypoint=rails panoptes runner db/fig_dev_seed_data/fig_dev_seed_data.rb`
+0. To seed the development database with an Admin user and a Doorkeeper client application for API access run `docker-compose run --rm --entrypoint="bundle exec rails runner db/fig_dev_seed_data/fig_dev_seed_data.rb" panoptes`
 
 0. Open up the application in your browser:
   + It should be running on http://localhost:3000
@@ -76,9 +76,9 @@ There are multiple options for setting up a testing environment:
 
 0. Run it entirely from within docker-compose:
 
-    0. Create config files if you don't already have them, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint=rake panoptes configure:local`
-    0. To create the testing database, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint=rake panoptes db:setup`.
-    0. Run the full spec suite `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint=rspec panoptes`. Note: this will be slow. Use rspec focus set or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
+    0. Create config files if you don't already have them, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake configure:local" panoptes`
+    0. To create the testing database, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" panoptes`.
+    0. Run the full spec suite `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes`. Note: this will be slow. Use rspec focus set or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
 
 0. Use parts of docker-compose manually and wire them up manually to create a testing environment.
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ It's possible to run Panoptes only having to install the `fig_rake` gem. Alterna
 0. Run `docker-compose build` to build the containers Panoptes API container. You will need to re-run this command on any changes to `Dockerfile.dev`
 
 0. Install the gem dependencies for the application
-  * Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
+    * Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
 
 0. Setup the configuration files via a rake task
-  * Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:local" panoptes`
-  * Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:doorkeeper_keys" panoptes`
-  * Alternatively, manually copy the example configuration files and setup the doorkeeper keys.
-    * Run: `find config/*.yml.hudson -exec bash -c 'for x; do x=${x#./}; cp -i "$x" "${x/.hudson/}"; done' _ {} +`
+    * Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:local" panoptes`
+    * Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:doorkeeper_keys" panoptes`
+    * Alternatively, manually copy the example configuration files and setup the doorkeeper keys.
+      - Run: `find config/*.yml.hudson -exec bash -c 'for x; do x=${x#./}; cp -i "$x" "${x/.hudson/}"; done' _ {} +`
 
 0. Create and run the application containers with `docker-compose up`
 
@@ -71,24 +71,19 @@ Once all the above steps complete you will have a working copy of the checked ou
 There are multiple options for setting up a testing environment:
 
 1. Run it entirely from within docker-compose:
-
-  1. Run `docker-compose build` to build the panoptes container.
-  0. Install the gem dependencies for the application
-    * Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
-  0. Create config files if you don't already have them, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake configure:local" panoptes`
-  0. To create the testing database, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" panoptes`
-  0. Run the full spec suite `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes` noting that running all tests is slow.
-    * Use rspec focus keyword in your specs or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
+    1. Run `docker-compose build` to build the panoptes container.
+    0. Install the gem dependencies for the application
+        * Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
+    0. Create config files if you don't already have them, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake configure:local" panoptes`
+    0. To create the testing database, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" panoptes`
+    0. Run the full spec suite `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes` noting that running all tests is slow.
+        * Use rspec focus keyword in your specs or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
 
 0. Use parts of docker-compose manually and wire them up manually to create a testing environment.
-
-    ```
-    docker-compose run -d --name postgres --service-ports postgres
-    docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes
-    ```
+    1. Run `docker-compose run -d --name postgres --service-ports postgres` to start the postgres container
+    0. Run `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes` to run the full test suite
 
 0. Assuming you have the correct Ruby environment already setup:
-
     1. Run `bundle install`
     0. Start the docker Postgres container by running `docker-compose run -d --name postgres --service-ports postgres` or run your own
     0. Modify your `config/database.yml` test env to point to the running Postgres server, e.g. `host: localhost`

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ It's possible to run Panoptes only having to install the `fig_rake` gem. Alterna
 0. Run `docker-compose build` to build the containers Panoptes API container. You will need to re-run this command on any changes to `Dockerfile.dev`
 
 0. Install the gem dependencies for the application
-  + Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
+  * Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
 
 0. Setup the configuration files via a rake task
-  + Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:local" panoptes`
-  + Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:doorkeeper_keys" panoptes`
-  + Alternatively, manually copy the example configuration files and setup the doorkeeper keys.
-    + Run: `find config/*.yml.hudson -exec bash -c 'for x; do x=${x#./}; cp -i "$x" "${x/.hudson/}"; done' _ {} +`
+  * Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:local" panoptes`
+  * Run: `docker-compose run --rm --entrypoint="bundle exec rake configure:doorkeeper_keys" panoptes`
+  * Alternatively, manually copy the example configuration files and setup the doorkeeper keys.
+    * Run: `find config/*.yml.hudson -exec bash -c 'for x; do x=${x#./}; cp -i "$x" "${x/.hudson/}"; done' _ {} +`
 
 0. Create and run the application containers with `docker-compose up`
 
@@ -74,11 +74,11 @@ There are multiple options for setting up a testing environment:
 
   1. Run `docker-compose build` to build the panoptes container.
   0. Install the gem dependencies for the application
-    + Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
+    * Run: `docker-compose run --rm --entrypoint="bundle install" panoptes`
   0. Create config files if you don't already have them, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake configure:local" panoptes`
   0. To create the testing database, run `docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" panoptes`
   0. Run the full spec suite `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" panoptes` noting that running all tests is slow.
-    + Use rspec focus keyword in your specs or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
+    * Use rspec focus keyword in your specs or specify the spec you want to run, e.g. `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="rspec path/to/spec/file.rb" panoptes`
 
 0. Use parts of docker-compose manually and wire them up manually to create a testing environment.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ Your Pull Request will run on [travis-ci](https://travis-ci.org/zooniverse/Panop
 
 ## License
 
-Copyright 2014-2016 by the Zooniverse
+Copyright 2014-2018 by the Zooniverse
 
 Distributed under the Apache Public License v2. See LICENSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,17 +28,26 @@ cellect:
     - redis
     - postgres:pg
 
+gem_cache:
+  image: busybox
+  volumes:
+    - /gem_cache
+
 panoptes:
   dockerfile: Dockerfile.dev
   build: ./
   volumes:
     - ./:/rails_app
+  volumes_from:
+    - gem_cache
   ports:
     - "3000:3000"
   environment:
     - "RAILS_ENV=development"
     - "CELLECT_MIN_POOL_SIZE=100"
     - "ATTENTION_REDIS_URL=redis://redis:6379/1"
+    - "BUNDLE_PATH=/gem_cache"
+    - "BUNDLE_BIN=/gem_cache/bin"
   links:
     - redis:redis
     - postgres:pg

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -13,7 +13,8 @@ mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 
 if [ "$RAILS_ENV" == "development" ]; then
-  exec foreman start
+  bundle check || bundle install --binstubs="$BUNDLE_BIN"
+  exec bundle exec foreman start
 else
   USER_DATA=$(curl --fail http://169.254.169.254/latest/user-data || echo "")
 


### PR DESCRIPTION
avoid the cost of installing gems and rebuilding docker images, instead rely on a persisted cached volume. This should speed up dev builds. I've also updated and tested the readme instructions to get started.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
