### PR TITLE
Refresh workflow worker deadlock issues

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -4,7 +4,17 @@ class CalculateProjectCompletenessWorker
   include Sidekiq::Worker
   using Refinements::RangeClamping
 
-  sidekiq_options queue: :data_medium
+  sidekiq_options congestion: {
+    interval: 300,
+    max_in_interval: 1,
+    min_delay: 300,
+    reject_with: :cancel,
+    key: ->(project_id) {
+      "calc_project_completeness_worker#{project_id}"
+    }
+  }
+
+  sidekiq_options queue: :data_medium, unique: :until_executed
 
   def perform(project_id)
     project = Project.find(project_id)

--- a/app/workers/refresh_workflow_status_worker.rb
+++ b/app/workers/refresh_workflow_status_worker.rb
@@ -15,11 +15,9 @@ class RefreshWorkflowStatusWorker
 
   def perform(workflow_id)
     workflow = Workflow.find(workflow_id)
-    # run these in band and in order to ensure
-    # we don't have state race conditions
-    # between workers and/or db transactions
+    # run the first worker manually to ensure we don't have state race
+    # conditions between workers and/or db transactions
     UnfinishWorkflowWorker.new.perform(workflow.id)
-    WorkflowRetiredCountWorker.new.perform(workflow.id)
-    CalculateProjectCompletenessWorker.new.perform(workflow.project_id)
+    WorkflowRetiredCountWorker.perform_async(workflow.id)
   end
 end

--- a/app/workers/refresh_workflow_status_worker.rb
+++ b/app/workers/refresh_workflow_status_worker.rb
@@ -4,7 +4,7 @@ class RefreshWorkflowStatusWorker
   sidekiq_options congestion: {
     interval: 15,
     max_in_interval: 1,
-    min_delay: 0,
+    min_delay: 15,
     reject_with: :reschedule,
     key: ->(workflow_id) {
       "refresh_worklow_status_worker_#{workflow_id}"

--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -14,7 +14,7 @@ class RetireSubjectWorker
       end
     end
 
-    RefreshWorkflowStatusWorker.perform_async(workflow.id)
+    WorkflowRetiredCountWorker.perform_async(workflow.id)
 
     subject_ids.each do |subject_id|
       NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)

--- a/app/workers/workflow_retired_count_worker.rb
+++ b/app/workers/workflow_retired_count_worker.rb
@@ -24,5 +24,7 @@ class WorkflowRetiredCountWorker
     if workflow.finished_at.nil? && workflow.finished?
       Workflow.where(id: workflow.id).update_all(finished_at: Time.now)
     end
+
+    CalculateProjectCompletenessWorker.perform_async(workflow.project_id)
   end
 end

--- a/spec/workers/refresh_workflow_status_worker_spec.rb
+++ b/spec/workers/refresh_workflow_status_worker_spec.rb
@@ -3,24 +3,13 @@ require 'spec_helper'
 RSpec.describe RefreshWorkflowStatusWorker do
   let(:worker) { described_class.new }
   let(:workflow) { create(:workflow) }
-  let(:unfinish_worker_double) { double(:peform) }
-  let(:retired_count_worker_double) { double(:peform) }
-  let(:completeness_worker_double) { double(:peform) }
-  let(:klass_doubles) do
-    {
-      UnfinishWorkflowWorker => unfinish_worker_double,
-      WorkflowRetiredCountWorker => retired_count_worker_double,
-      CalculateProjectCompletenessWorker => completeness_worker_double
-    }
-  end
 
   describe "#perform" do
+    let(:unfinish_worker_double) { double(:peform) }
     before do
-      klass_doubles.each do |klass, double|
-        allow(klass)
-          .to receive(:new)
-          .and_return(double)
-      end
+      allow(UnfinishWorkflowWorker)
+      .to receive(:new)
+      .and_return(unfinish_worker_double)
     end
 
     it "should call a chain of ordered workers" do
@@ -28,13 +17,9 @@ RSpec.describe RefreshWorkflowStatusWorker do
         .to receive(:perform)
         .with(workflow.id)
         .ordered
-      expect(retired_count_worker_double)
-        .to receive(:perform)
+      expect(WorkflowRetiredCountWorker)
+        .to receive(:perform_async)
         .with(workflow.id)
-        .ordered
-      expect(completeness_worker_double)
-        .to receive(:perform)
-        .with(workflow.project_id)
         .ordered
       worker.perform(workflow.id)
     end

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RetireSubjectWorker do
     end
 
     it 'queues a workflow retired counter' do
-      expect(RefreshWorkflowStatusWorker).to receive(:perform_async).with(workflow.id)
+      expect(WorkflowRetiredCountWorker).to receive(:perform_async).with(workflow.id)
       worker.perform(workflow.id, [sms.subject_id])
     end
 

--- a/spec/workers/workflow_retired_count_worker_spec.rb
+++ b/spec/workers/workflow_retired_count_worker_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe WorkflowRetiredCountWorker do
       expect(WorkflowCounter).to receive(:new).with(workflow).and_return(counter)
       worker.perform(workflow.id)
     end
+
+    it 'should schedule a project completeness calculation worker' do
+      expect(CalculateProjectCompletenessWorker)
+        .to receive(:perform_async)
+        .with(workflow.project_id)
+      worker.perform(workflow.id)
+    end
   end
 
   describe "finishing workflows" do


### PR DESCRIPTION
Reduce the workflow deadlocks scope and count things less during retirement and set link events.  This will now rely on the retired count worker to call the project completeness worker to update the stats more regularly combined with more restrictive congestion rate limits on count workers to avoid concurrent workflow updates.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
