### PR TITLE
focus the called workers for workflow link actions

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -99,7 +99,7 @@ class Api::V1::WorkflowsController < Api::ApiController
       RefreshWorkflowStatusWorker.perform_async(workflow.id)
     end
 
-    if relation_index == 0
+    if relation_index&.zero?
       NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)
     end
   end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -99,7 +99,7 @@ class Api::V1::WorkflowsController < Api::ApiController
       RefreshWorkflowStatusWorker.perform_async(workflow.id)
     end
 
-    if relation_index.zero?
+    if relation_index == 0
       NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)
     end
   end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -93,13 +93,11 @@ class Api::V1::WorkflowsController < Api::ApiController
   # Allways update the state of the workflow & selector services
   # when modifying the subject sets or retired_subjects links
   def post_link_actions(workflow)
-    relation_index = %w(subject_sets retired_subjects).index(relation.to_s)
-
-    if relation_index
+    if %w(subject_sets retired_subjects).include?(relation.to_s)
       RefreshWorkflowStatusWorker.perform_async(workflow.id)
     end
 
-    if relation_index&.zero?
+    if relation.to_s == "subject_sets"
       NotifySubjectSelectorOfChangeWorker.perform_async(workflow.id)
     end
   end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -634,9 +634,9 @@ describe Api::V1::WorkflowsController, type: :controller do
         expect(NotifySubjectSelectorOfChangeWorker)
           .to receive(:perform_async)
           .with(workflow.id)
-          expect(RefreshWorkflowStatusWorker)
-            .to receive(:perform_async)
-            .with(workflow.id)
+        expect(RefreshWorkflowStatusWorker)
+          .to receive(:perform_async)
+          .with(workflow.id)
         delete :destroy_links, destroy_link_params
       end
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -392,7 +392,6 @@ describe Api::V1::WorkflowsController, type: :controller do
       let(:copied_resource) { resource.reload.send(test_relation).first }
 
       it_behaves_like "supports update_links"
-
       it_behaves_like "reloads the non logged in queues", :subject_sets
 
       it "should call SubjectSetStatusesCreateWorker" do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -353,48 +353,28 @@ describe Api::V1::WorkflowsController, type: :controller do
           post :update_links, update_link_params
         end
 
-        context "when the workflow has subjects" do
-          case link_to_test
-          when :subject_sets
-            it "should call refresh workflow status worker" do
-              expect(RefreshWorkflowStatusWorker)
+        it 'should run refresh workflow status worker' do
+          expect(RefreshWorkflowStatusWorker)
+            .to receive(:perform_async)
+        end
+
+        case link_to_test
+        when :subject_sets
+          it "should call post link subject set workers", :aggregate_failures do
+            test_relation_ids.each do |set_id|
+              expect(SubjectSetStatusesCreateWorker)
+              .to receive(:perform_async)
+              .with(set_id, resource.id)
+            end
+            expect(NotifySubjectSelectorOfChangeWorker)
               .to receive(:perform_async)
               .with(resource.id)
-            end
-
-            it 'should notify the subject selector that the available subjects changed' do
-              expect(NotifySubjectSelectorOfChangeWorker).to receive(:perform_async)
-                .with(resource.id)
-            end
-          when :retired_subjects
-            it 'should call the workflow retired counter worker' do
-              expect(RefreshWorkflowStatusWorker)
-                .to receive(:perform_async)
-                .with(resource.id)
-            end
-
-            it 'should notify the subject selector that subjects were retired' do
-              expect(NotifySubjectSelectorOfRetirementWorker).to receive(:perform_async)
-                .with(linked_resource.id.to_s, workflow.id)
-            end
           end
-        end
-
-        context "when the workflow has no subjects" do
-          let(:linked_resource) { create(:subject_set, project: subject_set_project) }
-
-          if %i(subject_sets retired_subjects).include?(link_to_test)
-            it 'should run the workers', :aggregate_failures, :focus do
-              expect(NotifySubjectSelectorOfChangeWorker).to receive(:perform_async)
-              expect(RefreshWorkflowStatusWorker).to receive(:perform_async)
-            end
+        when :retired_subjects
+          it 'should notify the subject selector that subjects were retired' do
+            expect(NotifySubjectSelectorOfRetirementWorker).to receive(:perform_async)
+              .with(linked_resource.id.to_s, workflow.id)
           end
-        end
-      end
-
-      context "without authorized user" do
-        it 'should not attempt to call cellect', :aggregate_failures do
-          expect(NotifySubjectSelectorOfChangeWorker).not_to receive(:perform_async)
         end
       end
     end
@@ -412,6 +392,7 @@ describe Api::V1::WorkflowsController, type: :controller do
       let(:copied_resource) { resource.reload.send(test_relation).first }
 
       it_behaves_like "supports update_links"
+
       it_behaves_like "reloads the non logged in queues", :subject_sets
 
       it "should call SubjectSetStatusesCreateWorker" do


### PR DESCRIPTION
This PR adds greater targeting of the called workers when updating/deleting workflow links for subjects_sets and/or retired_subjects. E.g. when adding subject_sets the SWS Create worker should be called but not the Notify Selector of retirement worker. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
