### PR TITLE
Ensure dormant mailers are not directing people to inactive or complete projects

### DIFF
--- a/app/mailers/dormant_user_mailer.rb
+++ b/app/mailers/dormant_user_mailer.rb
@@ -8,6 +8,7 @@ class DormantUserMailer < ApplicationMailer
     @last_project = last_classified_project(user.id)
     google_analytic_prefix = "?utm_source=Newsletter&utm_campaign="
     @dormant_with_classification_ga_code = "#{google_analytic_prefix}dormant_with_classifications"
+    @dormant_with_last_project_complete_ga_code = "#{google_analytic_prefix}dormant_with_last_project_complete"
     @dormant_without_classification_ga_code = "#{google_analytic_prefix}dormant_no_classifications"
     mail(to: @email_to, subject: DEFAULT_SUBJECT)
   end

--- a/app/mailers/dormant_user_mailer.rb
+++ b/app/mailers/dormant_user_mailer.rb
@@ -6,7 +6,7 @@ class DormantUserMailer < ApplicationMailer
     @user = user
     @email_to = user.email
     @last_project = last_classified_project(user.id)
-    @last_launch_approved_project = @last_project && @last_project.launch_approved
+    @last_launch_approved_project = @last_project&.launch_approved
     google_analytic_prefix = "?utm_source=Newsletter&utm_campaign="
     @dormant_with_classification_ga_code = "#{google_analytic_prefix}dormant_with_classifications"
     @dormant_with_last_project_complete_ga_code = "#{google_analytic_prefix}dormant_with_last_project_complete"

--- a/app/mailers/dormant_user_mailer.rb
+++ b/app/mailers/dormant_user_mailer.rb
@@ -6,6 +6,7 @@ class DormantUserMailer < ApplicationMailer
     @user = user
     @email_to = user.email
     @last_project = last_classified_project(user.id)
+    @last_launch_approved_project = @last_project && @last_project.launch_approved
     google_analytic_prefix = "?utm_source=Newsletter&utm_campaign="
     @dormant_with_classification_ga_code = "#{google_analytic_prefix}dormant_with_classifications"
     @dormant_with_last_project_complete_ga_code = "#{google_analytic_prefix}dormant_with_last_project_complete"

--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @user.display_name %>,
 
-<% if @last_project && @last_project.launch_approved && @last_project.completeness < 1.0 %>
+<% if @last_launch_approved_project && @last_project.completeness < 1.0 %>
 We still need your help on <%=@last_project.display_name%>!
 
 Pick up where you last left off (https://www.zooniverse.org/projects/<%=@last_project.slug%><%=@dormant_with_classification_ga_code%>&utm_content=b) or check out some of the other exciting projects on the Zooniverse: https://zooniverse.org/projects<%=@dormant_with_classification_ga_code%>&utm_content=a.
@@ -15,7 +15,7 @@ The Zooniverse Team
 
 Unsubscribe Notice: You are receiving this email because you have taken part in <%=@last_project.display_name%>
 
-<% elsif @last_project && @last_project.launch_approved && @last_project.completeness == 1.0 %>
+<% elsif @last_launch_approved_project && @last_project.completeness == 1.0 %>
 Thank you for your help on <%=@last_project.display_name%>, we are really happy to say that all the data for this project has now been classified! Keep an eye out on the project result page for updates about the outcomes from this project: https://www.zooniverse.org/projects/<%=@last_project.slug%>/about/results<%=@dormant_with_last_project_complete_ga_code%>&utm_content=b.
 
 Our other projects still need you though! Whether it is helping to classify galaxies, map orangutan nesting sites, identify antibiotic resistant bacteria or transcribe anti-slavery manuscripts, there are many exciting research projects to get involved with in the Zooniverse.

--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @user.display_name %>,
 
-<% if @last_project %>
+<% if @last_project && @last_project.launch_approved %>
 We still need your help on <%=@last_project.display_name%>!
 
 Pick up where you last left off (https://www.zooniverse.org/projects/<%=@last_project.slug%><%=@dormant_with_classification_ga_code%>&utm_content=b) or check out some of the other exciting projects on the Zooniverse: https://zooniverse.org/projects<%=@dormant_with_classification_ga_code%>&utm_content=a.

--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -22,7 +22,7 @@ Our other projects still need you though! Whether it is helping to classify gala
 
 Check out the complete suite of projects here: https://zooniverse.org/projects<%=@dormant_with_last_project_complete_ga_code%>&utm_content=a.
 
-Don't forget to log in so you can keep track of your contributions and get involved on the project discussion boards (https://zooniverse.org/talk<%=@dormant_with_last_project_complete_ga_code%>&utm_content=c).
+Don't forget to log in so you can keep track of your contributions and get involved on the project discussion boards.
 
 Thanks for your help, and see you out there!
 
@@ -37,7 +37,7 @@ Whether it is helping to classify galaxies, map orangutan nesting sites, identif
 
 Check out the complete suite of projects here: https://zooniverse.org/projects<%=@dormant_without_classification_ga_code%>&utm_content=a.
 
-Don't forget to log in so you can keep track of your contributions and get involved on the project discussion boards (https://zooniverse.org/talk<%=@dormant_without_classification_ga_code%>&utm_content=c).
+Don't forget to log in so you can keep track of your contributions and get involved on the project discussion boards.
 
 Thanks for your help, and see you out there!
 

--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -16,13 +16,13 @@ The Zooniverse Team
 Unsubscribe Notice: You are receiving this email because you have taken part in <%=@last_project.display_name%>
 
 <% elsif @last_project && @last_project.launch_approved && @last_project.completeness == 1.0 %>
-Thank you for your help on <%=@last_project.display_name%>, we are really happy to say that all the data for this project has now been classified! Keep an eye out on the project result page for updates about the outcomes from this project: https://www.zooniverse.org/projects/<%=@last_project.slug%>/about/results.
+Thank you for your help on <%=@last_project.display_name%>, we are really happy to say that all the data for this project has now been classified! Keep an eye out on the project result page for updates about the outcomes from this project: https://www.zooniverse.org/projects/<%=@last_project.slug%>/about/results<%=@dormant_with_last_project_complete_ga_code%>&utm_content=b.
 
 Our other projects still need you though! Whether it is helping to classify galaxies, map orangutan nesting sites, identify antibiotic resistant bacteria or transcribe anti-slavery manuscripts, there are many exciting research projects to get involved with in the Zooniverse.
 
-Check out the complete suite of projects here: https://zooniverse.org/projects.
+Check out the complete suite of projects here: https://zooniverse.org/projects<%=@dormant_with_last_project_complete_ga_code%>&utm_content=a.
 
-Don't forget to log in so you can keep track of your contributions and get involved on the project discussion boards (https://zooniverse.org/talk).
+Don't forget to log in so you can keep track of your contributions and get involved on the project discussion boards (https://zooniverse.org/talk<%=@dormant_with_last_project_complete_ga_code%>&utm_content=c).
 
 Thanks for your help, and see you out there!
 

--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @user.display_name %>,
 
-<% if @last_project && @last_project.launch_approved %>
+<% if @last_project && @last_project.launch_approved && @last_project.completeness < 1.0 %>
 We still need your help on <%=@last_project.display_name%>!
 
 Pick up where you last left off (https://www.zooniverse.org/projects/<%=@last_project.slug%><%=@dormant_with_classification_ga_code%>&utm_content=b) or check out some of the other exciting projects on the Zooniverse: https://zooniverse.org/projects<%=@dormant_with_classification_ga_code%>&utm_content=a.

--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -16,8 +16,19 @@ The Zooniverse Team
 Unsubscribe Notice: You are receiving this email because you have taken part in <%=@last_project.display_name%>
 
 <% elsif @last_project && @last_project.launch_approved && @last_project.completeness == 1.0 %>
-Thank you for your help on <%=@last_project.display_name%>, we are really happy to say that all the data for this project has now been classified! 
+Thank you for your help on <%=@last_project.display_name%>, we are really happy to say that all the data for this project has now been classified! Keep an eye out on the project result page for updates about the outcomes from this project: https://www.zooniverse.org/projects/<%=@last_project.slug%>/about/results.
 
+Our other projects still need you though! Whether it is helping to classify galaxies, map orangutan nesting sites, identify antibiotic resistant bacteria or transcribe anti-slavery manuscripts, there are many exciting research projects to get involved with in the Zooniverse.
+
+Check out the complete suite of projects here: https://zooniverse.org/projects.
+
+Don't forget to log in so you can keep track of your contributions and get involved on the project discussion boards (https://zooniverse.org/talk).
+
+Thanks for your help, and see you out there!
+
+The Zooniverse Team
+
+Unsubscribe Notice: You are receiving this email because you have taken part in <%=@last_project.display_name%>
 
 <% else %>
 Our projects still need you!

--- a/app/views/dormant_user_mailer/email_dormant_user.text.erb
+++ b/app/views/dormant_user_mailer/email_dormant_user.text.erb
@@ -14,6 +14,11 @@ Thanks for your help, and see you out there!
 The Zooniverse Team
 
 Unsubscribe Notice: You are receiving this email because you have taken part in <%=@last_project.display_name%>
+
+<% elsif @last_project && @last_project.launch_approved && @last_project.completeness == 1.0 %>
+Thank you for your help on <%=@last_project.display_name%>, we are really happy to say that all the data for this project has now been classified! 
+
+
 <% else %>
 Our projects still need you!
 

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -89,15 +89,14 @@ RSpec.describe DormantUserMailer, :type => :mailer do
         create(:user_project_preference, user: user, project: create(:project, completeness: 1.0))
       end
 
-      it 'should not have the users last project url in the body' do
-        last_project = user_project_preference.project
-        expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
-      end
-
       it 'should thank the user for their contributions to the project' do
         last_project = user_project_preference.project
         expect(mail.body).to include("Thank you for your help on #{last_project.display_name}")
-      
+      end
+
+      it 'should have the url for project result page in the body' do
+        last_project = user_project_preference.project
+        expect(mail.body).to include("https://www.zooniverse.org/projects/#{last_project.slug}/about/results")
       end
     end
   end

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -71,16 +71,16 @@ RSpec.describe DormantUserMailer, :type => :mailer do
         last_project = user_project_preference.project
         expect(mail.body).to include("https://www.zooniverse.org/projects/#{last_project.slug}")
       end
+    end
 
-      context 'when the last project is not launch approved' do
-        before(:context) do
-          user_project_preference.project.launch_approved = true
-        end
+    context 'when the last project is not launch approved' do
+      let(:user_project_preference) do
+        create(:user_project_preference, user: user, project: create(:project, launch_approved: false))
+      end
 
-        it 'should not have the last project url in the body' do
-          last_project = user_project_preference.project
-          expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
-        end
+      it 'should not have the last project url in the body' do
+        last_project = user_project_preference.project
+        expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
       end
     end
   end

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -83,5 +83,16 @@ RSpec.describe DormantUserMailer, :type => :mailer do
         expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
       end
     end
+
+    context 'when the users last project is completed' do
+      let(:user_project_preference) do
+        create(:user_project_preference, user: user, project: create(:project, completeness: 1.0))
+      end
+
+      it 'should not have the users last project url in the body' do
+        last_project = user_project_preference.project
+        expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
+      end
+    end
   end
 end

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -72,7 +72,16 @@ RSpec.describe DormantUserMailer, :type => :mailer do
         expect(mail.body).to include("https://www.zooniverse.org/projects/#{last_project.slug}")
       end
 
-    end
+      context 'when the last project is not launch approved' do
+        before(:context) do
+          (user_project_preference.project).launch_approved = true
+        end
 
+        it 'should not have the last project url in the body' do
+          last_project = user_project_preference.project
+          expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
+        end
+      end
+    end
   end
 end

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DormantUserMailer, :type => :mailer do
 
       context 'when the last project is not launch approved' do
         before(:context) do
-          (user_project_preference.project).launch_approved = true
+          user_project_preference.project.launch_approved = true
         end
 
         it 'should not have the last project url in the body' do

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe DormantUserMailer, :type => :mailer do
         last_project = user_project_preference.project
         expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
       end
+
+      it 'should thank the user for their contributions to the project' do
+        last_project = user_project_preference.project
+        expect(mail.body).to include("Thank you for your help on #{last_project.display_name}")
+      
+      end
     end
   end
 end

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe DormantUserMailer, :type => :mailer do
       end
     end
 
-    context 'when the last project is not launch approved' do
+    context 'when the users last project is not launch approved' do
       let(:user_project_preference) do
         create(:user_project_preference, user: user, project: create(:project, launch_approved: false))
       end

--- a/spec/mailers/dormant_user_mailer_spec.rb
+++ b/spec/mailers/dormant_user_mailer_spec.rb
@@ -57,46 +57,46 @@ RSpec.describe DormantUserMailer, :type => :mailer do
 
     end
 
-    context "when the user has user project preferences" do
+    context "when user has user project preference" do
       let(:user_project_preference) do
-        create(:user_project_preference, user: user)
+        create(:user_project_preference, project: project, user: user)
+      end
+      let(:last_project) { user_project_preference.project }
+
+      before do
+        last_project
       end
 
-      it 'should have the name of the users last classified project in the body' do
-        last_project = user_project_preference.project
-        expect(mail.body).to include(last_project.display_name)
+      context "when the users upp is their last project" do
+        let(:project) { create(:project, owner: user) }
+
+        it 'should have the name of the users last classified project in the body' do
+          expect(mail.body).to include(last_project.display_name)
+        end
+
+        it 'should have the url for the users last classified project in the body' do
+          expect(mail.body).to include("https://www.zooniverse.org/projects/#{last_project.slug}")
+        end
       end
 
-      it 'should have the url for the users last classified project in the body' do
-        last_project = user_project_preference.project
-        expect(mail.body).to include("https://www.zooniverse.org/projects/#{last_project.slug}")
-      end
-    end
+      context 'when the users last project is not launch approved' do
+        let(:project) { create(:project, launch_approved: false, owner: user) }
 
-    context 'when the users last project is not launch approved' do
-      let(:user_project_preference) do
-        create(:user_project_preference, user: user, project: create(:project, launch_approved: false))
+        it 'should not have the last project url in the body' do
+          expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
+        end
       end
 
-      it 'should not have the last project url in the body' do
-        last_project = user_project_preference.project
-        expect(mail.body).not_to include("https://www.zooniverse.org/projects/#{last_project.slug}")
-      end
-    end
+      context 'when the users last project is completed' do
+        let(:project) { create(:project, completeness: 1.0, owner: user) }
 
-    context 'when the users last project is completed' do
-      let(:user_project_preference) do
-        create(:user_project_preference, user: user, project: create(:project, completeness: 1.0))
-      end
+        it 'should thank the user for their contributions to the project' do
+          expect(mail.body).to include("Thank you for your help on #{last_project.display_name}")
+        end
 
-      it 'should thank the user for their contributions to the project' do
-        last_project = user_project_preference.project
-        expect(mail.body).to include("Thank you for your help on #{last_project.display_name}")
-      end
-
-      it 'should have the url for project result page in the body' do
-        last_project = user_project_preference.project
-        expect(mail.body).to include("https://www.zooniverse.org/projects/#{last_project.slug}/about/results")
+        it 'should have the url for project result page in the body' do
+          expect(mail.body).to include("https://www.zooniverse.org/projects/#{last_project.slug}/about/results")
+        end
       end
     end
   end


### PR DESCRIPTION
This pull request addresses issue 2951.

When we send dormant mailers, if the user has contributed to a project previously then they get sent a project-specific callback. However, in some cases, the last project a user contributed to may be in beta/inactive or completed and so a general call back to all projects would be better.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
