### PR TITLE
Translation update string versions

### DIFF
--- a/app/models/concerns/unversioned.rb
+++ b/app/models/concerns/unversioned.rb
@@ -1,0 +1,11 @@
+# This module should not exist, but some models need to behave "like" a versioned resource,
+# without having versioning added to them yet.
+module Unversioned
+  def latest_version_id
+    0
+  end
+
+  def version_ids
+    [latest_version_id]
+  end
+end

--- a/app/models/concerns/versioning.rb
+++ b/app/models/concerns/versioning.rb
@@ -43,4 +43,8 @@ module Versioning
   def latest_version_id
     send(self.class.versioned_association).order(id: :desc).select(:id).first.id
   end
+
+  def version_ids
+    send(self.class.versioned_association).pluck(:id)
+  end
 end

--- a/app/models/field_guide.rb
+++ b/app/models/field_guide.rb
@@ -1,6 +1,7 @@
 class FieldGuide < ActiveRecord::Base
   include Translatable
   include LanguageValidation
+  include Unversioned
 
   belongs_to :project
   has_many :attached_images, -> { where(type: "field_guide_attached_image") },
@@ -11,11 +12,6 @@ class FieldGuide < ActiveRecord::Base
 
   def self.translatable_attributes
     %i(items)
-  end
-
-  # TODO: Add Versioning to this model, and then remove this override
-  def latest_version_id
-    0
   end
 
   def items

--- a/app/models/organization_page.rb
+++ b/app/models/organization_page.rb
@@ -1,6 +1,7 @@
 class OrganizationPage < ActiveRecord::Base
   include Translatable
   include LanguageValidation
+  include Unversioned
 
   has_paper_trail ignore: [:language]
 
@@ -10,10 +11,5 @@ class OrganizationPage < ActiveRecord::Base
 
   def self.translatable_attributes
     %i(title content)
-  end
-
-  # TODO: Add Versioning to this model, and then remove this override
-  def latest_version_id
-    0
   end
 end

--- a/app/models/project_page.rb
+++ b/app/models/project_page.rb
@@ -1,6 +1,7 @@
 class ProjectPage < ActiveRecord::Base
   include Translatable
   include LanguageValidation
+  include Unversioned
 
   has_paper_trail ignore: [:language]
 
@@ -10,10 +11,5 @@ class ProjectPage < ActiveRecord::Base
 
   def self.translatable_attributes
     %i(title content)
-  end
-
-  # TODO: Add Versioning to this model, and then remove this override
-  def latest_version_id
-    0
   end
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,14 +1,15 @@
 class Translation < ActiveRecord::Base
   belongs_to :translated, polymorphic: true, required: true
+
   validate :validate_translated_is_translatable
   validate :validate_strings
   validates_presence_of :language
-
-  before_validation :downcase_language, on: :create
-
+  validate :validate_string_versions
   validates_uniqueness_of :language,
     scope: %i(translated_type translated_id),
     message: "translation already exists for this resource"
+
+  before_validation :downcase_language, on: :create
 
   # TODO: Versioning and maintaining a live, published version
 
@@ -51,6 +52,26 @@ class Translation < ActiveRecord::Base
   def validate_translated_is_translatable
     unless translated.is_a?(Translatable)
       errors.add(:translated, "must be a translatable model")
+    end
+  end
+
+  def validate_string_versions
+    unless string_versions.is_a?(Hash)
+      errors.add(:string_versions, "must be present but can be empty")
+      return
+    end
+
+    # Next we need to validate that all of the specified IDs in this attribute are
+    # actually IDs that belong to the translated resource.
+
+    return unless translated.present? # This is a different validation error
+
+    known_version_ids = translated.version_ids
+    referenced_version_ids = string_versions.values.uniq
+    unknown_version_ids = referenced_version_ids - known_version_ids
+
+    if unknown_version_ids.present?
+      errors.add(:string_versions, "references unknown versions: #{unknown_version_ids.join(", ")}")
     end
   end
 

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,6 @@
 class Tutorial < ActiveRecord::Base
   include Translatable
+  include Unversioned
 
   belongs_to :project
   has_many :workflow_tutorials
@@ -11,11 +12,6 @@ class Tutorial < ActiveRecord::Base
 
   def self.translatable_attributes
     %i(display_name steps)
-  end
-
-  # TODO: Add Versioning to this model, and then remove this override
-  def latest_version_id
-    0
   end
 
   def steps

--- a/app/schemas/translation_create_schema.rb
+++ b/app/schemas/translation_create_schema.rb
@@ -13,6 +13,10 @@ class TranslationCreateSchema < JsonSchema
       type "object"
     end
 
+    property "string_versions" do
+      type "object"
+    end
+
     property "translated_type" do
       type "string"
     end

--- a/app/schemas/translation_update_schema.rb
+++ b/app/schemas/translation_update_schema.rb
@@ -8,5 +8,9 @@ class TranslationUpdateSchema < JsonSchema
     property "strings" do
       type "object"
     end
+
+    property "string_versions" do
+      type "object"
+    end
   end
 end

--- a/spec/factories/translations.rb
+++ b/spec/factories/translations.rb
@@ -9,15 +9,7 @@ FactoryBot.define do
       "urls.0.label" => "Blog",
       "urls.1.label" => "Twitter"
     })
-    string_versions({
-      title: 1,
-      description: 1,
-      introduction: 1,
-      workflow_description: 1,
-      researcher_quote: 1,
-      "urls.0.label" => 1,
-      "urls.1.label" => 1
-    })
+    string_versions({})
 
     association :translated, factory: :project
     language "en"

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -28,6 +28,21 @@ RSpec.describe Translation, type: :model do
     expect(translation.errors[:strings]).to match_array(invalid_strings_msg)
   end
 
+  it 'should not be valid without string_versions' do
+    invalid_msg = ["must be present but can be empty"]
+    translation.string_versions = nil
+    expect(translation.valid?).to be false
+    expect(translation.errors[:string_versions]).to match_array(invalid_msg)
+  end
+
+  it 'should not be valid when referencing an unknown version' do
+    invalid_msg = ["references unknown versions: 1, 2"]
+    translation.strings = {foo: "Foo", bar: "Bar"}
+    translation.string_versions = {foo: 1, bar: 2}
+    expect(translation.valid?).to be false
+    expect(translation.errors[:string_versions]).to match_array(invalid_msg)
+  end
+
   it 'should not be valid without a translated resource' do
     translation.translated = nil
     expect(translation).to_not be_valid


### PR DESCRIPTION
This makes the string_versions editable through the API, but checks that the referenced version numbers make sense.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
