### PR TITLE
move ux testing attribute backfill op to rake task

### DIFF
--- a/db/migrate/20180404144354_backfill_ux_testing_default.rb
+++ b/db/migrate/20180404144354_backfill_ux_testing_default.rb
@@ -1,15 +1,9 @@
 class BackfillUxTestingDefault < ActiveRecord::Migration
-  disable_ddl_transaction!
-
   def change
-    User.find_in_batches do |users|
-      null_ux_testing_user_scope = User.where(
-        id: users.map(&:id),
-        ux_testing_email_communication: nil
-      )
-      null_ux_testing_user_scope.update_all(
-        ux_testing_email_communication: false
-      )
-    end
+    # moved to restartable rake task to avoid slowing
+    # the db by surpassing the IOPS limits
+    #
+    # see lib/tasks/user.rake
+    # task :backfill_ux_testing_email_field
   end
 end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -13,7 +13,7 @@ namespace :user do
 
   desc "Backfill UX testing emails comms field in batches"
   task backfill_ux_testing_email_field: :environment do
-    User.find_in_batches do |users|
+    User.select(:id).find_in_batches do |users|
       null_ux_testing_user_scope = User.where(
         id: users.map(&:id),
         ux_testing_email_communication: nil

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -11,6 +11,19 @@ namespace :user do
     end
   end
 
+  desc "Backfill UX testing emails comms field in batches"
+  task backfill_ux_testing_email_field: :environment do
+    User.find_in_batches do |users|
+      null_ux_testing_user_scope = User.where(
+        id: users.map(&:id),
+        ux_testing_email_communication: nil
+      )
+      null_ux_testing_user_scope.update_all(
+        ux_testing_email_communication: false
+      )
+    end
+  end
+
   namespace :limit do
 
     class UpdateUserLimitArgsError < StandardError; end


### PR DESCRIPTION
backfilling the ux testing email comms attribute may consume all the read IOPS for the database (it did on staging db). If this is the case we should ensure we can stop (and restart) to avoid slowing down the API nodes.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
