### PR TITLE
Ensure UserSeenSubjects are unique

### DIFF
--- a/db/migrate/20180710151618_make_uss_index_unique.rb
+++ b/db/migrate/20180710151618_make_uss_index_unique.rb
@@ -1,0 +1,8 @@
+class MakeUssIndexUnique < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    remove_index :user_seen_subjects, column: [:user_id, :workflow_id]
+    add_index :user_seen_subjects, [:user_id, :workflow_id], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3061,7 +3061,7 @@ CREATE UNIQUE INDEX index_user_project_preferences_on_project_id_and_user_id ON 
 -- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON public.user_seen_subjects USING btree (user_id, workflow_id);
+CREATE UNIQUE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON public.user_seen_subjects USING btree (user_id, workflow_id);
 
 
 --


### PR DESCRIPTION
On production we found that some users have more than one USS record for
a given workflow. This breaks Designator in particular, which will fail
to load its user seens cache for these users (in that workflow only).

To deploy make sure to run the rake task for cleanup first, otherwise
the migration will fail. There are only a couple of duplicates in the
database, so I guess that the chance of a new one appearing between the
rake task and running migrations is low enough that we don't need
anything more complicated than this.

Fixes #2829

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
