### PR TITLE
revert celluloid gem upgrades

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'active_record_union', '~> 1.3.0'
 gem 'activerecord-import', '~> 0.25'
 gem 'aws-sdk', '~> 2.10'
 gem "cellect-client", '~> 3.0.2'
-gem 'celluloid', '~> 0.18.0.pre' # to work around https://github.com/celluloid/celluloid/issues/696
 gem 'dalli-elasticache'
 gem 'devise', '~> 4.3'
 gem 'doorkeeper', '= 4.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,7 +451,6 @@ DEPENDENCIES
   activerecord-import (~> 0.25)
   aws-sdk (~> 2.10)
   cellect-client (~> 3.0.2)
-  celluloid (~> 0.18.0.pre)
   dalli-elasticache
   database_cleaner (~> 1.7.0)
   devise (~> 4.3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,9 @@ RSpec.configure do |config|
   # disable slave reads to deal with testing transaction isolation
   Slavery.disabled = true
 
+  # work around https://github.com/celluloid/celluloid/issues/696
+  Celluloid.shutdown_timeout = 1
+
   MOCK_REDIS ||= MockRedis.new
 
   config.before(:suite) do


### PR DESCRIPTION
sidetiq depends on the old pre 0.18 celluloid API. This error stops sidekiq from running. Ideally we can fork and bump sidetiq to get it working again to reap the timeout benefits but that'll have to wait. 
```
There was an error while trying to load the gem 'sidetiq'.
Gem Load Error is: Celluloid is not yet started; use Celluloid.boot
Backtrace for gem load error is:
/usr/local/bundle/gems/celluloid-0.18.0.pre/lib/celluloid.rb:38:in `actor_system'
/usr/local/bundle/gems/celluloid-0.18.0.pre/lib/celluloid.rb:208:in `actor_system'
/usr/local/bundle/gems/celluloid-0.18.0.pre/lib/celluloid.rb:214:in `actor_options'
/usr/local/bundle/gems/celluloid-0.18.0.pre/lib/celluloid.rb:185:in `new'
/usr/local/bundle/gems/celluloid-supervision-0.20.6/lib/celluloid/supervision/deprecate/supervise.rb:61:in `run!'
/usr/local/bundle/gems/sidetiq-0.7.2/lib/sidetiq/supervisor.rb:33:in `run!'
/usr/local/bundle/gems/sidetiq-0.7.2/lib/sidetiq.rb:65:in `<top (required)>'
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
