### PR TITLE
allow insecure localhost oauth apps

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -21,7 +21,7 @@ class ApplicationsController < Doorkeeper::ApplicationsController
   end
 
   def update
-    if @application.update!(application_params)
+    if @application.update(application_params)
       flash[:notice] = I18n.t(:notice, scope: [:doorkeeper, :flash, :applications, :update])
       respond_with :oauth, @application, location: oauth_application_url( @application )
     else

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -30,7 +30,7 @@
   <%= content_tag :div, class: "form-group#{' has-error' if application.errors[:default_scope].present?}" do %>
     <h3>Application Scopes</h3>
     <div class="row">
-      <% Doorkeeper::PanoptesScopes.optional.each do |scope| %>
+      <% Doorkeeper::Panoptes::Scopes.optional.each do |scope| %>
         <div class="col-sm-10">
           <%= f.label scope, class: 'col-sm-2 control-label', for: "application_default_scope_#{scope}" %>
           <%= check_box_tag "application[default_scope][]", scope, application.default_scope.include?(scope.to_s) %>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -22,6 +22,8 @@ Doorkeeper.configure do
 
   access_token_generator "Doorkeeper::JWT"
 
+  force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
   resource_owner_authenticator do
     u = current_user || warden.authenticate!(scope: :user)
     u if !u.disabled?

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -22,7 +22,16 @@ Doorkeeper.configure do
 
   access_token_generator "Doorkeeper::JWT"
 
-  force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+  # Remove the scheme check
+  # once Doorkeeper v5 is released (no backport fix)
+  # https://github.com/doorkeeper-gem/doorkeeper/issues/1091
+  force_ssl_in_redirect_uri do |uri|
+    if uri.scheme == 'https'
+      false
+    else
+      uri.host != 'localhost'
+    end
+  end
 
   resource_owner_authenticator do
     u = current_user || warden.authenticate!(scope: :user)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -24,7 +24,7 @@ Doorkeeper.configure do
   enable_application_owner :confirmation => true
 
   default_scopes  :public
-  optional_scopes *Doorkeeper::PanoptesScopes.optional
+  optional_scopes *Doorkeeper::Panoptes::Scopes.optional
 
   realm "Panoptes"
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,7 +1,17 @@
 module Doorkeeper
-  module PanoptesScopes
-    def self.optional
-      %i(user project group collection classification subject medium organization translation)
+  module Panoptes
+    module Scopes
+      def self.optional
+        %i(user project group collection classification subject medium organization translation)
+      end
+    end
+
+    module Host
+      ALLOWED_INSECURE_HOSTS = %w(localhost local.zooniverse.org).freeze
+
+      def self.force_secure_scheme?(host)
+        !ALLOWED_INSECURE_HOSTS.include?(host)
+      end
     end
   end
 end
@@ -29,7 +39,7 @@ Doorkeeper.configure do
     if uri.scheme == 'https'
       false
     else
-      uri.host != 'localhost'
+      Doorkeeper::Panoptes::Host.force_secure_scheme?(uri.host)
     end
   end
 

--- a/db/dev_seed_data/dev_seed_data.rb
+++ b/db/dev_seed_data/dev_seed_data.rb
@@ -55,7 +55,7 @@ app = Doorkeeper::Application.create do |da|
   # zooniverse first-party app
   da.trust_level = 2
   #scoped resources this app has access to
-  scopes = [:public] | Doorkeeper::PanoptesScopes.optional
+  scopes = [:public] | Doorkeeper::Panoptes::Scopes.optional
   da.default_scope = scopes.map(&:to_s)
 end
 puts "\nOauth Zooniverse first party app details:"

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -70,6 +70,16 @@ describe ApplicationsController, type: :controller do
       }.by(1)
     end
 
+    it 'should allows insecure local zooniverse scheme URIs' do
+      expect {
+        post :create, {
+          application: { name: "test app", redirect_uri: "http://local.zooniverse.org" }
+        }
+      }.to change {
+        Doorkeeper::Application.count
+      }.by(1)
+    end
+
     it 'should not allow insecure non-localhost scheme URIs' do
       sign_in normal_user
       expect {
@@ -107,6 +117,18 @@ describe ApplicationsController, type: :controller do
     it 'allows insecure localhost scheme URIs' do
       sign_in application.owner
       redirect_uri = "http://localhost"
+      expect {
+        put :update, id: application.id, application: {
+          redirect_uri: redirect_uri
+        }
+      }.to change {
+        application.reload.redirect_uri
+      }.to(redirect_uri)
+    end
+
+    it 'allows insecure localhost scheme URIs' do
+      sign_in application.owner
+      redirect_uri = "http://local.zooniverse.org"
       expect {
         put :update, id: application.id, application: {
           redirect_uri: redirect_uri

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -104,7 +104,7 @@ describe ApplicationsController, type: :controller do
       expect(application.reload.name).to eq('changed')
     end
 
-    it 'allows insecure localhost scheme URIs', :focus do
+    it 'allows insecure localhost scheme URIs' do
       sign_in application.owner
       redirect_uri = "http://localhost"
       expect {
@@ -116,7 +116,7 @@ describe ApplicationsController, type: :controller do
       }.to(redirect_uri)
     end
 
-    it 'should not allow insecure non-localhost scheme URIs', :focus do
+    it 'should not allow insecure non-localhost scheme URIs' do
       sign_in application.owner
       original_redirect = application.redirect_uri
       put :update, id: application.id, application: {redirect_uri: "http://example.com"}


### PR DESCRIPTION
Use the Doorkeeper `force_ssl_in_redirect_uri` config option to allow localhost apps to be insecure. 

Note: this will have to change when v5 of the gem is released (see comment in code).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
