### PR TITLE
disable spring in docker compose envs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ panoptes:
     - "ATTENTION_REDIS_URL=redis://redis:6379/1"
     - "BUNDLE_PATH=/gem_cache"
     - "BUNDLE_BIN=/gem_cache/bin"
+    - "DISABLE_SPRING=true"
   links:
     - redis:redis
     - postgres:pg


### PR DESCRIPTION
rails console can't start with gem path errors with spring, disable spring to avoid this. Seems there is a PR in to fix this but it hasn't been merged yet, https://github.com/rails/spring/pull/546#issuecomment-382812781

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
