### PR TITLE
add unique rate limiting to requeue classifications worker

### DIFF
--- a/app/workers/requeue_classifications_worker.rb
+++ b/app/workers/requeue_classifications_worker.rb
@@ -2,7 +2,7 @@ class RequeueClassificationsWorker
   include Sidekiq::Worker
   include Sidetiq::Schedulable
 
-  sidekiq_options queue: :data_medium
+  sidekiq_options queue: :data_medium, unique: :until_executed
 
   recurrence { hourly.minute_of_hour(0, 15, 30, 45)}
 


### PR DESCRIPTION
ensure we don't queue multiple requeue workers at any given time, especially if the query execution time is slow.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
