### PR TITLE
use shell to check if we are on a prod tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,8 @@ pipeline {
             }
           }
 
-          if (TAG_NAME == 'production') {
+          def tag = sh(returnStdout: true, script: "git tag --contains | head -1").trim()
+          if (tag == 'production') {
             stage('Update production tag') {
               newImage.push('production')
             }


### PR DESCRIPTION
TAG_NAME env var is not available in the script block (yet?), instead use the scm and git shell to determine when we are on a tag https://notesfromthelifeboat.com/post/building-git-tags-with-jenkins/

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
