### PR TITLE
Track workflow versions without Papertrail

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -58,6 +58,21 @@ class Workflow < ActiveRecord::Base
     %i(display_name strings)
   end
 
+  before_save :update_version
+
+  def update_version
+    self.major_version ||= 0
+    self.minor_version ||= 0
+
+    if changes.include? :tasks
+      self.major_version += 1
+    end
+
+    if changes.include? :strings
+      self.minor_version += 1
+    end
+  end
+
   # select a workflow without any json attributes (some can be very large)
   # this can be used generally in most workers
   # access to non-loaded attributes will raise an undefined_error

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -61,9 +61,6 @@ class Workflow < ActiveRecord::Base
   before_save :update_version
 
   def update_version
-    self.major_version ||= 0
-    self.minor_version ||= 0
-
     if (changes.keys & %w(tasks grouped pairwise prioritized)).present?
       self.major_version += 1
     end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -64,7 +64,7 @@ class Workflow < ActiveRecord::Base
     self.major_version ||= 0
     self.minor_version ||= 0
 
-    if changes.include? :tasks
+    if (changes.keys & %w(tasks grouped pairwise prioritized)).present?
       self.major_version += 1
     end
 

--- a/db/migrate/20181001154345_workflow_version_numbers.rb
+++ b/db/migrate/20181001154345_workflow_version_numbers.rb
@@ -2,5 +2,21 @@ class WorkflowVersionNumbers < ActiveRecord::Migration
   def change
     add_column :workflows, :major_version, :integer
     add_column :workflows, :minor_version, :integer
+
+    reversible do |dir|
+      dir.up do
+        change_column_default :workflows, :major_version, 0
+        change_column_default :workflows, :minor_version, 0
+      end
+    end
+
+    Workflow.update_all major_version: 0, minor_version: 0
+
+    reversible do |dir|
+      dir.up do
+        change_column_null :workflows, :major_version, false
+        change_column_null :workflows, :minor_version, false
+      end
+    end
   end
 end

--- a/db/migrate/20181001154345_workflow_version_numbers.rb
+++ b/db/migrate/20181001154345_workflow_version_numbers.rb
@@ -1,0 +1,6 @@
+class WorkflowVersionNumbers < ActiveRecord::Migration
+  def change
+    add_column :workflows, :major_version, :integer
+    add_column :workflows, :minor_version, :integer
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+
+FactoryBot.create :full_project

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1667,8 +1667,8 @@ CREATE TABLE public.workflows (
     subject_selection_strategy integer DEFAULT 0,
     mobile_friendly boolean DEFAULT false NOT NULL,
     strings jsonb DEFAULT '{}'::jsonb,
-    major_version integer,
-    minor_version integer
+    major_version integer DEFAULT 0 NOT NULL,
+    minor_version integer DEFAULT 0 NOT NULL
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1666,7 +1666,9 @@ CREATE TABLE public.workflows (
     activated_state integer DEFAULT 0 NOT NULL,
     subject_selection_strategy integer DEFAULT 0,
     mobile_friendly boolean DEFAULT false NOT NULL,
-    strings jsonb DEFAULT '{}'::jsonb
+    strings jsonb DEFAULT '{}'::jsonb,
+    major_version integer,
+    minor_version integer
 );
 
 
@@ -4174,4 +4176,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180808140938');
 INSERT INTO schema_migrations (version) VALUES ('20180821125430');
 
 INSERT INTO schema_migrations (version) VALUES ('20180821151555');
+
+INSERT INTO schema_migrations (version) VALUES ('20181001154345');
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -242,6 +242,14 @@ namespace :migrate do
         w.send(:update_workflow_version_cache)
       end
     end
+
+    desc "Backfill new style of version numbers from Papertrail versions"
+    task :backfill_major_minor_versions => :environment do
+      Workflow.find_each do |workflow|
+        workflow.update! major_version: workflow.current_version_number.to_i,
+                         minor_version: workflow.primary_content.current_version_number.to_i
+      end
+    end
   end
 
   namespace :workflow_contents do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -143,7 +143,7 @@ describe Workflow, type: :model do
 
     it 'tracks minor version number' do
       expect do
-        workflow.update!(strings: {})
+        workflow.update!(strings: {a: 4})
       end.to change { workflow.minor_version }.by(1)
 
       expect do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -130,6 +130,26 @@ describe Workflow, type: :model do
       expect(workflow.current_version_number.to_i).to eq(previous_number + 1)
       expect(workflow.current_version_number.to_i).to eq(ModelVersion.version_number(workflow))
     end
+
+    it 'tracks major version number' do
+      expect do
+        workflow.update!(tasks: {blha: 'asdfasd', quera: "asdfas"})
+      end.to change { workflow.major_version }.by(1)
+
+      expect do
+        workflow.update!(strings: {})
+      end.not_to change { workflow.major_version }
+    end
+
+    it 'tracks minor version number' do
+      expect do
+        workflow.update!(strings: {})
+      end.to change { workflow.minor_version }.by(1)
+
+      expect do
+        workflow.update!(tasks: {blha: 'asdfasd', quera: "asdfas"})
+      end.not_to change { workflow.minor_version }
+    end
   end
 
   describe "#retirement_scheme" do


### PR DESCRIPTION
This will start keeping track of the workflow version in a way that's independent from the Papertrail calculation. It's in a new column so that it can be done while keeping the old method online for now. This will allow us to check that after a while of having this running and tracking, the version numbers are exactly the same as the papertrail ones. After that, a PR will remove the old style and get the serializer to use these new columns.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
