### PR TITLE
do not allow empty retirement counts

### DIFF
--- a/app/models/concerns/retirement_validator.rb
+++ b/app/models/concerns/retirement_validator.rb
@@ -1,0 +1,49 @@
+class RetirementValidator
+  attr_reader :workflow
+
+  def initialize(workflow)
+    @workflow = workflow
+  end
+
+  def validate
+    return if empty_retirement_config?
+
+    if invalid_valid_criteria?
+      add_error(
+        :"retirement.criteria",
+        "Retirement criteria must be one of #{retirement_criteria.keys.join(', ')}"
+      )
+    end
+
+    if invalid_count_option?
+      add_error(
+        :"retirement.options.count",
+        "Retirement count must be a number"
+      )
+    end
+  end
+
+  private
+
+  def add_error(field, message)
+    workflow.errors.add(field, message)
+  end
+
+  def empty_retirement_config?
+    workflow.retirement.empty?
+  end
+
+  def retirement_criteria
+    @retirement_criteria ||= RetirementSchemes::CRITERIA
+  end
+
+  def invalid_valid_criteria?
+    !retirement_criteria.keys.include?(workflow.retirement['criteria'])
+  end
+
+  def invalid_count_option?
+    has_options = workflow.retirement.fetch("options", {})
+    options_count = has_options.fetch("count", 0)
+    !options_count.is_a?(Integer)
+  end
+end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -40,12 +40,7 @@ class Workflow < ActiveRecord::Base
 
   validates_presence_of :project, :display_name
 
-  validate do |workflow|
-    criteria = RetirementSchemes::CRITERIA.keys
-    unless workflow.retirement.empty? || criteria.include?(workflow.retirement['criteria'])
-      workflow.errors.add(:"retirement.criteria", "Retirement criteria must be one of #{criteria.join(', ')}")
-    end
-  end
+  validate :retirement_config
 
   can_through_parent :project, :update, :index, :show, :destroy, :update_links,
     :destroy_links, :translate, :versions, :version, :retire_subject, :create_classifications_export
@@ -120,5 +115,9 @@ class Workflow < ActiveRecord::Base
       else
         retired_subjects_count >= subjects_count
       end
+  end
+
+  def retirement_config
+    RetirementValidator.new(self).validate
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -143,7 +143,9 @@ describe Workflow, type: :model do
     end
 
     context "classification_count" do
-      let(:retirement) { { 'criteria' => 'classification_count', 'options' => {'count' => 1} } }
+      let(:retirement) do
+        { 'criteria' => 'classification_count', 'options' => {'count' => 1} }
+      end
 
       it "should return a classification count scheme" do
         expect(subject.retirement_scheme).to be_a(RetirementSchemes::ClassificationCount)
@@ -172,6 +174,27 @@ describe Workflow, type: :model do
       let(:retirement) { { 'criteria' => 'classification_count' } }
 
       it { is_expected.to be_valid }
+
+      describe "empty count vales" do
+        let(:retirement) do
+          {
+            'criteria' => 'classification_count',
+            'options' => { 'count' =>nil }
+           }
+        end
+
+        it "should not be valid" do
+          expect(subject.valid?).to eq(false)
+        end
+
+        it "should have a useful error message" do
+          subject.valid?
+          expected_msg = "Retirement count must be a number"
+          expect(
+            subject.errors[:"retirement.options.count"]
+          ).to match_array([expected_msg])
+        end
+      end
     end
 
     context "anything else" do


### PR DESCRIPTION
add custom workflow retirement validatator and ensure the classification count option has an integer in it.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
