### PR TITLE
Add explicit translation scope tests for resources

### DIFF
--- a/app/controllers/api/v1/translations_controller.rb
+++ b/app/controllers/api/v1/translations_controller.rb
@@ -36,9 +36,7 @@ class Api::V1::TranslationsController < Api::ApiController
 
   private
 
-  # allow translators to access the translated_resource via the translate role
-  # otherwise they'd need access to something like can_by_role :update
-  # on the translated resource
+  # ensure translators can update and create translated resources
   def controlled_scope
     if %i(update create).include?(action_name.to_sym)
       :translate

--- a/app/policies/aggregation_policy.rb
+++ b/app/policies/aggregation_policy.rb
@@ -19,7 +19,7 @@ class AggregationPolicy < ApplicationPolicy
   end
 
   scope :index, :show, with: ReadScope
-  scope :update, :destroy, :update_links, :destroy_links, :versions, :version, with: WriteScope
+  scope :update, :destroy, :versions, :version, with: WriteScope
 
   def linkable_subjects
     policy_for(Subject).scope_for(:show)

--- a/app/policies/field_guide_policy.rb
+++ b/app/policies/field_guide_policy.rb
@@ -6,7 +6,7 @@ class FieldGuidePolicy < ApplicationPolicy
     end
   end
 
-  scope :index, :show, :update, :destroy, with: Scope
+  scope :index, :show, :update, :destroy, :translate, with: Scope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -27,7 +27,7 @@ class MembershipPolicy < ApplicationPolicy
     end
   end
 
-  scope :index, :show, :update, :destroy, :update_links, :destroy_links, with: Scope
+  scope :index, :show, :update, :destroy, with: Scope
 
   def linkable_users
     User.all

--- a/app/policies/organization_page_policy.rb
+++ b/app/policies/organization_page_policy.rb
@@ -6,15 +6,8 @@ class OrganizationPagePolicy < ApplicationPolicy
     end
   end
 
-  class TranslateScope < Scope
-    def resolve(_action)
-      parent_scope = policy_for(Organization).scope_for(:translate)
-      scope.where(organization_id: parent_scope.select(:id))
-    end
-  end
-
-  scope :index, :show, with: Scope
-  scope :update, :destroy, :update_links, :destroy_links, :versions, :version, with: TranslateScope
+  scope :index, :show, :update, :destroy, :translate, :update_links,
+        :destroy_links, :versions, :version, with: Scope
 
   def linkable_organizations
     policy_for(Organization).scope_for(:update)

--- a/app/policies/organization_page_policy.rb
+++ b/app/policies/organization_page_policy.rb
@@ -6,8 +6,7 @@ class OrganizationPagePolicy < ApplicationPolicy
     end
   end
 
-  scope :index, :show, :update, :destroy, :translate, :update_links,
-        :destroy_links, :versions, :version, with: Scope
+  scope :index, :show, :update, :destroy, :translate, :versions, :version, with: Scope
 
   def linkable_organizations
     policy_for(Organization).scope_for(:update)

--- a/app/policies/project_page_policy.rb
+++ b/app/policies/project_page_policy.rb
@@ -6,9 +6,7 @@ class ProjectPagePolicy < ApplicationPolicy
     end
   end
 
-  # TODO: look into removing :update_links, :destroy_links as these route actions don't exist for this resource
-  scope :index, :show, :update, :destroy, :translate, :versions,
-        :version, :update_links, :destroy_links, with: Scope
+  scope :index, :show, :update, :destroy, :translate, :versions, :version, with: Scope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/app/policies/project_page_policy.rb
+++ b/app/policies/project_page_policy.rb
@@ -6,6 +6,7 @@ class ProjectPagePolicy < ApplicationPolicy
     end
   end
 
+  # TODO: look into removing :update_links, :destroy_links as these route actions don't exist for this resource
   scope :index, :show, :update, :destroy, :translate, :versions,
         :version, :update_links, :destroy_links, with: Scope
 

--- a/app/policies/project_page_policy.rb
+++ b/app/policies/project_page_policy.rb
@@ -6,17 +6,8 @@ class ProjectPagePolicy < ApplicationPolicy
     end
   end
 
-  class TranslateScope < Scope
-    def resolve(_action)
-      parent_scope = policy_for(Project).scope_for(:translate)
-      scope.where(project_id: parent_scope.select(:id))
-    end
-  end
-
-  scope :index, :show, with: Scope
-  scope :update, :destroy, :translate,
-        :update_links, :destroy_links,
-        :versions, :version, with: TranslateScope
+  scope :index, :show, :update, :destroy, :translate, :versions,
+        :version, :update_links, :destroy_links, with: Scope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/app/policies/project_page_policy.rb
+++ b/app/policies/project_page_policy.rb
@@ -14,7 +14,9 @@ class ProjectPagePolicy < ApplicationPolicy
   end
 
   scope :index, :show, with: Scope
-  scope :update, :destroy, :update_links, :destroy_links, :versions, :version, with: TranslateScope
+  scope :update, :destroy, :translate,
+        :update_links, :destroy_links,
+        :versions, :version, with: TranslateScope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/app/policies/subject_policy.rb
+++ b/app/policies/subject_policy.rb
@@ -6,7 +6,7 @@ class SubjectPolicy < ApplicationPolicy
     end
   end
 
-  scope :index, :show, :update, :destroy, :update_links, :destroy_links, :versions, :version, with: Scope
+  scope :index, :show, :update, :destroy, :versions, :version, with: Scope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/app/policies/tutorial_policy.rb
+++ b/app/policies/tutorial_policy.rb
@@ -6,7 +6,7 @@ class TutorialPolicy < ApplicationPolicy
     end
   end
 
-  scope :index, :show, :update, :destroy, with: Scope
+  scope :index, :show, :update, :destroy, :translate, with: Scope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/spec/policies/membership_policy_spec.rb
+++ b/spec/policies/membership_policy_spec.rb
@@ -66,13 +66,9 @@ describe MembershipPolicy do
 
         expect(scope.resolve(:update)).to include(membership1, membership2)
         expect(scope.resolve(:destroy)).to include(membership1, membership2)
-        expect(scope.resolve(:update_links)).to include(membership1, membership2)
-        expect(scope.resolve(:destroy_links)).to include(membership1, membership2)
 
         expect(scope.resolve(:update)).not_to include(membership3, membership4)
         expect(scope.resolve(:destroy)).not_to include(membership3, membership4)
-        expect(scope.resolve(:update_links)).not_to include(membership3, membership4)
-        expect(scope.resolve(:destroy_links)).not_to include(membership3, membership4)
       end
     end
 
@@ -87,8 +83,6 @@ describe MembershipPolicy do
         expect(scope.resolve(:show)).to include(membership1, membership2)
         expect(scope.resolve(:update)).to include(membership1, membership2)
         expect(scope.resolve(:destroy)).to include(membership1, membership2)
-        expect(scope.resolve(:update_links)).to include(membership1, membership2)
-        expect(scope.resolve(:destroy_links)).to include(membership1, membership2)
       end
     end
   end

--- a/spec/policies/project_page_policy_spec.rb
+++ b/spec/policies/project_page_policy_spec.rb
@@ -49,6 +49,24 @@ describe ProjectPagePolicy do
       end
     end
 
+    context 'for a translator user' do
+      let(:api_user) { ApiUser.new(logged_in_user) }
+
+      before do
+        create(
+          :access_control_list,
+          resource: private_project,
+          user_group: logged_in_user.identity_group,
+          roles: ["translator"]
+        )
+      end
+
+      it "includes project_pages from private translation projects" do
+        resolved_scope = Pundit.policy!(api_user, ProjectPage).scope_for(:translate)
+        expect(resolved_scope).to match_array(private_project_page)
+      end
+    end
+
     context 'for an admin' do
       let(:admin_user) { create :user, admin: true }
       let(:api_user) { ApiUser.new(admin_user, admin: true) }

--- a/spec/policies/project_page_policy_spec.rb
+++ b/spec/policies/project_page_policy_spec.rb
@@ -6,14 +6,14 @@ describe ProjectPagePolicy do
     let(:logged_in_user) { create(:user) }
     let(:resource_owner) { create(:user) }
 
-    let(:public_project)  { build(:project, owner: resource_owner) }
+    let(:public_project)  { build(:project) }
     let(:private_project) { build(:project, owner: resource_owner, private: true) }
 
     let(:public_project_page) { build(:project_page, project: public_project) }
     let(:private_project_page) { build(:project_page, project: private_project) }
 
-    let(:resolved_scope) do
-      Pundit.policy!(api_user, ProjectPage).scope_for(:index)
+    subject do
+      PunditScopeTester.new(ProjectPage, api_user)
     end
 
     before do
@@ -24,34 +24,47 @@ describe ProjectPagePolicy do
     context 'for an anonymous user' do
       let(:api_user) { ApiUser.new(anonymous_user) }
 
-      it "includes project_pages from public projects" do
-        expect(resolved_scope).to match_array(public_project_page)
-      end
+      its(:index) { is_expected.to match_array([public_project_page]) }
+      its(:show) { is_expected.to match_array([public_project_page]) }
+      its(:update) { is_expected.to be_empty }
+      its(:destroy) { is_expected.to be_empty }
+      its(:translate) { is_expected.to be_empty }
+      its(:update_links) { is_expected.to be_empty }
+      its(:destroy_links) { is_expected.to be_empty }
+      its(:versions) { is_expected.to be_empty }
+      its(:version) { is_expected.to be_empty }
     end
 
     context 'for a normal user' do
       let(:api_user) { ApiUser.new(logged_in_user) }
 
-      it "includes project_pages from public projects" do
-        expect(resolved_scope).to match_array(public_project_page)
-      end
+      its(:index) { is_expected.to match_array([public_project_page]) }
+      its(:show) { is_expected.to match_array([public_project_page]) }
+      its(:update) { is_expected.to be_empty }
+      its(:destroy) { is_expected.to be_empty }
+      its(:translate) { is_expected.to be_empty }
+      its(:update_links) { is_expected.to be_empty }
+      its(:destroy_links) { is_expected.to be_empty }
+      its(:versions) { is_expected.to be_empty }
+      its(:version) { is_expected.to be_empty }
     end
 
     context 'for the resource owner' do
       let(:api_user) { ApiUser.new(resource_owner) }
 
-      it "includes project_pages from public projects" do
-        expect(resolved_scope).to include(public_project_page)
-      end
-
-      it 'includes project_pages from owned private projects' do
-        expect(resolved_scope).to include(private_project_page)
-      end
+      its(:index) { is_expected.to match_array([public_project_page, private_project_page]) }
+      its(:show) { is_expected.to match_array([public_project_page, private_project_page]) }
+      its(:update) { is_expected.to match_array([private_project_page]) }
+      its(:destroy) { is_expected.to match_array([private_project_page]) }
+      its(:translate) { is_expected.to match_array([private_project_page]) }
+      its(:update_links) { is_expected.to match_array([private_project_page]) }
+      its(:destroy_links) { is_expected.to match_array([private_project_page]) }
+      its(:versions) { is_expected.to match_array([private_project_page]) }
+      its(:version) { is_expected.to match_array([private_project_page]) }
     end
 
     context 'for a translator user' do
       let(:api_user) { ApiUser.new(logged_in_user) }
-
       before do
         create(
           :access_control_list,
@@ -61,19 +74,33 @@ describe ProjectPagePolicy do
         )
       end
 
-      it "includes project_pages from private translation projects" do
-        resolved_scope = Pundit.policy!(api_user, ProjectPage).scope_for(:translate)
-        expect(resolved_scope).to match_array(private_project_page)
-      end
+      its(:index) { is_expected.to match_array([public_project_page, private_project_page]) }
+      its(:show) { is_expected.to match_array([public_project_page, private_project_page]) }
+      its(:update) { is_expected.to match_array([private_project_page]) }
+      its(:destroy) { is_expected.to match_array([private_project_page]) }
+      its(:translate) { is_expected.to match_array([private_project_page]) }
+      its(:update_links) { is_expected.to match_array([private_project_page]) }
+      its(:destroy_links) { is_expected.to match_array([private_project_page]) }
+      its(:versions) { is_expected.to match_array([private_project_page]) }
+      its(:version) { is_expected.to match_array([private_project_page]) }
     end
 
     context 'for an admin' do
       let(:admin_user) { create :user, admin: true }
       let(:api_user) { ApiUser.new(admin_user, admin: true) }
-
-      it 'includes everything' do
-        expect(resolved_scope).to include(public_project_page, private_project_page)
+      let(:all_project_pages) do
+        [public_project_page, private_project_page]
       end
+
+      its(:index) { is_expected.to match_array(all_project_pages) }
+      its(:show) { is_expected.to match_array(all_project_pages) }
+      its(:update) { is_expected.to match_array(all_project_pages) }
+      its(:destroy) { is_expected.to match_array(all_project_pages) }
+      its(:translate) { is_expected.to match_array(all_project_pages) }
+      its(:update_links) { is_expected.to match_array(all_project_pages) }
+      its(:destroy_links) { is_expected.to match_array(all_project_pages) }
+      its(:versions) { is_expected.to match_array(all_project_pages) }
+      its(:version) { is_expected.to match_array(all_project_pages) }
     end
   end
 end

--- a/spec/policies/project_page_policy_spec.rb
+++ b/spec/policies/project_page_policy_spec.rb
@@ -29,8 +29,6 @@ describe ProjectPagePolicy do
       its(:update) { is_expected.to be_empty }
       its(:destroy) { is_expected.to be_empty }
       its(:translate) { is_expected.to be_empty }
-      its(:update_links) { is_expected.to be_empty }
-      its(:destroy_links) { is_expected.to be_empty }
       its(:versions) { is_expected.to match_array([public_project_page]) }
       its(:version) { is_expected.to match_array([public_project_page]) }
     end
@@ -43,8 +41,6 @@ describe ProjectPagePolicy do
       its(:update) { is_expected.to be_empty }
       its(:destroy) { is_expected.to be_empty }
       its(:translate) { is_expected.to be_empty }
-      its(:update_links) { is_expected.to be_empty }
-      its(:destroy_links) { is_expected.to be_empty }
       its(:versions) { is_expected.to match_array([public_project_page]) }
       its(:version) { is_expected.to match_array([public_project_page]) }
     end
@@ -57,8 +53,6 @@ describe ProjectPagePolicy do
       its(:update) { is_expected.to match_array([private_project_page]) }
       its(:destroy) { is_expected.to match_array([private_project_page]) }
       its(:translate) { is_expected.to match_array([private_project_page]) }
-      its(:update_links) { is_expected.to match_array([private_project_page]) }
-      its(:destroy_links) { is_expected.to match_array([private_project_page]) }
       its(:versions) { is_expected.to match_array([public_project_page, private_project_page]) }
       its(:version) { is_expected.to match_array([public_project_page, private_project_page]) }
     end
@@ -79,8 +73,6 @@ describe ProjectPagePolicy do
       its(:update) { is_expected.to be_empty }
       its(:destroy) { is_expected.to be_empty }
       its(:translate) { is_expected.to match_array([private_project_page]) }
-      its(:update_links) { is_expected.to be_empty }
-      its(:destroy_links) { is_expected.to be_empty }
       its(:versions) { is_expected.to match_array([public_project_page, private_project_page]) }
       its(:version) { is_expected.to match_array([public_project_page, private_project_page]) }
     end
@@ -97,8 +89,6 @@ describe ProjectPagePolicy do
       its(:update) { is_expected.to match_array(all_project_pages) }
       its(:destroy) { is_expected.to match_array(all_project_pages) }
       its(:translate) { is_expected.to match_array(all_project_pages) }
-      its(:update_links) { is_expected.to match_array(all_project_pages) }
-      its(:destroy_links) { is_expected.to match_array(all_project_pages) }
       its(:versions) { is_expected.to match_array(all_project_pages) }
       its(:version) { is_expected.to match_array(all_project_pages) }
     end

--- a/spec/policies/project_page_policy_spec.rb
+++ b/spec/policies/project_page_policy_spec.rb
@@ -31,8 +31,8 @@ describe ProjectPagePolicy do
       its(:translate) { is_expected.to be_empty }
       its(:update_links) { is_expected.to be_empty }
       its(:destroy_links) { is_expected.to be_empty }
-      its(:versions) { is_expected.to be_empty }
-      its(:version) { is_expected.to be_empty }
+      its(:versions) { is_expected.to match_array([public_project_page]) }
+      its(:version) { is_expected.to match_array([public_project_page]) }
     end
 
     context 'for a normal user' do
@@ -45,8 +45,8 @@ describe ProjectPagePolicy do
       its(:translate) { is_expected.to be_empty }
       its(:update_links) { is_expected.to be_empty }
       its(:destroy_links) { is_expected.to be_empty }
-      its(:versions) { is_expected.to be_empty }
-      its(:version) { is_expected.to be_empty }
+      its(:versions) { is_expected.to match_array([public_project_page]) }
+      its(:version) { is_expected.to match_array([public_project_page]) }
     end
 
     context 'for the resource owner' do
@@ -59,8 +59,8 @@ describe ProjectPagePolicy do
       its(:translate) { is_expected.to match_array([private_project_page]) }
       its(:update_links) { is_expected.to match_array([private_project_page]) }
       its(:destroy_links) { is_expected.to match_array([private_project_page]) }
-      its(:versions) { is_expected.to match_array([private_project_page]) }
-      its(:version) { is_expected.to match_array([private_project_page]) }
+      its(:versions) { is_expected.to match_array([public_project_page, private_project_page]) }
+      its(:version) { is_expected.to match_array([public_project_page, private_project_page]) }
     end
 
     context 'for a translator user' do
@@ -76,13 +76,13 @@ describe ProjectPagePolicy do
 
       its(:index) { is_expected.to match_array([public_project_page, private_project_page]) }
       its(:show) { is_expected.to match_array([public_project_page, private_project_page]) }
-      its(:update) { is_expected.to match_array([private_project_page]) }
-      its(:destroy) { is_expected.to match_array([private_project_page]) }
+      its(:update) { is_expected.to be_empty }
+      its(:destroy) { is_expected.to be_empty }
       its(:translate) { is_expected.to match_array([private_project_page]) }
-      its(:update_links) { is_expected.to match_array([private_project_page]) }
-      its(:destroy_links) { is_expected.to match_array([private_project_page]) }
-      its(:versions) { is_expected.to match_array([private_project_page]) }
-      its(:version) { is_expected.to match_array([private_project_page]) }
+      its(:update_links) { is_expected.to be_empty }
+      its(:destroy_links) { is_expected.to be_empty }
+      its(:versions) { is_expected.to match_array([public_project_page, private_project_page]) }
+      its(:version) { is_expected.to match_array([public_project_page, private_project_page]) }
     end
 
     context 'for an admin' do

--- a/spec/policies/subject_policy_spec.rb
+++ b/spec/policies/subject_policy_spec.rb
@@ -48,8 +48,8 @@ describe SubjectPolicy do
 
       its(:index) { is_expected.to match_array([public_subject, private_subject]) }
       its(:show) { is_expected.to match_array([public_subject, private_subject]) }
-      its(:update) { is_expected.to be_empty }
-      its(:destroy) { is_expected.to be_empty }
+      its(:update) { is_expected.to match_array([private_subject]) }
+      its(:destroy) { is_expected.to match_array([private_subject]) }
       its(:version) { is_expected.to match_array([public_subject, private_subject]) }
       its(:versions) { is_expected.to match_array([public_subject, private_subject]) }
     end


### PR DESCRIPTION
ensure we test translators can add resource translations by moving the policy scope specs to the `PunditScopeTester` with explicit scope checks across translated resources. Also removed the resource policy `*_links` action scopes that aren't wired up via routes so can't be reached and updated associated policy specs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
