### PR TITLE
run set count workers outside the destroy transaction

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -57,6 +57,9 @@ class Api::V1::SubjectSetsController < Api::ApiController
     super do |subject_set|
       notify_subject_selector(subject_set)
       reset_subject_counts(subject_set.id)
+      reset_workflow_retired_counts(
+        subject_set.subject_sets_workflows.pluck(:workflow_id)
+      )
     end
   end
 
@@ -103,8 +106,6 @@ class Api::V1::SubjectSetsController < Api::ApiController
       linked_sms_ids = value.split(',').map(&:to_i)
       set_member_subjects = resource.set_member_subjects.where(subject_id: linked_sms_ids)
       remove_linked_set_member_subjects(set_member_subjects)
-
-      reset_workflow_retired_counts(controlled_resource.workflows.pluck(:id))
     else
       super
     end


### PR DESCRIPTION
ensure we aren’t in the transaction when the count workers run and leave us with incorrect data.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
