### PR TITLE
[WIP] Allow a project to change it's primary language

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -59,9 +59,6 @@ class Api::V1::ProjectsController < Api::ApiController
 
   def update
     super do |resource|
-      # TODO: extract this primary project content update
-      # to a service object that sits in the project
-      # transaction.
       content_attributes = primary_content_attributes(update_params)
       unless content_attributes.blank?
         resource.primary_content.update!(content_attributes)

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -58,10 +58,34 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def update
+    primary_language_update = update_params.delete(:primary_language)
     super do |resource|
       content_attributes = primary_content_attributes(update_params)
-      unless content_attributes.blank?
-        resource.primary_content.update!(content_attributes)
+
+      if primary_language_update
+        content_attrs = { project_id: resource.id }
+        old_primary_content = ProjectContent.find_by(
+          content_attrs.merge(language: resource.primary_language)
+        )
+        new_content_attrs = content_attrs.merge(
+          language: primary_language_update
+        )
+        new_primary_content = ProjectContent.find_or_initialize_by(new_content_attrs) do |pc|
+          attrs_to_add = old_primary_content.dup.attributes.except("language", "project_id").compact
+          attrs_to_add.each do |attribute, value|
+            pc.send("#{attribute}=", value)
+          end
+        end
+        resource.primary_language = primary_language_update
+        new_primary_content.assign_attributes(content_attributes)
+        # add the new contents resource to the has_many without saving it
+        # allow the project.save! in the update super operation to autosave it
+        # as that association is set to autosave
+        if new_primary_content.new_record?
+          resource.association(:project_contents).add_to_target(new_primary_content)
+        end
+      elsif !content_attributes.blank?
+        resource.primary_content.assign_attributes(content_attributes)
       end
 
       tags = Tags::BuildTags.run!(api_user: api_user, tag_array: update_params[:tags]) if update_params[:tags]

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -628,6 +628,31 @@ describe Api::V1::ProjectsController, type: :controller do
       let(:controller_action_params) { update_params.merge(id: resource.id) }
     end
 
+    describe "primary_language", :focus do
+      let(:new_lang_code) { "en-AU" }
+      let(:update_params) do
+        {
+          projects: {
+            primary_language: new_lang_code,
+          }
+        }
+      end
+
+      before(:each) do
+        default_request scopes: scopes, user_id: authorized_user.id
+      end
+
+      it "should change the primary language" do
+        put :update, update_params.merge(id: resource.id)
+        expect(response).to have_http_status(:ok)
+        expect(resource.reload.primary_language).to eq(new_lang_code)
+      end
+
+      it "should copy the project contents to the new language" do
+        pending("i'm not sure this is a valid idea")
+      end
+    end
+
     describe "launch_approved" do
       let(:ps) do
         ps = update_params

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -628,12 +628,14 @@ describe Api::V1::ProjectsController, type: :controller do
       let(:controller_action_params) { update_params.merge(id: resource.id) }
     end
 
-    describe "primary_language", :focus do
+    describe "primary_language" do
       let(:new_lang_code) { "en-AU" }
+      let(:new_display_name) { "Sweet home Chicago" }
       let(:update_params) do
         {
           projects: {
             primary_language: new_lang_code,
+            display_name: new_display_name
           }
         }
       end
@@ -642,14 +644,20 @@ describe Api::V1::ProjectsController, type: :controller do
         default_request scopes: scopes, user_id: authorized_user.id
       end
 
-      it "should change the primary language" do
+      it "should update ok" do
         put :update, update_params.merge(id: resource.id)
         expect(response).to have_http_status(:ok)
+      end
+
+      it "should change the primary language" do
+        put :update, update_params.merge(id: resource.id)
         expect(resource.reload.primary_language).to eq(new_lang_code)
       end
 
-      it "should copy the project contents to the new language" do
-        pending("i'm not sure this is a valid idea")
+      it "should update the new language content model" do
+        put :update, update_params.merge(id: resource.id)
+        contents_title = resource.reload.primary_content.title
+        expect(contents_title).to eq(new_display_name)
       end
     end
 


### PR DESCRIPTION
fixes #2749 - If a project requests to update it's primary language code we should find any existing project contents model or build a new one, then update it's attributes and link it to the existing project resource as the primary_content model.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
