### PR TITLE
Move jenkins file to declarative format and use existing jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,23 +46,27 @@ pipeline {
       }
     }
 
-    stage('Migrate Staging DB') {
+    stage('Migrate') {
       when {
         branch 'master'
       }
-      agent {
-        docker { image 'zooniverse/operations:latest' }
-      }
-      steps {
-        sh """#!/bin/bash -e
-          source auto_cleanup.sh
-          source deploylib.sh
-          INSTANCE_ID=\$(./launch_latest.sh -q panoptes-api-staging)
-          INSTANCE_DNS_NAME=\$(instance_dns_name \$INSTANCE_ID)
-          # Wait for instance/panoptes to come up
-          timeout_cmd "timeout 5m ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes true"
-          ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes ./migrate.sh
-        """
+      stages {
+        stage('Staging DB') {
+          agent {
+            docker { image 'zooniverse/operations:latest' }
+          }
+          steps {
+            sh """#!/bin/bash -e
+              source auto_cleanup.sh
+              source deploylib.sh
+              INSTANCE_ID=\$(./launch_latest.sh -q panoptes-api-staging)
+              INSTANCE_DNS_NAME=\$(instance_dns_name \$INSTANCE_ID)
+              # Wait for instance/panoptes to come up
+              timeout_cmd "timeout 5m ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes true"
+              ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes ./migrate.sh
+            """
+          }
+        }
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,10 @@ node {
     newImage.push()
   }
 
-  if (BRANCH_NAME == 'master') {
+  when {
+    # change back to branch 'master', remove anyOf
+    anyOf { branch 'master'; branch 'fix_jenkinsfile' }
+
     stage('Update latest tag') {
       newImage.push('latest')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,54 +1,56 @@
 pipeline {
   agent any
 
-  node {
+  stages {
+    stage('Checkout SCM') {
       checkout scm
-  }
+    }
 
-  stage('Build Docker image') {
-    steps {
-      script {
-        def dockerRepoName = 'zooniverse/panoptes-jenkins'
-        def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
-        def newImage = docker.build(dockerImageName)
-        newImage.push()
+    stage('Build Docker image') {
+      steps {
+        script {
+          def dockerRepoName = 'zooniverse/panoptes-jenkins'
+          def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
+          def newImage = docker.build(dockerImageName)
+          newImage.push()
 
-        if (BRANCH_NAME == 'master') {
-          stage('Update latest tag') {
-            newImage.push('latest')
+          if (BRANCH_NAME == 'master') {
+            stage('Update latest tag') {
+              newImage.push('latest')
+            }
           }
         }
       }
     }
-  }
 
-  stage('Deployment') {
-    when {
-      // change back to branch 'master', remove anyOf
-      anyOf { branch 'master'; branch 'fix_jenkinsfile' }
+    stage('Deployment') {
+      when {
+        // change back to branch 'master', remove anyOf
+        anyOf { branch 'master'; branch 'fix_jenkinsfile' }
 
-      stage('Build staging AMIs') {
-        failFast true
+        stage('Build staging AMIs') {
+          failFast true
 
-        parallel {
-          stage('Build API') {
-            build job: 'Panoptes/job/Build Panoptes Staging AMI'
-          }
-          stage('Build Dump workers') {
-            build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
+          parallel {
+            stage('Build API') {
+              build job: 'Panoptes/job/Build Panoptes Staging AMI'
+            }
+            stage('Build Dump workers') {
+              build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
+            }
           }
         }
-      }
 
-      stage('Deploy staging') {
-        failFast true
+        stage('Deploy staging') {
+          failFast true
 
-        parallel {
-          stage('Build API') {
-            build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
-          }
-          stage('Build Dump workers') {
-            build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
+          parallel {
+            stage('Build API') {
+              build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
+            }
+            stage('Build Dump workers') {
+              build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 
     stage('Build staging AMIs') {
       when {
-        anyOf { branch 'master'; branch 'fix_jenkinsfile' }
+        branch 'master' }
       }
       failFast true
       parallel {
@@ -40,7 +40,7 @@ pipeline {
 
     stage('Deploy staging AMIs') {
       when {
-        anyOf { branch 'master'; branch 'fix_jenkinsfile' }
+        branch 'master'
       }
       failFast true
       parallel {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,17 +18,15 @@ node {
     }
 
     stage('Build staging AMIs') {
-      parallel api: {
-        sh """
-          cd "/var/jenkins_home/jobs/Zooniverse GitHub/jobs/operations/branches/master/workspace" && \
-          ./rebuild.sh panoptes-api-staging
-        """
-      },
-      worker: {
-        sh """
-          cd "/var/jenkins_home/jobs/Zooniverse GitHub/jobs/operations/branches/master/workspace" && \
-          ./rebuild.sh panoptes-dumpworker-staging
-        """
+      parallel {
+        failFast true
+
+        stage('Build API') {
+          build job: 'Panoptes/job/Build Panoptes Staging AMI'
+        },
+        stage('Build Dump workers') {
+          build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
+        }
       }
     }
 
@@ -50,17 +48,15 @@ node {
     }
 
     stage('Deploy staging') {
-      parallel api: {
-        sh """
-          cd "/var/jenkins_home/jobs/Zooniverse GitHub/jobs/operations/branches/master/workspace" && \
-          ./deploy_latest.sh panoptes-api-staging
-        """
-      },
-      worker: {
-        sh """
-          cd "/var/jenkins_home/jobs/Zooniverse GitHub/jobs/operations/branches/master/workspace" && \
-          ./deploy_latest.sh panoptes-dumpworker-staging
-        """
+      parallel {
+        failFast true
+
+        stage('Build API') {
+          build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
+        },
+        stage('Build Dump workers') {
+          build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,12 +27,12 @@ pipeline {
       parallel {
         stage('Build API') {
           steps {
-            build job: 'Panoptes/job/Build Panoptes Staging AMI'
+            build job: '/Build Panoptes Staging AMI'
           }
         }
         stage('Build Dump workers') {
           steps {
-            build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
+            build job: '/Build Panoptes Staging Dump Worker AMI'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
   }
 
   when {
-    # change back to branch 'master', remove anyOf
+    // change back to branch 'master', remove anyOf
     anyOf { branch 'master'; branch 'fix_jenkinsfile' }
 
     stage('Update latest tag') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,5 +37,24 @@ pipeline {
         }
       }
     }
+
+    stage('Deploy staging AMIs') {
+      when {
+        anyOf { branch 'master'; branch 'fix_jenkinsfile' }
+      }
+      failFast true
+      parallel {
+        stage('Deploy API') {
+          steps {
+            build job: '/Deploy latest Panoptes Staging build'
+          }
+        }
+        stage('Deploy Dump workers') {
+          steps {
+            build job: '/Deploy latest Panoptes Staging dump worker build'
+          }
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,36 +12,38 @@ node {
     newImage.push()
   }
 
-  when {
-    // change back to branch 'master', remove anyOf
-    anyOf { branch 'master'; branch 'fix_jenkinsfile' }
+  stage('Deployment') {
+    when {
+      // change back to branch 'master', remove anyOf
+      anyOf { branch 'master'; branch 'fix_jenkinsfile' }
 
-    stage('Update latest tag') {
-      newImage.push('latest')
-    }
+      //stage('Update latest tag') {
+      //  newImage.push('latest')
+      //}
 
-    stage('Build staging AMIs') {
-      failFast true
+      stage('Build staging AMIs') {
+        failFast true
 
-      parallel {
-        stage('Build API') {
-          build job: 'Panoptes/job/Build Panoptes Staging AMI'
-        }
-        stage('Build Dump workers') {
-          build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
+        parallel {
+          stage('Build API') {
+            build job: 'Panoptes/job/Build Panoptes Staging AMI'
+          }
+          stage('Build Dump workers') {
+            build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
+          }
         }
       }
-    }
 
-    stage('Deploy staging') {
-      failFast true
+      stage('Deploy staging') {
+        failFast true
 
-      parallel {
-        stage('Build API') {
-          build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
-        }
-        stage('Build Dump workers') {
-          build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
+        parallel {
+          stage('Build API') {
+            build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
+          }
+          stage('Build Dump workers') {
+            build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,9 +22,6 @@ pipeline {
     }
 
     stage('Build staging AMIs') {
-      when {
-        branch 'master'
-      }
       failFast true
       parallel {
         stage('Build API') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,10 @@ pipeline {
       parallel {
         stage('Build API') {
           agent {
-            docker { image 'zooniverse/operations:latest' }
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v $HOME/.ssh/:/home/ubuntu/.ssh -e "AWS_DEFAULT_REGION=us-east-1" -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"'
+            }
           }
           steps {
             sh './rebuild.sh panoptes-api-staging'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,23 +30,6 @@ node {
       }
     }
 
-    stage('Migrate') {
-      sh """#!/bin/bash -e
-
-        cd "/var/jenkins_home/jobs/Zooniverse GitHub/jobs/operations/branches/master/workspace"
-
-        source auto_cleanup.sh
-        source deploylib.sh
-
-        INSTANCE_ID=\$(./launch_latest.sh -q panoptes-api-staging)
-        INSTANCE_DNS_NAME=\$(instance_dns_name \$INSTANCE_ID)
-
-        # Wait for instance/panoptes to come up
-        timeout_cmd "timeout 5m ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes true"
-        ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes ./migrate.sh
-      """
-    }
-
     stage('Deploy staging') {
       parallel {
         failFast true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 pipeline {
   agent any
 
-  checkout scm
+  node {
+      checkout scm
+  }
 
   stage('Build Docker image') {
     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,8 @@ pipeline {
 
         if (BRANCH_NAME == 'master') {
           stage('Update latest tag') {
-          newImage.push('latest')
+            newImage.push('latest')
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,9 @@ pipeline {
 
   stages {
     stage('Checkout SCM') {
-      checkout scm
+      steps {
+        checkout scm
+      }
     }
 
     stage('Build Docker image') {
@@ -17,39 +19,6 @@ pipeline {
           if (BRANCH_NAME == 'master') {
             stage('Update latest tag') {
               newImage.push('latest')
-            }
-          }
-        }
-      }
-    }
-
-    stage('Deployment') {
-      when {
-        // change back to branch 'master', remove anyOf
-        anyOf { branch 'master'; branch 'fix_jenkinsfile' }
-
-        stage('Build staging AMIs') {
-          failFast true
-
-          parallel {
-            stage('Build API') {
-              build job: 'Panoptes/job/Build Panoptes Staging AMI'
-            }
-            stage('Build Dump workers') {
-              build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
-            }
-          }
-        }
-
-        stage('Deploy staging') {
-          failFast true
-
-          parallel {
-            stage('Build API') {
-              build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
-            }
-            stage('Build Dump workers') {
-              build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,11 @@
 #!groovy
 
 pipeline {
-  agent any
+  agent none
 
   stages {
     stage('Build Docker image') {
+      agent any
       steps {
         script {
           def dockerRepoName = 'zooniverse/panoptes-jenkins'
@@ -22,74 +23,122 @@ pipeline {
     }
 
     stage('Build staging AMIs') {
+      when { branch 'master' }
       failFast true
       parallel {
         stage('Build API') {
+          options {
+            skipDefaultCheckout true
+          }
           agent {
             docker {
               image 'zooniverse/operations:latest'
-              args '-v $HOME/.ssh/:/home/ubuntu/.ssh -e "AWS_DEFAULT_REGION=us-east-1" -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
             }
           }
           steps {
-            sh './rebuild.sh panoptes-api-staging'
+            sh """#!/bin/bash -e
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./rebuild.sh panoptes-api-staging
+              kill \${KEEP_ALIVE_ECHO_JOB}
+            """
           }
         }
         stage('Build Dump workers') {
-          agent {
-            docker { image 'zooniverse/operations:latest' }
+          options {
+            skipDefaultCheckout true
           }
-          steps {
-            sh './rebuild.sh panoptes-dumpworker-staging'
-          }
-        }
-      }
-    }
-
-    stage('Migrate') {
-      when {
-        branch 'master'
-      }
-      stages {
-        stage('Staging DB') {
           agent {
-            docker { image 'zooniverse/operations:latest' }
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+            }
           }
           steps {
             sh """#!/bin/bash -e
-              source auto_cleanup.sh
-              source deploylib.sh
-              INSTANCE_ID=\$(./launch_latest.sh -q panoptes-api-staging)
-              INSTANCE_DNS_NAME=\$(instance_dns_name \$INSTANCE_ID)
-              # Wait for instance/panoptes to come up
-              timeout_cmd "timeout 5m ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes true"
-              ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes ./migrate.sh
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./rebuild.sh panoptes-dumpworker-staging
+              kill \${KEEP_ALIVE_ECHO_JOB}
             """
           }
         }
       }
     }
 
-    stage('Deploy staging AMIs') {
-      when {
-        branch 'master'
+    stage('Migrate Staging DB') {
+      when { branch 'master' }
+      options {
+        skipDefaultCheckout true
       }
+      agent {
+        docker {
+          image 'zooniverse/operations:latest'
+          args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+        }
+      }
+      steps {
+        sh """#!/bin/bash -e
+          while true; do sleep 3; echo -n "."; done &
+          KEEP_ALIVE_ECHO_JOB=\$!
+          cd /operations
+          source auto_cleanup.sh
+          source deploylib.sh
+          INSTANCE_ID=\$(./launch_latest.sh -q panoptes-api-staging)
+          INSTANCE_DNS_NAME=\$(instance_dns_name \$INSTANCE_ID)
+          # Wait for instance/panoptes to come up
+          timeout_cmd "timeout 5m ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes true"
+          ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes ./migrate.sh
+          kill \${KEEP_ALIVE_ECHO_JOB}
+        """
+      }
+    }
+
+    stage('Deploy staging AMIs') {
+      when { branch 'master' }
       failFast true
       parallel {
         stage('Deploy API') {
+          options {
+            skipDefaultCheckout true
+          }
           agent {
-            docker { image 'zooniverse/operations:latest' }
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+            }
           }
           steps {
-            sh './deploy_latest.sh panoptes-api-staging'
+            sh """#!/bin/bash -e
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./deploy_latest.sh panoptes-api-staging
+              kill \${KEEP_ALIVE_ECHO_JOB}
+            """
           }
         }
         stage('Deploy Dump workers') {
+          options {
+            skipDefaultCheckout true
+          }
           agent {
-            docker { image 'zooniverse/operations:latest' }
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+            }
           }
           steps {
-            sh './deploy_latest.sh panoptes-dumpworker-staging'
+            sh """#!/bin/bash -e
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./deploy_latest.sh panoptes-dumpworker-staging
+              kill \${KEEP_ALIVE_ECHO_JOB}
+            """
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,5 +18,45 @@ pipeline {
         }
       }
     }
+
+    stage('Building and deploying') {
+      when {
+        // change back to branch 'master', remove anyOf
+        anyOf { branch 'master'; branch 'fix_jenkinsfile' }
+
+        stage('Build staging AMIs') {
+          failFast true
+          parallel {
+            stage('Build API') {
+              steps {
+                build job: 'Panoptes/job/Build Panoptes Staging AMI'
+              }
+            }
+            stage('Build Dump workers') {
+              steps {
+                build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
+              }
+            }
+          }
+        }
+
+        stage('Deploy built staging AMIs') {
+          failFast true
+
+          parallel {
+            stage('Build API') {
+              steps {
+                build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
+              }
+            }
+            stage('Build Dump workers') {
+              steps {
+                build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,25 +43,23 @@ pipeline {
       }
     }
 
-    stage('Migrate') {
+    stage('Migrate Staging DB') {
       when {
         branch 'master'
       }
       agent {
         docker { image 'zooniverse/operations:latest' }
       }
-      stage('Staging DB') {
-        steps {
-          sh """#!/bin/bash -e
-            source auto_cleanup.sh
-            source deploylib.sh
-            INSTANCE_ID=\$(./launch_latest.sh -q panoptes-api-staging)
-            INSTANCE_DNS_NAME=\$(instance_dns_name \$INSTANCE_ID)
-            # Wait for instance/panoptes to come up
-            timeout_cmd "timeout 5m ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes true"
-            ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes ./migrate.sh
-          """
-        }
+      steps {
+        sh """#!/bin/bash -e
+          source auto_cleanup.sh
+          source deploylib.sh
+          INSTANCE_ID=\$(./launch_latest.sh -q panoptes-api-staging)
+          INSTANCE_DNS_NAME=\$(instance_dns_name \$INSTANCE_ID)
+          # Wait for instance/panoptes to come up
+          timeout_cmd "timeout 5m ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes true"
+          ssh ubuntu@\$INSTANCE_DNS_NAME docker-compose -f /opt/docker_start/docker-compose.yml -p panoptes-api-staging exec -T panoptes ./migrate.sh
+        """
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,41 +19,20 @@ pipeline {
       }
     }
 
-    stage('Building and deploying') {
+    stage('Build staging AMIs') {
       when {
-        // change back to branch 'master', remove anyOf
         anyOf { branch 'master'; branch 'fix_jenkinsfile' }
-
-        stage('Build staging AMIs') {
-          failFast true
-          parallel {
-            stage('Build API') {
-              steps {
-                build job: 'Panoptes/job/Build Panoptes Staging AMI'
-              }
-            }
-            stage('Build Dump workers') {
-              steps {
-                build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
-              }
-            }
+      }
+      failFast true
+      parallel {
+        stage('Build API') {
+          steps {
+            build job: 'Panoptes/job/Build Panoptes Staging AMI'
           }
         }
-
-        stage('Deploy built staging AMIs') {
-          failFast true
-
-          parallel {
-            stage('Build API') {
-              steps {
-                build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
-              }
-            }
-            stage('Build Dump workers') {
-              steps {
-                build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
-              }
-            }
+        stage('Build Dump workers') {
+          steps {
+            build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,12 +2,6 @@ pipeline {
   agent any
 
   stages {
-    stage('Checkout SCM') {
-      steps {
-        checkout scm
-      }
-    }
-
     stage('Build Docker image') {
       steps {
         script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,17 +25,20 @@ pipeline {
       when {
         branch 'master'
       }
-      agent {
-        docker { image 'zooniverse/operations:latest' }
-      }
       failFast true
       parallel {
         stage('Build API') {
+          agent {
+            docker { image 'zooniverse/operations:latest' }
+          }
           steps {
             sh './rebuild.sh panoptes-api-staging'
           }
         }
         stage('Build Dump workers') {
+          agent {
+            docker { image 'zooniverse/operations:latest' }
+          }
           steps {
             sh './rebuild.sh panoptes-dumpworker-staging'
           }
@@ -67,17 +70,20 @@ pipeline {
       when {
         branch 'master'
       }
-      agent {
-        docker { image 'zooniverse/operations:latest' }
-      }
       failFast true
       parallel {
         stage('Deploy API') {
+          agent {
+            docker { image 'zooniverse/operations:latest' }
+          }
           steps {
             sh './deploy_latest.sh panoptes-api-staging'
           }
         }
         stage('Deploy Dump workers') {
+          agent {
+            docker { image 'zooniverse/operations:latest' }
+          }
           steps {
             sh './deploy_latest.sh panoptes-dumpworker-staging'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,12 +18,12 @@ node {
     }
 
     stage('Build staging AMIs') {
-      parallel {
-        failFast true
+      failFast true
 
+      parallel {
         stage('Build API') {
           build job: 'Panoptes/job/Build Panoptes Staging AMI'
-        },
+        }
         stage('Build Dump workers') {
           build job: 'Panoptes/job/Build Panoptes Staging Dump Worker AMI'
         }
@@ -31,12 +31,12 @@ node {
     }
 
     stage('Deploy staging') {
-      parallel {
-        failFast true
+      failFast true
 
+      parallel {
         stage('Build API') {
           build job: 'Panoptes/job/Deploy latest Panoptes Staging build'
-        },
+        }
         stage('Build Dump workers') {
           build job: 'Panoptes/job/	Deploy latest Panoptes Staging dump worker build'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+#!groovy
+
 pipeline {
   agent any
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 
     stage('Build staging AMIs') {
       when {
-        branch 'master' }
+        branch 'master'
       }
       failFast true
       parallel {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node {
     newImage.push()
   }
 
-  if (BRANCH_NAME == 'master') { // TODO: change this to "master"
+  if (BRANCH_NAME == 'master') {
     stage('Update latest tag') {
       newImage.push('latest')
     }


### PR DESCRIPTION
The current jenkins file relies on the workspace of the operations repo to exist and it may not (see failed jobs for panoptes master branch in jenkins). This PR fixes the above failures and moves the Jenkinsfile to a declarative (https://jenkins.io/doc/book/pipeline/syntax/#declarative-directives) instead of the scripted format. 

The declarative format should provide greater consistency of the Jenkins file format across repos and allow us to use tag builds longer term (https://jenkins.io/blog/2018/05/16/pipelines-with-git-tags/), while still using a script step to build and reuse the docker image caches.

### TODO
- [x] Unlink the cascading staging jobs to ensure they run through this Jenkinsfile
- [ ] Move dockerhub named repo to original panoptes one (or in a later PR off this one)
- [ ] Add production tag image building step (or in a later PR off this one)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
