### PR TITLE
limit the number of concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,11 @@
 pipeline {
   agent none
 
+  options {
+    quietPeriod(120)
+    disableConcurrentBuilds()
+  }
+
   stages {
     stage('Build Docker image') {
       agent any


### PR DESCRIPTION
avoid PR merging / branch commit activity kicking off multiple builds that could have race conditions to which version gets run (deployed / built).

Add jenkins job options to:
1. Increase the quiet period to 2 minutes to collapse branch / PR activity into the same build
2. disable concurrent builds per branch / PR and queue them instead. This is important as we want master branch / production tag deploys to run serially.

https://jenkins.io/doc/book/pipeline/syntax/#options

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
