### PR TITLE
ensure a finished project doesn't change state automatically

### DIFF
--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -4,7 +4,6 @@ describe CalculateProjectCompletenessWorker do
   let(:worker) { described_class.new }
   let(:project) { create :project }
 
-
   it "should fail quickly when it can't find the project" do
     expect(Project).not_to receive(:transaction)
     worker.perform("-1")

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -89,9 +89,9 @@ describe CalculateProjectCompletenessWorker do
       it "should not move the project to paused" do
         expect {
           worker.perform(project)
-        }.not_to change {
-          project.state
-        }
+        }.not_to(
+          change { project.state }
+        )
       end
 
       it "should move a paused project to active" do
@@ -106,9 +106,9 @@ describe CalculateProjectCompletenessWorker do
       it "should not move an active project to active" do
         expect {
           worker.perform(project)
-        }.not_to change {
-          project.state
-        }
+        }.not_to(
+          change { project.state }
+        )
       end
 
       context "with a finished project" do
@@ -119,18 +119,18 @@ describe CalculateProjectCompletenessWorker do
         it "should not move to active" do
           expect {
             worker.perform(project)
-          }.not_to change {
-            project.state
-          }
+          }.not_to(
+            change { project.state }
+          )
         end
 
         it "should not move a complete project to paused" do
           allow(worker).to receive(:project_completeness).and_return(1.0)
           expect {
             worker.perform(project)
-          }.not_to change {
-            project.state
-          }
+          }.not_to(
+            change { project.state }
+          )
         end
       end
     end

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -4,26 +4,30 @@ describe CalculateProjectCompletenessWorker do
   let(:worker) { described_class.new }
   let(:project) { create :project }
 
-  describe '#project_completeness' do
-    it 'returns the average of the workflow completenesses' do
-      project = double(active_workflows: [
-        double(completeness: 1),
-        double(completeness: 0)
-      ])
 
-      expect(worker.project_completeness(project)).to eq(0.5)
+  it "should fail quickly when it can't find the project" do
+    expect(Project).not_to receive(:transaction)
+    worker.perform("-1")
+  end
+
+  describe '#project_completeness' do
+    let(:project) do
+      double(
+        active_workflows: [ double(completeness: 1), double(completeness: 0) ]
+      )
+    end
+    before do
+      allow(worker).to receive(:project).and_return(project)
     end
 
-    context "when it can't find the project" do
-      it "should fail quickly" do
-        expect(Project).not_to receive(:transaction)
-        worker.perform("-1")
-      end
+    it 'returns the average of the workflow completenesses' do
+      expect(worker.project_completeness).to eq(0.5)
     end
 
     context "when a project has no active workflows" do
       it "should set to 0.0" do
-        expect(worker.project_completeness(project)).to eq(0.0)
+        allow(project).to receive(:active_workflows).and_return([])
+        expect(worker.project_completeness).to eq(0.0)
       end
     end
   end
@@ -108,13 +112,27 @@ describe CalculateProjectCompletenessWorker do
         }
       end
 
-      it "should not move a finished project to active" do
-        project.finished!
-        expect {
-          worker.perform(project)
-        }.not_to change {
-          project.state
-        }
+      context "with a finished project" do
+        before do
+          project.finished!
+        end
+
+        it "should not move to active" do
+          expect {
+            worker.perform(project)
+          }.not_to change {
+            project.state
+          }
+        end
+
+        it "should not move a complete project to paused" do
+          allow(worker).to receive(:project_completeness).and_return(1.0)
+          expect {
+            worker.perform(project)
+          }.not_to change {
+            project.state
+          }
+        end
       end
     end
 


### PR DESCRIPTION
Don't automatically change a finished project's state, allow this to be a place we archive projects manually from the paused state.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
