### PR TITLE
serialise the user banned private attribute

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,7 +9,7 @@ class UserSerializer
     project_email_communication beta_email_communication
     uploaded_subjects_count subject_limit admin login_prompt zooniverse_id
     upload_whitelist valid_email ux_testing_email_communication
-    intervention_notifications
+    intervention_notifications banned
   ).freeze
 
   attributes :id, :login, :display_name, :credited_name, :email, :languages,
@@ -17,7 +17,8 @@ class UserSerializer
     :project_email_communication, :beta_email_communication,
     :subject_limit, :uploaded_subjects_count, :admin, :href, :login_prompt,
     :private_profile, :zooniverse_id, :upload_whitelist, :avatar_src,
-    :valid_email, :ux_testing_email_communication, :intervention_notifications
+    :valid_email, :ux_testing_email_communication, :intervention_notifications,
+    :banned
 
   can_include :classifications, :project_preferences, :collection_preferences,
     projects: { param: "owner", value: "login" },


### PR DESCRIPTION
Support the admin UI banned functionality, allow admins to see the banned state of a user.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
