### PR TITLE
Fan out lifecycle work on classification associations

### DIFF
--- a/app/workers/recent_create_worker.rb
+++ b/app/workers/recent_create_worker.rb
@@ -1,0 +1,8 @@
+class RecentCreateWorker
+  include Sidekiq::Worker
+
+  def perform(classification_id)
+    classification = Classification.find(classification_id)
+    Recent.create_from_classification(classification)
+  end
+end

--- a/app/workers/user_project_preferences_worker.rb
+++ b/app/workers/user_project_preferences_worker.rb
@@ -1,0 +1,16 @@
+class UserProjectPreferencesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_high, unique: :until_executed
+
+  def perform(user_id, project_id)
+    user = User.find(user_id)
+    project = Project.find(project_id)
+
+    UserProjectPreferences::FindOrCreate.run!(
+      user: user,
+      project: project
+    )
+  rescue ActiveRecord::RecordNotFound
+  end
+end

--- a/app/workers/user_seen_subjects_worker.rb
+++ b/app/workers/user_seen_subjects_worker.rb
@@ -1,0 +1,17 @@
+class UserSeenSubjectsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_high
+
+  def perform(user_id, workflow_id, subject_ids)
+    user = User.find(user_id)
+    workflow = Workflow.find_without_json_attrs(workflow_id)
+
+    UserSeenSubject.add_seen_subjects_for_user(
+      user: user,
+      workflow: workflow,
+      subject_ids: subject_ids
+    )
+  rescue ActiveRecord::RecordNotFound
+  end
+end

--- a/spec/workers/recent_create_worker_spec.rb
+++ b/spec/workers/recent_create_worker_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe RecentCreateWorker do
+  let(:classification) { create(:classification) }
+
+  it 'should call create_from_classification' do
+    expect(Recent)
+      .to receive(:create_from_classification)
+      .with(classification)
+    subject.perform(classification.id)
+  end
+end

--- a/spec/workers/user_project_preferences_worker_spec.rb
+++ b/spec/workers/user_project_preferences_worker_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe UserProjectPreferencesWorker do
+  let(:project) { create(:project) }
+  let(:user) { project.owner }
+
+  it 'should call the operation' do
+    expect(UserProjectPreferences::FindOrCreate)
+      .to receive(:run!)
+      .with(user: user, project: project)
+    subject.perform(user.id, project.id)
+  end
+end

--- a/spec/workers/user_seen_subjects_worker_spec.rb
+++ b/spec/workers/user_seen_subjects_worker_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe UserSeenSubjectsWorker do
+  let(:workflow) { create(:workflow) }
+  let(:user) { workflow.project.owner }
+  let(:subject_ids) { [1, 2]}
+
+  it 'should call add_seen_subjects_for_user' do
+    expect(UserSeenSubject)
+      .to receive(:add_seen_subjects_for_user)
+      .with({user: user, workflow: workflow, subject_ids: subject_ids})
+    subject.perform(user.id, workflow.id, subject_ids)
+  end
+end


### PR DESCRIPTION
Avoid long running transactions, keep them focused and quick. Instead of updating the associated records in the same transaction, queue workers to create / update the associated models as fast as we can. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
