### PR TITLE
add extra email pref management options to footer

### DIFF
--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -30,3 +30,7 @@ The Zooniverse Team
 Unsubscribe Notice: You are receiving this email because you have signed up to the Zooniverse.
 <% end %>
 To unsubscribe to these messages instantly visit <%= unsubscribe_url(token: @user.unsubscribe_token) %>
+Please be aware that this action will unsubscribe you from ALL Zooniverse emails.
+Alternatively visit https://zooniverse.org/unsubscribe
+
+To manage your email subscription preferences visit https://zooniverse.org/settings

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe DormantUserMailer, :type => :mailer do
       expect(mail.body).to include(unsubscribe_url)
     end
 
+    it 'should contain a generic unsubscribe notice' do
+      generic_unsubscribe = "Alternatively visit https://zooniverse.org/unsubscribe"
+      expect(mail.body).to include(generic_unsubscribe)
+    end
+
+    it 'should contain a notice on how to manage your subscription prefs' do
+      manage_subs = "To manage your email subscription preferences visit https://zooniverse.org/settings"
+      expect(mail.body).to include(manage_subs)
+    end
+
     context "when the user has not classified before" do
 
       it 'should give a link to the main projects page' do


### PR DESCRIPTION
Give users multiple options to unsubscribe from these dormant user emails.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
