### PR TITLE
Ensure we retire subject from custom retirement api end point

### DIFF
--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -9,7 +9,7 @@ class RetireSubjectWorker
     if workflow_exists?
       Array.wrap(subject_ids).each do |subject_id|
         count = subject_workflow_status(subject_id)
-        RetirementWorker.perform_async(count.id, reason)
+        RetirementWorker.perform_async(count.id, true, reason)
       end
     end
   end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -5,14 +5,15 @@ class RetirementWorker
 
   def perform(status_id, reason="classification_count", force_retire: false)
     status = SubjectWorkflowStatus.find(status_id)
-    if status.retire?
+    not_retired = !status.retired?
+    if (force_retire && not_retired) || status.retire?
       status.retire!(reason)
 
-      workflow_id = status.workflow_id
-      WorkflowRetiredCountWorker.perform_async(workflow_id)
-      PublishRetirementEventWorker.perform_async(workflow_id)
-      NotifySubjectSelectorOfRetirementWorker
-        .perform_async(status.subject_id, workflow_id)
+      WorkflowRetiredCountWorker.perform_async(status.workflow_id)
+      PublishRetirementEventWorker.perform_async(status.workflow_id)
+      NotifySubjectSelectorOfRetirementWorker.perform_async(
+        status.subject_id, status.workflow_id
+      )
     end
   rescue ActiveRecord::RecordNotFound
   end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -3,9 +3,9 @@ class RetirementWorker
 
   sidekiq_options queue: :high
 
-  def perform(status_id, reason="classification_count")
-    status = SubjectWorkflowStatus.where(id: status_id).first
-    if status&.retire?
+  def perform(status_id, reason="classification_count", force_retire: false)
+    status = SubjectWorkflowStatus.find(status_id)
+    if status.retire?
       status.retire!(reason)
 
       workflow_id = status.workflow_id
@@ -14,5 +14,6 @@ class RetirementWorker
       NotifySubjectSelectorOfRetirementWorker
         .perform_async(status.subject_id, workflow_id)
     end
+  rescue ActiveRecord::RecordNotFound
   end
 end

--- a/app/workers/retirement_worker.rb
+++ b/app/workers/retirement_worker.rb
@@ -3,7 +3,7 @@ class RetirementWorker
 
   sidekiq_options queue: :high
 
-  def perform(status_id, reason="classification_count", force_retire: false)
+  def perform(status_id, force_retire=false, reason="classification_count")
     status = SubjectWorkflowStatus.find(status_id)
     not_retired = !status.retired?
     if (force_retire && not_retired) || status.retire?

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -17,14 +17,22 @@ RSpec.describe RetireSubjectWorker do
     end
 
     it 'should call the retirement worker with the subject workflow status resource' do
-      expect(RetirementWorker).to receive(:perform_async).with(count.id, nil).ordered
-      expect(RetirementWorker).to receive(:perform_async).with(count2.id, nil).ordered
+      expect(RetirementWorker)
+        .to receive(:perform_async)
+        .with(count.id, true, nil)
+        .ordered
+      expect(RetirementWorker)
+        .to receive(:perform_async)
+        .with(count2.id, true, nil)
+        .ordered
       worker.perform(workflow.id, subject_ids)
     end
 
     it 'should pass the reason to the retirement worker' do
       reason = "nothing_here"
-      expect(RetirementWorker).to receive(:perform_async).with(count.id, reason)
+      expect(RetirementWorker)
+        .to receive(:perform_async)
+        .with(count.id, true, reason)
       worker.perform(workflow.id, subject.id, reason)
     end
 

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe RetirementWorker do
   let(:worker) { described_class.new }
   let(:sms) { create :set_member_subject }
   let(:workflow) { create :workflow, subject_sets: [sms.subject_set] }
-  let(:count) { create(:subject_workflow_status, subject: sms.subject, workflow: workflow) }
-  let(:setup_count_find) do
-    allow(SubjectWorkflowStatus).to receive(:find).with(count.id).and_return(count)
+  let(:status) { create(:subject_workflow_status, subject: sms.subject, workflow: workflow) }
+  let(:setup_status_find) do
+    allow(SubjectWorkflowStatus).to receive(:find).with(status.id).and_return(status)
   end
 
   describe "#perform" do
@@ -19,90 +19,90 @@ RSpec.describe RetirementWorker do
 
     context "sms is retireable" do
       before(:each) do
-        allow(count).to receive(:retire?).and_return(true)
-        setup_count_find
+        allow(status).to receive(:retire?).and_return(true)
+        setup_status_find
       end
 
       it 'should retire the subject for the workflow' do
-        worker.perform(count.id)
+        worker.perform(status.id)
         sms.reload
         expect(sms.retired_workflows).to include(workflow)
       end
 
       it 'should record a default reason for retirement' do
-        expect { worker.perform(count.id) }.to change {
-          count.reload.retirement_reason
+        expect { worker.perform(status.id) }.to change {
+          status.reload.retirement_reason
         }.to("classification_count")
       end
 
       it 'should record the reason for retirement' do
         reason = "nothing_here"
-        expect { worker.perform(count.id, reason) }.to change {
-          count.reload.retirement_reason
+        expect { worker.perform(status.id, reason) }.to change {
+          status.reload.retirement_reason
         }.to(reason)
       end
 
       it 'should allow a nil reason for retirement' do
-        expect { worker.perform(count.id, nil) }.not_to change {
-          count.reload.retirement_reason
+        expect { worker.perform(status.id, nil) }.not_to change {
+          status.reload.retirement_reason
         }
       end
 
-      it 'should call the workflow retired counter worker' do
+      it 'should call the workflow retired statuser worker' do
         expect(WorkflowRetiredCountWorker)
           .to receive(:perform_async)
-          .with(count.workflow.id)
-        worker.perform(count.id)
+          .with(status.workflow.id)
+        worker.perform(status.id)
       end
 
       it "should call the publish retire event worker" do
         expect(PublishRetirementEventWorker)
           .to receive(:perform_async)
           .with(workflow.id)
-        worker.perform(count.id)
+        worker.perform(status.id)
       end
 
       it "should notify the subject selector" do
         expect(NotifySubjectSelectorOfRetirementWorker)
           .to receive(:perform_async)
           .with(sms.subject_id, workflow.id)
-        worker.perform(count.id)
+        worker.perform(status.id)
       end
     end
 
     shared_examples "it does not run the post retirement workers" do
       it 'should not queue a notify selector retirement' do
         expect(NotifySubjectSelectorOfRetirementWorker).not_to receive(:perform_async)
-        worker.perform(count.id)
+        worker.perform(status.id)
       end
 
-      it 'should not queue a retired count worker' do
+      it 'should not queue a retired status worker' do
         expect(WorkflowRetiredCountWorker).not_to receive(:perform_async)
-        worker.perform(count.id)
+        worker.perform(status.id)
       end
 
       it "should not call the publish retire event worker" do
         expect(PublishRetirementEventWorker).not_to receive(:perform_async)
-        worker.perform(count.id)
+        worker.perform(status.id)
       end
     end
 
     context "sms is not retireable" do
       before do
-        allow(count).to receive(:retire?).and_return(false)
-        setup_count_find
+        allow(status).to receive(:retire?).and_return(false)
+        setup_status_find
       end
 
       it 'should not retire subject for the workflow' do
-        worker.perform(count.id)
+        worker.perform(status.id)
         sms.reload
         expect(sms.retired_workflows).to_not include(workflow)
       end
 
       context "with a force_retire param" do
         it "should retire the subject" do
-          expect(count).to receive(:retire!).with("classification_count")
-          worker.perform(count.id, force_retire: true)
+          expect(status).to receive(:retire!).with("classification_count")
+          worker.perform(status.id, force_retire: true)
         end
       end
 
@@ -111,19 +111,19 @@ RSpec.describe RetirementWorker do
 
     context 'when the sms is already retired' do
       before(:each) do
-        allow(count).to receive(:retired_at).and_return 1.minute.ago.utc
-        setup_count_find
+        allow(status).to receive(:retired_at).and_return 1.minute.ago.utc
+        setup_status_find
       end
 
       it 'should not retire the subject for the workflow' do
-        expect(count).to_not receive :retire!
-        worker.perform count.id
+        expect(status).to_not receive :retire!
+        worker.perform status.id
       end
 
       context "with a force_retire param" do
         it "should not retire the subject" do
-          expect(count).not_to receive(:retire!)
-          worker.perform(count.id, force_retire: true)
+          expect(status).not_to receive(:retire!)
+          worker.perform(status.id, force_retire: true)
         end
       end
 

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -100,6 +100,13 @@ RSpec.describe RetirementWorker do
       end
 
       it_behaves_like "it does not run the post retirement workers"
+
+      context "with a force_retire param" do
+        it "should retire the subject" do
+          expect(count).to receive(:retire!).with("classification_count")
+          worker.perform(count.id, force_retire: true)
+        end
+      end
     end
 
     context 'when the sms is already retired' do

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -99,14 +99,14 @@ RSpec.describe RetirementWorker do
         expect(sms.retired_workflows).to_not include(workflow)
       end
 
-      it_behaves_like "it does not run the post retirement workers"
-
       context "with a force_retire param" do
         it "should retire the subject" do
           expect(count).to receive(:retire!).with("classification_count")
           worker.perform(count.id, force_retire: true)
         end
       end
+
+      it_behaves_like "it does not run the post retirement workers"
     end
 
     context 'when the sms is already retired' do
@@ -118,6 +118,13 @@ RSpec.describe RetirementWorker do
       it 'should not retire the subject for the workflow' do
         expect(count).to_not receive :retire!
         worker.perform count.id
+      end
+
+      context "with a force_retire param" do
+        it "should not retire the subject" do
+          expect(count).not_to receive(:retire!)
+          worker.perform(count.id, force_retire: true)
+        end
       end
 
       it_behaves_like "it does not run the post retirement workers"

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RetirementWorker do
   end
 
   describe "#perform" do
-
     it "should ignore any missing SubjectWorkflowStatus resources" do
       expect{
         worker.perform(-1)

--- a/spec/workers/retirement_worker_spec.rb
+++ b/spec/workers/retirement_worker_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe RetirementWorker do
 
       it 'should record the reason for retirement' do
         reason = "nothing_here"
-        expect { worker.perform(status.id, reason) }.to change {
+        expect { worker.perform(status.id, false, reason) }.to change {
           status.reload.retirement_reason
         }.to(reason)
       end
 
       it 'should allow a nil reason for retirement' do
-        expect { worker.perform(status.id, nil) }.not_to change {
+        expect { worker.perform(status.id, false, nil) }.not_to change {
           status.reload.retirement_reason
         }
       end
@@ -101,7 +101,7 @@ RSpec.describe RetirementWorker do
       context "with a force_retire param" do
         it "should retire the subject" do
           expect(status).to receive(:retire!).with("classification_count")
-          worker.perform(status.id, force_retire: true)
+          worker.perform(status.id, true)
         end
       end
 
@@ -122,7 +122,7 @@ RSpec.describe RetirementWorker do
       context "with a force_retire param" do
         it "should not retire the subject" do
           expect(status).not_to receive(:retire!)
-          worker.perform(status.id, force_retire: true)
+          worker.perform(status.id, true)
         end
       end
 


### PR DESCRIPTION
Linked to changes in #2773 - force the retirement operation when calling it via the API instead of relying on the retirement checks on the `SubjectWorkflowStatus` resource. 

Noting that i forgot that sidekiq doesn't handle keyword parameters but luckily i remembered just in time. Still had to have two bites at this..Also some changes here are me renaming the `count` testing resource to `status` and some formatting in `spec/workers/retirement_worker_spec.rb`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
