### PR TITLE
Fix current_user_roles filter param after PostgresExt removal

### DIFF
--- a/app/controllers/concerns/filter_by_current_user_roles.rb
+++ b/app/controllers/concerns/filter_by_current_user_roles.rb
@@ -8,7 +8,8 @@ module FilterByCurrentUserRoles
   # Filter controlled_resources by what role you have onto them,
   # e.g., "only show me projects that I am a collaborator in".
   def add_roles_to_filter_params!
-    roles_filter = params.delete(:current_user_roles).try(:split, ",")
+    roles_filter = params.delete(:current_user_roles)
+    roles_filter = roles_filter.split(',') if String === roles_filter
     if !roles_filter.blank? && api_user.logged_in?
       @controlled_resources = controlled_resources
                                        .joins(:access_control_lists)

--- a/spec/support/filter_by_current_user_roles.rb
+++ b/spec/support/filter_by_current_user_roles.rb
@@ -14,18 +14,26 @@ RSpec.shared_examples "filters by current user roles" do
              roles: [role])
     end
     default_request scopes: scopes, user_id: authorized_user.id
-    get :index, index_options
   end
 
   it "should respond with the correct number of role items" do
+    get :index, index_options
+    expect(json_response[api_resource_name].length).to eq(role_filter_resources.size)
+  end
+
+  it "should work with Rails style array params" do
+    index_options[:current_user_roles] = ["owner", "collaborator"]
+    get :index, index_options
     expect(json_response[api_resource_name].length).to eq(role_filter_resources.size)
   end
 
   it 'should not include the resource id when the user has a different role' do
+    get :index, index_options
     expect(response_ids).to_not include(viewer_resource.id.to_s)
   end
 
   it "should respond with the correct items" do
+    get :index, index_options
     filtered_ids = role_filter_resources.map(&:id).map(&:to_s)
     expect(response_ids).to include(*filtered_ids)
   end
@@ -34,6 +42,7 @@ RSpec.shared_examples "filters by current user roles" do
     let(:index_options) { { current_user_roles: 'owner' } }
 
     it "should respond with the correct number of owner items" do
+      get :index, index_options
       expect(json_response[api_resource_name].length).to eq(owner_resources.count)
     end
   end


### PR DESCRIPTION
This would happen if using `?current_user_role[]=a` style params, which Rails
will automatically parse and turn into an array of strings. Rails adds an
Array#split method, which caused the .try to execute and return a nested array,
which in turn happened to work with PostgresExt, but not with the new syntax.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
