### PR TITLE
only recount and notify if a subject retires

### DIFF
--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -5,19 +5,25 @@ class RetireSubjectWorker
 
   def perform(workflow_id, subject_ids, reason=nil)
     workflow = Workflow.find(workflow_id)
+    retired_subjects = 0
+
     Workflow.transaction do
       subject_ids.each do |subject_id|
         begin
-          workflow.retire_subject(subject_id, reason)
+          if workflow.retire_subject(subject_id, reason)
+            retired_subjects += 1
+          end
         rescue ActiveRecord::RecordInvalid
         end
       end
     end
 
-    WorkflowRetiredCountWorker.perform_async(workflow.id)
+    if retired_subjects > 0
+      WorkflowRetiredCountWorker.perform_async(workflow.id)
 
-    subject_ids.each do |subject_id|
-      NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
+      subject_ids.each do |subject_id|
+        NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
+      end
     end
   rescue ActiveRecord::RecordNotFound
   end

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RetireSubjectWorker do
       }.to raise_error(RuntimeError, 'some error')
     end
 
-    context "with a retired subject" do
+    context "when given subjects are all already retired" do
       before do
         count.update_columns(retirement_reason: "blank", retired_at: Time.zone.now)
       end

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -35,24 +35,46 @@ RSpec.describe RetireSubjectWorker do
       expect(count.reload.retired_at).not_to be_nil
     end
 
-    it 'queues a workflow retired counter' do
-      expect(WorkflowRetiredCountWorker).to receive(:perform_async).with(workflow.id)
+    it 'should ignore unknown subjects' do
+      expect(count.reload.retired_at).to be_nil
+      worker.perform(workflow.id, [-1, sms.subject_id])
+      expect(count.reload.retired_at).not_to be_nil
+    end
+
+    it 'queues a notify selector retirement' do
+      expect(NotifySubjectSelectorOfRetirementWorker).to receive(:perform_async).with(sms.subject_id, workflow.id)
       worker.perform(workflow.id, [sms.subject_id])
     end
 
-    it 'queues a cellect retirement if the workflow uses cellect' do
-      expect(NotifySubjectSelectorOfRetirementWorker).to receive(:perform_async).with(sms.subject_id, workflow.id)
+    it 'queues a retired count worker' do
+      expect(WorkflowRetiredCountWorker).to receive(:perform_async).with(workflow.id)
       worker.perform(workflow.id, [sms.subject_id])
     end
 
     it 'does not queue workers if something went wrong' do
       allow(Workflow).to receive(:find).and_return(workflow)
       allow(workflow).to receive(:retire_subject).with(sms.subject_id, nil) { raise "some error" }
-      expect(RefreshWorkflowStatusWorker).not_to receive(:perform_async)
+      expect(WorkflowRetiredCountWorker).not_to receive(:perform_async)
       expect(NotifySubjectSelectorOfRetirementWorker).not_to receive(:perform_async)
       expect {
         worker.perform(workflow.id, [sms.subject_id])
       }.to raise_error(RuntimeError, 'some error')
+    end
+
+    context "with a retired subject" do
+      before do
+        count.update_columns(retirement_reason: "blank", retired_at: Time.zone.now)
+      end
+
+      it 'should not queue a notify selector retirement' do
+        expect(NotifySubjectSelectorOfRetirementWorker).not_to receive(:perform_async)
+        worker.perform(workflow.id, [sms.subject_id])
+      end
+
+      it 'should not queue a retired count worker' do
+        expect(WorkflowRetiredCountWorker).not_to receive(:perform_async)
+        worker.perform(workflow.id, [sms.subject_id])
+      end
     end
   end
 end


### PR DESCRIPTION
Avoid extra work if the subject is already retired. Do not run retired count worker of notify the selector services if the subject is already retired.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
