### PR TITLE
Ensure subjects selected with Designator are returned in selection order

### DIFF
--- a/lib/subjects/designator_selector.rb
+++ b/lib/subjects/designator_selector.rb
@@ -35,6 +35,7 @@ module Subjects
 
       subject_ids = self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
       return [] unless subject_ids.present?
+      raise "Hacking attempt" unless subject_ids.all? { |i| i.is_a? Integer }
 
       sms_scope = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id)
         .order("idx(array[#{subject_ids.join(',')}], set_member_subjects.subject_id)")

--- a/lib/subjects/designator_selector.rb
+++ b/lib/subjects/designator_selector.rb
@@ -34,7 +34,11 @@ module Subjects
       return [] unless enabled?
 
       subject_ids = self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
+      return [] unless subject_ids.present?
+
       sms_scope = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id)
+        .order("idx(array[#{subject_ids.join(',')}], set_member_subjects.subject_id)")
+
       sms_scope.pluck("set_member_subjects.id")
     end
 

--- a/spec/lib/subjects/designator_selector_spec.rb
+++ b/spec/lib/subjects/designator_selector_spec.rb
@@ -4,7 +4,7 @@ describe Subjects::DesignatorSelector do
   let(:client) { instance_double(DesignatorClient) }
   let(:workflow) { instance_double(Workflow, id: 1) }
   let(:selector) { described_class.new(workflow)}
-  
+
   before do
     allow(described_class).to receive(:client).and_return(client)
   end
@@ -77,7 +77,18 @@ describe Subjects::DesignatorSelector do
       allow(client).to receive(:get_subjects).with(workflow.id, 2, nil, 10).and_return(set_member_subjects.map(&:subject_id))
 
       set_member_subject_ids = selector.get_subjects(user, nil, 10)
-      expect(set_member_subject_ids).to match_array(set_member_subjects.map(&:id))
+      expect(set_member_subject_ids).to eq(set_member_subjects.map(&:id))
+    end
+
+    it 'returns set_member_subject_ids in the same order that Designator returned the subject_ids' do
+      subject_set = create(:subject_set, workflows: [workflow])
+      set_member_subjects = create_list(:set_member_subject, 5, subject_set: subject_set)
+      set_member_subjects.reverse!
+
+      allow(client).to receive(:get_subjects).with(workflow.id, 2, nil, 10).and_return(set_member_subjects.map(&:subject_id))
+
+      set_member_subject_ids = selector.get_subjects(user, nil, 10)
+      expect(set_member_subject_ids).to eq(set_member_subjects.map(&:id))
     end
 
     it 'returns an empty array unless enabled', :aggregate_failures do

--- a/spec/lib/subjects/designator_selector_spec.rb
+++ b/spec/lib/subjects/designator_selector_spec.rb
@@ -91,6 +91,12 @@ describe Subjects::DesignatorSelector do
       expect(set_member_subject_ids).to eq(set_member_subjects.map(&:id))
     end
 
+    it 'does not allow sql injection' do
+      allow(client).to receive(:get_subjects).with(workflow.id, 2, nil, 10).and_return([1, 2, '1], set_member_subjects.id); DROP TABLE users; -- '])
+      expect { selector.get_subjects(user, nil, 10) }
+        .to raise_error(StandardError, "Hacking attempt")
+    end
+
     it 'returns an empty array unless enabled', :aggregate_failures do
       Panoptes.flipper["designator"].disable
       expect(client).not_to receive(:get_subjects)


### PR DESCRIPTION
We were getting reports that training images were "clustering" rather than being interleaved. This was a side effect of getting the SetMemberSubjects without any explicit ordering.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
