### PR TITLE
rework project relation preloading

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -52,14 +52,13 @@ class ProjectSerializer
       end
     end
 
-    if Panoptes.flipper["eager_load_projects"].enabled?
-      preloads = if context[:cards]
+    preloads =
+      if context[:cards]
         :avatar
       else
         PRELOADS
       end
-      scope = scope.preload(*preloads)
-    end
+    scope = scope.preload(*preloads)
 
     super(params, scope, context)
   end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -8,7 +8,7 @@ class ProjectSerializer
   include CachedSerializer
 
   PRELOADS = [
-    # :project_contents, Note: re-add when the eager_load from translatable_resources is removed
+    :project_contents,
     :workflows,
     :active_workflows,
     :subject_sets,

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -11,31 +11,20 @@ describe ProjectSerializer do
     s
   end
 
-  it "should not preload the serialized associations by default" do
-    expect_any_instance_of(Project::ActiveRecord_Relation).not_to receive(:preload)
+  it "should preload the serialized associations ny default" do
+    expect_any_instance_of(Project::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(*ProjectSerializer::PRELOADS)
+      .and_call_original
     ProjectSerializer.page({}, Project.all, {})
   end
 
-  context "with enabled preload feature" do
-    before do
-      Panoptes.flipper["eager_load_projects"].enable
-    end
-
-    it "should preload avatars with cards context" do
-      expect_any_instance_of(Project::ActiveRecord_Relation)
-        .to receive(:preload)
-        .with(:avatar)
-        .and_call_original
-      ProjectSerializer.page({}, Project.all, {cards: true})
-    end
-
-    it "should preload the serialized associations without cards context" do
-      expect_any_instance_of(Project::ActiveRecord_Relation)
-        .to receive(:preload)
-        .with(*ProjectSerializer::PRELOADS)
-        .and_call_original
-      ProjectSerializer.page({}, Project.all, {})
-    end
+  it "should preload avatars with cards context" do
+    expect_any_instance_of(Project::ActiveRecord_Relation)
+      .to receive(:preload)
+      .with(:avatar)
+      .and_call_original
+    ProjectSerializer.page({}, Project.all, {cards: true})
   end
 
   describe "#content" do


### PR DESCRIPTION
closes #2699 - Remove the feature flag in code as it's been the default for a while now. Also ensure we preload the `project_contents` model for projects as we've removed the eager load AR restriction on this.

# Todo after merge and deploy
- [ ] Cleanup the feature flags on staging and production systems.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
