### PR TITLE
avoid copy / dup on workflow tasks just to serialize them

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -73,10 +73,6 @@ class Workflow < ActiveRecord::Base
     where(project: subject_set.project)
   end
 
-  def tasks
-    read_attribute(:tasks).with_indifferent_access
-  end
-
   def retired_subjects
     subject_workflow_statuses.retired.includes(:subject).map(&:subject)
   end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -36,9 +36,8 @@ class WorkflowSerializer
 
   def tasks
     if content
-      tasks = @model.tasks.dup
-      TasksVisitors::InjectStrings.new(content.strings).visit(tasks)
-      tasks
+      TasksVisitors::InjectStrings.new(content.strings).visit(@model.tasks)
+      @model.tasks
     else
       {}
     end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -298,7 +298,7 @@ describe Api::V1::WorkflowsController, type: :controller do
       context "when the user updates help text within a task" do
         let(:update_params) do
           tasks = resource.tasks
-          tasks[:interest][:help] = "Something new"
+          tasks["interest"]["help"] = "Something new"
           {tasks: tasks}
         end
 


### PR DESCRIPTION
Avoid copying / modifying workflow task hash objects (especially large objects) just to serialize them. Instead modify the strings in place via task visitor as they won’t be updated post the serialiser stage.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
