### PR TITLE
touch the project to clear the serializer cachesafter updating completeness 

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -30,6 +30,7 @@ class CalculateProjectCompletenessWorker
       end
 
       project.update_columns(columns_to_update)
+      project.touch
     end
   rescue ActiveRecord::RecordNotFound
     nil

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -108,4 +108,15 @@ describe CalculateProjectCompletenessWorker do
       end
     end
   end
+
+  describe "project touch timestamp" do
+    before do
+      allow(Project).to receive(:find).and_return(project)
+    end
+
+    it "should touch the project timestamp on update" do
+      expect(project).to receive(:touch).once
+      worker.perform(project)
+    end
+  end
 end


### PR DESCRIPTION
closes #2242 - when we update the completeness metric and activity states we should flush the serializer cache so the UI updates.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
