### PR TITLE
limit the max workflow page size to 25

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -33,6 +33,8 @@ class Workflow < ActiveRecord::Base
 
   enum subject_selection_strategy: %i{default cellect designator builtin}
 
+  max_paginates_per 25
+
   DEFAULT_RETIREMENT_OPTIONS = {
     'criteria' => 'classification_count',
     'options' => {'count' => 15}

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -98,4 +98,15 @@ describe WorkflowSerializer do
       end
     end
   end
+
+  describe "#page_size" do
+    let(:scope) { Workflow.where(id: workflow.id) }
+    let(:params) {{ page_size: 50 }}
+
+    it "should default to the max model limit" do
+      result = WorkflowSerializer.page(params, scope)
+      page_size = result.dig(:meta, :workflows, :page_size)
+      expect(page_size).to eq(25)
+    end
+  end
 end


### PR DESCRIPTION
ensure large workflow responses don't tie up API resources but still allow the client to enumerate all the workflows via paging.

pinging @mcbouslog - as per our discussion in chicago, limiting this should be ok for all our sites right?

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
