### PR TITLE
Include credited_name in all user requests

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -86,7 +86,7 @@ The User resource has the following attributes:
 - languages
 
 *id*, *zooniverse_id*, *created_at*, *updated_at*, and
- *classification_count* are created and updated by the Panoptes API.
+ *classification_count* are created and updated by the Panoptes API. `credited_name` is the publicly available name with which a volunteer will be credited on papers, posters, etc. When serialized, if an `@` character is found, the user's login will be returned instead for privacy reasons.
 
 + Parameters
     + id (integer) ... ID of the User as an integer key

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -38,7 +38,11 @@ class UserSerializer
   end
 
   def credited_name
-    @model.credited_name.include?('@') ? @model.login : @model.credited_name
+    if !@model.credited_name || @model.credited_name.include?('@')
+      @model.login
+    else
+      @model.credited_name
+    end
   end
 
   private

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -43,7 +43,7 @@ class UserSerializer
     @permitted ||= @context[:include_private] || requester
   end
 
-  %w(credited_name email languages global_email_communication
+  %w(email languages global_email_communication
      project_email_communication beta_email_communication
      uploaded_subjects_count subject_limit admin login_prompt zooniverse_id
      upload_whitelist valid_email, ux_testing_email_communication).each do |me_only_attribute|

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -37,6 +37,10 @@ class UserSerializer
     @model.avatar&.url_for_format(:get)
   end
 
+  def credited_name
+    @model.credited_name.include?('@') ? @model.login : @model.credited_name
+  end
+
   private
 
   def permitted_requester?

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -86,10 +86,6 @@ describe Api::V1::UsersController, type: :controller do
           expect(not_requester).to_not include("email")
         end
 
-        it 'should not have a credited name' do
-          expect(not_requester).to_not include("credited_name")
-        end
-
         it 'should not have a global email communication' do
           expect(not_requester).to_not include("global_email_communication")
         end
@@ -131,10 +127,6 @@ describe Api::V1::UsersController, type: :controller do
 
       it 'should not have an email address' do
         expect(json_response[api_resource_name][0]).to_not include("email")
-      end
-
-      it 'should not have a credited name' do
-        expect(json_response[api_resource_name][0]).to_not include("credited_name")
       end
 
       it 'should not have languages' do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -61,4 +61,13 @@ RSpec.describe UserSerializer do
       expect(result[:users][0][:avatar_src]).to eq(avatar.url_for_format(:get))
     end
   end
+
+  describe "a confused user" do
+    let!(:confused_user) { create(:user, credited_name: "oops@email.com", login: "confused_user" )}
+    let(:confused_serializer) { described_class.serialize(confused_user) }
+
+    it "serialized the user's login as credited_name if credited_name contains an @" do
+      expect(confused_serializer[:users][0][:credited_name]).to eq("confused_user")
+    end
+  end
 end


### PR DESCRIPTION
A user's credited name is collected for the purpose of displaying publicly and therefore should be included in public user requests. In the event that credited_name is nil OR includes an `@` (to protect against leaking an email address), the user's login is serialized as credited_name instead.

This will allow science teams (SGL, specifically) to query the API for user information and update their discoveries with appropriate names.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
