### PR TITLE
move puma to phased restarts

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,4 @@
+# For more information: https://github.com/puma/puma/blob/master/examples/config.rb
 app_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
 
 pidfile "#{app_path}/tmp/pids/server.pid"
@@ -14,15 +15,6 @@ end
 
 bind "tcp://0.0.0.0:#{port}"
 
-# Code to run before doing a restart. This code should
-# close log files, database connections, etc.
-#
-# This can be called multiple times to add code each time.
-#
-# on_restart do
-#   puts 'On restart...'
-# end
-
 # === Cluster mode ===
 case rails_env
 when "production"
@@ -33,38 +25,5 @@ when "staging"
   threads 0,4
 end
 
-# Code to run when a worker boots to setup the process before booting
-# the app.
-#
-# This can be called multiple times to add hooks.
-#
-on_worker_boot do
-  ActiveSupport.on_load(:active_record) do
-    ActiveRecord::Base.establish_connection
-  end
-end
-
-before_fork do
-  ActiveRecord::Base.connection_pool.disconnect!
-end
-
-preload_app!
-
 # Additional text to display in process listing
-#
 tag 'panoptes_api'
-#
-# If you do not specify a tag, Puma will infer it. If you do not want Puma
-# to add a tag, use an empty string.
-
-# Verifies that all workers have checked in to the master process within
-# the given timeout. If not the worker process will be restarted. Default
-# value is 60 seconds.
-#
-# worker_timeout 60
-
-# Change the default worker timeout for booting
-#
-# If unspecified, this defaults to the value of worker_timeout.
-#
-# worker_boot_timeout 60

--- a/scripts/docker/restart_puma.sh
+++ b/scripts/docker/restart_puma.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# simple script to hot restart puma, https://github.com/puma/puma#restart
-# e.g. docker exec -it 'panoptes_container_name' bash -c "/rails_app/scripts/docker/restart_puma.sh"
-pkill -F tmp/pids/server.pid -USR2
+# https://github.com/puma/puma#restart
+# simple script to phase restart the puma workers to avoid any downtime
+# e.g. docker-compose exec panoptes scripts/docker/restart_puma.sh"
+pkill -F tmp/pids/server.pid -USR1


### PR DESCRIPTION
switch from preloading app via master with COW memory savings to standard workers that can be phase restarted. This cleans up the worker / boot hooks to avoid connection management as any worker will contain the connection information it needs.

One thing to note is that this will use a bit more RAM than before as we don't fork from a common master process.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
