### PR TITLE
handle string window params for dormant user query

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,7 +117,7 @@ class User < ActiveRecord::Base
         has_not_recently_classified =
           if last_classified_upp
             time_since_activity = Time.now.utc - last_classified_upp.updated_at
-            time_since_activity >= window.days.to_i
+            time_since_activity >= window.to_i.days.to_i
           else
             true
           end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -90,6 +90,10 @@ describe User, type: :model do
           it "should return the user" do
             expect(dormant_user_ids).to match_array([user.id])
           end
+
+          it "should handle window period string params" do
+            expect(dormant_user_ids("5")).to match_array([user.id])
+          end
         end
 
         context "user last classified 2 days ago" do


### PR DESCRIPTION
Allow the last classified window check to handle string params that come via rake task / sidekiq. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
