### PR TITLE
[WIP] remove classifications created_at and gold_standard indexes

### DIFF
--- a/app/workers/calculate_project_activity_worker.rb
+++ b/app/workers/calculate_project_activity_worker.rb
@@ -3,13 +3,17 @@ class CalculateProjectActivityWorker
 
   sidekiq_options queue: :data_medium
 
-  def perform(project_id)
+  def perform(project_id, period=nil)
     project = Project.find(project_id)
     Project.transaction do
       project_activity = 0
       project.workflows.each do |workflow|
-        activity_count = workflow_activity(workflow)
-        workflow.update_columns activity: activity_count
+        activity_period = WorkflowActivityPeriod.new(workflow, period)
+        activity_count = activity_period.count
+        workflow.update_columns(
+          activity: activity_count,
+          activity_classification_id: activity_period.earliest_activity_classification_id
+        )
         project_activity += activity_count
       end
       project.update_columns activity: project_activity
@@ -18,7 +22,34 @@ class CalculateProjectActivityWorker
     nil
   end
 
-  def workflow_activity(workflow, period=24.hours.ago)
-    workflow.classifications.where("created_at >= ?", period).count
+  class WorkflowActivityPeriod
+    attr_reader :workflow, :period
+    ACTIVITY_PERIOD = 24.hours.ago
+
+    def initialize(workflow, period)
+      @workflow = workflow
+      @period = period || ACTIVITY_PERIOD
+    end
+
+    def count
+      activity_scope.count
+    end
+
+    def earliest_activity_classification_id
+      earliest_classification_id = activity_scope.select(:id).first
+      earliest_classification_id&.id
+    end
+
+    private
+
+    def activity_scope
+      workflow_period_activity_scope.after_id(
+        workflow.activity_classification_id
+      )
+    end
+
+    def workflow_period_activity_scope
+      workflow.classifications.where("created_at >= ?", period)
+    end
   end
 end

--- a/db/migrate/20180926081727_add_last_activity_classification_id_to_workflow.rb
+++ b/db/migrate/20180926081727_add_last_activity_classification_id_to_workflow.rb
@@ -1,0 +1,22 @@
+class AddLastActivityClassificationIdToWorkflow < ActiveRecord::Migration
+  def change
+    add_column :workflows, :activity_classification_id, :integer
+
+    # backfill the workflow activity columns
+    period = CalculateProjectActivityWorker::WorkflowActivityPeriod::ACTIVITY_PERIOD
+    Workflow.select(:id).find_each do |workflow|
+      # ensure we backfill to the earliest classification id
+      # to avoid shrinking the activity counter window
+      earliest_period_classification =
+        workflow
+        .classifications
+        .where("created_at >= ?", period)
+        .order(:id)
+        .first
+
+      if classification_id = earliest_period_classification&.id
+        workflow.update_column(:activity_classification_id, classification_id)
+      end
+    end
+  end
+end

--- a/db/migrate/20180926081727_add_last_activity_classification_id_to_workflow.rb
+++ b/db/migrate/20180926081727_add_last_activity_classification_id_to_workflow.rb
@@ -2,7 +2,7 @@ class AddLastActivityClassificationIdToWorkflow < ActiveRecord::Migration
   def change
     add_column :workflows, :activity_classification_id, :integer
 
-    # backfill the workflow activity columns
+    # backfill the workflow activity_classification_id column
     period = CalculateProjectActivityWorker::WorkflowActivityPeriod::ACTIVITY_PERIOD
     Workflow.select(:id).find_each do |workflow|
       # ensure we backfill to the earliest classification id

--- a/db/migrate/20180926082355_remove_classification_indexes_again.rb
+++ b/db/migrate/20180926082355_remove_classification_indexes_again.rb
@@ -1,0 +1,6 @@
+class RemoveClassificationIndexesAgain < ActiveRecord::Migration
+  def change
+    remove_index :classifications, column: :created_at
+    remove_index :classifications, column: :gold_standard
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2427,20 +2427,6 @@ CREATE INDEX index_classifications_on_completed ON public.classifications USING 
 
 
 --
--- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_classifications_on_created_at ON public.classifications USING btree (created_at);
-
-
---
--- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_classifications_on_gold_standard ON public.classifications USING btree (gold_standard) WHERE (gold_standard IS TRUE);
-
-
---
 -- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4177,4 +4163,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180821125430');
 INSERT INTO schema_migrations (version) VALUES ('20180821151555');
 
 INSERT INTO schema_migrations (version) VALUES ('20180926081727');
+
+INSERT INTO schema_migrations (version) VALUES ('20180926082355');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1666,7 +1666,8 @@ CREATE TABLE public.workflows (
     activated_state integer DEFAULT 0 NOT NULL,
     subject_selection_strategy integer DEFAULT 0,
     mobile_friendly boolean DEFAULT false NOT NULL,
-    strings jsonb DEFAULT '{}'::jsonb
+    strings jsonb DEFAULT '{}'::jsonb,
+    activity_classification_id integer
 );
 
 
@@ -4174,4 +4175,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180808140938');
 INSERT INTO schema_migrations (version) VALUES ('20180821125430');
 
 INSERT INTO schema_migrations (version) VALUES ('20180821151555');
+
+INSERT INTO schema_migrations (version) VALUES ('20180926081727');
 

--- a/spec/workers/calculate_project_activity_worker_spec.rb
+++ b/spec/workers/calculate_project_activity_worker_spec.rb
@@ -5,39 +5,104 @@ describe CalculateProjectActivityWorker do
   let(:workflow) { create(:workflow) }
   let(:project) { workflow.project }
   let(:user) { project.user }
-
-  let(:classifications) do
+  let(:in_period_classifications) do
     create_list(:classification, 2, project: project, workflow: workflow)
+  end
+  let(:non_normal_period_classification) do
     c = create(:classification, project: project, workflow: workflow)
     c.update_column(:created_at, 25.hours.ago)
+    c
+  end
+  let(:classifications) do
+    [ non_normal_period_classification, in_period_classifications ].flatten
   end
 
   describe '#perform' do
-    it 'should update the workflow and project activity' do
-      classifications
-      count = worker.workflow_activity(workflow)
-      expect_any_instance_of(Workflow).to receive(:update_columns).with(activity: count)
-      expect_any_instance_of(Project).to receive(:update_columns).with(activity: count)
-      worker.perform(project.id)
-    end
-
     context "when it can't find the project" do
       it "should fail quickly" do
         expect(Project).not_to receive(:transaction)
         worker.perform("-1")
       end
     end
+
+    context "with classifications and the tracked activity classification id" do
+      before do
+        classifications
+        workflow.update_column(:activity_classification_id, 1)
+      end
+      let(:activity_count) { 2 }
+
+      it 'should update the workflow activity attributes' do
+        expect_any_instance_of(Workflow)
+          .to receive(:update_columns)
+          .with({
+            activity: activity_count,
+            activity_classification_id: in_period_classifications.first.id
+          })
+        worker.perform(project.id)
+      end
+
+      it 'should update the project activity attributes' do
+        expect_any_instance_of(Project)
+          .to receive(:update_columns)
+          .with({activity: activity_count})
+        worker.perform(project.id)
+      end
+
+      context "with a longer activity period" do
+        it 'should have different counts and track a different activity classification' do
+          expect_any_instance_of(Workflow)
+            .to receive(:update_columns)
+            .with({
+              activity: 3,
+              activity_classification_id: non_normal_period_classification.id
+            })
+          worker.perform(project.id, 48.hours.ago)
+        end
+      end
+    end
   end
 
-  describe '#workflow_activity' do
+  describe CalculateProjectActivityWorker::WorkflowActivityPeriod do
+    let(:period) do
+      CalculateProjectActivityWorker::WorkflowActivityPeriod::ACTIVITY_PERIOD
+    end
+    subject { described_class.new(workflow, period) }
+
     it 'returns 0 when no classifications have been made yet' do
-      expect(worker.workflow_activity(workflow)).to eq(0)
+      expect(subject.count).to eq(0)
     end
 
-    context "with classifications" do
-      it 'should only count classification in last 24 hours' do
+    context "with classifications and the tracked activity classification id" do
+      before do
         classifications
-        expect(worker.workflow_activity(workflow)).to eq(2)
+        workflow.update_column(:activity_classification_id, 1)
+      end
+
+      it 'should only count classification in last 24 hours' do
+        expect(subject.count).to eq(2)
+      end
+
+      context "with a longer activity period" do
+        let(:period) { 48.hours.ago }
+
+        it 'should only count classification in last 48 hours' do
+          expect(subject.count).to eq(3)
+        end
+      end
+
+      context "with a later activity_classification_id" do
+        it 'should only count the classifications after the id' do
+          id = in_period_classifications.first.id
+          workflow.update_column(:activity_classification_id, id)
+          expect(subject.count).to eq(1)
+        end
+
+        it 'should only count the classifications after the id' do
+          id = in_period_classifications.last.id
+          workflow.update_column(:activity_classification_id, id)
+          expect(subject.count).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
Drop the classifications created_at & gold_standard indexes. 

Gold standard index has 0 scans as it's always combined with more restrictive index lookups and ends up as a row filter in the query planner. 

Query plans from the query in the below counter shows that the classifications_subjects join index lookup combined with the classifications id index are used with row filters on the other attributes (including created_at). This index isn't used in our query paths and can go. https://github.com/zooniverse/Panoptes/blob/1943b27116c1eb1c870a8cc2ef463d2d1edafb4a/app/counters/subject_workflow_counter.rb#L19

The only caveat with this new query path is that if the `workflow.activity_classification_id` drifts to far into the past away from the period of interest (last 24.hours by default), think paused / finished projects that don't have any new activity. These queries then become a possibly large index scan with row lookups (basically a seq scan from a later starting point). 

The only way to combat this would be to record the last classification id for a workflow to limit the search space on the id index. However this will still result in long running queries for very active projects (SGL, etc). 

## TODO
- [ ] Test if using the project_id & id composite index helps address the old projects index search. In theory this index should have a small number of rows to search for old, non-active projects and could address the less restrictive searches.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
