### PR TITLE
Also write org contents to org itself

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -189,9 +189,8 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def primary_content_attributes(content_attributes)
-    content_from_params(content_attributes.dup, CONTENT_FIELDS) do |ps|
-      ps[:title] = ps[:display_name]
-    end
+    content_attributes = content_attributes.merge(title: content_attributes[:display_name])
+    ContentFromParams.content_from_params(content_attributes, CONTENT_FIELDS)
   end
 
   def available_to_export

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -7,8 +7,6 @@ class Api::V1::ProjectsController < Api::ApiController
   include FilterByTags
   include AdminAllowed
   include Versioned
-  include UrlLabels
-  include ContentFromParams
   include Slug
   include MediumResponse
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -21,6 +21,8 @@ class Organization < ActiveRecord::Base
 
   accepts_nested_attributes_for :organization_contents
 
+  alias_attribute :title, :display_name
+
   def self.translatable_attributes
     %i(display_name title description introduction announcement url_labels)
   end

--- a/app/operations/concerns/content_from_params.rb
+++ b/app/operations/concerns/content_from_params.rb
@@ -1,14 +1,14 @@
 module ContentFromParams
-  def content_from_params(ps, content_fields)
-    yield ps if block_given?
-    content = ps.slice(*content_fields)
-    content[:language] = ps[:primary_language]
-    if ps.key? :urls
-      urls, labels = UrlLabels.extract_url_labels(ps[:urls])
-      content[:url_labels] = labels
-      ps[:urls] = urls
+  def self.content_from_params(params, content_fields)
+    content_params = params.slice(*content_fields)
+    content_params[:language] = params[:primary_language]
+
+    if params.key? :urls
+      urls, labels = UrlLabels.extract_url_labels(params[:urls])
+      content_params[:url_labels] = labels
+      params[:urls] = urls
     end
-    ps.except!(*content_fields)
-    content.select { |k,v| !!v }
+
+    content_params.select { |k,v| !!v }
   end
 end

--- a/app/operations/concerns/content_from_params.rb
+++ b/app/operations/concerns/content_from_params.rb
@@ -4,7 +4,7 @@ module ContentFromParams
     content = ps.slice(*content_fields)
     content[:language] = ps[:primary_language]
     if ps.key? :urls
-      urls, labels = extract_url_labels(ps[:urls])
+      urls, labels = UrlLabels.extract_url_labels(ps[:urls])
       content[:url_labels] = labels
       ps[:urls] = urls
     end

--- a/app/operations/concerns/url_labels.rb
+++ b/app/operations/concerns/url_labels.rb
@@ -1,5 +1,5 @@
 module UrlLabels
-  def extract_url_labels(urls)
+  def self.extract_url_labels(urls)
     visitor = TasksVisitors::ExtractStrings.new
     visitor.visit(urls)
     [urls, visitor.collector]

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -33,7 +33,7 @@ module Organizations
         primary_language: primary_language,
         categories: categories,
         urls: urls
-      }.merge(organization_contents_params.slice(:title, :description, :introduction, :announcement, :url_labels)))
+      }.merge(organization_contents_params.slice(:description, :introduction, :announcement, :url_labels)))
     end
 
     def organization_contents_params

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -1,8 +1,5 @@
 module Organizations
   class Create < Operation
-    include UrlLabels
-    include ContentFromParams
-
     string :display_name
     string :primary_language
 
@@ -51,10 +48,8 @@ module Organizations
     end
 
     def organization_contents_from_params
-      content_from_params(
-        inputs,
-        Api::V1::OrganizationsController::CONTENT_FIELDS
-      )
+      fields = Api::V1::OrganizationsController::CONTENT_FIELDS
+      ContentFromParams.content_from_params(inputs, fields)
     end
   end
 end

--- a/app/operations/organizations/create.rb
+++ b/app/operations/organizations/create.rb
@@ -27,12 +27,13 @@ module Organizations
     private
 
     def build_organization
-      Organization.new(
+      Organization.new({
         owner: api_user.user,
         display_name: display_name,
         primary_language: primary_language,
-        categories: categories
-      )
+        categories: categories,
+        urls: urls
+      }.merge(organization_contents_params.slice(:title, :description, :introduction, :announcement, :url_labels)))
     end
 
     def organization_contents_params

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -22,14 +22,17 @@ module Organizations
           org_update.delete(:tags)
         end
 
+        content_update.merge! content_params
+        org_update.merge!(content_update.with_indifferent_access.except(:language))
+
         organization.update!(org_update.symbolize_keys)
         organization.organization_contents.find_or_initialize_by(language: language).tap do |content|
-          content_update.merge! content_params
           content.update! content_update.symbolize_keys
         end
         org_update[:listed] == true ? organization.touch(:listed_at) : organization[:listed_at] = nil
 
         organization.save!
+        organization
       end
     end
 
@@ -46,7 +49,7 @@ module Organizations
     def content_params
       params = inputs[:organization_params].merge("title" => organization_params["display_name"])
       fields = Api::V1::OrganizationsController::CONTENT_FIELDS
-      ContentFromParams.content_from_params(params, fields)
+      @content_params ||= ContentFromParams.content_from_params(params, fields)
     end
   end
 end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -2,9 +2,6 @@ require_relative '../../../lib/filters/organization_filter.rb'
 
 module Organizations
   class Update < Operation
-    include UrlLabels
-    include ContentFromParams
-
     organization :organization_params
     string :id
 
@@ -27,10 +24,7 @@ module Organizations
 
         organization.update!(org_update.symbolize_keys)
         organization.organization_contents.find_or_initialize_by(language: language).tap do |content|
-          results = content_from_params(inputs[:organization_params], Api::V1::OrganizationsController::CONTENT_FIELDS) do |ps|
-            ps["title"] = ps["display_name"]
-          end
-          content_update.merge! results
+          content_update.merge! content_params
           content.update! content_update.symbolize_keys
         end
         org_update[:listed] == true ? organization.touch(:listed_at) : organization[:listed_at] = nil
@@ -47,6 +41,12 @@ module Organizations
 
     def language
       @language ||= organization_params[:primary_language] ? organization_params[:primary_language] : @organization.primary_language
+    end
+
+    def content_params
+      params = inputs[:organization_params].merge("title" => organization_params["display_name"])
+      fields = Api::V1::OrganizationsController::CONTENT_FIELDS
+      ContentFromParams.content_from_params(params, fields)
     end
   end
 end

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -23,7 +23,7 @@ module Organizations
         end
 
         content_update.merge! content_params
-        org_update.merge!(content_update.with_indifferent_access.except(:language))
+        org_update.merge!(content_update.with_indifferent_access.except(:title, :language))
 
         organization.update!(org_update.symbolize_keys)
         organization.organization_contents.find_or_initialize_by(language: language).tap do |content|

--- a/db/migrate/20180808140938_add_content_fields_to_organizations.rb
+++ b/db/migrate/20180808140938_add_content_fields_to_organizations.rb
@@ -1,0 +1,9 @@
+class AddContentFieldsToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :title, :string
+    add_column :organizations, :description, :string
+    add_column :organizations, :introduction, :text
+    add_column :organizations, :url_labels, :jsonb
+    add_column :organizations, :announcement, :string
+  end
+end

--- a/db/migrate/20180808140938_add_content_fields_to_organizations.rb
+++ b/db/migrate/20180808140938_add_content_fields_to_organizations.rb
@@ -1,6 +1,5 @@
 class AddContentFieldsToOrganizations < ActiveRecord::Migration
   def change
-    add_column :organizations, :title, :string
     add_column :organizations, :description, :string
     add_column :organizations, :introduction, :text
     add_column :organizations, :url_labels, :jsonb

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -777,7 +777,6 @@ CREATE TABLE public.organizations (
     urls jsonb DEFAULT '[]'::jsonb,
     listed boolean DEFAULT false NOT NULL,
     categories character varying[] DEFAULT '{}'::character varying[],
-    title character varying,
     description character varying,
     introduction text,
     url_labels jsonb,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -776,7 +776,12 @@ CREATE TABLE public.organizations (
     updated_at timestamp without time zone NOT NULL,
     urls jsonb DEFAULT '[]'::jsonb,
     listed boolean DEFAULT false NOT NULL,
-    categories character varying[] DEFAULT '{}'::character varying[]
+    categories character varying[] DEFAULT '{}'::character varying[],
+    title character varying,
+    description character varying,
+    introduction text,
+    url_labels jsonb,
+    announcement character varying
 );
 
 
@@ -4158,4 +4163,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180710151618');
 INSERT INTO schema_migrations (version) VALUES ('20180724112620');
 
 INSERT INTO schema_migrations (version) VALUES ('20180726133210');
+
+INSERT INTO schema_migrations (version) VALUES ('20180808140938');
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -291,4 +291,19 @@ namespace :migrate do
       end
     end
   end
+
+  namespace :contents do
+    desc "Copy org contents to orgs"
+    task :copy_org_contents do
+      Organization.find_each do |org|
+        content = org.primary_content
+        org.title = content.title
+        org.description = content.description
+        org.introduction = content.introduction
+        org.url_labels = content.url_labels
+        org.announcement = content.announcement
+        org.save!
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -108,6 +108,8 @@ describe Api::V1::OrganizationsController, type: :controller do
           organizations: {
             display_name: "The Illuminati",
             description: "This organization is the most organized organization to ever organize",
+            introduction: "org intro",
+            announcement: "We dont exist",
             urls: [{label: "Blog", url: "http://blogo.com/example"}],
             primary_language: "zh-tw",
             categories: %w(stuff things moar)
@@ -136,6 +138,15 @@ describe Api::V1::OrganizationsController, type: :controller do
           it 'should create the organization with the categories' do
             categories = resource_class.find(created_id).send(test_attr)
             expect(categories).to match_array(expected_categories)
+          end
+
+          it 'should set content attributes on the main model' do
+            resource = resource_class.find(created_id)
+            expect(resource.title).to eq("The Illuminati")
+            expect(resource.description).to eq("This organization is the most organized organization to ever organize")
+            expect(resource.introduction).to eq("org intro")
+            expect(resource.url_labels).to eq({"0.label" => "Blog"})
+            expect(resource.announcement).to eq("We dont exist")
           end
         end
       end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -12,6 +12,12 @@ FactoryBot.define do
     urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
     categories %w(bugs fossils plants)
 
+    description "This is the description for an Organization"
+    title "Test Organization"
+    introduction "This is the intro for an Organization"
+    announcement "Alert: This organization has something to let you know"
+    url_labels({"0.label" => "Blog", "1.label" => "Twitter"})
+
     association :owner, factory: :user
 
     after(:build) do |o, env|

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     categories %w(bugs fossils plants)
 
     description "This is the description for an Organization"
-    title "Test Organization"
     introduction "This is the intro for an Organization"
     announcement "Alert: This organization has something to let you know"
     url_labels({"0.label" => "Blog", "1.label" => "Twitter"})

--- a/spec/operations/organizations/create_spec.rb
+++ b/spec/operations/organizations/create_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Organizations::Create do
+  let(:user){ create :user }
+  let(:api_user){ ApiUser.new(user) }
+  let(:params) do
+    {
+      display_name: "The Illuminati",
+      description: "This organization is the most organized organization to ever organize",
+      introduction: "org intro",
+      announcement: "We dont exist",
+      urls: [{label: "Blog", url: "http://blogo.com/example"}],
+      primary_language: "zh-tw",
+      categories: %w(stuff things moar)
+    }
+  end
+
+  let(:operation) { described_class.with(api_user: api_user) }
+
+  it 'creates an organization' do
+    organization = operation.run!(**params)
+    expect(organization).to be_persisted
+  end
+
+  it 'sets the urls, splitting out translatable content' do
+    organization = operation.run!(**params)
+    expect(organization.urls).to eq([{"label" => "0.label", "url" => "http://blogo.com/example"}])
+    expect(organization.url_labels).to eq({"0.label" => "Blog"})
+  end
+
+  it 'sets the content attributes on its primary_content' do
+    organization = operation.run!(**params)
+    expect(organization.primary_content.introduction).to eq('org intro')
+  end
+
+  it 'sets the content attributes on itself' do
+    organization = operation.run!(**params)
+    expect(organization.introduction).to eq('org intro')
+  end
+end

--- a/spec/operations/organizations/update_spec.rb
+++ b/spec/operations/organizations/update_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Organizations::Update do
+  let(:user){ create :user }
+  let(:api_user){ ApiUser.new(user) }
+  let(:organization) { create :organization }
+
+  let(:params) do
+    {
+      display_name: "The Illuminati",
+      description: "This organization is the most organized organization to ever organize",
+      introduction: "org intro",
+      announcement: "We dont exist",
+      urls: [{label: "Blog", url: "http://blogo.com/example"}],
+      categories: %w(stuff things moar)
+    }
+  end
+
+  let(:operation) { described_class.with(api_user: api_user, id: organization.id.to_s) }
+
+  it 'sets the urls, splitting out translatable content' do
+    organization = operation.run!(organization_params: params)
+    organization.reload
+    expect(organization.urls).to eq([{"label" => "0.label", "url" => "http://blogo.com/example"}])
+    expect(organization.url_labels).to eq({"0.label" => "Blog"})
+  end
+
+  it 'sets the content attributes on its primary_content' do
+    organization = operation.run!(organization_params: params)
+    expect(organization.reload.primary_content.introduction).to eq('org intro')
+  end
+
+  it 'sets the content attributes on itself' do
+    organization = operation.run!(organization_params: params)
+    expect(organization.introduction).to eq('org intro')
+  end
+end


### PR DESCRIPTION
This is part of a series of PRs to eventually remove the *Content models.

This one makes it so that we write what used to go in OrgContent also to the Org directly. It has a rake data migration to backfill existing data. A followup will then be able to use the Org directly for reading.

I'll do the same in two more PRs for Project and Workflow contents.

Once nothing is read from the content models anymore, I'll do a final PR which cleans up those models (removing the tables, we'll discuss whether to keep the API - which would then read from the main models but simulate the old resources).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
