### PR TITLE
Allow users to edit and delete their account

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/app/assets/stylesheets/base.css
+++ b/app/assets/stylesheets/base.css
@@ -1,6 +1,6 @@
 html, body {
   background: #fbfbfb;
-  font: 400 10px/20px Arial, sans-serif;
+  font: 400 12px/20px Arial, sans-serif;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
 }
@@ -66,19 +66,19 @@ h1 {
 }
 
 h2 {
-  font-size: 4.2em;
+  font-size: 3.2em;
 }
 
 h3 {
-  font-size: 3.6em;
+  font-size: 3em;
 }
 
 h4 {
-  font-size: 3em
+  font-size: 2.8em;
 }
 
 h5 {
-  font-size: 2.4em
+  font-size: 2.4em;
 }
 
 h6 {

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -19,6 +19,19 @@ class RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def destroy
+    if current_user.valid_password?(params[:user][:current_password])
+      UserInfoScrubber.scrub_personal_info!(current_user)
+      Activation.disable_instances!([current_user])
+      Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+      set_flash_message! :notice, :destroyed
+      respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+    else
+      flash[:delete_alert] = "Incorrect password"
+      render action: :edit
+    end
+  end
+
   private
 
   def create_from_json

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,22 +1,26 @@
-<div class="form-container">
-  <h2>Change your password</h2>
+<div class="form-container panel panel-default">
+  <div class="panel-body">
+    <h2>Change your password</h2>
 
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "form" }) do |f| %>
-    <%= devise_error_messages! %>
-    <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put}) do |f| %>
+      <%= devise_error_messages! %>
+      <%= f.hidden_field :reset_password_token %>
 
-    <fieldset class="fieldset--password">
-      <%= f.label :password, "New password" %><br />
-      <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
-    </fieldset>
+      <div class="form-group">
+        <%= f.label :password, "New password" %><br />
+        <%= f.password_field :password, autofocus: true, autocomplete: "off", class: 'form-control' %>
+      </div>
 
-    <fieldset class="fieldset--password">
-      <%= f.label :password_confirmation, "Confirm new password" %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "off" %>
-    </fieldset>
+      <div class="form-group">
+        <%= f.label :password_confirmation, "Confirm new password" %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control' %>
+      </div>
 
-    <div class="submit-container"><%= f.submit "Change my password" %></div>
-  <% end %>
-
-  <%= render "devise/shared/links" %>
+      <%= f.submit "Change my password", class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+  
+  <div class="panel-footer">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,20 @@
-<div class="form-container">
-  <h2>Forgot your password?</h2>
+<div class="form-container panel panel-default">
+  <div class="panel-body">
+    <h2>Forgot your password?</h2>
 
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "form form--new-password" }) do |f| %>
-    <%= devise_error_messages! %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= devise_error_messages! %>
 
-    <fieldset class="fieldset--email">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, required: true %>
-    </fieldset>
+      <div class="form-group">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, required: true, class: 'form-control' %>
+      </div>
 
-    <div class="submit-container"><%= f.submit "Send me reset email" %></div>
-  <% end %>
+      <%= f.submit "Send me reset email", class: 'btn btn-primary' %>
+    <% end %>
+  </div>
 
-  <%= render "devise/shared/links" %>
+  <div class="panel-footer">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,35 +1,77 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="form-container panel panel-default">
+    <div class="panel-body">
+        <h2>Update your profile</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+            <%= devise_error_messages! %>
 
-  <div><%= f.label :login %><br />
-    <%= f.text_field :login, autofocus: true %></div>
+            <div class="form-group">
+                    <%= f.label :login %><br />
+                    <%= f.text_field :login, autofocus: true, class: 'form-control' %>
+            </div>
 
-  <div><%= f.label :display_name %><br />
-    <%= f.text_field :display_name %></div>
+            <div class="form-group">
+                    <%= f.label :display_name %><br />
+                    <%= f.text_field :display_name, class: 'form-control' %>
+            </div>
 
-  <div><%= f.label :email %><br />
-    <%= f.email_field :email %></div>
+            <div class="form-group">
+                    <%= f.label :email %><br />
+                    <%= f.email_field :email, class: 'form-control' %>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+                <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+                    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+                <% end %>
+            </div>
 
-  <div><%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %></div>
+            <div class="form-group">
+                <div class="fieldset--password">
+                    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+                    <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
+                </div>
 
-  <div><%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %></div>
+                <div class="fieldset--password">
+                    <%= f.label :password_confirmation %><br />
+                    <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control' %>
+                </div>
+            </div>
 
-  <div><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off" %></div>
+            <div class="form-group">
+                <div class="fieldset--password">
+                    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+                    <%= f.password_field :current_password, autocomplete: "off", class: 'form-control' %>
+                </div>
+            </div>
 
-  <div><%= f.submit "Update" %></div>
-<% end %>
+            <%= f.submit "Update", class: 'btn btn-primary' %>
+        <% end %>
+    </div>
+</div>
 
-<h3>Cancel my account</h3>
+<hr>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<div class="form-container" >
+    <h6>Cancel my account</h6>
 
-<%= link_to "Back", :back %>
+    <p>
+        If for whatever reason you no longer wish to maintain an account with us,
+        you can delete it here. Please note that any classifications you've made on
+        projects, and any comments you've posted on our Talk discussion fora will
+        remain.
+    </p>
+
+    <% if flash[:delete_alert] %>
+        <p class="alert"><%= flash[:delete_alert] %></p>
+    <% end %>
+    
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :delete }) do |f| %>
+        <div class="form-group">
+            <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+            <%= f.password_field :current_password, autocomplete: "off", class: 'form-control' %>
+        </div>
+
+        <%= f.submit "Cancel my account", class: 'btn btn-danger' %>
+    <% end %>
+
+    <%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,77 +1,83 @@
 <div class="form-container panel panel-default">
-    <div class="panel-body">
-        <h2>Update your profile</h2>
+  <div class="panel-body">
+    <h2>Update your profile</h2>
 
-        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-            <%= devise_error_messages! %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= devise_error_messages! %>
 
-            <div class="form-group">
-                    <%= f.label :login %><br />
-                    <%= f.text_field :login, autofocus: true, class: 'form-control' %>
-            </div>
+      <div class="form-group">
+        <%= f.label :login %><br />
+        <%= f.text_field :login, autofocus: true, class: 'form-control' %>
+      </div>
 
-            <div class="form-group">
-                    <%= f.label :display_name %><br />
-                    <%= f.text_field :display_name, class: 'form-control' %>
-            </div>
+      <div class="form-group">
+        <%= f.label :display_name %><br />
+        <%= f.text_field :display_name, class: 'form-control' %>
+      </div>
 
-            <div class="form-group">
-                    <%= f.label :email %><br />
-                    <%= f.email_field :email, class: 'form-control' %>
+      <div class="form-group">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, class: 'form-control' %>
 
-                <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-                    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-                <% end %>
-            </div>
-
-            <div class="form-group">
-                <div class="fieldset--password">
-                    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-                    <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
-                </div>
-
-                <div class="fieldset--password">
-                    <%= f.label :password_confirmation %><br />
-                    <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control' %>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <div class="fieldset--password">
-                    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-                    <%= f.password_field :current_password, autocomplete: "off", class: 'form-control' %>
-                </div>
-            </div>
-
-            <%= f.submit "Update", class: 'btn btn-primary' %>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
         <% end %>
-    </div>
+      </div>
+
+      <div class="form-group">
+        <div class="fieldset--password">
+          <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+          <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
+        </div>
+
+        <div class="fieldset--password">
+          <%= f.label :password_confirmation %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control' %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div class="fieldset--password">
+          <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+          <%= f.password_field :current_password, autocomplete: "off", class: 'form-control' %>
+        </div>
+      </div>
+
+      <%= f.submit "Update", class: 'btn btn-primary' %>
+    <% end %>
+  </div>
 </div>
 
 <hr>
 
-<div class="form-container" >
-    <h6>Cancel my account</h6>
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="form-container" >
+        <h6>Cancel my account</h6>
 
-    <p>
-        If for whatever reason you no longer wish to maintain an account with us,
-        you can delete it here. Please note that any classifications you've made on
-        projects, and any comments you've posted on our Talk discussion fora will
-        remain.
-    </p>
+        <p>
+          If for whatever reason you no longer wish to maintain an account with us,
+          you can delete it here. Please note that any classifications you've made on
+          projects, and any comments you've posted on our Talk discussion fora will
+          remain.
+        </p>
 
-    <% if flash[:delete_alert] %>
-        <p class="alert"><%= flash[:delete_alert] %></p>
-    <% end %>
-    
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :delete }) do |f| %>
-        <div class="form-group">
+        <% if flash[:delete_alert] %>
+          <p class="alert"><%= flash[:delete_alert] %></p>
+        <% end %>
+        
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :delete }) do |f| %>
+          <div class="form-group">
             <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
             <%= f.password_field :current_password, autocomplete: "off", class: 'form-control' %>
-        </div>
+          </div>
 
-        <%= f.submit "Cancel my account", class: 'btn btn-danger' %>
-    <% end %>
+          <%= f.submit "Cancel my account", class: 'btn btn-danger' %>
+        <% end %>
 
-    <%= link_to "Back", :back %>
+        <%= link_to "Back", :back %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,57 +1,59 @@
-<div class="form-container">
-    <h2>Sign up</h2>
+<div class="form-container panel panel-default">
+  <div class="panel-body">
+    <h2>Create account</h2>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "form form--new-user"}) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
 
-        <div class="row" >
-        <fieldset class="fieldset--text">
-            <%= f.label :login, "Username (required)" %><small class="errored"><%= resource.errors[:login].join(', ')%></small><br />
-            <%= f.text_field :login, autofocus: true, required: true %>
-        </fieldset>
+      <div class="form-group <%= "has-errors" if resource.errors[:login].present? %>">
+        <%= f.label :login, "Username (required)" %><small class="errored"><%= resource.errors[:login].join(', ')%></small><br />
+        <%= f.text_field :login, autofocus: true, required: true, class: 'form-control' %>
+      </div>
+
+      <div class="form-group <%= "has-errors" if resource.errors[:display_name].present? %>">
+        <%= f.label :credited_name, "Real Name (optional)" %><small class="errored"><%= resource.errors[:display_name].join(', ')%></small><br />
+        <%= f.text_field :display_name, class: 'form-control' %>
+        <small>We’ll use this to give you credit in scientific papers, posters, etc</small>
+      </div>
+
+      <div class="form-group <%= "has-errors" if resource.errors[:email].present? %>">
+        <%= f.label :email, "Email (required)"%><small class="errored"><%= resource.errors[:email].join(', ')%></small><br />
+        <%= f.email_field :email, required: true, class: 'form-control' %>
+      </div>
+
+      <div class="form-group" >
+        <%= f.label :password, "Password (required)"%><small class="errored"><%= resource.errors[:password].join(', ')%></small><br />
+        <%= f.password_field :password, autocomplete: "off", required: true, class: 'form-control' %>
+
+        <%= f.label :password_confirmation, "Password confirmation (required)" %><small class="errored"><%= resource.errors[:password_confirmation].join(', ')%></small><br />
+        <%= f.password_field :password_confirmation, autocomplete: "off", required: true, class: 'form-control' %>
+      </div>
+
+      <div class="checkbox" >
+        <label for="privacy">
+          <input name="privacy" id="privacy" type="checkbox" />
+          I have read and agreed to the <a href="https://www.zooniverse.org/privacy">Privacy Policy</a>
+        </label>
+      </div>
+
+        <div class="checkbox">
+          <%= f.label :global_email_communication do %>
+            <%= f.check_box :global_email_communication, checked: true %>
+            It’s okay to send me email every once in a while.
+          <% end %>
         </div>
 
-        <div class="row" >
-        <fieldset class="fieldset--text">
-            <%= f.label :credited_name, "Real Name (optional)" %><small class="errored"><%= resource.errors[:display_name].join(', ')%></small><br />
-            <%= f.text_field :display_name %>
-            <small>We’ll use this to give you credit in scientific papers, posters, etc</small>
-        </fieldset>
+        <div class="checkbox">
+          <%= f.label :beta_email_communication do %>
+            <%= f.check_box :beta_email_communication, checked: false %>
+            I’d like to help test new projects, and be emailed when they’re available.
+          <% end %>
         </div>
 
-        <div class="row" >
-        <fieldset class="fieldset--email">
-            <%= f.label :email, "Email (required)"%><small class="errored"><%= resource.errors[:email].join(', ')%></small><br />
-            <%= f.email_field :email, required: true %>
-        </fieldset>
-        </div>
-
-        <div class="row" >
-        <fieldset class="fieldset--password">
-            <%= f.label :password, "Password (required)"%><small class="errored"><%= resource.errors[:password].join(', ')%></small><br />
-            <%= f.password_field :password, autocomplete: "off", required: true %>
-        </fieldset>
-
-        <fieldset class="fieldset--password">
-            <%= f.label :password_confirmation, "Password confirmation (required)" %><small class="errored"><%= resource.errors[:password_confirmation].join(', ')%></small><br />
-            <%= f.password_field :password_confirmation, autocomplete: "off", required: true %>
-        </fieldset>
-        </div>
-
-        <div class="row" >
-            <fieldset class="fieldset--email">
-                <input name="privacy" type="checkbox" />
-                <label for="privacy">I have read and agreed to the <a href="https://www.zooniverse.org/privacy">Privacy Policy</a></label><br />
-
-                <%= f.check_box :global_email_communication, checked: true %>
-                <%= f.label :global_email_communication, "It’s okay to send me email every once in a while."  %><br />
-
-                <%= f.check_box :beta_email_communication, checked: false %>
-                <%= f.label :beta_email_communication, "I’d like to help test new projects, and be emailed when they’re available." %><br />
-            </fieldset>
-        </div>
-
-        <div class="submit-container"><%= f.submit "Sign up" %></div>
+      <%= f.submit "Create account", class: 'btn btn-primary' %>
     <% end %>
+  </div>
 
+  <div class="panel-footer">
     <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,23 +1,25 @@
-<div class="form-container">
-  <h2>Sign in</h2>
+<div class="form-container panel panel-default">
+  <div class="panel-body">
+    <h2>Sign in</h2>
 
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "form form--new-session"}) do |f| %>
-    <fieldset class="fieldset--text">
-      <%= f.label :login, "Username or Email Address" %><br />
-      <%= f.text_field :login, autofocus: true, required: true %>
-    </fieldset>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "form form--new-session"}) do |f| %>
+      <fieldset class="fieldset--text">
+        <%= f.label :login, "Username or Email Address" %><br />
+        <%= f.text_field :login, autofocus: true, required: true %>
+      </fieldset>
 
-    <fieldset class="fieldset--password">
-      <%= f.label :password %><br />
-      <%= f.password_field :password, autocomplete: "off" %>
-    </fieldset>
+      <fieldset class="fieldset--password">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "off" %>
+      </fieldset>
 
-    <% if devise_mapping.rememberable? -%>
-      <fieldset class="fieldset--remember"><%= f.check_box :remember_me %> <%= f.label :remember_me %></fieldset>
-    <% end -%>
+      <% if devise_mapping.rememberable? -%>
+        <fieldset class="fieldset--remember"><%= f.check_box :remember_me %> <%= f.label :remember_me %></fieldset>
+      <% end -%>
 
-    <div class="submit-container"><%= f.submit "Sign in" %></div>
-  <% end %>
+      <div class="submit-container"><%= f.submit "Sign in" %></div>
+    <% end %>
 
-  <%= render "devise/shared/links" %>
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -1,4 +1,4 @@
-<nav class="devise-shared-links">
+<nav class="devise-shared-links clearfix">
 
   <div class="oauth-links">
     <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
@@ -30,7 +30,7 @@
     <% end -%>
 
     <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-      <%= link_to "Sign up", new_registration_path(resource_name), class: 'devise-shared-link sign-up-link' %>
+      <%= link_to "Create account", new_registration_path(resource_name), class: 'devise-shared-link sign-up-link' %>
     <% end -%>
   </div>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,9 +30,11 @@ Rails.application.routes.draw do
     post "/users/sign_in" => "sessions#create", as: :user_session
     delete "/users/sign_out" => "sessions#destroy", as: :destroy_user_session
 
+    get '/profile' => 'registrations#edit', as: :edit_user_registration
     get "/users/sign_up" => "registrations#new", as: :new_user_registration
     post "/users" => "registrations#create", as: :user_registration
     put "/users" => "registrations#update"
+    delete "/users" => "registrations#destroy", as: :destroy_user_registration
   end
 
   get "unsubscribe", to: "emails#unsubscribe_via_token"

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -357,6 +357,11 @@ describe RegistrationsController, type: :controller do
           expect(flash[:notice]).to be_present
         end
 
+        it 'signs out the user' do
+          expect(controller).to receive(:sign_out)
+          delete :destroy, user: {current_password: password}
+        end
+
         it 'deactivates the user' do
           delete :destroy, user: {current_password: password}
           expect(user.reload.active?).to be_falsey

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -384,8 +384,6 @@ describe RegistrationsController, type: :controller do
           resource.memberships |
           resource.collections
       end
-
-      # it_behaves_like "is deactivatable"
     end
   end
 end


### PR DESCRIPTION
I think that it might be easiest to keep features like these in Panoptes as HTML rather than APIs. That way we enforce consistency across frontends.

* Renamed "sign up" to "create account". The suble distinction between "sign up" and "sign in" confuses me every time I look at this screen.

![image](https://user-images.githubusercontent.com/277/40230352-1e781cc4-5a8f-11e8-8b3c-090d5eda0533.png)

![image](https://user-images.githubusercontent.com/277/40232224-e02599ae-5a95-11e8-9bef-5356a35e62ce.png)

![image](https://user-images.githubusercontent.com/277/40232242-ec8f3e3e-5a95-11e8-8c71-19bd834e8ff8.png)


Closes #2410 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
