### PR TITLE
Remove medium mime restrictions

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -111,7 +111,6 @@ class Api::V1::SubjectsController < Api::ApiController
                           }
                         end
       location_params[:metadata] = { index: i }
-      location_params[:allow_any_content_type] = true if api_user.is_admin?
       location_params
     end
   end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -14,39 +14,48 @@ RSpec.describe Medium, :type => :model do
   end
 
   describe "#content_type" do
-
-    it 'should be invalid with an disallowed content_types' do
-      aggregate_failures "disallowed content types" do
-        %w(text/html video/mp4).each do |content_type|
-          m = build(:medium, content_type: content_type)
-          expect(m).to_not be_valid
-        end
-      end
-    end
-
     it 'should not be valid with an empty content_type' do
-      m = build(:medium, content_type: "", src: nil)
+      m = build(:medium, content_type: "")
       expect(m).to_not be_valid
     end
 
-    it 'should be valid with allowed content_types' do
-      aggregate_failures "allowed content types" do
-        Medium::ALLOWED_UPLOAD_CONTENT_TYPES.each do |content_type|
-          m = build(:medium, content_type: content_type)
-          expect(m).to be_valid
+    context "non-export medium types" do
+      it 'should be valid with all content_types' do
+        aggregate_failures "content types" do
+          limited_list_of_allowed_mime_types = %w(
+            image/jpeg
+            image/png
+            image/gif
+            image/svg+xml
+            audio/mpeg
+            audio/mp3
+            audio/mp4
+            audio/x-m4a
+            text/plain
+            text/html
+            video/mp4
+          )
+          limited_list_of_allowed_mime_types.each do |content_type|
+            m = build(:medium, content_type: content_type)
+            expect(m).to be_valid
+          end
         end
       end
     end
 
-    context "with the allow_any_content_type flag set" do
+    context "export medium types" do
+      let(:export_medium) do
+        build(:medium, type: "project_test_export")
+      end
 
-      it 'should be valid with both content_types' do
-        aggregate_failures "content types" do
-          %w(text/html video/mp4).each do |content_type|
-            m = build(:medium, allow_any_content_type: true, content_type: content_type)
-            expect(m).to be_valid
-          end
-        end
+      it 'should be valid for csv content_types' do
+        export_medium.content_type = "text/csv"
+        expect(export_medium).to be_valid
+      end
+
+      it 'should not be valid non-csv content_types' do
+        export_medium.content_type = "text/html"
+        expect(export_medium).not_to be_valid
       end
     end
   end


### PR DESCRIPTION
Allow users to upload any content/mime type media resources. The UI may not support these for say some subject locations, the failure mode will be in the UI. 

This still restricts the medium export types to be 'text/csv' only. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
