### PR TITLE
lock doorkeeper at 4.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "cellect-client", '~> 3.0.2'
 gem 'celluloid', '~> 0.18.0.pre' # to work around https://github.com/celluloid/celluloid/issues/696
 gem 'dalli-elasticache'
 gem 'devise', '~> 4.3'
-gem 'doorkeeper', '~> 4.4'
+gem 'doorkeeper', '= 4.4.0'
 gem 'doorkeeper-jwt', '~> 0.2.1'
 gem 'httparty'
 gem 'faraday', '~> 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (4.4.1)
+    doorkeeper (4.4.0)
       railties (>= 4.2)
     doorkeeper-jwt (0.2.1)
       jwt (~> 1.5.2, >= 1.5.2)
@@ -455,7 +455,7 @@ DEPENDENCIES
   dalli-elasticache
   database_cleaner (~> 1.7.0)
   devise (~> 4.3)
-  doorkeeper (~> 4.4)
+  doorkeeper (= 4.4.0)
   doorkeeper-jwt (~> 0.2.1)
   factory_bot_rails
   faraday (~> 0.9)


### PR DESCRIPTION
4.4.1 changes bearer token to Bearer as per the oauth spec, out JS client check doesn't handle the change in case and thus breaks login for CFE. Once v2.11.2 of https://github.com/zooniverse/panoptes-javascript-client/commit/1b2fb0550608cc5e142e36e9038d0a75ef81379f is deployed to all CFEs we can revert this and upgrade the doorkeeper gem

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
