### PR TITLE
Add a rake task to export a project's email list

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -20,7 +20,7 @@ namespace :project do
 
   namespace :email_list do
     desc "Export a project's email list to S3"
-    task export: [:project_id] => [:environment] do |t, args|
+    task :export, [:project_id] => [:environment] do |t, args|
       EmailsProjectsExportWorker.perform(args[:project_id])
     end
   end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -17,4 +17,14 @@ namespace :project do
       end
     end
   end
+
+  namespace :email_list do
+    desc "Export a project's email list to S3"
+    task export: :environemnt do
+      project_ids = Array.wrap(ENV['EXPORT_PROJECT_IDS'].try(:split, ","))
+      project_ids.each do |project_id|
+        EmailsProjectsExportWorker.perform(project_id)
+      end
+    end
+  end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -21,7 +21,7 @@ namespace :project do
   namespace :email_list do
     desc "Export a project's email list to S3"
     task :export, [:project_id] => [:environment] do |t, args|
-      EmailsProjectsExportWorker.perform(args[:project_id])
+      EmailsProjectsExportWorker.perform_async(args[:project_id])
     end
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -20,7 +20,7 @@ namespace :project do
 
   namespace :email_list do
     desc "Export a project's email list to S3"
-    task export: :environemnt do
+    task export: :environment do
       project_ids = Array.wrap(ENV['EXPORT_PROJECT_IDS'].try(:split, ","))
       project_ids.each do |project_id|
         EmailsProjectsExportWorker.perform(project_id)

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -20,11 +20,8 @@ namespace :project do
 
   namespace :email_list do
     desc "Export a project's email list to S3"
-    task export: :environment do
-      project_ids = Array.wrap(ENV['EXPORT_PROJECT_IDS'].try(:split, ","))
-      project_ids.each do |project_id|
-        EmailsProjectsExportWorker.perform(project_id)
-      end
+    task export: [:project_id] => [:environment] do |t, args|
+      EmailsProjectsExportWorker.perform(args[:project_id])
     end
   end
 end


### PR DESCRIPTION
Sometimes we want to set up lists for non-launch approved projects, or
manually update a list outside the normal schedule.




- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.