### PR TITLE
do not retry emailing dormant users on error

### DIFF
--- a/app/workers/email_dormant_users_worker.rb
+++ b/app/workers/email_dormant_users_worker.rb
@@ -3,6 +3,9 @@ class EmailDormantUsersWorker
 
   class DoNotRunOnStagingError < StandardError; end
 
+  # skip retries for this job so we don't email users multiple times
+  sidekiq_options retry: 0
+
   def perform(num_days_since_activity, only_user_ids_ending_in)
     raise DoNotRunOnStagingError if Rails.env.staging?
 

--- a/spec/workers/email_dormant_users_worker_spec.rb
+++ b/spec/workers/email_dormant_users_worker_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe EmailDormantUsersWorker do
   let(:worker) { described_class.new }
 
+  it "should be not retry on failure" do
+    retry_count = worker.class.get_sidekiq_options['retry']
+    expect(retry_count).to eq(0)
+  end
+
   it "should raise error if running on staging" do
     allow(Rails).to receive(:env) { "staging".inquiry }
     expect {


### PR DESCRIPTION
avoid sidekiq's retry mechanism to send emails, instead go straight to the dead set for appraisal.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
