### PR TITLE
decrease SWS create worker run priority

### DIFF
--- a/app/workers/subject_set_statuses_create_worker.rb
+++ b/app/workers/subject_set_statuses_create_worker.rb
@@ -1,7 +1,7 @@
 class SubjectSetStatusesCreateWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :data_medium, lock: :until_executed
+  sidekiq_options queue: :data_low, lock: :until_executed
 
   def perform(subject_set_id, workflow_id)
     return unless Panoptes.flipper[:subject_set_statuses_create_worker].enabled?

--- a/app/workers/subject_workflow_status_create_worker.rb
+++ b/app/workers/subject_workflow_status_create_worker.rb
@@ -1,7 +1,7 @@
 class SubjectWorkflowStatusCreateWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :data_low, lock: :until_executed
+  sidekiq_options lock: :until_executed
 
   def perform(subject_id, workflow_id)
     return unless Panoptes.flipper[:subject_workflow_status_create_worker].enabled?

--- a/app/workers/subject_workflow_status_create_worker.rb
+++ b/app/workers/subject_workflow_status_create_worker.rb
@@ -1,7 +1,7 @@
 class SubjectWorkflowStatusCreateWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :data_high, lock: :until_executed
+  sidekiq_options queue: :data_low, lock: :until_executed
 
   def perform(subject_id, workflow_id)
     return unless Panoptes.flipper[:subject_workflow_status_create_worker].enabled?


### PR DESCRIPTION
Ensure these run when they can.

NOTE: take care when launching large numbers of unique lock jobs as they can increase redis memory usage (possibly OOM and kill redis).


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
