### PR TITLE
remove set_member_subject scope lookups on all subject selections

### DIFF
--- a/lib/subjects/cellect_selector.rb
+++ b/lib/subjects/cellect_selector.rb
@@ -37,9 +37,7 @@ module Subjects
     def get_subjects(user, group_id, limit)
       return unless enabled?
 
-      subject_ids = self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
-      sms_scope = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id)
-      sms_scope.pluck("set_member_subjects.id")
+      self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
     end
 
     def enabled?

--- a/lib/subjects/complete_remover.rb
+++ b/lib/subjects/complete_remover.rb
@@ -1,23 +1,23 @@
 module Subjects
   class CompleteRemover
 
-    attr_reader :user, :workflow, :sms_ids
+    attr_reader :user, :workflow, :subject_ids
 
-    def initialize(user, workflow, sms_ids)
+    def initialize(user, workflow, subject_ids)
       @user = user
       @workflow = workflow
-      @sms_ids = sms_ids
+      @subject_ids = subject_ids
     end
 
     def incomplete_ids
-      return sms_ids if sms_ids.empty?
-      sms_ids - retired_seen_ids
+      return subject_ids if subject_ids.empty?
+      subject_ids - retired_seen_ids
     end
 
     private
 
     def retired_seen_ids
-      Set.new(retired_seen_scope.pluck(:id)).to_a
+      Set.new(retired_seen_scope.pluck(:subject_id)).to_a
     end
 
     def retired_seen_scope
@@ -29,11 +29,13 @@ module Subjects
     end
 
     def retired_scope
-      SetMemberSubject.retired_for_workflow(workflow).where(set_member_subjects: {id: sms_ids})
+      SetMemberSubject
+      .retired_for_workflow(workflow)
+      .where(set_member_subjects: {subject_id: subject_ids})
     end
 
     def seen_scope
-      SetMemberSubject.where(id: sms_ids, subject_id: user_seen_ids)
+      SetMemberSubject.where(subject_id: user_seen_ids)
     end
 
     def user_seens

--- a/lib/subjects/designator_selector.rb
+++ b/lib/subjects/designator_selector.rb
@@ -33,10 +33,7 @@ module Subjects
     def get_subjects(user, group_id, limit)
       return [] unless enabled?
 
-      subject_ids = self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
-      return [] unless subject_ids.present?
-      raise "Hacking attempt" unless subject_ids.all? { |i| i.is_a? Integer }
-      subject_ids
+      self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
     end
 
     def enabled?

--- a/lib/subjects/designator_selector.rb
+++ b/lib/subjects/designator_selector.rb
@@ -36,11 +36,7 @@ module Subjects
       subject_ids = self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
       return [] unless subject_ids.present?
       raise "Hacking attempt" unless subject_ids.all? { |i| i.is_a? Integer }
-
-      sms_scope = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id)
-        .order("idx(array[#{subject_ids.join(',')}], set_member_subjects.subject_id)")
-
-      sms_scope.pluck("set_member_subjects.id")
+      subject_ids
     end
 
     def enabled?

--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -9,7 +9,7 @@ module Subjects
     def any_workflow_data
       any_workflow_data_scope
         .limit(limit)
-        .pluck("set_member_subjects.id")
+        .pluck("set_member_subjects.subject_id")
         .shuffle
     end
 

--- a/lib/subjects/postgresql_in_order_selection.rb
+++ b/lib/subjects/postgresql_in_order_selection.rb
@@ -14,7 +14,7 @@ module Subjects
       .where(id: available)
       .order(priority: :asc)
       .limit(limit)
-      .pluck(:id)
+      .pluck(:subject_id)
     end
   end
 end

--- a/lib/subjects/postgresql_random_selection.rb
+++ b/lib/subjects/postgresql_random_selection.rb
@@ -10,7 +10,7 @@ module Subjects
     end
 
     def select
-      ids = available_scope.pluck(:id).sample(limit)
+      ids = available_scope.pluck(:subject_id).sample(limit)
       if reassign_random?
         RandomOrderShuffleWorker.perform_async(ids)
       end

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -63,6 +63,8 @@ module Subjects
     end
 
     def active_subjects_in_selection_order(subject_ids)
+      # when on Rails 5 - move to .order(["idx(array[?]), id", subject_ids])
+      # instead of manually checking and raising
       unless subject_ids.all? { |i| i.is_a? Integer }
         raise MalformedSelectedIds.new(
           "Selector returns non-integers, hacking attempt?!"

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -5,6 +5,7 @@ module Subjects
     class MissingParameter < StandardError; end
     class MissingSubjectSet < StandardError; end
     class MissingSubjects < StandardError; end
+    class MalformedSelectedIds < StandardError; end
 
     attr_reader :user, :params, :workflow, :scope
 
@@ -62,6 +63,12 @@ module Subjects
     end
 
     def active_subjects_in_selection_order(subject_ids)
+      unless subject_ids.all? { |i| i.is_a? Integer }
+        raise MalformedSelectedIds.new(
+          "Selector returns non-integers, hacking attempt?!"
+        )
+      end
+
       scope
       .active
       .where(id: subject_ids)

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -21,16 +21,20 @@ module Subjects
     end
 
     def selected_subjects
-      sms_ids = run_strategy_selection unless workflow.finished_at
-      sms_ids = fallback_selection if sms_ids.blank?
-      active_subjects_in_selection_order(sms_ids)
+      unless workflow.finished_at
+        subject_ids = run_strategy_selection
+      end
+
+      if subject_ids.blank?
+        subject_ids = fallback_selection
+      end
+
+      active_subjects_in_selection_order(subject_ids)
     end
 
     private
 
     def run_strategy_selection
-      eventlog.info "Selecting subjects based on workflow config", workflow_id: workflow.id, user_id: user&.id
-
       Subjects::StrategySelection.new(
         workflow,
         user,
@@ -40,44 +44,30 @@ module Subjects
     end
 
     def fallback_selection
-      msg = if workflow.finished_at
-        "Skipped selection for the finished workflow"
-      else
-        "Preferred strategy returned no results, trying fallback"
-      end
-      eventlog.info msg, workflow_id: workflow.id, user_id: user&.id
-
       opts = { limit: subjects_page_size, subject_set_id: subject_set_id }
       fallback_selector = PostgresqlSelection.new(workflow, user, opts)
 
-      sms_ids = fallback_selector.select
-      if data_available = !sms_ids.empty?
-        if Panoptes.flipper[:cellect_sync_error_reload].enabled?
+      subject_ids = fallback_selector.select
+      if data_available = !subject_ids.empty?
+        if Panoptes.flipper[:selector_sync_error_reload].enabled?
           NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)
         end
-        Honeybadger.notify(
-          error_class:   "Subject selector data sync error",
-          error_message: "Primary subject selector returns no data but PG selector does",
-          context: {
-            workflow: workflow.id
-          }
-        )
       end
 
-      if sms_ids.blank?
-        eventlog.info "Fallback failed to return unseen unretired data, falling back to selecting anything", workflow_id: workflow.id, user_id: user&.id
+      if subject_ids.blank?
         fallback_selector.any_workflow_data
       else
-        sms_ids
+        subject_ids
       end
     end
 
-    def active_subjects_in_selection_order(sms_ids)
-      scope.active
-        .eager_load(:set_member_subjects)
-        .where(set_member_subjects: {id: sms_ids})
-        .order("idx(array[#{sms_ids.join(',')}], set_member_subjects.id)")
+    def active_subjects_in_selection_order(subject_ids)
+      scope
+      .active
+      .where(id: subject_ids)
+      .order("idx(array[#{subject_ids.join(',')}], id)")
     end
+
 
     def needs_set_id?
       workflow.grouped && !params.has_key?(:subject_set_id)

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -68,7 +68,6 @@ module Subjects
       .order("idx(array[#{subject_ids.join(',')}], id)")
     end
 
-
     def needs_set_id?
       workflow.grouped && !params.has_key?(:subject_set_id)
     end

--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -17,7 +17,7 @@ module Subjects
     end
 
     def select
-      used_strategy, selected_ids = select_sms_ids
+      used_strategy, selected_ids = select_subject_ids
       eventlog.info("Selected subjects", used_strategy: used_strategy, subject_ids: selected_ids)
 
       selected_ids = selected_ids.compact
@@ -32,7 +32,7 @@ module Subjects
 
     private
 
-    def select_sms_ids
+    def select_subject_ids
       select_with(desired_selector)
     rescue CellectClient::ConnectionError, DesignatorClient::GenericError
       select_with(default_selector)

--- a/spec/lib/subjects/complete_remover_spec.rb
+++ b/spec/lib/subjects/complete_remover_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe Subjects::CompleteRemover do
   let(:append_subject_ids) { (1..10).to_a | subject_ids }
   let(:workflow) { create(:workflow) }
   let(:user) { workflow.project.owner }
-  let(:sms) { create(:set_member_subject) }
-  let(:subject_ids) { [ sms.subject_id ] }
-
-  subject { described_class.new(user, workflow, append_subject_ids) }
+  let(:subject) { create(:subject) }
+  let(:subject_ids) { [ subject.id ] }
+  let(:complete_remover) do
+    described_class.new(user, workflow, append_subject_ids)
+  end
 
   describe "#incomplete_ids"  do
-    let(:result) { subject.incomplete_ids }
+    let(:result) { complete_remover.incomplete_ids }
 
     it "should return the whole set if there are no seen or retired subjects" do
       expect(result).to match_array(append_subject_ids)
@@ -27,9 +28,9 @@ RSpec.describe Subjects::CompleteRemover do
 
     context "with seen subjects" do
 
-      it "should return the diff set when seens match inputs", :focus do
+      it "should return the diff set when seens match inputs" do
         create(:user_seen_subject, user: user, workflow: workflow, subject_ids: subject_ids)
-        expected = append_sms_ids - sms_ids
+        expected = append_subject_ids - subject_ids
         expect(result).to match_array(expected)
       end
     end
@@ -37,20 +38,19 @@ RSpec.describe Subjects::CompleteRemover do
     context "with retired subjects" do
 
       it "should return the diff set when retired match inputs" do
-        create(:subject_workflow_status, subject: sms.subject, workflow: workflow, retired_at: DateTime.now)
-        expected = append_sms_ids - sms_ids
+        create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: Time.now)
+        expected = append_subject_ids - subject_ids
         expect(result).to match_array(expected)
       end
     end
 
     context "with retired and seen subjects" do
-      let(:another_sms) { create(:set_member_subject) }
-      let(:sms_ids) { [ sms.id, another_sms.id ] }
+      let(:another_subject) { create(:subject) }
 
       it "should return the non retired seen set " do
-        create(:subject_workflow_status, subject: another_sms.subject, workflow: workflow, retired_at: DateTime.now)
+        create(:subject_workflow_status, subject: another_subject, workflow: workflow, retired_at: Time.now)
         create(:user_seen_subject, user: user, workflow: workflow, subject_ids: subject_ids)
-        expected = append_sms_ids - sms_ids
+        expected = append_subject_ids - [ subject.id, another_subject.id ]
         expect(result).to match_array(expected)
       end
     end

--- a/spec/lib/subjects/complete_remover_spec.rb
+++ b/spec/lib/subjects/complete_remover_spec.rb
@@ -1,24 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe Subjects::CompleteRemover do
-  let(:append_sms_ids) { (1..10).to_a | sms_ids }
+  let(:append_subject_ids) { (1..10).to_a | subject_ids }
   let(:workflow) { create(:workflow) }
   let(:user) { workflow.project.owner }
   let(:sms) { create(:set_member_subject) }
-  let(:sms_ids) { [ sms.id ] }
-  let(:subject_ids) { [ sms.subject.id ] }
+  let(:subject_ids) { [ sms.subject_id ] }
 
-  subject { described_class.new(user, workflow, append_sms_ids) }
+  subject { described_class.new(user, workflow, append_subject_ids) }
 
-  describe "#incomplete_ids" do
+  describe "#incomplete_ids"  do
     let(:result) { subject.incomplete_ids }
 
     it "should return the whole set if there are no seen or retired subjects" do
-      expect(result).to match_array(append_sms_ids)
+      expect(result).to match_array(append_subject_ids)
     end
 
     context "with an empty set" do
-      let(:append_sms_ids){ [] }
+      let(:append_subject_ids){ [] }
 
       it "should fast return if the set is empty" do
         expect(subject).not_to receive(:retired_seen_ids)
@@ -28,7 +27,7 @@ RSpec.describe Subjects::CompleteRemover do
 
     context "with seen subjects" do
 
-      it "should return the diff set when seens match inputs" do
+      it "should return the diff set when seens match inputs", :focus do
         create(:user_seen_subject, user: user, workflow: workflow, subject_ids: subject_ids)
         expected = append_sms_ids - sms_ids
         expect(result).to match_array(expected)

--- a/spec/lib/subjects/designator_selector_spec.rb
+++ b/spec/lib/subjects/designator_selector_spec.rb
@@ -70,12 +70,6 @@ describe Subjects::DesignatorSelector do
       selector.get_subjects(user, nil, 10)
     end
 
-    it 'does not allow sql injection' do
-      allow(client).to receive(:get_subjects).with(workflow.id, 2, nil, 10).and_return([1, 2, '1], set_member_subjects.id); DROP TABLE users; -- '])
-      expect { selector.get_subjects(user, nil, 10) }
-        .to raise_error(StandardError, "Hacking attempt")
-    end
-
     it 'returns an empty array unless enabled', :aggregate_failures do
       Panoptes.flipper["designator"].disable
       expect(client).not_to receive(:get_subjects)

--- a/spec/lib/subjects/designator_selector_spec.rb
+++ b/spec/lib/subjects/designator_selector_spec.rb
@@ -70,27 +70,6 @@ describe Subjects::DesignatorSelector do
       selector.get_subjects(user, nil, 10)
     end
 
-    it 'converts subject_ids from the client into set_member_subject ids' do
-      subject_set = create(:subject_set, workflows: [workflow])
-      set_member_subjects = create_list(:set_member_subject, 5, subject_set: subject_set)
-
-      allow(client).to receive(:get_subjects).with(workflow.id, 2, nil, 10).and_return(set_member_subjects.map(&:subject_id))
-
-      set_member_subject_ids = selector.get_subjects(user, nil, 10)
-      expect(set_member_subject_ids).to eq(set_member_subjects.map(&:id))
-    end
-
-    it 'returns set_member_subject_ids in the same order that Designator returned the subject_ids' do
-      subject_set = create(:subject_set, workflows: [workflow])
-      set_member_subjects = create_list(:set_member_subject, 5, subject_set: subject_set)
-      set_member_subjects.reverse!
-
-      allow(client).to receive(:get_subjects).with(workflow.id, 2, nil, 10).and_return(set_member_subjects.map(&:subject_id))
-
-      set_member_subject_ids = selector.get_subjects(user, nil, 10)
-      expect(set_member_subject_ids).to eq(set_member_subjects.map(&:id))
-    end
-
     it 'does not allow sql injection' do
       allow(client).to receive(:get_subjects).with(workflow.id, 2, nil, 10).and_return([1, 2, '1], set_member_subjects.id); DROP TABLE users; -- '])
       expect { selector.get_subjects(user, nil, 10) }

--- a/spec/lib/subjects/fallback_selection_spec.rb
+++ b/spec/lib/subjects/fallback_selection_spec.rb
@@ -19,7 +19,7 @@ describe Subjects::FallbackSelection do
     let(:subject_set_id) { nil }
     let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
     let(:expected_ids) do
-      workflow.set_member_subjects.pluck("set_member_subjects.id")
+      workflow.set_member_subjects.pluck("set_member_subjects.subject_id")
     end
     let(:subject_ids) { selector.any_workflow_data }
 

--- a/spec/lib/subjects/postgresql_in_order_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_in_order_selection_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Subjects::PostgresqlInOrderSelection do
   end
 
   describe "priority selection" do
-    let(:ordered) { available.order(priority: :asc).pluck(:id) }
+    let(:ordered) { available.order(priority: :asc).pluck(:subject_id) }
     let(:limit) { available.size }
 
     before do

--- a/spec/lib/subjects/postgresql_in_order_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_in_order_selection_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Subjects::PostgresqlInOrderSelection do
         sms_subject = create(:subject, project: project, uploader: uploader)
         sms = create(:set_member_subject, subject: sms_subject, subject_set: subject_set, priority: -10.to_f)
         first_id = selector.select.first
-        expect(first_id).to eq(sms.id)
+        expect(first_id).to eq(sms.subject_id)
       end
     end
   end

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Subjects::PostgresqlSelection do
       end
 
       describe "priority selection" do
-        let(:ordered) { sms.order(priority: :asc).pluck(:id) }
+        let(:ordered) { sms.order(priority: :asc).pluck(:subject_id) }
         let(:limit) { ordered.size }
         let(:opts) { { limit: limit } }
 
@@ -103,7 +103,7 @@ RSpec.describe Subjects::PostgresqlSelection do
 
         it 'should only select subjects in the specified group' do
           result = subject.select
-          ordered = sms.limit(result.length).order(priority: :asc).pluck(:id)
+          ordered = sms.limit(result.length).order(priority: :asc).pluck(:subject_id)
           expect(result).to eq(ordered)
         end
       end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Subjects::Selector do
       end
     end
 
-    context "when the cellect selection strategy returns an empty set" do
+    context "when the selection strategy returns an empty set" do
       before do
         workflow.designator!
         stub_designator_client
@@ -95,19 +95,14 @@ RSpec.describe Subjects::Selector do
         subject.get_subjects
       end
 
-      it "should notify cellect to reload" do
-        Panoptes.flipper[:cellect_sync_error_reload].enable
+      it "should notify selector to reload" do
+        Panoptes.flipper[:selector_sync_error_reload].enable
         expect(NotifySubjectSelectorOfChangeWorker).to receive(:perform_async).with(workflow.id)
         subject.get_subjects
       end
 
-      it "should not notify cellect to reload if the feature is disabled" do
+      it "should not notify selector to reload if the feature is disabled" do
         expect(NotifySubjectSelectorOfChangeWorker).not_to receive(:perform_async)
-        subject.get_subjects
-      end
-
-      it "should notify us this sync error occurred" do
-        expect(Honeybadger).to receive(:notify)
         subject.get_subjects
       end
 
@@ -146,8 +141,8 @@ RSpec.describe Subjects::Selector do
 
     it "should respect the order of the sms selection" do
       ordered_sms = smses.sample(5)
-      sms_ids = ordered_sms.map(&:id)
-      expect(subject).to receive(:run_strategy_selection).and_return(sms_ids)
+      subject_ids = ordered_sms.map(&:subject_id)
+      expect(subject).to receive(:run_strategy_selection).and_return(subject_ids)
       subjects = subject.selected_subjects
       expect(ordered_sms.map(&:subject_id)).to eq(subjects.map(&:id))
     end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -146,5 +146,16 @@ RSpec.describe Subjects::Selector do
       subjects = subject.selected_subjects
       expect(ordered_sms.map(&:subject_id)).to eq(subjects.map(&:id))
     end
+
+    it 'does not allow sql injection' do
+      hacking_attempt = [1, 2, '1], set_member_subjects.id); DROP TABLE users; -- ']
+      expect(subject).to receive(:run_strategy_selection).and_return(hacking_attempt)
+      expect {
+        subject.selected_subjects
+      }.to raise_error(
+        Subjects::Selector::MalformedSelectedIds,
+        "Selector returns non-integers, hacking attempt?!"
+      )
+    end
   end
 end

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Subjects::StrategySelection do
           end
 
           it 'should not return retired subjects' do
-            expect(result).not_to include(sms.id)
+            expect(result).not_to include(sms.subject_id)
           end
 
           context "when the sms is retired for a different workflow" do
@@ -57,7 +57,7 @@ RSpec.describe Subjects::StrategySelection do
             end
 
             it 'should return all the subjects' do
-              expect(result).to include(sms.id)
+              expect(result).to include(sms.subject_id)
             end
           end
         end

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'subjects/cellect_session'
 
 RSpec.describe Subjects::StrategySelection do
   let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -93,13 +93,6 @@ RSpec.describe Subjects::StrategySelection do
           run_selection
         end
 
-        it "should use a cellect session instance for session tracking" do
-          stub_cellect_connection
-          stub_redis_connection
-          expect(Subjects::CellectSession).to receive(:new).and_call_original
-          run_selection
-        end
-
         context "when the cellect client can't reach a server" do
           it "should fall back to postgres strategy" do
             allow(CellectClient).to receive(:get_subjects)

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe Subjects::StrategySelection do
         let(:run_selection) { subject.select }
 
         before do
-          allow(Panoptes.flipper).to receive(:enabled?).with("cellect").and_return(true)
           workflow.subject_selection_strategy = "cellect"
         end
 

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Subjects::StrategySelection do
 
     context "removing completes is enabled" do
       it "should call the complete remover after selection", :aggregate_failures do
-        expect(subject).to receive(:select_sms_ids).and_return([:default, [1,2,3]]).ordered
+        expect(subject).to receive(:select_subject_ids).and_return([:default, [1,2,3]]).ordered
         expect(Subjects::CompleteRemover)
           .to receive(:new)
           .with(user, workflow, an_instance_of(Array))
@@ -35,7 +35,9 @@ RSpec.describe Subjects::StrategySelection do
         let(:result) { subject.select }
 
         before do
-          allow(subject).to receive(:select_sms_ids).and_return([:default, smses.map(&:id)])
+          allow(subject)
+          .to receive(:select_subject_ids)
+          .and_return([:default, smses.map(&:subject_id)])
         end
 
         context "retired subjects" do
@@ -68,7 +70,7 @@ RSpec.describe Subjects::StrategySelection do
           end
 
           it 'should not return seen subjects' do
-            expect(result).not_to include(sms.id)
+            expect(result).not_to include(sms.subject_id)
           end
         end
       end

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -100,14 +100,6 @@ RSpec.describe Subjects::StrategySelection do
           run_selection
         end
 
-        it "should convert the cellect subject_ids to panoptes sms_ids" do
-          allow(CellectClient).to receive(:get_subjects)
-            .and_return(result_ids)
-          expect(SetMemberSubject).to receive(:by_subject_workflow)
-            .with(result_ids, workflow.id).and_call_original
-          run_selection
-        end
-
         context "when the cellect client can't reach a server" do
           it "should fall back to postgres strategy" do
             allow(CellectClient).to receive(:get_subjects)
@@ -132,14 +124,6 @@ RSpec.describe Subjects::StrategySelection do
             .to receive(:get_subjects)
             .with(user, subject_set.id, limit)
             .and_return(result_ids)
-          run_selection
-        end
-
-        it "should convert the designator subject_ids to panoptes sms_ids" do
-          allow_any_instance_of(DesignatorClient).to receive(:get_subjects)
-            .and_return(result_ids)
-          expect(SetMemberSubject).to receive(:by_subject_workflow)
-            .with(result_ids, workflow.id).and_call_original
           run_selection
         end
       end


### PR DESCRIPTION
Consolidate selectors to return only subject ids vs the extra lookup on `SetMemberSubject` as we trust the selector services correctly deal with the links between subjects and workflows. This avoids the extra query costs to convert subject_ids to sms scopes via the external selectors which were join queries and used on every selection request. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
