### PR TITLE
avoid repeat loading of the workflow resource in RetireSubjectWorker

### DIFF
--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -1,28 +1,28 @@
 class RetireSubjectWorker
   include Sidekiq::Worker
-  attr_reader :workflow
+  attr_reader :workflow_id
 
   sidekiq_options queue: :high
 
   def perform(workflow_id, subject_ids, reason=nil)
-    begin
-      @workflow = Workflow.find(workflow_id)
-    rescue ActiveRecord::RecordNotFound
-      return nil
-    end
-
-    Array.wrap(subject_ids).each do |subject_id|
-      count = subject_workflow_status(subject_id)
-      RetirementWorker.perform_async(count.id, reason)
+    @workflow_id = workflow_id
+    if workflow_exists?
+      Array.wrap(subject_ids).each do |subject_id|
+        count = subject_workflow_status(subject_id)
+        RetirementWorker.perform_async(count.id, reason)
+      end
     end
   end
 
   private
 
+  def workflow_exists?
+    Workflow.where(id: workflow_id).exists?
+  end
+
   def subject_workflow_status(subject_id)
-    workflow
-    .subject_workflow_statuses
-    .where(subject_id: subject_id)
+    SubjectWorkflowStatus
+    .where(workflow_id: workflow_id, subject_id: subject_id)
     .first_or_create!
   end
 end


### PR DESCRIPTION
Follow up to #2785 - we really only want to know if the workflow exists we don’t need the whole resource to do this in the RetireSubjectWorker. 

I am going to look at our workers and how they use the workflow resource as we could be serializing more data over the wire and from the db than we currently need / use. 

However littering the code with `Workflow.select(:id, :project_id, ..).find(id)` is not ideal and will probably mean we miss it in the future. It may be easier to just slice the task object to it's own model and `accept_nested_attributes` from the workflow to deal with this. That way we can safely use the workflow resource and ensure we pre/eager_load the tasks association for the serializers.

This may also be a time to think about how to better store these json task definitions and if they should be in the db at all, should we instead slice them out to a media resource in aws instead? Something to think about, in the meantime this PR is a start on avoiding lots of db fetches we don't use. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
