### PR TITLE
Cleanup subject placeholder SubjectWorkflowStatus records when removing subjects

### DIFF
--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -1,9 +1,10 @@
 module Subjects
   class Remover
-    attr_reader :subject_id
+    attr_reader :subject_id, :panoptes_client
 
-    def initialize(subject_id)
+    def initialize(subject_id, client=nil)
       @subject_id = subject_id
+      @panoptes_client = client || Panoptes::Client.new(env: Rails.env)
     end
 
     def cleanup
@@ -59,8 +60,11 @@ module Subjects
       panoptes_client.discussions(focus_id: subject_id, focus_type: 'Subject').empty?
     end
 
-    def panoptes_client
-      @client ||= Panoptes::Client.new(env: Rails.env)
+    def has_been_talked_about?
+      panoptes_client.discussions(
+        focus_id: subject_id,
+        focus_type: 'Subject'
+      ).any?
     end
 
     def notify_subject_selector(workflow_ids)

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -29,13 +29,10 @@ module Subjects
     private
 
     def can_be_removed?
-      # subject has been collected or classified
       return false if has_been_collected_or_classified?
 
-      # subject has been talked about
       return false if has_been_talked_about?
 
-      # subject has been counted or retired via a SubjectWorkflowStatus record
       return false if has_been_counted_or_retired?
 
       # subject has no record of use in zooniverse

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -8,11 +8,13 @@ module Subjects
 
     def cleanup
       if can_be_removed?
-        locations = orphan.locations
-        set_member_subjects = orphan.set_member_subjects
-        workflow_ids = orphan.workflows.pluck(:id)
+        locations = orphan_subject.locations
+        set_member_subjects = orphan_subject.set_member_subjects
+        workflow_ids = orphan_subject.workflows.pluck(:id)
         ActiveRecord::Base.transaction do
-          orphan.delete
+          # clean up the linked sws records, https://github.com/zooniverse/Panoptes/pull/2822
+          orphan_subject_sws_scope.delete_all
+          orphan_subject.delete
           locations.map(&:destroy)
           set_member_subjects.map(&:destroy)
         end
@@ -26,17 +28,31 @@ module Subjects
     private
 
     def can_be_removed?
-      !!orphan && no_talk_discussions?
+      # subject has been collected or classified
+      return false unless orphan_subject_scope.exists?
+
+      # subject has been talked about
+      return false unless no_talk_discussions?
+
+      # subject has been counted or retired via a SubjectWorkflowStatus record
+      if has_not_been_counted_or_retired?
+        true
+      else
+        false
+      end
     end
 
-    def orphan
-      @orphan ||= Subject
-       .where(id: subject_id)
-       .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
-       .where("classification_subjects.subject_id IS NULL")
-       .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
-       .where("collections_subjects.subject_id IS NULL")
-       .first
+    def orphan_subject_scope
+      Subject
+      .where(id: subject_id)
+      .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
+      .where("classification_subjects.subject_id IS NULL")
+      .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
+      .where("collections_subjects.subject_id IS NULL")
+    end
+
+    def orphan_subject
+      @orphan_subject ||= orphan_subject_scope.first
     end
 
     def no_talk_discussions?
@@ -49,8 +65,20 @@ module Subjects
 
     def notify_subject_selector(workflow_ids)
       workflow_ids.each do |workflow_id|
-        NotifySubjectSelectorOfRetirementWorker.perform_async(orphan.id, workflow_id)
+        NotifySubjectSelectorOfRetirementWorker.perform_async(orphan_subject.id, workflow_id)
       end
+    end
+
+    def orphan_subject_sws_scope
+      SubjectWorkflowStatus.where(subject_id: subject_id)
+    end
+
+    def orphan_subject_sws_counted_or_retired_scope
+      orphan_subject_sws_scope.where("classifications_count > 0 OR retired_at IS NOT NULL")
+    end
+
+    def has_not_been_counted_or_retired?
+      !orphan_subject_sws_counted_or_retired_scope.exists?
     end
   end
 end

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -42,15 +42,17 @@ module Subjects
       true
     end
 
+    def orphan_subject_scope
+      Subject
+      .where(id: subject_id)
+      .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
+      .where("classification_subjects.subject_id IS NULL")
+      .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
+      .where("collections_subjects.subject_id IS NULL")
+    end
+
     def orphan_subject
-      @orphan_subject ||=
-        Subject
-        .where(id: subject_id)
-        .joins("LEFT OUTER JOIN classification_subjects ON classification_subjects.subject_id = subjects.id")
-        .where("classification_subjects.subject_id IS NULL")
-        .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
-        .where("collections_subjects.subject_id IS NULL")
-        .first
+      @orphan_subject ||= orphan_subject_scope.first
     end
 
     def has_been_collected_or_classified?

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Subjects::Remover do
         end
       end
 
-      context "with a non-zero count sws record" do
+      context "with a retired count sws record" do
         let(:linked_sws) do
           create(
             :subject_workflow_status,

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe Subjects::Remover do
   let(:subjects) { subject_set.subjects }
   let(:subject) { subjects.sample }
   let!(:linked_sws) do
-    create(:subject_workflow_status, workflow: workflow, subject: subject)
+    create(
+      :subject_workflow_status,
+      workflow: workflow,
+      subject: subject,
+      classifications_count: 0
+    )
   end
   let(:remover) { Subjects::Remover.new(subject.id) }
 

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Subjects::Remover do
       end
 
       context "without a real subject" do
+        let(:linked_sws) { nil }
         let(:subject) { double(id: 100) }
 
         it "should ignore non existant subject ids" do

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Subjects::Remover do
         expect { Medium.find(media_ids) }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "notify cellect about the subject removal" do
+      it "notify selector service about the subject removal" do
         expect(NotifySubjectSelectorOfRetirementWorker)
           .to receive(:perform_async)
           .with(subject.id, workflow.id)

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -15,31 +15,27 @@ RSpec.describe Subjects::Remover do
       classifications_count: 0
     )
   end
-  let(:remover) { Subjects::Remover.new(subject.id) }
+  let(:panoptes_client) { instance_double(Panoptes::Client) }
+  let(:remover) { Subjects::Remover.new(subject.id, panoptes_client) }
 
   describe "#cleanup" do
-
     describe "testing the client configuration" do
-
       it "should setup the panoptes client with the correct env" do
         expect(Panoptes::Client)
           .to receive(:new)
           .with(env: Rails.env)
-          .and_call_original
-        remover.cleanup
+        Subjects::Remover.new(subject.id)
       end
     end
 
     context "with a client test double testing the client configuration" do
-      let(:panoptes_client) { instance_double(Panoptes::Client) }
       let(:discussions) { [] }
 
       before do
         allow(panoptes_client)
-          .to receive(:discussions)
-          .with(focus_id: subject.id, focus_type: "Subject")
-          .and_return(discussions)
-        allow(remover).to receive(:panoptes_client).and_return(panoptes_client)
+        .to receive(:discussions)
+        .with(focus_id: subject.id, focus_type: "Subject")
+        .and_return(discussions)
       end
 
       context "without a real subject" do


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/40595/faults/39095676

Since https://github.com/zooniverse/Panoptes/pull/2822 SWS records are being auto created to optimize internal pg subject selection. These records need to be cleaned up before the subject is removed to avoid the database FK constraints. 

This PR checks for any linked SWS records with non zero classification_counts OR non-empty retirement status. Any of these linked SWS records will fail the orphan test and not attempt to cleanup the subject. All empty placeholder SWS records are cleaned up before deleting the orphan subject.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
