### PR TITLE
[WIP] Convert contents association to singular resource contents model

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -119,7 +119,7 @@ class Api::V1::ProjectsController < Api::ApiController
     admin_allowed create_params, *admin_allowed_params
 
     content_attributes = primary_content_attributes(create_params)
-    create_params[:project_contents] = [ ProjectContent.new(content_attributes) ]
+    create_params[:project_contents] = ProjectContent.new(content_attributes)
 
     if create_params.key?(:tags)
       create_params[:tags] = Tags::BuildTags.run!(api_user: api_user, tag_array: create_params[:tags])
@@ -150,7 +150,7 @@ class Api::V1::ProjectsController < Api::ApiController
       case item
       when Workflow
         item.dup.tap do |dup_object|
-          dup_object.workflow_contents = item.workflow_contents.map(&:dup)
+          dup_object.workflow_contents = item.workflow_contents.dup
         end
       when SubjectSet
         if !item.belongs_to_project?(project_id)

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -3,19 +3,10 @@ module Translatable
 
   included do
     validates :primary_language, format: {with: /\A[a-z]{2}(\z|-[A-z]{2})/}
-    has_many content_association, autosave: true, inverse_of: name.downcase.to_sym, dependent: :destroy
-    has_one :primary_content, -> (translatable) { where(language: translatable.primary_language) }, class_name: content_model
+    has_one content_association, autosave: true, inverse_of: name.downcase.to_sym, class_name: content_model, dependent: :destroy
     can_be_linked content_model.name.underscore.to_sym, :scope_for, :translate, :user
 
-    before_validation do |translatable|
-      primary_content_association = translatable.content_association.find do |content|
-        content.language == translatable.primary_language
-      end
-      translatable.primary_content = primary_content_association
-    end
-
     validates content_association, presence: true
-    validates :primary_content, presence: true
   end
 
   module ClassMethods
@@ -28,8 +19,10 @@ module Translatable
     end
   end
 
+  # this should really go away
+  # or get updated from all the translation resource via workers
   def available_languages
-    content_association.map { |ca| ca.language.downcase }
+    [content_association.language.downcase]
   end
 
   def content_association

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -4,9 +4,18 @@ module Translatable
   included do
     validates :primary_language, format: {with: /\A[a-z]{2}(\z|-[A-z]{2})/}
     has_many content_association, autosave: true, inverse_of: name.downcase.to_sym, dependent: :destroy
+    has_one :primary_content, -> (translatable) { where(language: translatable.primary_language) }, class_name: content_model
     can_be_linked content_model.name.underscore.to_sym, :scope_for, :translate, :user
 
+    before_validation do |translatable|
+      primary_content_association = translatable.content_association.find do |content|
+        content.language == translatable.primary_language
+      end
+      translatable.primary_content = primary_content_association
+    end
+
     validates content_association, presence: true
+    validates :primary_content, presence: true
   end
 
   module ClassMethods
@@ -25,16 +34,5 @@ module Translatable
 
   def content_association
     @content_association ||= send(self.class.content_association)
-  end
-
-  # TODO: this should become the association instead of the has_many
-  def primary_content
-    @primary_content ||= if content_association.loaded?
-      content_association.to_a.find do |content|
-        content.language == primary_language
-      end
-    else
-      content_association.find_by(language: primary_language)
-    end
   end
 end

--- a/app/models/concerns/translation_strings.rb
+++ b/app/models/concerns/translation_strings.rb
@@ -33,7 +33,6 @@ class TranslationStrings
     content_assocation = resource.class.content_association
     resource
       .send(content_assocation)
-      .find_by(language: resource.primary_language)
       .attributes
       .dup
       .except(:id)

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -17,7 +17,7 @@ module Organizations
     def execute
       Organization.transaction(requires_new: true) do
         organization = build_organization
-        organization.organization_contents.build(organization_contents_params)
+        organization.build_organization_contents(organization_contents_params)
 
         tag_objects = Tags::BuildTags.run!(api_user: api_user, tag_array: tags) if tags
         organization.tags = tag_objects unless tags.nil?

--- a/app/serializers/concerns/content_serializer.rb
+++ b/app/serializers/concerns/content_serializer.rb
@@ -1,8 +1,0 @@
-module ContentSerializer
-  def content
-    return @content if @content
-    content = @model.primary_content.attributes.with_indifferent_access
-    content.default = ""
-    @content = content.slice(*fields)
-  end
-end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,7 +1,6 @@
 class OrganizationSerializer
   include RestPack::Serializer
   include OwnerLinkSerializer
-  include ContentSerializer
   include MediaLinksSerializer
   include CachedSerializer
 
@@ -36,10 +35,6 @@ class OrganizationSerializer
     end
   end
 
-  def fields
-    %i(title description introduction announcement)
-  end
-
   def self.links
     links = super
     links["organizations.pages"] = {
@@ -47,5 +42,12 @@ class OrganizationSerializer
                                type: "organization_pages"
                               }
     links
+  end
+
+  def content
+    return @content if @content
+    content = @model.organization_contents.attributes.with_indifferent_access
+    content.default = ""
+    @content = content.slice(*Api::V1::OrgnazationsController::CONTENT_FIELDS)
   end
 end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -19,8 +19,7 @@ class WorkflowSerializer
 
   can_filter_by :active, :mobile_friendly
 
-  # :workflow_contents, Note: re-add when the eager_load from translatable_resources is removed
-  preload :subject_sets, :attached_images
+  preload :subject_sets, :attached_images, :workflow_contents
 
   def version
     "#{@model.current_version_number}.#{content_version}"
@@ -45,7 +44,7 @@ class WorkflowSerializer
   end
 
   def content
-    @content ||= @model.primary_content
+    @content ||= @model.workflow_contents
   end
 
   def retirement

--- a/spec/controllers/api/v1/organization_contents_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_contents_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::OrganizationContentsController, type: :controller do
     create(:organization_content, language: "en-CA", organization: organization)
   end
   let(:resource_class) { OrganizationContent }
-  let(:primary_content) { organization.primary_content }
+  let(:organization_contents) { organization.organization_contents }
 
   let(:acl_roles) { %w(translator) }
   let(:acl) do
@@ -28,12 +28,12 @@ RSpec.describe Api::V1::OrganizationContentsController, type: :controller do
     let(:acl_roles) { %w(collaborator) }
 
     let!(:private_resource) do
-      create(:unlisted_organization).organization_contents.first
+      create(:unlisted_organization).organization_contents
     end
 
     before { acl }
 
-    let(:n_visible) { 3 }
+    let(:n_visible) { 2 }
 
     it_behaves_like "is indexable"
   end
@@ -87,7 +87,7 @@ RSpec.describe Api::V1::OrganizationContentsController, type: :controller do
 
         before(:each) do
           default_request user_id: authorized_user.id, scopes: scopes
-          params = update_params.merge(id: primary_content.id)
+          params = update_params.merge(id: organization_contents.id)
           put :update, params
         end
 
@@ -96,8 +96,8 @@ RSpec.describe Api::V1::OrganizationContentsController, type: :controller do
         end
 
         it 'should not update the content' do
-          primary_content.reload
-          expect(primary_content.title).to_not eq(test_attr_value)
+          organization_contents.reload
+          expect(organization_contents.title).to_not eq(test_attr_value)
         end
       end
     end
@@ -112,7 +112,7 @@ RSpec.describe Api::V1::OrganizationContentsController, type: :controller do
     context "primary-langauge content" do
       before(:each) do
         default_request user_id: authorized_user.id, scopes: scopes
-        delete :destroy, id: primary_content.id
+        delete :destroy, id: organization_contents.id
       end
 
       it 'should return forbidden' do
@@ -120,7 +120,7 @@ RSpec.describe Api::V1::OrganizationContentsController, type: :controller do
       end
 
       it 'should not delete the content' do
-        expect(OrganizationContent.find(primary_content.id)).to eq(primary_content)
+        expect(OrganizationContent.find(organization_contents.id)).to eq(organization_contents)
       end
     end
   end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -445,7 +445,7 @@ describe Api::V1::ProjectsController, type: :controller do
       end
 
       describe "project contents" do
-        let(:contents) { Project.find(created_project_id).project_contents.first }
+        let(:contents) { Project.find(created_project_id).project_contents }
 
         it "should create an associated project_content model" do
           expect(contents).to_not be_nil

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -16,8 +16,7 @@ FactoryBot.define do
 
     after(:build) do |o, env|
       if env.build_contents
-        o.organization_contents << build_list(:organization_content, 1, organization: o, language: o.primary_language)
-        o.organization_contents << build_list(:organization_content, 1, organization: o, language: 'en-US')
+        o.organization_contents = build(:organization_content, organization: o, language: o.primary_language)
       end
 
       if env.build_media

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :project, aliases: [:project_with_contents] do
     transient do
       build_contents true
-      build_extra_contents false
     end
 
     sequence(:name) { |n| "test_project_#{ n }" }
@@ -22,11 +21,7 @@ FactoryBot.define do
 
     after(:build) do |p, env|
       if env.build_contents
-        p.project_contents << build_list(:project_content, 1, project: p, language: p.primary_language)
-        if env.build_extra_contents
-          p.project_contents << build_list(:project_content, 1, project: p, language: 'zh-TW')
-          p.project_contents << build_list(:project_content, 1, project: p, language: 'en-US')
-        end
+        p.project_contents = build(:project_content, project: p, language: p.primary_language)
       end
     end
 

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :workflow, aliases: [:workflow_with_contents] do
     transient do
       build_contents true
-      build_extra_contents false
     end
 
     display_name "A Workflow"
@@ -59,11 +58,7 @@ FactoryBot.define do
 
     after(:build) do |w, env|
       if env.build_contents
-        w.workflow_contents << build_list(:workflow_content, 1, workflow: w, language: w.primary_language)
-        if env.build_extra_contents
-          w.workflow_contents << build_list(:workflow_content, 1, workflow: w, language: 'en-US')
-          w.workflow_contents << build_list(:workflow_content, 1, workflow: w, language: 'zh-TW')
-        end
+        w.workflow_contents = build(:workflow_content, workflow: w, language: w.primary_language)
       end
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -22,7 +22,7 @@ describe Project, type: :model do
   end
 
   it_behaves_like "is translatable" do
-    let(:translatable) { create(:project_with_contents, build_extra_contents: true) }
+    let(:translatable) { create(:project_with_contents) }
     let(:translatable_without_content) { build(:project, build_contents: false) }
     let(:primary_language_factory) { :project }
     let(:private_model) { create(:project, private: true) }

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -12,7 +12,7 @@ describe Workflow, type: :model do
   it_behaves_like "has subject_count"
 
   it_behaves_like "is translatable" do
-    let(:translatable) { create(:workflow_with_contents, build_extra_contents: true) }
+    let(:translatable) { create(:workflow_with_contents) }
     let(:translatable_without_content) { build(:workflow, build_contents: false) }
     let(:primary_language_factory) { :workflow }
     let(:private_project) { create(:project, private: true) }

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -11,31 +11,20 @@ describe ProjectSerializer do
     s
   end
 
-  it "should not preload the serialized associations by default" do
-    expect_any_instance_of(Project::ActiveRecord_Relation).not_to receive(:preload)
-    ProjectSerializer.page({}, Project.all, {})
+  it "should preload avatars with cards context" do
+    expect_any_instance_of(Project::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(:avatar)
+      .and_call_original
+    ProjectSerializer.page({}, Project.all, {cards: true})
   end
 
-  context "with enabled preload feature" do
-    before do
-      Panoptes.flipper["eager_load_projects"].enable
-    end
-
-    it "should preload avatars with cards context" do
-      expect_any_instance_of(Project::ActiveRecord_Relation)
-        .to receive(:preload)
-        .with(:avatar)
-        .and_call_original
-      ProjectSerializer.page({}, Project.all, {cards: true})
-    end
-
-    it "should preload the serialized associations without cards context" do
-      expect_any_instance_of(Project::ActiveRecord_Relation)
-        .to receive(:preload)
-        .with(*ProjectSerializer::PRELOADS)
-        .and_call_original
-      ProjectSerializer.page({}, Project.all, {})
-    end
+  it "should preload the serialized associations without cards context" do
+    expect_any_instance_of(Project::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(*ProjectSerializer::PRELOADS)
+      .and_call_original
+    ProjectSerializer.page({}, Project.all, {})
   end
 
   describe "#content" do

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe WorkflowSerializer do
   let(:workflow) { create(:workflow_with_contents) }
-  let(:content) { workflow.workflow_contents.first }
+  let(:content) { workflow.workflow_contents }
   let(:serializer) do
     serializer = WorkflowSerializer.new
     serializer.instance_variable_set(:@model, workflow)
@@ -14,7 +14,7 @@ describe WorkflowSerializer do
   it_should_behave_like "a panoptes restpack serializer" do
     let(:resource) { workflow }
     let(:includes) { %i(project subject_sets tutorial_subject) }
-    let(:preloads) { %i(subject_sets attached_images) }
+    let(:preloads) { %i(subject_sets attached_images workflow_contents) }
   end
 
   it_should_behave_like "a filter has many serializer" do
@@ -44,15 +44,11 @@ describe WorkflowSerializer do
     end
   end
 
-  context "when there is no content_association" do
+  context "when there is no workflow_contents association" do
     let!(:workflow) do
       create(:workflow) do |workflow|
-        workflow.workflow_contents = []
+        workflow.workflow_contents = nil
       end
-    end
-
-    it "should not have a content association" do
-      expect(workflow.content_association).to be_empty
     end
 
     describe "#version", versioning: true do

--- a/spec/support/translatable.rb
+++ b/spec/support/translatable.rb
@@ -13,29 +13,6 @@ shared_examples "is translatable" do
     end
   end
 
-  describe "#primary_content" do
-    it "should have a primary_content association" do
-      expected_content_class = translatable.class.content_model
-      expect(translatable.primary_content).to be_a(expected_content_class)
-    end
-
-    context "without a primary_content association" do
-      before do
-        translatable.send(:"#{described_class.name.underscore}_contents=", [])
-        translatable.primary_content = nil
-        translatable.valid?
-      end
-
-      it "should not be valid" do
-        expect(translatable).to be_invalid
-      end
-
-      it "should have the correct error message" do
-        expect(translatable.errors[:primary_content]).to eq(["can't be blank"])
-      end
-    end
-  end
-
   describe "#primary_language" do
     let(:factory) { primary_language_factory }
     let(:locale_field) { :primary_language }

--- a/spec/support/translatable.rb
+++ b/spec/support/translatable.rb
@@ -13,6 +13,29 @@ shared_examples "is translatable" do
     end
   end
 
+  describe "#primary_content" do
+    it "should have a primary_content association" do
+      expected_content_class = translatable.class.content_model
+      expect(translatable.primary_content).to be_a(expected_content_class)
+    end
+
+    context "without a primary_content association" do
+      before do
+        translatable.send(:"#{described_class.name.underscore}_contents=", [])
+        translatable.primary_content = nil
+        translatable.valid?
+      end
+
+      it "should not be valid" do
+        expect(translatable).to be_invalid
+      end
+
+      it "should have the correct error message" do
+        expect(translatable.errors[:primary_content]).to eq(["can't be blank"])
+      end
+    end
+  end
+
   describe "#primary_language" do
     let(:factory) { primary_language_factory }
     let(:locale_field) { :primary_language }

--- a/spec/workers/translation_sync_worker_spec.rb
+++ b/spec/workers/translation_sync_worker_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe TranslationSyncWorker do
       let(:translation) do
         create(:translation, translated: project, language: project.primary_language)
       end
-      let(:primary_content) { project.primary_content }
+      let(:project_contents) { project.project_contents }
       let(:new_title) { "freshly translated for you" }
 
       it "should update the translation strings for the supplied resource" do
         old_title = translation.strings["title"]
-        primary_content.update_column(:title, new_title)
+        project_contents.update_column(:title, new_title)
         expect {
           worker.perform(project.class.to_s, project.id, project.primary_language)
         }.to change {


### PR DESCRIPTION
related to #2751 - that PR will have to change if this makes it in.

Since we removed the load_with_languages #2697 we can now convert the (project|workflow|organization|)_contents models from has_many to has_one to allow preloading the contents model on the resource serializer scopes. Translations are now in their own resource and synced on change via the parent resource but still by the *_contents model strings so long term these *_content model strings can be folded back into the parent resource and extracted to translations model from there.

# Todo

- [x] Remove the `eager_load_projects` flipper feature once this is deployed - #2837

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
