### PR TITLE
Consolidate retirement worker behaviour

### DIFF
--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -1,30 +1,28 @@
 class RetireSubjectWorker
   include Sidekiq::Worker
+  attr_reader :workflow
 
   sidekiq_options queue: :high
 
   def perform(workflow_id, subject_ids, reason=nil)
-    workflow = Workflow.find(workflow_id)
-    retired_subjects = 0
-
-    Workflow.transaction do
-      subject_ids.each do |subject_id|
-        begin
-          if workflow.retire_subject(subject_id, reason)
-            retired_subjects += 1
-          end
-        rescue ActiveRecord::RecordInvalid
-        end
-      end
+    begin
+      @workflow = Workflow.find(workflow_id)
+    rescue ActiveRecord::RecordNotFound
+      return nil
     end
 
-    if retired_subjects > 0
-      WorkflowRetiredCountWorker.perform_async(workflow.id)
-
-      subject_ids.each do |subject_id|
-        NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
-      end
+    Array.wrap(subject_ids).each do |subject_id|
+      count = subject_workflow_status(subject_id)
+      RetirementWorker.perform_async(count.id, reason)
     end
-  rescue ActiveRecord::RecordNotFound
+  end
+
+  private
+
+  def subject_workflow_status(subject_id)
+    workflow
+    .subject_workflow_statuses
+    .where(subject_id: subject_id)
+    .first_or_create!
   end
 end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -3,10 +3,10 @@ class RetirementWorker
 
   sidekiq_options queue: :high
 
-  def perform(status_id)
-    status = load_subject_workflow_status(status_id)
+  def perform(status_id, reason="classification_count")
+    status = SubjectWorkflowStatus.where(id: status_id).first
     if status&.retire?
-      status.retire!("classification_count")
+      status.retire!(reason)
 
       workflow_id = status.workflow_id
       WorkflowRetiredCountWorker.perform_async(workflow_id)
@@ -14,11 +14,5 @@ class RetirementWorker
       NotifySubjectSelectorOfRetirementWorker
         .perform_async(status.subject_id, workflow_id)
     end
-  end
-
-  private
-
-  def load_subject_workflow_status(status_id)
-    SubjectWorkflowStatus.where(id: status_id).eager_load(:workflow).first
   end
 end

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -7,74 +7,31 @@ RSpec.describe RetireSubjectWorker do
   let(:sms) { subject.set_member_subjects.first }
   let(:set) { sms.subject_set }
   let(:sms2) { create(:set_member_subject, subject_set: set) }
-  let!(:count) { create(:subject_workflow_status, subject: subject, workflow: workflow) }
+  let(:count) { create(:subject_workflow_status, subject: subject, workflow: workflow) }
+  let(:count2) { create(:subject_workflow_status, subject: sms2.subject, workflow: workflow) }
   let(:subject_ids) { [sms.subject_id, sms2.subject_id] }
 
   describe "#perform" do
-    it 'should retire the subject for the workflow' do
-      expect(count.reload.retired_at).to be_nil
+    it 'should handle an unknow workflow' do
+      expect { worker.perform(-1, subject.id) }.not_to raise_error
+    end
+
+    it 'should call the retirement worker with the subject workflow status resource' do
+      expect(RetirementWorker).to receive(:perform_async).with(count.id, nil).ordered
+      expect(RetirementWorker).to receive(:perform_async).with(count2.id, nil).ordered
       worker.perform(workflow.id, subject_ids)
-      expect(count.reload.retired_at).not_to be_nil
     end
 
-    it 'should retire the subject for the workflow with a reason' do
+    it 'should pass the reason to the retirement worker' do
       reason = "nothing_here"
-      worker.perform(workflow.id, subject_ids, reason)
-      expect(count.reload.retirement_reason).to eq(reason)
+      expect(RetirementWorker).to receive(:perform_async).with(count.id, reason)
+      worker.perform(workflow.id, subject.id, reason)
     end
 
-    it 'should ignore unknown workflows' do
-      expect(count.reload.retired_at).to be_nil
-      worker.perform(-1, subject_ids)
-      expect(count.reload.retired_at).to be_nil
-    end
-
-    it 'should ignore unknown subjects' do
-      expect(count.reload.retired_at).to be_nil
-      worker.perform(workflow.id, [-1, sms.subject_id])
-      expect(count.reload.retired_at).not_to be_nil
-    end
-
-    it 'should ignore unknown subjects' do
-      expect(count.reload.retired_at).to be_nil
-      worker.perform(workflow.id, [-1, sms.subject_id])
-      expect(count.reload.retired_at).not_to be_nil
-    end
-
-    it 'queues a notify selector retirement' do
-      expect(NotifySubjectSelectorOfRetirementWorker).to receive(:perform_async).with(sms.subject_id, workflow.id)
-      worker.perform(workflow.id, [sms.subject_id])
-    end
-
-    it 'queues a retired count worker' do
-      expect(WorkflowRetiredCountWorker).to receive(:perform_async).with(workflow.id)
-      worker.perform(workflow.id, [sms.subject_id])
-    end
-
-    it 'does not queue workers if something went wrong' do
-      allow(Workflow).to receive(:find).and_return(workflow)
-      allow(workflow).to receive(:retire_subject).with(sms.subject_id, nil) { raise "some error" }
-      expect(WorkflowRetiredCountWorker).not_to receive(:perform_async)
-      expect(NotifySubjectSelectorOfRetirementWorker).not_to receive(:perform_async)
+    it 'should raise if there is a problem creating the sws resource' do
       expect {
-        worker.perform(workflow.id, [sms.subject_id])
-      }.to raise_error(RuntimeError, 'some error')
-    end
-
-    context "when given subjects are all already retired" do
-      before do
-        count.update_columns(retirement_reason: "blank", retired_at: Time.zone.now)
-      end
-
-      it 'should not queue a notify selector retirement' do
-        expect(NotifySubjectSelectorOfRetirementWorker).not_to receive(:perform_async)
-        worker.perform(workflow.id, [sms.subject_id])
-      end
-
-      it 'should not queue a retired count worker' do
-        expect(WorkflowRetiredCountWorker).not_to receive(:perform_async)
-        worker.perform(workflow.id, [sms.subject_id])
-      end
+        worker.perform(workflow.id, -1)
+      }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RetirementWorker do
   let(:workflow) { create :workflow, subject_sets: [sms.subject_set] }
   let(:count) { create(:subject_workflow_status, subject: sms.subject, workflow: workflow) }
 
-  describe "#perform" do
+  describe "#perform"  do
     context "sms is retireable" do
       before(:each) do
         allow_any_instance_of(SubjectWorkflowStatus).to receive(:retire?).and_return(true)
@@ -18,10 +18,23 @@ RSpec.describe RetirementWorker do
         expect(sms.retired_workflows).to include(workflow)
       end
 
-      it 'should record a reason for retirement' do
+      it 'should record a default reason for retirement' do
         expect { worker.perform(count) }.to change {
           count.reload.retirement_reason
         }.to("classification_count")
+      end
+
+      it 'should record the reason for retirement' do
+        reason = "nothing_here"
+        expect { worker.perform(count, reason) }.to change {
+          count.reload.retirement_reason
+        }.to(reason)
+      end
+
+      it 'should allow a nil reason for retirement' do
+        expect { worker.perform(count, nil) }.not_to change {
+          count.reload.retirement_reason
+        }
       end
 
       it 'should call the workflow retired counter worker' do
@@ -46,6 +59,23 @@ RSpec.describe RetirementWorker do
       end
     end
 
+    shared_examples "it does not run the post retirement workers" do
+      it 'should not queue a notify selector retirement' do
+        expect(NotifySubjectSelectorOfRetirementWorker).not_to receive(:perform_async)
+        worker.perform(count)
+      end
+
+      it 'should not queue a retired count worker' do
+        expect(WorkflowRetiredCountWorker).not_to receive(:perform_async)
+        worker.perform(count)
+      end
+
+      it "should not call the publish retire event worker" do
+        expect(PublishRetirementEventWorker).not_to receive(:perform_async)
+        worker.perform(count.id)
+      end
+    end
+
     context "sms is not retireable" do
       it 'should not retire subject for the workflow' do
         allow_any_instance_of(SubjectWorkflowStatus).to receive(:retire?).and_return(false)
@@ -53,6 +83,8 @@ RSpec.describe RetirementWorker do
         sms.reload
         expect(sms.retired_workflows).to_not include(workflow)
       end
+
+      it_behaves_like "it does not run the post retirement workers"
     end
 
     context 'when the sms is already retired' do
@@ -65,6 +97,8 @@ RSpec.describe RetirementWorker do
         expect(count).to_not receive :retire!
         worker.perform count.id
       end
+
+      it_behaves_like "it does not run the post retirement workers"
     end
   end
 end


### PR DESCRIPTION
Avoid 2 retirement workers (1 via the custom API & one from classification receipt) and consolidate on one for the retirement behaviour. 

The `RetireSubjectWorker` will still be called from the operation and will find or create the `subject workflow status` resource and pass this to the retirement worker. This allows us to consolidate behaviour on the `RetirementWorker` for post retirement behaviour (counting, notifications, publishing) in one worker.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
