### PR TITLE
invert the upp multi column index order

### DIFF
--- a/db/migrate/20180614131933_invert_upp_user_project_index.rb
+++ b/db/migrate/20180614131933_invert_upp_user_project_index.rb
@@ -1,0 +1,14 @@
+class InvertUppUserProjectIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :user_project_preferences,
+      %i(project_id user_id),
+      unique: true,
+      algorithm: :concurrently
+
+    remove_index :user_project_preferences,
+      column: %i(user_id project_id),
+      unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3051,10 +3051,10 @@ CREATE INDEX index_user_groups_on_private ON public.user_groups USING btree (pri
 
 
 --
--- Name: index_user_project_preferences_on_user_id_and_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_project_preferences_on_project_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX index_user_project_preferences_on_user_id_and_project_id ON public.user_project_preferences USING btree (user_id, project_id);
+CREATE UNIQUE INDEX index_user_project_preferences_on_project_id_and_user_id ON public.user_project_preferences USING btree (project_id, user_id);
 
 
 --
@@ -4148,4 +4148,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180404144531');
 INSERT INTO schema_migrations (version) VALUES ('20180510100328');
 
 INSERT INTO schema_migrations (version) VALUES ('20180510121206');
+
+INSERT INTO schema_migrations (version) VALUES ('20180614131933');
 


### PR DESCRIPTION
allow project volunteers counters to use this index as well as the search by project_id and user_id for creating / finding upps. 

Specifically https://github.com/zooniverse/Panoptes/blob/36217cd5e18cd6f23fae43006bd5a1d417ffa706/app/counters/project_counter.rb#L9 and https://github.com/zooniverse/Panoptes/blob/36217cd5e18cd6f23fae43006bd5a1d417ffa706/app/operations/user_project_preferences/find_or_create.rb#L8

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
