### PR TITLE
Avoid db fetch of the whole workflow in the retire operation

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def retire_subjects
-    operation.with(workflow: controlled_resource).run!(params)
+    operation.run!(params)
     render nothing: true, status: 204
   end
 

--- a/app/operations/workflows/retire_subjects.rb
+++ b/app/operations/workflows/retire_subjects.rb
@@ -6,9 +6,9 @@ module Workflows
       in: SubjectWorkflowStatus.retirement_reasons.keys,
       allow_nil: true
     }
+    validates :workflow_id, presence: true
 
-    object :workflow
-
+    integer :workflow_id
     integer :subject_id, default: nil
     array :subject_ids, default: [] do
       integer
@@ -17,7 +17,7 @@ module Workflows
 
     def execute
       return if subject_ids.empty?
-      RetireSubjectWorker.perform_async(workflow.id, subject_ids, retirement_reason)
+      RetireSubjectWorker.perform_async(workflow_id, subject_ids, retirement_reason)
     end
 
     def subject_ids

--- a/spec/operations/workflows/retire_subjects_spec.rb
+++ b/spec/operations/workflows/retire_subjects_spec.rb
@@ -6,14 +6,20 @@ describe Workflows::RetireSubjects do
   let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
   let(:subject_set_id) { subject_set.id }
   let(:subject1) { create(:subject, subject_sets: [subject_set]) }
-
+  let(:params) do
+    {
+      workflow_id: workflow.id,
+      subject_id: subject1.id,
+      retirement_reason: "other"
+    }
+  end
   let(:operation) { described_class.with(api_user: api_user) }
 
   it "should call the retire subject worker with the subject_id" do
     expect(RetireSubjectWorker)
       .to receive(:perform_async)
       .with(workflow.id, [ subject1.id ], "other")
-    operation.run! workflow: workflow, subject_id: subject1.id, retirement_reason: "other"
+    operation.run!(params)
   end
 
   it "should call the retire subject worker with the subject_ids" do
@@ -22,23 +28,29 @@ describe Workflows::RetireSubjects do
     expect(RetireSubjectWorker)
       .to receive(:perform_async)
       .with(workflow.id, subject_ids, nil)
-    operation.run! workflow: workflow, subject_ids: subject_ids
+    run_params = params.except(:subject_id, :retirement_reason)
+    operation.run!(run_params.merge(subject_ids: subject_ids))
   end
 
   it 'rewrites the reason blank to nothing here' do
     expect(RetireSubjectWorker)
       .to receive(:perform_async)
       .with(workflow.id, [subject1.id], "nothing_here")
-    operation.run! workflow: workflow, subject_id: subject1.id, retirement_reason: "blank"
+    operation.run!(params.merge(retirement_reason: "blank"))
   end
 
-  it 'is invalid with an invalid retirement reason' do
-    result = operation.run workflow: workflow, subject_id: subject1.id, retirement_reason: "nope"
+  it 'is invalid with a missing workflow_id param' do
+    result = operation.run(params.except(:workflow_id))
     expect(result).not_to be_valid
   end
 
-  it 'is valid with a missing parameter' do
-    result = operation.run workflow: workflow, subject_id: subject1.id
+  it 'is invalid with an invalid retirement reason' do
+    result = operation.run(params.merge(retirement_reason: "nope"))
+    expect(result).not_to be_valid
+  end
+
+  it 'is valid with an allowed missing parameter' do
+    result = operation.run(params.except(:retirement_reason))
     expect(result).to be_valid
   end
 end


### PR DESCRIPTION
When retiring subjects we can use the `params[:workflow_id]` instead of the workflow resource in the operation. 

The authorization scheme will still issue a check via `controlled_resources.exists?` which is a count query on the db to ensure we have access to retire subjects for a given workflow. As we only use the `workflow_id` attribute and don't need the whole workflow, we can avoid paying the cost to serialize and instantiate this data from the db. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
