### PR TITLE
Auto create SubjectWorkflowStatus records for subject selection

### DIFF
--- a/app/controllers/api/v1/set_member_subjects_controller.rb
+++ b/app/controllers/api/v1/set_member_subjects_controller.rb
@@ -36,5 +36,5 @@ class Api::V1::SetMemberSubjectsController < Api::ApiController
 
   def linked_workflow_ids(set_id)
     SubjectSetsWorkflow.where(subject_set_id: set_id).pluck(:workflow_id)
-    end
+  end
 end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -25,7 +25,14 @@ class Api::V1::SubjectSetsController < Api::ApiController
     super do |subject_set|
       notify_subject_selector(subject_set)
       reset_subject_counts(subject_set.id)
-      reset_workflow_finished_at(subject_set.workflows.pluck(:id))
+
+      subject_set.subject_sets_workflows.pluck(:workflow_id).each do |workflow_id|
+        UnfinishWorkflowWorker.perform_async(workflow_id)
+        params[:subjects].each do |subject_id|
+          SubjectWorkflowStatusCreateWorker.perform_async(subject_id, workflow_id)
+        end
+
+      end
     end
   end
 
@@ -93,12 +100,6 @@ class Api::V1::SubjectSetsController < Api::ApiController
         [ resource.id, subject_id, rand ]
       end
 
-      resource.subject_sets_workflows.pluck(:workflow_id).each do |workflow_id|
-        subject_ids_to_link.each do |subject_id|
-          SubjectWorkflowStatusCreateWorker.perform_async(subject_id, workflow_id)
-        end
-      end
-
       SetMemberSubject.import IMPORT_COLUMNS, new_sms_values, validate: false
     else
       super
@@ -131,9 +132,5 @@ class Api::V1::SubjectSetsController < Api::ApiController
 
   def reset_subject_counts(set_id)
     SubjectSetSubjectCounterWorker.perform_async(set_id)
-  end
-
-  def reset_workflow_finished_at(workflow_ids)
-    workflow_ids.map { |id| UnfinishWorkflowWorker.perform_async(id) }
   end
 end

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -92,6 +92,13 @@ class Api::V1::SubjectSetsController < Api::ApiController
       new_sms_values = subject_ids_to_link.map do |subject_id|
         [ resource.id, subject_id, rand ]
       end
+
+      resource.subject_sets_workflows.pluck(:workflow_id).each do |workflow_id|
+        subject_ids_to_link.each do |subject_id|
+          SubjectWorkflowStatusCreateWorker.perform_async(subject_id, workflow_id)
+        end
+      end
+
       SetMemberSubject.import IMPORT_COLUMNS, new_sms_values, validate: false
     else
       super

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -90,6 +90,9 @@ class Api::V1::WorkflowsController < Api::ApiController
           NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
         end
       when "subject_sets"
+        params[:subject_sets].each do |set_id|
+          SubjectSetStatusesCreateWorker.perform_async(set_id, workflow.id)
+        end
         NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)
       end
     end

--- a/app/workers/subject_set_statuses_create_worker.rb
+++ b/app/workers/subject_set_statuses_create_worker.rb
@@ -1,0 +1,24 @@
+class SubjectSetStatusesCreateWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_high, unique: :until_executed
+
+  def perform(subject_set_id, workflow_id)
+    set_is_linked_to_workflow = SubjectSetsWorkflow.where(
+      subject_set_id: subject_set_id,
+      workflow_id: workflow_id
+    ).exists?
+    return unless set_is_linked_to_workflow
+
+    linked_subject_select_scope = SetMemberSubject
+      .where(subject_set_id: subject_set_id)
+      .select(:id,:subject_id)
+
+    linked_subject_select_scope.find_each do |sms|
+      SubjectWorkflowStatusCreateWorker.perform_async(
+        sms.subject_id,
+        workflow_id
+      )
+    end
+  end
+end

--- a/app/workers/subject_workflow_status_create_worker.rb
+++ b/app/workers/subject_workflow_status_create_worker.rb
@@ -10,6 +10,6 @@ class SubjectWorkflowStatusCreateWorker
         workflow_id: workflow_id
       )
     end
-  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid
+  rescue ActiveRecord::RecordInvalid
   end
 end

--- a/app/workers/subject_workflow_status_create_worker.rb
+++ b/app/workers/subject_workflow_status_create_worker.rb
@@ -1,0 +1,15 @@
+class SubjectWorkflowStatusCreateWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_high, unique: :until_executed
+
+  def perform(subject_id, workflow_id)
+    if SetMemberSubject.by_subject_workflow(subject_id, workflow_id).exists?
+      SubjectWorkflowStatus.create!(
+        subject_id: subject_id,
+        workflow_id: workflow_id
+      )
+    end
+  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid
+  end
+end

--- a/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe Api::V1::SetMemberSubjectsController, type: :controller do
       linked_workflow_ids = subject_set.subject_sets_workflows.pluck(:workflow_id)
       linked_workflow_ids.each do |workflow_id|
         expect(SubjectWorkflowStatusCreateWorker)
-          .to receive(:perform_async)
-          .with(linked_subject.id, workflow_id)
-        end
+        .to receive(:perform_async)
+        .with(linked_subject.id, workflow_id)
+      end
       default_request user_id: authorized_user.id, scopes: scopes
       post :create, create_params
     end

--- a/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
@@ -39,13 +39,14 @@ RSpec.describe Api::V1::SetMemberSubjectsController, type: :controller do
   end
 
   describe "#create" do
+    let(:linked_subject) { create(:subject) }
     let(:test_attr) { :subject_set }
     let(:test_attr_value) { subject_set }
     let(:create_params) do
       {
         set_member_subjects: {
           links: {
-            subject: create(:subject).id.to_s,
+            subject: linked_subject.id.to_s,
             subject_set: subject_set.id.to_s
           }
         }
@@ -57,6 +58,17 @@ RSpec.describe Api::V1::SetMemberSubjectsController, type: :controller do
     it 'should call the set count worker after action' do
       default_request user_id: authorized_user.id, scopes: scopes
       expect(SubjectSetSubjectCounterWorker).to receive(:perform_async).once
+      post :create, create_params
+    end
+
+    it 'should call the sws status create worker' do
+      linked_workflow_ids = subject_set.subject_sets_workflows.pluck(:workflow_id)
+      linked_workflow_ids.each do |workflow_id|
+        expect(SubjectWorkflowStatusCreateWorker)
+          .to receive(:perform_async)
+          .with(linked_subject.id, workflow_id)
+        end
+      default_request user_id: authorized_user.id, scopes: scopes
       post :create, create_params
     end
   end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -162,9 +162,8 @@ describe Api::V1::SubjectSetsController, type: :controller do
       end
 
       it "should call SWS create worker" do
-        subject_ids = subjects.map(&:id)
         resource.workflows.each do |workflow|
-          subject_ids.each do |subject_id|
+          test_relation_ids.each do |subject_id|
             expect(SubjectWorkflowStatusCreateWorker)
             .to receive(:perform_async)
             .with(subject_id, workflow.id)

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -161,6 +161,18 @@ describe Api::V1::SubjectSetsController, type: :controller do
         run_update_links
       end
 
+      it "should call SWS create worker" do
+        subject_ids = subjects.map(&:id)
+        resource.workflows.each do |workflow|
+          subject_ids.each do |subject_id|
+            expect(SubjectWorkflowStatusCreateWorker)
+            .to receive(:perform_async)
+            .with(subject_id, workflow.id)
+          end
+        end
+        run_update_links
+      end
+
       context "when the linking resources are not persisted" do
 
         it "should return a 422 with a missing subject" do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -411,6 +411,20 @@ describe Api::V1::WorkflowsController, type: :controller do
       it_behaves_like "supports update_links"
       it_behaves_like "reloads the non logged in queues", :subject_sets
 
+      it "should call SubjectSetStatusesCreateWorker" do
+        expect(SubjectSetStatusesCreateWorker)
+        .to receive(:perform_async)
+        .with(subject_set_id, resource.id)
+
+        default_request scopes: scopes, user_id: authorized_user.id
+        params = {
+          link_relation: test_relation.to_s,
+          test_relation => test_relation_ids,
+          resource_id => resource.id
+        }
+        post :update_links, params
+      end
+
       context "when the subject_set links belong to another project" do
         let!(:subject_set_project) do
           workflows.find { |w| w.project != project }.project

--- a/spec/workers/subject_set_statuses_create_worker_spec.rb
+++ b/spec/workers/subject_set_statuses_create_worker_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe SubjectSetStatusesCreateWorker do
+  let(:worker) { described_class.new }
+  let(:subject_set) { create(:subject_set_with_subjects) }
+  let(:workflow) { subject_set.workflows.first }
+  let(:workflow_id) { workflow.id }
+  let(:subject_ids) { subject_set.set_member_subjects.pluck(:subject_id) }
+  let(:worker) do
+    SubjectSetStatusesCreateWorker.new
+  end
+
+  describe "#perform" do
+    it "should not raise if the subject set can't be found" do
+      expect {
+        worker.perform(-1, workflow_id)
+      }.not_to raise_error
+    end
+
+    it "should not raise if the workflow can't be found" do
+      expect {
+        worker.perform(subject_set.id, -1)
+      }.not_to raise_error
+    end
+
+    it "should call a SubjectWorkflowStatusCreateWorker for each subject" do
+      subject_ids.each do |subject_id|
+        expect(SubjectWorkflowStatusCreateWorker)
+          .to receive(:perform_async)
+          .with(subject_id, workflow_id)
+      end
+      worker.perform(subject_set.id, workflow_id)
+    end
+  end
+end

--- a/spec/workers/subject_workflow_status_create_worker_spec.rb
+++ b/spec/workers/subject_workflow_status_create_worker_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe SubjectWorkflowStatusCreateWorker do
+  let(:worker) { described_class.new }
+  let(:sms) do
+    create(:set_member_subject)
+  end
+  let(:workflow) { sms.workflows.first }
+  let(:workflow_id) { workflow.id }
+  let(:subject_id) { sms.subject_id }
+  let(:worker) do
+    SubjectWorkflowStatusCreateWorker.new
+  end
+
+  describe "#perform" do
+    it "should not raise if the subject can't be found" do
+      expect {
+        worker.perform(-1, workflow_id)
+      }.not_to raise_error
+    end
+
+    it "should not raise if the workflow can't be found" do
+      expect {
+        worker.perform(subject_id, -1)
+      }.not_to raise_error
+    end
+
+    it "should create a SubjectWorkflowStatus record" do
+      expect {
+        worker.perform(subject_id, workflow_id)
+      }.to change {
+        SubjectWorkflowStatus.count
+      }.by(1)
+    end
+
+    it "should create the correctly linked SubjectWorkflowStatus record" do
+      expect(
+        SubjectWorkflowStatus.where(
+          subject_id: subject_id,
+          workflow_id: workflow_id
+        ).exists?
+      ).to be_falsey
+      worker.perform(subject_id, workflow_id)
+      expect(
+        SubjectWorkflowStatus.where(
+          subject_id: subject_id,
+          workflow_id: workflow_id
+        ).exists?
+      ).to be_truthy
+    end
+
+    it "should ignore already created SubjectWorkflowStatus record" do
+      create(:subject_workflow_status, subject: sms.subject, workflow: workflow)
+      expect {
+        worker.perform(subject_id, workflow_id)
+      }.not_to change {
+        SubjectWorkflowStatus.count
+      }
+    end
+
+    it "should ignore subjects that aren't linked to the workflow" do
+      unlinked_workflow = create(:workflow)
+      expect {
+        worker.perform(subject_id, unlinked_workflow.id)
+      }.not_to change {
+        SubjectWorkflowStatus.count
+      }
+    end
+  end
+end


### PR DESCRIPTION
This will ensure the internal pg selector has the records it needs for the optimized query in #2817.

Ensure the subject workflow status records are automatically created when creating set member subjects (import via sets and on the resource) and when linking a set to a workflow (copy a set paradigm).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
