### PR TITLE
update sidekiq-unique-jobs again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ GEM
     sidekiq-congestion (0.1.0)
       congestion (~> 0.0.3)
       sidekiq (>= 3.0)
-    sidekiq-unique-jobs (6.0.4)
+    sidekiq-unique-jobs (6.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 6.0)
       thor (~> 0)


### PR DESCRIPTION
seems there is a fix to remove all orphaned keys in this 6.0.5 release. https://github.com/mhenrixon/sidekiq-unique-jobs/issues/234#issuecomment-411070779

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
