### PR TITLE
Ensure classifications records are processed correctly.

### DIFF
--- a/spec/lib/classification_lifecycle_spec.rb
+++ b/spec/lib/classification_lifecycle_spec.rb
@@ -64,7 +64,12 @@ describe ClassificationLifecycle do
       end
 
       it "should call the #process_project_preference" do
-        expect(subject).to receive(:update_seen_subjects)
+        expect(subject).to receive(:process_project_preference)
+        subject.execute
+      end
+
+      it "should call the #create_recent" do
+        expect(subject).to receive(:create_recent)
         subject.execute
       end
 
@@ -73,18 +78,23 @@ describe ClassificationLifecycle do
         subject.execute
       end
 
-      it "should call the #create_recent" do
-        expect(subject).to receive(:update_seen_subjects)
+      it "should call #create_export_row" do
+        expect(subject).to receive(:create_export_row)
+        subject.execute
+      end
+
+      it "should call #notify_subject_selector" do
+        expect(subject).to receive(:notify_subject_selector)
+        subject.execute
+      end
+
+      it "should call #update_counters" do
+        expect(subject).to receive(:update_counters)
         subject.execute
       end
 
       it "should call #publish_data" do
         expect(subject).to receive(:publish_data)
-        subject.execute
-      end
-
-      it "should call #create_export_row" do
-        expect(subject).to receive(:create_export_row)
         subject.execute
       end
 
@@ -103,36 +113,6 @@ describe ClassificationLifecycle do
         uss = instance_double("UserSeenSubject")
         allow(uss).to receive(:subjects_seen?).and_return(false)
         allow(UserSeenSubject).to receive(:find_by).and_return(uss)
-      end
-
-      it "should call the #update_classification_data!" do
-        expect(subject).to receive(:update_classification_data!)
-        subject.execute
-      end
-
-      it "should call the #process_project_preference" do
-        expect(subject).to receive(:process_project_preference)
-        subject.execute
-      end
-
-      it "should call the #create_recent" do
-        expect(subject).to receive(:create_recent)
-        subject.execute
-      end
-
-      it "should call the #update_seen_subjects" do
-        expect(subject).to receive(:update_seen_subjects)
-        subject.execute
-      end
-
-      it "should call #publish_data" do
-        expect(subject).to receive(:publish_data)
-        subject.execute
-      end
-
-      it "should call #create_export_row" do
-        expect(subject).to receive(:create_export_row)
-        subject.execute
       end
 
       it 'should count towards retirement' do
@@ -289,7 +269,7 @@ describe ClassificationLifecycle do
 
     it_behaves_like "create and update"
 
-    it 'should call process_project_preferences' do
+    it 'should do something' do
       expect(subject).to receive(:process_project_preference)
       subject.execute
     end


### PR DESCRIPTION
This PR addresses the scheduling failures of classification lifecycle jobs, e.g. redis goes down after this jobs starts, and this job fails to schedule others / can't requeue itself. Ensure the runtime order of data updates and worker calls as follow:

1. Updating the classification data and save the record (fast fail if invalid)
2. Queue up the associated worker jobs
3. Update the `lifecycled_at` field if all workers are scheduled.

Should any failure occur in step 2 and the job doesn't make it back to sidekiq to run again the `RequeueClassificationsWorker` will ensure these jobs eventually get processed and ensure we update the associated data records.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
