### PR TITLE
Serialize empty associations as an empty array

### DIFF
--- a/app/serializers/aggregation_serializer.rb
+++ b/app/serializers/aggregation_serializer.rb
@@ -1,5 +1,5 @@
 class AggregationSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :created_at, :updated_at, :aggregation, :href

--- a/app/serializers/concerns/acl_serializer.rb
+++ b/app/serializers/concerns/acl_serializer.rb
@@ -1,7 +1,7 @@
 module ACLSerializer
   extend ActiveSupport::Concern
 
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   module ClassMethods

--- a/app/serializers/concerns/filter_has_many.rb
+++ b/app/serializers/concerns/filter_has_many.rb
@@ -17,7 +17,7 @@ module FilterHasMany
         has_many_filters(filters),
         self,
         params,
-        paging_scope(params, scope),
+        paging_scope(params, scope, context),
         context
       )
 

--- a/app/serializers/medium_serializer.rb
+++ b/app/serializers/medium_serializer.rb
@@ -1,5 +1,5 @@
 class MediumSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :href, :src, :content_type, :media_type, :external_link,

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -1,5 +1,5 @@
 class MembershipSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :state, :href

--- a/app/serializers/organization_content_serializer.rb
+++ b/app/serializers/organization_content_serializer.rb
@@ -1,5 +1,5 @@
 class OrganizationContentSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
 
   attributes :id, :language, :title, :description, :introduction, :announcement, :href
 

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,5 +1,5 @@
 class OrganizationSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include OwnerLinkSerializer
   include MediaLinksSerializer
   include CachedSerializer

--- a/app/serializers/project_content_serializer.rb
+++ b/app/serializers/project_content_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectContentSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :language, :title, :description, :introduction,

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -111,9 +111,6 @@ class ProjectSerializer
     @content = content.slice(*CONTENT_FIELDS)
   end
 
-
-  private
-
   # This method is overridden from PanoptesRestpack to ignore "owners".
   # Owners is a special non-ActiveRecord relation that we support via
   # can_include, but we can't preload it via AR/SQL.

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -53,12 +53,10 @@ class ProjectSerializer
   end
 
   def self.paging_scope(params, scope, context)
-    preload_relations = preloads | param_preloads(params)
-
     if context[:cards]
       scope.preload(:avatar)
-    elsif !preload_relations.empty?
-      scope.preload(*preload_relations)
+    else
+      super(params, scope, context)
     end
   end
 

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include OwnerLinkSerializer
   include MediaLinksSerializer
   include CachedSerializer
@@ -109,5 +109,12 @@ class ProjectSerializer
     content = @model.primary_content.attributes.with_indifferent_access
     content.default = ""
     @content = content.slice(*CONTENT_FIELDS)
+  end
+
+
+  private
+
+  def self.param_preloads(params)
+    super - [:owners]
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -114,6 +114,9 @@ class ProjectSerializer
 
   private
 
+  # This method is overridden from PanoptesRestpack to ignore "owners".
+  # Owners is a special non-ActiveRecord relation that we support via
+  # can_include, but we can't preload it via AR/SQL.
   def self.param_preloads(params)
     super - [:owners]
   end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -107,11 +107,4 @@ class ProjectSerializer
     content.default = ""
     @content = content.slice(*CONTENT_FIELDS)
   end
-
-  # This method is overridden from PanoptesRestpack to ignore "owners".
-  # Owners is a special non-ActiveRecord relation that we support via
-  # can_include, but we can't preload it via AR/SQL.
-  def self.param_preloads(params)
-    super - [:owners]
-  end
 end

--- a/app/serializers/set_member_subject_serializer.rb
+++ b/app/serializers/set_member_subject_serializer.rb
@@ -1,5 +1,5 @@
 class SetMemberSubjectSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
 
   attributes :id, :created_at, :updated_at, :priority, :href
   can_include :subject_set, :subject, :retired_workflows

--- a/app/serializers/subject_set_import_serializer.rb
+++ b/app/serializers/subject_set_import_serializer.rb
@@ -1,5 +1,5 @@
 class SubjectSetImportSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :href, :created_at, :updated_at, :source_url

--- a/app/serializers/tags_serializer.rb
+++ b/app/serializers/tags_serializer.rb
@@ -1,5 +1,5 @@
 class TagSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
 
   attributes :id, :href, :created_at, :updated_at, :popularity, :name
 

--- a/app/serializers/user_collection_preference_serializer.rb
+++ b/app/serializers/user_collection_preference_serializer.rb
@@ -1,5 +1,5 @@
 class UserCollectionPreferenceSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :preferences, :href

--- a/app/serializers/user_group_serializer.rb
+++ b/app/serializers/user_group_serializer.rb
@@ -1,5 +1,5 @@
 class UserGroupSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include RecentLinkSerializer
   include CachedSerializer
 

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -1,5 +1,5 @@
 class UserProjectPreferenceSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :email_communication, :preferences, :href,

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -1,5 +1,5 @@
 class VersionSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :changeset, :whodunnit, :created_at, :type, :href

--- a/app/serializers/workflow_content_serializer.rb
+++ b/app/serializers/workflow_content_serializer.rb
@@ -1,5 +1,5 @@
 class WorkflowContentSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :language, :strings, :href

--- a/app/serializers/workflow_version_serializer.rb
+++ b/app/serializers/workflow_version_serializer.rb
@@ -1,5 +1,5 @@
 class WorkflowVersionSerializer
-  include RestPack::Serializer
+  include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :href, :created_at, :updated_at,

--- a/lib/serialization/panoptes_restpack.rb
+++ b/lib/serialization/panoptes_restpack.rb
@@ -136,6 +136,9 @@ module Serialization
     class PreloadsFromIncludeParams
       attr_reader :params, :allowed_includes
 
+      OWNER_RELATIONS = %i(owners owner).freeze
+      OWNER_PRELOAD = [ owner: { identity_membership: :user } ].freeze
+
       def initialize(params, allowed_includes)
         @params = params
         @allowed_includes = allowed_includes
@@ -145,14 +148,15 @@ module Serialization
         return [] unless params.key?(:include)
 
         preloads = preloads_from_params
+        includes_owner_relation = preloads & OWNER_RELATIONS
 
-        unless preloads.include?(:owners)
-          return preloads
+        if includes_owner_relation.empty?
+          preloads
+        else
+          includable_preloads = preloads - includes_owner_relation
+          includable_preloads << OWNER_PRELOAD
+          includable_preloads
         end
-
-        includable_preloads = preloads - [ :owners ]
-        includable_preloads << [ owner: { identity_membership: :user } ]
-        includable_preloads
       end
 
       private

--- a/lib/serialization/panoptes_restpack.rb
+++ b/lib/serialization/panoptes_restpack.rb
@@ -29,10 +29,11 @@ module Serialization
 
     module ClassMethodOverrides
       def page(params = {}, scope = nil, context = {})
-        super(params, paging_scope(params, scope), context)
+        page_scope = paging_scope(params, scope, context)
+        super(params, page_scope, context)
       end
 
-      def paging_scope(params, scope)
+      def paging_scope(params, scope, context)
         preload_relations = preloads | param_preloads(params)
 
         unless preload_relations.empty?

--- a/lib/serialization/panoptes_restpack.rb
+++ b/lib/serialization/panoptes_restpack.rb
@@ -122,8 +122,8 @@ module Serialization
                           end
                         end
 
-          # PATCH: Compared to the original, deleted an `if links_value.present?`
-          # clause around this next line:
+          # https://github.com/zooniverse/restpack_serializer/blob/a0c2bc4725dbdd86783f09c88054280e110da752/lib/restpack_serializer/serializable.rb#L101
+          # PATCH: Compared to the original above, we now add all links even when blank
           data[:links][association.name.to_sym] = links_value
         end
 

--- a/spec/serializers/collection_serializer_spec.rb
+++ b/spec/serializers/collection_serializer_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe CollectionSerializer do
   let(:collection) { create(:collection_with_subjects) }
 
-  it_should_behave_like "a panoptes restpack serializer" do
+  it_should_behave_like "a panoptes restpack serializer", "test_owner_include" do
     let(:resource) { collection }
-    let(:includes) { [ :owner, :collection_roles, :subjects ] }
+    let(:includes) { %i(collection_roles subjects projects) }
     let(:preloads) do
       [
         [ owner: { identity_membership: :user } ],

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -11,7 +11,7 @@ describe ProjectSerializer do
     s
   end
 
-  it "should preload the serialized associations ny default" do
+  it "should preload the serialized associations by default" do
     expect_any_instance_of(Project::ActiveRecord_Relation)
       .to receive(:preload)
       .with(*ProjectSerializer.preloads)
@@ -25,6 +25,12 @@ describe ProjectSerializer do
       .with(:avatar)
       .and_call_original
     ProjectSerializer.page({}, Project.all, {cards: true})
+  end
+
+  it_should_behave_like "a panoptes restpack serializer", "test_owner_include" do
+    let(:resource) { project }
+    let(:includes) { %i(workflows active_workflows subject_sets project_roles) }
+    let(:preloads) { ProjectSerializer.preloads }
   end
 
   describe "#urls" do

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -14,7 +14,7 @@ describe ProjectSerializer do
   it "should preload the serialized associations ny default" do
     expect_any_instance_of(Project::ActiveRecord_Relation)
       .to receive(:preload)
-      .with(*ProjectSerializer::PRELOADS)
+      .with(*ProjectSerializer.preloads)
       .and_call_original
     ProjectSerializer.page({}, Project.all, {})
   end
@@ -54,19 +54,19 @@ describe ProjectSerializer do
       end
 
       it 'includes filtered projects' do
-        results = described_class.page({"state" => "paused"}, Project)
+        results = described_class.page({"state" => "paused"}, Project.all)
         expect(results[:projects].map { |p| p[:id] }).to include(paused_project.id.to_s)
         expect(results[:projects].count).to eq(1)
       end
 
       it 'includes non-enum states' do
-        results = described_class.page({"state" => "live"}, Project)
+        results = described_class.page({"state" => "live"}, Project.all)
         expect(results[:projects].map { |p| p[:id] }).to include(live_project.id.to_s)
         expect(results[:projects].count).to eq(1)
       end
 
       it 'does not include projects with a state, even if live' do
-        results = described_class.page({"state" => "live"}, Project)
+        results = described_class.page({"state" => "live"}, Project.all)
         expect(results[:projects].map { |p| p[:id] }).not_to include(paused_live_project.id.to_s)
         expect(results[:projects].map { |p| p[:id] }).not_to include(paused_project.id.to_s)
       end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -27,10 +27,14 @@ describe ProjectSerializer do
     ProjectSerializer.page({}, Project.all, {cards: true})
   end
 
-  it_should_behave_like "a panoptes restpack serializer", "test_owner_include" do
+  it_should_behave_like "a panoptes restpack serializer", "test_owner_include", "test_blank_links" do
     let(:resource) { project }
     let(:includes) { %i(workflows active_workflows subject_sets project_roles) }
     let(:preloads) { ProjectSerializer.preloads }
+    let(:expected_links) do
+      non_owners_includes = described_class.can_includes - [:owners]
+      non_owners_includes | [:owner] | described_class.media_links
+    end
   end
 
   describe "#urls" do

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -1,4 +1,4 @@
-shared_examples "a panoptes restpack serializer" do
+shared_examples "a panoptes restpack serializer" do |test_owner_include=false|
   let(:scope) { resource.class.all }
 
   describe "preload associations" do
@@ -57,6 +57,27 @@ shared_examples "a panoptes restpack serializer" do
         .with(*includes)
         .and_call_original
       described_class.page({include: includes.join(',')}, scope, {})
+    end
+
+    context "with owner include params" do
+      if !!test_owner_include
+        let(:params) do
+          param_includes = (includes | ["owners"]).join(',')
+          { include: param_includes }
+        end
+        let(:expected_includes) do
+          includes | [[ owner: { identity_membership: :user } ]]
+        end
+
+        it "should handle the special owner relation include param" do
+          expect_any_instance_of(
+            resource.class::ActiveRecord_Relation
+          ).to receive(:preload)
+          .with(*expected_includes)
+          .and_call_original
+          described_class.page(params, scope, {})
+        end
+      end
     end
   end
 end

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -1,5 +1,6 @@
-shared_examples "a panoptes restpack serializer" do |test_owner_include=false|
+shared_examples "a panoptes restpack serializer" do |test_owner_include=false, test_blank_links=false|
   let(:scope) { resource.class.all }
+  let(:test_link_serialization) { false }
 
   describe "preload associations" do
     around do |example|
@@ -76,6 +77,15 @@ shared_examples "a panoptes restpack serializer" do |test_owner_include=false|
           .with(*expected_includes)
           .and_call_original
           described_class.page(params, scope, {})
+        end
+      end
+    end
+
+    describe "link serialization" do
+      if !!test_blank_links
+        it "should include all link keys even if blank" do
+          result_links = described_class.single({}, scope, {})[:links]
+          expect(result_links.keys).to match_array(expected_links)
         end
       end
     end

--- a/spec/support/panoptes_restpack_serializer.rb
+++ b/spec/support/panoptes_restpack_serializer.rb
@@ -62,21 +62,30 @@ shared_examples "a panoptes restpack serializer" do |test_owner_include=false, t
 
     context "with owner include params" do
       if !!test_owner_include
-        let(:params) do
-          param_includes = (includes | ["owners"]).join(',')
-          { include: param_includes }
-        end
-        let(:expected_includes) do
-          includes | [[ owner: { identity_membership: :user } ]]
+        before do
+          added_owner_includes = described_class.can_includes | %i(owners owner)
+          allow(described_class)
+          .to receive(:can_includes)
+          .and_return(added_owner_includes)
         end
 
-        it "should handle the special owner relation include param" do
-          expect_any_instance_of(
-            resource.class::ActiveRecord_Relation
-          ).to receive(:preload)
-          .with(*expected_includes)
-          .and_call_original
-          described_class.page(params, scope, {})
+        %i(owners owner).each do |owner_include_variant|
+          let(:params) do
+            param_includes = (includes | [owner_include_variant]).join(',')
+            { include: param_includes }
+          end
+          let(:expected_includes) do
+            includes | [[ owner: { identity_membership: :user } ]]
+          end
+
+          it "should handle the special owner relation include param" do
+            expect_any_instance_of(
+              resource.class::ActiveRecord_Relation
+            ).to receive(:preload)
+            .with(*expected_includes)
+            .and_call_original
+            described_class.page(params, scope, {})
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #2902 

Empty associations would be ignored by Restpack, and not serialized in the links at all. This change overrides the method in Restpack doing so, such that these will appear in the links as an empty array.
 
# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
