### PR TITLE
handle non-array link payloads for workflow links

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -35,11 +35,11 @@ class Api::V1::WorkflowsController < Api::ApiController
 
       case relation.to_s
       when "retired_subjects"
-        params[:retired_subjects].each do |subject_id|
+        Array.wrap(params[:retired_subjects]).each do |subject_id|
           NotifySubjectSelectorOfRetirementWorker.perform_async(subject_id, workflow.id)
         end
       when "subject_sets"
-        params[:subject_sets].each do |set_id|
+        Array.wrap(params[:subject_sets]).each do |set_id|
           SubjectSetStatusesCreateWorker.perform_async(set_id, workflow.id)
         end
       end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -410,7 +410,6 @@ describe Api::V1::WorkflowsController, type: :controller do
         post :update_links, params
       end
 
-
       it "should handle non-array link formats" do
         default_request scopes: scopes, user_id: authorized_user.id
         params = {

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -410,6 +410,19 @@ describe Api::V1::WorkflowsController, type: :controller do
         post :update_links, params
       end
 
+
+      it "should handle non-array link formats" do
+        default_request scopes: scopes, user_id: authorized_user.id
+        params = {
+          link_relation: test_relation.to_s,
+          test_relation => linked_resource.id.to_s,
+          resource_id => resource.id
+        }
+        post :update_links, params
+        linked_subject_set_ids = resource.subject_sets.pluck(:id)
+        expect(linked_subject_set_ids).to eq([linked_resource.id])
+      end
+
       context "when the subject_set links belong to another project" do
         let!(:subject_set_project) do
           workflows.find { |w| w.project != project }.project


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/40595/faults/39292400#notice-trace

Seems the previous fix for this was overwritten by a recent PR from myself. This is currently blocking subject sets from linking to workflows and needs to be patched asap.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
