### PR TITLE
reinstate the reverted PR #2925 - reverted in #2946

### DIFF
--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -13,22 +13,6 @@ class OrganizationSerializer
   can_filter_by :display_name, :slug, :listed
   can_include :organization_contents, :organization_roles, :projects, :owners, :pages
 
-  def title
-    content[:title]
-  end
-
-  def description
-    content[:description]
-  end
-
-  def introduction
-    content[:introduction]
-  end
-
-  def announcement
-    content[:announcement]
-  end
-
   def avatar_src
     if avatar = @model.avatar
       avatar.external_link ? avatar.external_link : avatar.src
@@ -54,12 +38,8 @@ class OrganizationSerializer
   end
 
   def urls
-    if content
-      urls = @model.urls.dup
-      TasksVisitors::InjectStrings.new(content[:url_labels]).visit(urls)
-      urls
-    else
-      []
-    end
+    urls = @model.urls.dup
+    TasksVisitors::InjectStrings.new(@model.url_labels).visit(urls)
+    urls
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -82,34 +82,10 @@ class ProjectSerializer
     end
   end
 
-  def title
-    content[:title]
-  end
-
-  def description
-    content[:description]
-  end
-
-  def workflow_description
-    content[:workflow_description]
-  end
-
-  def introduction
-    content[:introduction]
-  end
-
-  def researcher_quote
-    content[:researcher_quote]
-  end
-
   def urls
-    if content
-      urls = @model.urls.dup
-      TasksVisitors::InjectStrings.new(content[:url_labels]).visit(urls)
-      urls
-    else
-      []
-    end
+    urls = @model.urls.dup
+    TasksVisitors::InjectStrings.new(@model.url_labels).visit(urls)
+    urls
   end
 
   def tags

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -36,7 +36,7 @@ class WorkflowSerializer
 
   def tasks
     if content
-      TasksVisitors::InjectStrings.new(content.strings).visit(@model.tasks)
+      TasksVisitors::InjectStrings.new(@model.strings).visit(@model.tasks)
       @model.tasks
     else
       {}

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -18,6 +18,12 @@ FactoryBot.define do
     live false
     urls [{"label" => "0.label", "url" => "http://blog.example.com/"}, {"label" => "1.label", "url" => "http://twitter.com/example"}]
 
+    description "Some Lorem Ipsum"
+    introduction "MORE IPSUM"
+    workflow_description "Go outside"
+    researcher_quote "This is my favorite project"
+    url_labels({"0.label" => "Blog", "1.label" => "Twitter", "2.label" => "Science Case"})
+
     association :owner, factory: :user
 
     after(:build) do |p, env|

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -57,6 +57,23 @@ FactoryBot.define do
     retired_set_member_subjects_count 0
     subject_selection_strategy "builtin"
 
+    strings({
+            "interest.question" => "Draw a circle",
+            "interest.help" => "Duh?",
+            "interest.tools.0.label" => "Red",
+            "interest.tools.1.label" => "Green",
+            "interest.tools.2.label" => "Blue",
+            "interest.tools.3.label" => "Purple",
+            "interest.tools.3.details.0.answers.0.label"=>"Painfully wow",
+            "interest.tools.3.details.0.answers.1.label"=>"Just wow",
+            "interest.tools.3.details.0.question"=>"Wow rating:",
+            "shape.question" => "What shape is this galaxy",
+            "shape.help" => "Duh?",
+            "shape.answers.0.label" => "Smooth",
+            "shape.answers.1.label" => "Features",
+            "shape.answers.2.label" => "Star or artifact",
+            })
+
     after(:build) do |w, env|
       if env.build_contents
         w.workflow_contents << build_list(:workflow_content, 1, workflow: w, language: w.primary_language)
@@ -106,6 +123,13 @@ FactoryBot.define do
           }
         }
       )
+
+      strings ({
+        "init.help" => "You know what a cat looks like right?",
+        "init.answers.0.label" => "Yes",
+        "init.answers.1.label" => "No",
+        "init.question" => "Is there a cat in the image"
+      })
 
       after(:build) do |w, env|
         if env.build_contents
@@ -274,6 +298,11 @@ FactoryBot.define do
           }
         }
       )
+
+      strings ({
+        "init.answers.0.label" => "yes",
+        "init.question" => "Fire present?"
+      })
 
       after(:build) do |w, env|
         if env.build_contents

--- a/spec/serializers/organization_serializer_spec.rb
+++ b/spec/serializers/organization_serializer_spec.rb
@@ -11,57 +11,45 @@ describe OrganizationSerializer do
     s
   end
 
-  describe "#content" do
-    let(:organization_with_media) { create(:organization, build_media: true) }
-    let(:links) { [:avatar, :background] }
-    let(:serialized) { OrganizationSerializer.resource({include: 'avatar,background,owners'}, Organization.where(id: organization_with_media.id), context) }
+  let(:organization_with_media) { create(:organization, build_media: true) }
+  let(:links) { [:avatar, :background] }
+  let(:serialized) { OrganizationSerializer.resource({include: 'avatar,background,owners'}, Organization.where(id: organization_with_media.id), context) }
 
-    it "should return organization content for the preferred language" do
-      expect(serializer.content).to be_a( Hash )
-      expect(serializer.content).to include(:title)
+  describe "includes avatar and background" do
+    it "should include avatar" do
+      expect(serialized[:linked][:avatars].map{ |r| r[:id] })
+      .to include(organization_with_media.avatar.id.to_s)
     end
 
-    it "includes the defined content fields" do
-      fields = Api::V1::OrganizationsController::CONTENT_PARAMS.map(&:to_s)
-      expect(serializer.content.keys).to contain_exactly(*fields)
+    it "should include background" do
+      expect(serialized[:linked][:backgrounds].map{ |r| r[:id] })
+      .to include(organization_with_media.background.id.to_s)
     end
 
-    describe "includes avatar and background" do
-      it "should include avatar" do
-        expect(serialized[:linked][:avatars].map{ |r| r[:id] })
-        .to include(organization_with_media.avatar.id.to_s)
-      end
+    it "should include owners" do
+      expect(serialized[:linked][:owners].map{ |r| r[:id] })
+      .to include(organization_with_media.owner.id.to_s)
+    end
+  end
 
-      it "should include background" do
-        expect(serialized[:linked][:backgrounds].map{ |r| r[:id] })
-        .to include(organization_with_media.background.id.to_s)
-      end
+  describe "media links" do
+    it "should include top level links for media" do
+      expect(serialized[:links]).to include(*links.map{ |l| "organizations.#{l}" })
+    end
 
-      it "should include owners" do
-        expect(serialized[:linked][:owners].map{ |r| r[:id] })
-        .to include(organization_with_media.owner.id.to_s)
+    it "should include resource level links for media" do
+      expect(serialized[:organizations][0][:links]).to include(*links)
+    end
+
+    it "should include hrefs for links" do
+      serialized[:organizations][0][:links].slice(*links).each do |_, linked|
+        expect(linked).to include(:href)
       end
     end
 
-    describe "media links" do
-      it "should include top level links for media" do
-        expect(serialized[:links]).to include(*links.map{ |l| "organizations.#{l}" })
-      end
-
-      it "should include resource level links for media" do
-        expect(serialized[:organizations][0][:links]).to include(*links)
-      end
-
-      it "should include hrefs for links" do
-        serialized[:organizations][0][:links].slice(*links).each do |_, linked|
-          expect(linked).to include(:href)
-        end
-      end
-
-      it "should include the id for single links" do
-        serialized[:organizations][0][:links].slice(:avatar, :background).each do |_, linked|
-          expect(linked).to include(:id)
-        end
+    it "should include the id for single links" do
+      serialized[:organizations][0][:links].slice(:avatar, :background).each do |_, linked|
+        expect(linked).to include(:id)
       end
     end
   end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -27,18 +27,6 @@ describe ProjectSerializer do
     ProjectSerializer.page({}, Project.all, {cards: true})
   end
 
-  describe "#content" do
-    it "should return project content for the preferred language" do
-      expect(serializer.content).to be_a( Hash )
-      expect(serializer.content).to include(:title)
-    end
-
-    it "includes the defined content fields" do
-      fields = Api::V1::ProjectsController::CONTENT_FIELDS.map(&:to_s)
-      expect(serializer.content.keys).to contain_exactly(*fields)
-    end
-  end
-
   describe "#urls" do
     it "should return the translated version of the url labels" do
       urls = [{"label" => "Blog",


### PR DESCRIPTION
Revert "Revert "Contents read from model (#2925)" (#2946)"
This reverts commit b1389baeca89961c5d62da6d811de8e9a3f7e9dd.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
