### PR TITLE
Start workflow versions at 1

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -79,6 +79,11 @@ class Workflow < ActiveRecord::Base
     if changes.include? :strings
       self.minor_version += 1
     end
+
+    if new_record?
+      self.major_version = 1 if major_version < 1
+      self.minor_version = 1 if minor_version < 1
+    end
   end
 
   def save_version

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -195,6 +195,14 @@ describe Workflow, type: :model do
       expect(workflow.current_version_number.to_i).to eq(ModelVersion.version_number(workflow))
     end
 
+    it 'defaults version numbers to 1' do
+      workflow = Workflow.new(project: create(:project), display_name: "FOO", primary_language: 'en-us')
+      workflow_content = workflow.workflow_contents.build(language: 'en-us')
+      workflow.save!
+      expect(workflow.major_version).to eq(1)
+      expect(workflow.minor_version).to eq(1)
+    end
+
     it 'tracks major version number' do
       expect do
         workflow.update!(tasks: {blha: 'asdfasd', quera: "asdfas"})


### PR DESCRIPTION
If tasks/strings are not set during the create call, the workflow
version needs to be incremented anyway.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
