### PR TITLE
ensure the final selector state propogates to selector context

### DIFF
--- a/lib/subjects/selector_context.rb
+++ b/lib/subjects/selector_context.rb
@@ -18,7 +18,7 @@ module Subjects
           retired_subject_ids: retired_subject_ids,
           user_has_finished_workflow: user_has_finished_workflow,
           finished_workflow: finished_workflow?,
-          selection_state: :normal,
+          selection_state: selector.selection_state,
           url_format: :get,
           select_context: true
         }.compact

--- a/spec/lib/subjects/selector_context_spec.rb
+++ b/spec/lib/subjects/selector_context_spec.rb
@@ -81,4 +81,13 @@ RSpec.describe Subjects::SelectorContext do
       expect(subject.format).to eq(expected_context)
     end
   end
+
+  context "with as the selector selection_state changes" do
+    it 'should return the expected state' do
+      Subjects::Selector::SELECTION_STATE_ENUM.values.each do |selection_state|
+        allow(selector).to receive(:selection_state).and_return(selection_state)
+        expect(subject.format[:selection_state]).to eq(selection_state)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Bug fix - ensure the final state of subject selection makes it to the selector context and then the serializer for use in the clients. This changes from hard coded to normal which is useless information as it's ignoring the selection state.

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
