### PR TITLE
remove manual docker prod tag push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,13 +18,6 @@ pipeline {
               newImage.push('latest')
             }
           }
-
-          def tag = sh(returnStdout: true, script: "git tag --contains | head -1").trim()
-          if (tag == 'production') {
-            stage('Update production tag') {
-              newImage.push('production')
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
the jenkins tag job does this via SCM and BRANCH_NAME so no need to manually do an extra push.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
