### PR TITLE
more robust spec testing workflow load no json

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -39,7 +39,7 @@ class Workflow < ActiveRecord::Base
     'options' => {'count' => 15}
   }.freeze
 
-  JSON_ATTRIBUTES = %w(tasks retirement aggregation configuration).freeze
+  JSON_ATTRIBUTES = %w(tasks retirement aggregation configuration strings).freeze
 
   # Used by HttpCacheable
   scope :private_scope, -> { where(project_id: Project.private_scope) }

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -40,19 +40,17 @@ describe Workflow, type: :model do
   describe "::find_without_json_attrs" do
     let(:workflow) { create(:workflow) }
     let(:json_attrs) do
-      %w(tasks retirement aggregation configuration)
-    end
-    let(:non_json_attrs) do
-      Workflow.attribute_names - json_attrs
+      col_information = Workflow.columns_hash.select do |name, col|
+        /\Ajson.*/.match?(col.sql_type)
+      end
+      col_information.keys
     end
 
-    it "should load the workflow without the tasks attribute" do
-      expect(Workflow)
-        .to receive(:select)
-        .with(*non_json_attrs)
-        .and_call_original
+    it "should load the workflow without the json attributes" do
       no_json_workflow = Workflow.find_without_json_attrs(workflow.id)
-      expect(no_json_workflow.id).to eq(workflow.id)
+      loaded_attributes = no_json_workflow.attributes.keys
+      non_json_attributes = loaded_attributes - json_attrs
+      expect(loaded_attributes).to match_array(non_json_attributes)
     end
   end
 


### PR DESCRIPTION
Linked to #2787 - Update the method to avoid loading large workflow json blobs for workers when we don't need them.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
