### PR TITLE
fix paging when filtering on login and email for users

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -17,9 +17,15 @@ class UserSerializer
 
   media_include :avatar, :profile_header
 
+  can_filter_by :login, :email
+
   preload :avatar
 
   cache_total_count true
+
+  def self.page(params = {}, scope = nil, context = {})
+    page_with_options DowncaseFilterOptions.new(self, params, scope, context)
+  end
 
   def admin
     !!@model.admin
@@ -69,5 +75,19 @@ class UserSerializer
 
   def add_links(model, data)
     data[:links] = {}
+  end
+
+  class DowncaseFilterOptions < RestPack::Serializer::Options
+    def scope_with_filters
+      scope_filter = {}
+      downcase_filters = @filters.except(:email, :login)
+
+      downcase_filters.keys.each do |filter|
+        value = query_to_array(@filters[filter])
+        scope_filter[filter] = value
+      end
+
+      @scope.where(scope_filter)
+    end
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -24,7 +24,7 @@ class UserSerializer
   cache_total_count true
 
   def self.page(params = {}, scope = nil, context = {})
-    page_with_options DowncaseFilterOptions.new(self, params, scope, context)
+    page_with_options NonCustomScopeFilterOptions.new(self, params, scope, context)
   end
 
   def admin
@@ -77,12 +77,14 @@ class UserSerializer
     data[:links] = {}
   end
 
-  class DowncaseFilterOptions < RestPack::Serializer::Options
+  class NonCustomScopeFilterOptions < RestPack::Serializer::Options
+    CUSTOM_SCOPE_FILTERS = %i(email login).freeze
+
     def scope_with_filters
       scope_filter = {}
-      downcase_filters = @filters.except(:email, :login)
 
-      downcase_filters.keys.each do |filter|
+      non_custom_filters = @filters.except(*CUSTOM_SCOPE_FILTERS)
+      non_custom_filters.keys.each do |filter|
         value = query_to_array(@filters[filter])
         scope_filter[filter] = value
       end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -228,6 +228,21 @@ describe Api::V1::UsersController, type: :controller do
           it "should respond with the correct item" do
             expect(json_response[api_resource_name][0]['display_name']).to eq(user.display_name)
           end
+
+          context "with filtering emails on multiple emails" do
+            let(:another_user) { create(:user) }
+            let(:emails_filter) do
+              [ email, another_user.email ].map(&:upcase).join(',')
+            end
+            let(:index_options) do
+              { email: emails_filter, admin: true, page_size: 1 }
+            end
+
+            it "should respond include the filter in the next href" do
+              next_href = json_response.dig("meta", "users", "next_href")
+              expect(next_href).to include("email=#{emails_filter}")
+            end
+          end
         end
 
         describe "filter by case insensitive email" do


### PR DESCRIPTION
fixes #2733 

Allow the filters to cascade into the serialiser to construct the meta href for paging. Care has to be taken here to ensure we don’t allow non-admins to activate the filter in the serialiser and that we also don’t pollute the custom AR scopes with the non-lowered params, hence the custom Restpack::Options class.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
