### PR TITLE
roll back selector changes in #2804

### DIFF
--- a/lib/subjects/cellect_selector.rb
+++ b/lib/subjects/cellect_selector.rb
@@ -37,7 +37,9 @@ module Subjects
     def get_subjects(user, group_id, limit)
       return unless enabled?
 
-      self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
+      subject_ids = self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
+      sms_scope = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id)
+      sms_scope.pluck("set_member_subjects.id")
     end
 
     def enabled?

--- a/lib/subjects/complete_remover.rb
+++ b/lib/subjects/complete_remover.rb
@@ -1,44 +1,48 @@
 module Subjects
   class CompleteRemover
 
-    attr_reader :user, :workflow, :subject_ids
+    attr_reader :user, :workflow, :sms_ids
 
-    def initialize(user, workflow, subject_ids)
+    def initialize(user, workflow, sms_ids)
       @user = user
       @workflow = workflow
-      @subject_ids = subject_ids
+      @sms_ids = sms_ids
     end
 
     def incomplete_ids
-      if subject_ids.empty?
-        subject_ids
-      else
-        subject_ids - retired_seen_subject_ids
-      end
+      return sms_ids if sms_ids.empty?
+      sms_ids - retired_seen_ids
     end
 
     private
 
-    def retired_seen_subject_ids
-      retired_subject_ids | user_seen_subject_ids
+    def retired_seen_ids
+      Set.new(retired_seen_scope.pluck(:id)).to_a
     end
 
-    def retired_subject_ids
-      SubjectWorkflowStatus
-      .where(workflow_id: workflow.id)
-      .where.not(retired_at: nil)
-      .where(subject_id: subject_ids)
-      .pluck(:subject_id)
+    def retired_seen_scope
+      if user_seen_ids.empty?
+        retired_scope
+      else
+        retired_scope.union_all(seen_scope)
+      end
     end
 
-    def user_seen_subject_ids
-      user_seen_subject = UserSeenSubject.find_by(
-        user: user,
-        workflow: workflow
-      )
+    def retired_scope
+      SetMemberSubject.retired_for_workflow(workflow).where(set_member_subjects: {id: sms_ids})
+    end
 
-      if user_seen_subject
-        user_seen_subject.subject_ids
+    def seen_scope
+      SetMemberSubject.where(id: sms_ids, subject_id: user_seen_ids)
+    end
+
+    def user_seens
+      @user_seens ||= UserSeenSubject.find_by(user: user, workflow: workflow)
+    end
+
+    def user_seen_ids
+      @user_seen_ids ||= if user_seens
+        user_seens.subject_ids
       else
         []
       end

--- a/lib/subjects/designator_selector.rb
+++ b/lib/subjects/designator_selector.rb
@@ -33,7 +33,14 @@ module Subjects
     def get_subjects(user, group_id, limit)
       return [] unless enabled?
 
-      self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
+      subject_ids = self.class.client.get_subjects(workflow.id, user.try(&:id), group_id, limit)
+      return [] unless subject_ids.present?
+      raise "Hacking attempt" unless subject_ids.all? { |i| i.is_a? Integer }
+
+      sms_scope = SetMemberSubject.by_subject_workflow(subject_ids, workflow.id)
+        .order("idx(array[#{subject_ids.join(',')}], set_member_subjects.subject_id)")
+
+      sms_scope.pluck("set_member_subjects.id")
     end
 
     def enabled?

--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -9,7 +9,7 @@ module Subjects
     def any_workflow_data
       any_workflow_data_scope
         .limit(limit)
-        .pluck("set_member_subjects.subject_id")
+        .pluck("set_member_subjects.id")
         .shuffle
     end
 

--- a/lib/subjects/postgresql_in_order_selection.rb
+++ b/lib/subjects/postgresql_in_order_selection.rb
@@ -14,7 +14,7 @@ module Subjects
       .where(id: available)
       .order(priority: :asc)
       .limit(limit)
-      .pluck(:subject_id)
+      .pluck(:id)
     end
   end
 end

--- a/lib/subjects/postgresql_random_selection.rb
+++ b/lib/subjects/postgresql_random_selection.rb
@@ -10,7 +10,7 @@ module Subjects
     end
 
     def select
-      ids = available_scope.pluck(:subject_id).sample(limit)
+      ids = available_scope.pluck(:id).sample(limit)
       if reassign_random?
         RandomOrderShuffleWorker.perform_async(ids)
       end

--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -17,7 +17,7 @@ module Subjects
     end
 
     def select
-      used_strategy, selected_ids = select_subject_ids
+      used_strategy, selected_ids = select_sms_ids
       eventlog.info("Selected subjects", used_strategy: used_strategy, subject_ids: selected_ids)
 
       selected_ids = selected_ids.compact
@@ -32,7 +32,7 @@ module Subjects
 
     private
 
-    def select_subject_ids
+    def select_sms_ids
       select_with(desired_selector)
     rescue CellectClient::ConnectionError, DesignatorClient::GenericError
       select_with(default_selector)

--- a/spec/lib/subjects/complete_remover_spec.rb
+++ b/spec/lib/subjects/complete_remover_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe Subjects::CompleteRemover do
-  let(:append_subject_ids) { (1..10).to_a | subject_ids }
+  let(:append_sms_ids) { (1..10).to_a | sms_ids }
   let(:workflow) { create(:workflow) }
   let(:user) { workflow.project.owner }
-  let(:subject) { create(:subject) }
-  let(:subject_ids) { [ subject.id ] }
-  let(:complete_remover) do
-    described_class.new(user, workflow, append_subject_ids)
-  end
+  let(:sms) { create(:set_member_subject) }
+  let(:sms_ids) { [ sms.id ] }
+  let(:subject_ids) { [ sms.subject.id ] }
 
-  describe "#incomplete_ids"  do
-    let(:result) { complete_remover.incomplete_ids }
+  subject { described_class.new(user, workflow, append_sms_ids) }
+
+  describe "#incomplete_ids" do
+    let(:result) { subject.incomplete_ids }
 
     it "should return the whole set if there are no seen or retired subjects" do
-      expect(result).to match_array(append_subject_ids)
+      expect(result).to match_array(append_sms_ids)
     end
 
     context "with an empty set" do
-      let(:append_subject_ids){ [] }
+      let(:append_sms_ids){ [] }
 
       it "should fast return if the set is empty" do
         expect(subject).not_to receive(:retired_seen_ids)
@@ -30,7 +30,7 @@ RSpec.describe Subjects::CompleteRemover do
 
       it "should return the diff set when seens match inputs" do
         create(:user_seen_subject, user: user, workflow: workflow, subject_ids: subject_ids)
-        expected = append_subject_ids - subject_ids
+        expected = append_sms_ids - sms_ids
         expect(result).to match_array(expected)
       end
     end
@@ -38,19 +38,20 @@ RSpec.describe Subjects::CompleteRemover do
     context "with retired subjects" do
 
       it "should return the diff set when retired match inputs" do
-        create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: Time.now)
-        expected = append_subject_ids - subject_ids
+        create(:subject_workflow_status, subject: sms.subject, workflow: workflow, retired_at: DateTime.now)
+        expected = append_sms_ids - sms_ids
         expect(result).to match_array(expected)
       end
     end
 
     context "with retired and seen subjects" do
-      let(:another_subject) { create(:subject) }
+      let(:another_sms) { create(:set_member_subject) }
+      let(:sms_ids) { [ sms.id, another_sms.id ] }
 
       it "should return the non retired seen set " do
-        create(:subject_workflow_status, subject: another_subject, workflow: workflow, retired_at: Time.now)
+        create(:subject_workflow_status, subject: another_sms.subject, workflow: workflow, retired_at: DateTime.now)
         create(:user_seen_subject, user: user, workflow: workflow, subject_ids: subject_ids)
-        expected = append_subject_ids - [ subject.id, another_subject.id ]
+        expected = append_sms_ids - sms_ids
         expect(result).to match_array(expected)
       end
     end

--- a/spec/lib/subjects/fallback_selection_spec.rb
+++ b/spec/lib/subjects/fallback_selection_spec.rb
@@ -19,7 +19,7 @@ describe Subjects::FallbackSelection do
     let(:subject_set_id) { nil }
     let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
     let(:expected_ids) do
-      workflow.set_member_subjects.pluck("set_member_subjects.subject_id")
+      workflow.set_member_subjects.pluck("set_member_subjects.id")
     end
     let(:subject_ids) { selector.any_workflow_data }
 

--- a/spec/lib/subjects/postgresql_in_order_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_in_order_selection_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Subjects::PostgresqlInOrderSelection do
   end
 
   describe "priority selection" do
-    let(:ordered) { available.order(priority: :asc).pluck(:subject_id) }
+    let(:ordered) { available.order(priority: :asc).pluck(:id) }
     let(:limit) { available.size }
 
     before do
@@ -41,7 +41,7 @@ RSpec.describe Subjects::PostgresqlInOrderSelection do
         sms_subject = create(:subject, project: project, uploader: uploader)
         sms = create(:set_member_subject, subject: sms_subject, subject_set: subject_set, priority: -10.to_f)
         first_id = selector.select.first
-        expect(first_id).to eq(sms.subject_id)
+        expect(first_id).to eq(sms.id)
       end
     end
   end

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Subjects::PostgresqlSelection do
       end
 
       describe "priority selection" do
-        let(:ordered) { sms.order(priority: :asc).pluck(:subject_id) }
+        let(:ordered) { sms.order(priority: :asc).pluck(:id) }
         let(:limit) { ordered.size }
         let(:opts) { { limit: limit } }
 
@@ -103,7 +103,7 @@ RSpec.describe Subjects::PostgresqlSelection do
 
         it 'should only select subjects in the specified group' do
           result = subject.select
-          ordered = sms.limit(result.length).order(priority: :asc).pluck(:subject_id)
+          ordered = sms.limit(result.length).order(priority: :asc).pluck(:id)
           expect(result).to eq(ordered)
         end
       end

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'subjects/cellect_session'
 
 RSpec.describe Subjects::StrategySelection do
   let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
@@ -19,7 +20,7 @@ RSpec.describe Subjects::StrategySelection do
 
     context "removing completes is enabled" do
       it "should call the complete remover after selection", :aggregate_failures do
-        expect(subject).to receive(:select_subject_ids).and_return([:default, [1,2,3]]).ordered
+        expect(subject).to receive(:select_sms_ids).and_return([:default, [1,2,3]]).ordered
         expect(Subjects::CompleteRemover)
           .to receive(:new)
           .with(user, workflow, an_instance_of(Array))
@@ -34,9 +35,7 @@ RSpec.describe Subjects::StrategySelection do
         let(:result) { subject.select }
 
         before do
-          allow(subject)
-          .to receive(:select_subject_ids)
-          .and_return([:default, smses.map(&:subject_id)])
+          allow(subject).to receive(:select_sms_ids).and_return([:default, smses.map(&:id)])
         end
 
         context "retired subjects" do
@@ -49,7 +48,7 @@ RSpec.describe Subjects::StrategySelection do
           end
 
           it 'should not return retired subjects' do
-            expect(result).not_to include(sms.subject_id)
+            expect(result).not_to include(sms.id)
           end
 
           context "when the sms is retired for a different workflow" do
@@ -58,7 +57,7 @@ RSpec.describe Subjects::StrategySelection do
             end
 
             it 'should return all the subjects' do
-              expect(result).to include(sms.subject_id)
+              expect(result).to include(sms.id)
             end
           end
         end
@@ -69,7 +68,7 @@ RSpec.describe Subjects::StrategySelection do
           end
 
           it 'should not return seen subjects' do
-            expect(result).not_to include(sms.subject_id)
+            expect(result).not_to include(sms.id)
           end
         end
       end
@@ -82,6 +81,7 @@ RSpec.describe Subjects::StrategySelection do
         let(:run_selection) { subject.select }
 
         before do
+          allow(Panoptes.flipper).to receive(:enabled?).with("cellect").and_return(true)
           workflow.subject_selection_strategy = "cellect"
         end
 
@@ -91,6 +91,21 @@ RSpec.describe Subjects::StrategySelection do
             .to receive(:get_subjects)
             .with(*cellect_params)
             .and_return(result_ids)
+          run_selection
+        end
+
+        it "should use a cellect session instance for session tracking" do
+          stub_cellect_connection
+          stub_redis_connection
+          expect(Subjects::CellectSession).to receive(:new).and_call_original
+          run_selection
+        end
+
+        it "should convert the cellect subject_ids to panoptes sms_ids" do
+          allow(CellectClient).to receive(:get_subjects)
+            .and_return(result_ids)
+          expect(SetMemberSubject).to receive(:by_subject_workflow)
+            .with(result_ids, workflow.id).and_call_original
           run_selection
         end
 
@@ -118,6 +133,14 @@ RSpec.describe Subjects::StrategySelection do
             .to receive(:get_subjects)
             .with(user, subject_set.id, limit)
             .and_return(result_ids)
+          run_selection
+        end
+
+        it "should convert the designator subject_ids to panoptes sms_ids" do
+          allow_any_instance_of(DesignatorClient).to receive(:get_subjects)
+            .and_return(result_ids)
+          expect(SetMemberSubject).to receive(:by_subject_workflow)
+            .with(result_ids, workflow.id).and_call_original
           run_selection
         end
       end


### PR DESCRIPTION
Revert "remove set_member_subject scope lookups on all subject selections (#2804)"

This reverts commit 36217cd5e18cd6f23fae43006bd5a1d417ffa706.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
