### PR TITLE
Speed up tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'active_record_union', '~> 1.3.0'
 gem 'activerecord-import', '~> 0.25'
 gem 'aws-sdk', '~> 2.10'
 gem "cellect-client", '~> 3.0.2'
+gem 'celluloid', '~> 0.18.0.pre' # to work around https://github.com/celluloid/celluloid/issues/696
 gem 'dalli-elasticache'
 gem 'devise', '~> 4.3'
 gem 'doorkeeper', '~> 4.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       attention (~> 0.0.4)
       http (~> 0.9)
       multi_json (~> 1.11)
-    celluloid (0.17.3)
+    celluloid (0.18.0.pre)
       celluloid-essentials
       celluloid-extras
       celluloid-fsm
@@ -177,7 +177,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.7)
     hashie (3.5.7)
-    hitimes (1.2.4)
+    hitimes (1.3.0)
     honeybadger (3.3.1)
     http (0.9.9)
       addressable (~> 2.3)
@@ -451,6 +451,7 @@ DEPENDENCIES
   activerecord-import (~> 0.25)
   aws-sdk (~> 2.10)
   cellect-client (~> 3.0.2)
+  celluloid (~> 0.18.0.pre)
   dalli-elasticache
   database_cleaner (~> 1.7.0)
   devise (~> 4.3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ RSpec.configure do |config|
   MOCK_REDIS ||= MockRedis.new
 
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with(:deletion)
 
     SidekiqUniqueJobs.configure do |suj_config|
       suj_config.enabled = !Rails.env.test?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,9 +33,6 @@ RSpec.configure do |config|
   # disable slave reads to deal with testing transaction isolation
   Slavery.disabled = true
 
-  # work around https://github.com/celluloid/celluloid/issues/696
-  Celluloid.shutdown_timeout = 1
-
   MOCK_REDIS ||= MockRedis.new
 
   config.before(:suite) do


### PR DESCRIPTION
I was sharpening up my editor--testsuite integration with some hotkeys
to run a single test, file, or rerun the last one. Because this made it
faster to run tests, it made it more apparent that we're wasting a bunch
of time in our tests.

Specifically, it turns out that in our case, deletion is faster than
truncation as a "reset the db" strategy in DatabaseCleaner. This means
we don't reset IDs back to 1 every test run, but who cares, right? This
was the cause of the delay between RSpec saying "Randomized with seed"
and it actually starting to run the first example.

A further delay was caused by Celluloid (used by Sidetiq). We've already
worked around it somewhat by setting the timeout to 1 second in test.
It's also not as bad as the truncation fix, since this delay sits at the
very end of the test run, after the results are already visible, but
still. After more than a year has passed, we still don't have a full
release of Celluloid, but at least now there is a prerelease that we can
bump to. This removes the warning and timeout delay entirely.


- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.