### PR TITLE
Optimize pg selection queries to be more selective

### DIFF
--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -39,7 +39,7 @@ class SetMemberSubject < ActiveRecord::Base
       .where(retired_at: nil)
       .select(:subject_id)
 
-    where(subject_id: non_retired_subject_ids)
+    by_workflow(workflow_id).where(subject_id: non_retired_subject_ids)
   end
 
   def self.retired_for_workflow(workflow_id)
@@ -48,7 +48,7 @@ class SetMemberSubject < ActiveRecord::Base
       .where.not(retired_at: nil)
       .select(:subject_id)
 
-    where(subject_id: retired_subject_ids)
+    by_workflow(workflow_id).where(subject_id: retired_subject_ids)
   end
 
   # THIS can be removed after https://github.com/zooniverse/Panoptes/pull/2805

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -53,10 +53,6 @@ class SetMemberSubject < ActiveRecord::Base
 
   # Be careful using this query as it's not selective on a large table
   # and the LEFT OUTER JOIN can take a long time to resolve
-  #
-  # Note: push this into where it's being used to ensure it's a more selective
-  # query and we don't use it on it's own
-  # After https://github.com/zooniverse/Panoptes/pull/2805 is in
   def self.unseen_for_user_by_workflow(user_id, workflow_id)
     all_sms = all_sms_for_user_by_workflow(user_id, workflow_id)
     unseen_smses = all_sms.where("seen_subject_ids.subject_id IS NULL")

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -51,14 +51,6 @@ class SetMemberSubject < ActiveRecord::Base
     by_workflow(workflow_id).where(subject_id: retired_subject_ids)
   end
 
-  # THIS can be removed after https://github.com/zooniverse/Panoptes/pull/2805
-  def self.seen_for_user_by_workflow(user_id, workflow_id)
-    all_sms = all_sms_for_user_by_workflow(user_id, workflow_id)
-    seen_smses = all_sms.where("seen_subject_ids.subject_id IS NOT NULL")
-
-    by_workflow(workflow_id).merge(seen_smses)
-  end
-
   # Be careful using this query as it's not selective on a large table
   # and the LEFT OUTER JOIN can take a long time to resolve
   #

--- a/lib/subjects/set_member_subject_selector.rb
+++ b/lib/subjects/set_member_subject_selector.rb
@@ -23,12 +23,11 @@ module Subjects
       SetMemberSubject.non_retired_for_workflow(workflow)
     end
 
-    def select_unseen_for_user
-      SetMemberSubject.unseen_for_user_by_workflow(user, workflow)
-    end
-
     def select_non_retired_unseen_for_user
-      select_unseen_for_user.merge(select_non_retired)
+      SetMemberSubject.unseen_for_user_by_workflow(
+        user,
+        workflow
+      ).merge(select_non_retired)
     end
   end
 end

--- a/spec/factories/set_member_subjects.rb
+++ b/spec/factories/set_member_subjects.rb
@@ -7,9 +7,20 @@ FactoryBot.define do
       sequence(:priority)
     end
 
-    after(:create) do |sms|
+    transient do
+      setup_subject_workflow_statuses false
+    end
+
+    after(:create) do |sms, env|
       SubjectSet.where(id: sms.subject_set_id)
         .update_all("set_member_subjects_count = set_member_subjects_count + 1")
+
+      if env.setup_subject_workflow_statuses
+        SubjectWorkflowStatus.create!(
+          subject_id: sms.subject_id,
+          workflow_id: sms.workflows.first.id
+        )
+      end
     end
   end
 end

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -20,7 +20,11 @@ RSpec.describe Subjects::PostgresqlSelection do
       uploader = create(:user)
       created_workflow = create(:workflow_with_subject_sets)
       create_list(:subject, sms_count, project: created_workflow.project, uploader: uploader).each do |subject|
-        create(:set_member_subject, subject: subject, subject_set: created_workflow.subject_sets.first)
+        create(:set_member_subject,
+          setup_subject_workflow_statuses: true,
+          subject: subject,
+          subject_set: created_workflow.subject_sets.first
+        )
       end
     end
 

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe Subjects::Selector do
   let(:workflow) { create(:workflow_with_subject_set) }
   let(:subject_set) { workflow.subject_sets.first }
   let(:user) { create(:user) }
-  let!(:smses) { create_list(:set_member_subject, 10, subject_set: subject_set).reverse }
+  let!(:smses) do
+    create_list(
+      :set_member_subject,
+      10,
+      setup_subject_workflow_statuses: true,
+      subject_set: subject_set
+    ).reverse
+  end
   let(:params) { { workflow_id: workflow.id } }
 
   subject { described_class.new(user, params) }
@@ -140,11 +147,7 @@ RSpec.describe Subjects::Selector do
   end
 
   describe '#selected_subject_ids' do
-
     it 'should return something when everything selected is retired' do
-      smses.each do |sms|
-        swc = create(:subject_workflow_status, subject: sms.subject, workflow: workflow, retired_at: Time.zone.now)
-      end
       expect(subject.selected_subject_ids.size).to be > 0
     end
 

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Subjects::Selector do
       ).update_all(
         retired_at: Time.zone.now
       )
-      expect(subject.selected_subjects.size).to be > 0
+      expect(subject.selected_subject_ids.size).to be > 0
     end
 
     it "should respect the order of the subjects from strategy selector" do

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -148,7 +148,13 @@ RSpec.describe Subjects::Selector do
 
   describe '#selected_subject_ids' do
     it 'should return something when everything selected is retired' do
-      expect(subject.selected_subject_ids.size).to be > 0
+      SubjectWorkflowStatus.where(
+        subject_id: smses.map(&:subject_id),
+        workflow_id: workflow.id
+      ).update_all(
+        retired_at: Time.zone.now
+      )
+      expect(subject.selected_subjects.size).to be > 0
     end
 
     it "should respect the order of the subjects from strategy selector" do

--- a/spec/lib/subjects/set_member_subject_selector_spec.rb
+++ b/spec/lib/subjects/set_member_subject_selector_spec.rb
@@ -104,13 +104,30 @@ describe Subjects::SetMemberSubjectSelector do
         end
       end
 
-      context "when there are set_member_subjects from another workfow" do
-        it "should only return set_member_subjects from the set workflow" do
+      context "when there are set_member_subjects from another workflow" do
+        before do
           sms = create(:set_member_subject)
-          workflow_smses = [ subject, non_retired_unseen]
-            .map(&:set_member_subjects)
-            .flatten
-          expect(sms_to_classify).to match_array(workflow_smses)
+        end
+
+        it "should not return set_member_subjects" do
+          expect(sms_to_classify).to be_empty
+        end
+
+        context "with linked subject_workflow_status records" do
+          it "should only return set_member_subjects from the workflow" do
+            workflow_smses = [ subject, non_retired_unseen]
+              .map(&:set_member_subjects)
+              .flatten
+
+            workflow_smses.each do |sms|
+              SubjectWorkflowStatus.create!(
+                subject_id: sms.subject_id,
+                workflow_id: workflow.id
+              )
+            end
+
+            expect(sms_to_classify).to match_array(workflow_smses)
+          end
         end
       end
     end

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -114,7 +114,6 @@ describe SetMemberSubject, :type => :model do
     context "when the workflow sms is retired" do
       it "should return the sms id" do
         count.retire!
-        binding.pry
         expect(SetMemberSubject.retired_for_workflow(workflow.id)).to include(sms)
       end
     end

--- a/spec/models/set_member_subject_spec.rb
+++ b/spec/models/set_member_subject_spec.rb
@@ -162,24 +162,6 @@ describe SetMemberSubject, :type => :model do
         end
       end
     end
-
-    describe ":seen_for_user_by_workflow" do
-      context "when the user has not seen any workflow subjects" do
-        let(:subject_ids) { [] }
-
-        it "should return the all the worflow set_member_subjects" do
-          expect(SetMemberSubject.seen_for_user_by_workflow(user, workflow)).to be_empty
-        end
-      end
-
-      context "when the user has seen all the workflow subjects" do
-        let(:subject_ids) { [smses.map(&:subject_id)] }
-
-        it "should return an empty set" do
-          expect(SetMemberSubject.seen_for_user_by_workflow(user, workflow)).to match_array(smses)
-        end
-      end
-    end
   end
 
   describe "#subject_set" do


### PR DESCRIPTION
The SMS table has grown significantly with our adoption. As such the left outer joins no longer scale. A few of these queries  and can consume a lot of database resources to the detriment of all our projects. This work moves away from the JOINS, specifically the LEFT OUTER JOINs to detect non-retired linked subjects as the selectivity on these joins was terrible and resolved long loops :(

Instead we now compose a simpler AREL with the unnested  seen subject ids, it no longer uses exists / not exists but instead uses a left outer join the SMS table to detect seen/unseens. This LOJ query requires a very selective scan on the SMS table to accompany it at all times. I've made a note in the code and i'm going to refactor this to ensure we only create very selective queries to ensure we can't run these accidentally. 

It also moves to sub queries to detect the currently linked workflow subjects and the retired / unretired state of the data. These sub queries create the high selectivity and are backed by an index on the SMS table. Accordingly i'm seeing these count queries resolve sub ~200ms vs time outs on the current version.

So that is much faster now but there is a catch. These queries will only detect subjects that have already been counted (have a linked `SubjectWorkflowStatus (SWS)` record). Ideally our selection services will load and serve data and thus populate the the status records and then these selectors will work. I'm going to alleviate this in another PR by ensuring that each SMS record creates a linked SWS record on import / create. Currently these get created through selection pressure, instead we will do this to ensure consistent and fast internal data selection services.

The resulting query looks as such
```
--explain analyze verbose

SELECT count(*)
FROM set_member_subjects 

-- find all the seen / unseen matches
LEFT OUTER JOIN (
  SELECT UNNEST(subject_ids) as subject_id 
  FROM user_seen_subjects 
  WHERE user_seen_subjects.user_id = 6
  AND user_seen_subjects.workflow_id = 6206
) as seen_subject_ids 
ON set_member_subjects.subject_id = seen_subject_ids.subject_id 

-- select the smses that are currently linked
WHERE set_member_subjects.subject_set_id IN (
  SELECT subject_sets_workflows.subject_set_id 
  FROM subject_sets_workflows 
  WHERE subject_sets_workflows.workflow_id = 6206
) 

-- select the not retired smses for workflow 
AND set_member_subjects.subject_id IN (
  SELECT subject_workflow_counts.subject_id 
  FROM subject_workflow_counts 
  WHERE subject_workflow_counts.workflow_id = 6206
  AND subject_workflow_counts.retired_at IS NULL
)
-- finally take all the unseen ones (invert this for the seen ones)                              
AND (seen_subject_ids.subject_id IS NULL) 
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
