### PR TITLE
add better cleanup token code

### DIFF
--- a/lib/gem_ext/doorkeeper/access_cleanup.rb
+++ b/lib/gem_ext/doorkeeper/access_cleanup.rb
@@ -1,34 +1,44 @@
 module Doorkeeper
   class AccessCleanup
-    attr_reader :keep_for_days
-
-    def initialize(keep_for_days: 30)
-      @keep_for_days = keep_for_days
-    end
-
-    def cleanup!
-      Doorkeeper::AccessGrant.transaction {
-        expired_grants.delete_all
-        expired_tokens.delete_all
-      }
+    def cleanup!(keep_old_refresh_tokens_for=14)
+      expired_grants.delete_all
+      revoked_grants.delete_all
+      expired_tokens.delete_all
+      revoked_tokens.delete_all
+      old_unused_refreshable_tokens(keep_old_refresh_tokens_for).delete_all
     end
 
     def expired_grants
-      Doorkeeper::AccessGrant.where(expiry_params)
+      Doorkeeper::AccessGrant.where(expired_clause)
+    end
+
+    def revoked_grants
+      Doorkeeper::AccessGrant.where(revoked_clause)
     end
 
     def expired_tokens
-      Doorkeeper::AccessToken.where(expiry_params)
+      Doorkeeper::AccessToken.where(refresh_token: nil).where(expired_clause)
     end
 
-    def delete_before
-      DateTime.now - keep_for_days.days
+    def revoked_tokens
+      Doorkeeper::AccessToken.where(revoked_clause)
     end
 
-    protected
+    def old_unused_refreshable_tokens(keep_for)
+      Doorkeeper::AccessToken
+      .where.not(refresh_token: nil)
+      .where(previous_refresh_token: nil)
+      .where("created_at < ?", Time.now - keep_for.days)
+    end
 
-    def expiry_params
-      ["created_at < ? OR revoked_at IS NOT NULL", delete_before]
+    private
+
+    def revoked_clause
+      "revoked_at IS NOT NULL"
+    end
+
+    def expired_clause
+      "created_at + interval '1 second' * expires_in < clock_timestamp()"
     end
   end
 end


### PR DESCRIPTION
avoid the oauth token table index bloat. Cleanup any expired and/or revoked grants/tokens. Also remove all non-refreshable expired tokens and clean up old refreshable tokens if the haven't been refreshed after 14 days (default).

I've also manually cleaned and rebuilt the index on the tokens table to reduce it from over a GB to ~400MB, we may have to look at recreating and dropping the old one on a schedule to avoid the bloat.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
