### PR TITLE
Remove save reloads on updates

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -126,9 +126,7 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   def add_relation(resource, relation, value)
     if relation == :retired_subjects && value.is_a?(Array)
-      resource.save!
       value.each {|id| resource.retire_subject(id) }
-      resource.reload
     else
       super
     end
@@ -137,9 +135,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   def new_items(resource, relation, value)
     case relation
     when :retired_subjects, 'retired_subjects'
-      resource.save!
       value.flat_map {|id| resource.retire_subject(id) }
-      resource.reload
     when :subject_sets, 'subject_sets'
       items = construct_new_items(super(resource, relation, value), resource.project_id)
       if items.any? { |item| item.is_a?(SubjectSet) }


### PR DESCRIPTION
workflow retired_subjects link shoud not update the resource. Avoid saving and reloading via link management on this relation.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
