### PR TITLE
Fixes serialization of org URLs

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -19,7 +19,8 @@ class Api::V1::OrganizationsController < Api::ApiController
   CONTENT_PARAMS = [:description,
                     :title,
                     :introduction,
-                    :announcement].freeze
+                    :announcement,
+                    :url_labels].freeze
 
   CONTENT_FIELDS = [:description,
                     :title,

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,5 +1,3 @@
-require "tasks_visitors/inject_strings"
-
 class OrganizationSerializer
   include RestPack::Serializer
   include OwnerLinkSerializer

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,10 +1,12 @@
+require "tasks_visitors/inject_strings"
+
 class OrganizationSerializer
   include RestPack::Serializer
   include OwnerLinkSerializer
   include MediaLinksSerializer
   include CachedSerializer
 
-  CONTENT_FIELDS = %i(title description introduction announcement).freeze
+  CONTENT_FIELDS = %i(title description introduction announcement url_labels).freeze
 
   attributes :id, :display_name, :description, :introduction, :title, :href,
     :primary_language, :listed_at, :listed, :slug, :urls, :categories, :announcement
@@ -51,5 +53,15 @@ class OrganizationSerializer
                                type: "organization_pages"
                               }
     links
+  end
+
+  def urls
+    if content
+      urls = @model.urls.dup
+      TasksVisitors::InjectStrings.new(content[:url_labels]).visit(urls)
+      urls
+    else
+      []
+    end
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,3 @@
-require "tasks_visitors/inject_strings"
-
 class ProjectSerializer
   include RestPack::Serializer
   include OwnerLinkSerializer

--- a/spec/operations/organizations/update_spec.rb
+++ b/spec/operations/organizations/update_spec.rb
@@ -18,7 +18,7 @@ describe Organizations::Update do
 
   let(:operation) { described_class.with(api_user: api_user, id: organization.id.to_s) }
 
-  it 'sets the urls, splitting out translatable content' do
+  it 'sets the content' do
     organization = operation.run!(organization_params: params)
     organization.reload
     expect(organization.urls).to eq([{"label" => "0.label", "url" => "http://blogo.com/example"}])

--- a/spec/operations/organizations/update_spec.rb
+++ b/spec/operations/organizations/update_spec.rb
@@ -18,7 +18,7 @@ describe Organizations::Update do
 
   let(:operation) { described_class.with(api_user: api_user, id: organization.id.to_s) }
 
-  it 'sets the content' do
+  it 'sets the untranslated attribute' do
     organization = operation.run!(organization_params: params)
     organization.reload
     expect(organization.urls).to eq([{"label" => "0.label", "url" => "http://blogo.com/example"}])

--- a/spec/serializers/organization_serializer_spec.rb
+++ b/spec/serializers/organization_serializer_spec.rb
@@ -91,20 +91,12 @@ describe OrganizationSerializer do
   end
 
   describe "#urls" do
-    let(:result) do
-      OrganizationSerializer.single({}, Organization.where(id: organization.id), {})
-    end
-    let(:result_urls) do
-      organization.urls.map do |url|
-        {
-          url: url["url"],
-          label: url["label"]
-        }
-      end
-    end
-
-    it "should return url attribute" do
-      expect(result[:urls]).to match_array(result_urls)
+    it "should return the translated version of the url labels" do
+      urls = [{"label" => "Blog",
+               "url" => "http://blog.example.com/"},
+              {"label" => "Twitter",
+               "url" => "http://twitter.com/example"}]
+      expect(serializer.urls).to eq(urls)
     end
   end
 


### PR DESCRIPTION
Organization URLs weren't being properly translated via the task visitor prior to serialization.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
