### PR TITLE
Respect set workflow links in subject dumps

### DIFF
--- a/spec/factories/subject_sets.rb
+++ b/spec/factories/subject_sets.rb
@@ -1,13 +1,17 @@
 FactoryBot.define do
   factory :subject_set do
+    transient do
+      num_workflows 1
+    end
+
     sequence(:display_name) { |n| "Subject Set #{n}" }
 
     metadata({ just_some: "stuff" })
     project
 
-    after(:create) do |ss|
-      if ss.workflows.empty?
-        create_list(:workflow, 1, subject_sets: [ss])
+    after(:create) do |ss, evaluator|
+      if ss.workflows.empty? && evaluator.num_workflows
+        create_list(:workflow, evaluator.num_workflows, subject_sets: [ss])
       end
     end
 


### PR DESCRIPTION
Fixes a bug in the subjects export that reported a row for each project workflow without checking if that subject was linked to that workflow. This will now print a row for each uniq subject set / workflow link including any non-linked subjects the project may have.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
