### PR TITLE
sort the subjects in a collection by default

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -8,7 +8,9 @@ class Collection < ActiveRecord::Base
   include SluggedName
 
   has_and_belongs_to_many :projects
-  has_many :collections_subjects, dependent: :destroy
+  has_many :collections_subjects,
+    -> { order(id: :desc) },
+    dependent: :destroy
   has_many :subjects, through: :collections_subjects
   has_many :collection_roles, -> { where.not("access_control_lists.roles = '{}'") }, class_name: "AccessControlList", as: :resource
   has_many :user_collection_preferences, dependent: :destroy

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -62,6 +62,11 @@ describe Collection, type: :model do
     it "should have many subjects" do
       expect(collection.subjects).to all( be_a(Subject) )
     end
+
+    it "should order the subject association by most recetly added" do
+      order_clause = "ORDER BY \"collections_subjects\".\"id\" DESC"
+      expect(collection.subjects.to_sql).to include(order_clause)
+    end
   end
 
   context "contribution" do


### PR DESCRIPTION
closes #2473 - show the latest added subjects in a collection first and the oldest ones last.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
