### PR TITLE
move a paused project to active if there is data to classify

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -27,6 +27,8 @@ class CalculateProjectCompletenessWorker
       columns_to_update = { completeness: completeness }
       if completeness.to_i == 1
         columns_to_update[:state] = Project.states[:paused]
+      elsif project.paused?
+        columns_to_update[:state] = Project.states[:active]
       end
 
       project.update_columns(columns_to_update)

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -83,7 +83,33 @@ describe CalculateProjectCompletenessWorker do
         .and_return([double(completeness: 0.91)])
       end
 
-      it "should not move a non-finished project to paused" do
+      it "should not move the project to paused" do
+        expect {
+          worker.perform(project)
+        }.not_to change {
+          project.state
+        }
+      end
+
+      it "should move a paused project to active" do
+        project.paused!
+        expect {
+          worker.perform(project)
+        }.to change {
+          project.reload.attributes["state"]
+        }.to(nil)
+      end
+
+      it "should not move an active project to active" do
+        expect {
+          worker.perform(project)
+        }.not_to change {
+          project.state
+        }
+      end
+
+      it "should not move a finished project to active" do
+        project.finished!
         expect {
           worker.perform(project)
         }.not_to change {


### PR DESCRIPTION
closes #2772 - when projects link new data and the completeness metric resets we should also remove the paused project state so it's active again

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
