### PR TITLE
avoid using internal selector on exernal failure

### DIFF
--- a/lib/subjects/strategy_selection.rb
+++ b/lib/subjects/strategy_selection.rb
@@ -35,7 +35,7 @@ module Subjects
     def select_subject_ids
       select_with(desired_selector)
     rescue CellectClient::ConnectionError, DesignatorClient::GenericError
-      select_with(default_selector)
+      []
     end
 
     def select_with(selector)

--- a/spec/lib/subjects/strategy_selection_spec.rb
+++ b/spec/lib/subjects/strategy_selection_spec.rb
@@ -60,13 +60,20 @@ RSpec.describe Subjects::StrategySelection do
         end
 
         context "when the cellect client can't reach a server" do
-          it "should fall back to postgres strategy" do
-            allow(CellectClient).to receive(:get_subjects)
-              .and_raise(CellectClient::ConnectionError)
+          before do
+            allow(CellectClient)
+            .to receive(:get_subjects)
+            .and_raise(CellectClient::ConnectionError)
+          end
+
+          it "should not use the internal selector" do
             expect_any_instance_of(Subjects::PostgresqlSelection)
-              .to receive(:select)
-              .and_call_original
+              .not_to receive(:select)
             run_selection
+          end
+
+          it "should return an empty array" do
+            expect(run_selection).to match_array([])
           end
         end
       end


### PR DESCRIPTION
closes #2982 - don't run the internal selector if we fail to get subjects from the external selector. Instead just return an empty list of subject_ids and allow the Subjects::Selector class to handle the failure mode.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
