### PR TITLE
handle nil resource id param values in controllers

### DIFF
--- a/lib/json_api_controller/resource_ids.rb
+++ b/lib/json_api_controller/resource_ids.rb
@@ -1,7 +1,8 @@
 module JsonApiController
   class ResourceIds
     def self.from(params, resource_name)
-      array_id_params(resource_ids(params, resource_name))
+      non_nil_params = params.compact
+      array_id_params(resource_ids(non_nil_params, resource_name))
     end
 
     def self.array_id_params(string_id_params)

--- a/spec/lib/json_api_controller/check_resources_exist_spec.rb
+++ b/spec/lib/json_api_controller/check_resources_exist_spec.rb
@@ -28,7 +28,7 @@ describe JsonApiController::CheckResourcesExist, type: :controller do
     end
 
     def resource_ids
-      params[:id]
+      JsonApiController::ResourceIds.from(params, resource_name)
     end
 
     def update
@@ -36,6 +36,10 @@ describe JsonApiController::CheckResourcesExist, type: :controller do
     end
 
     def show
+      render nothing: true
+    end
+
+    def index
       render nothing: true
     end
   end
@@ -63,6 +67,24 @@ describe JsonApiController::CheckResourcesExist, type: :controller do
   describe "user is not enrolled on controlled object" do
     it 'should raise an AccessDenied error' do
       expect{ put :update, id: controlled.id }.to raise_error(JsonApiController::AccessDenied)
+    end
+  end
+
+  describe "id params are extracted correctly" do
+    before do
+      routes.draw do
+        get "index" => "anonymous#index"
+      end
+    end
+
+    it 'should handle missing id values' do
+      # manually skip the pundit policy run validation
+      # as this spec won't return resource ids so won't activate the scope
+      # lookup in JsonApiController::CheckResourcesExist.resources_exist?
+      allow(controller).to receive(:policy_scoped?).and_return(true)
+      expect{
+        get :index, id: nil
+      }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
ensure we don't 500 on invalid id params (`{id:nil}`) instead handle these as if they weren't passed in at all.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
