### PR TITLE
handle the non-array link_ids format on workflow links update / destroy

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -87,11 +87,11 @@ class Api::V1::WorkflowsController < Api::ApiController
       RefreshWorkflowStatusWorker.perform_async(workflow.id)
       case relation.to_s
       when "retired_subjects"
-        params[:retired_subjects].each do |subject_id|
+        Array.wrap(params[:retired_subjects]).each do |subject_id|
           NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
         end
       when "subject_sets"
-        params[:subject_sets].each do |set_id|
+        Array.wrap(params[:subject_sets]).each do |set_id|
           SubjectSetStatusesCreateWorker.perform_async(set_id, workflow.id)
         end
         NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/40595/faults/38901874

Ensure we handle the non-array link_ids format when handling update & destroy links in the workflows controller.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
