### PR TITLE
Add timestamps to subject exports

### DIFF
--- a/lib/formatter/csv/subject.rb
+++ b/lib/formatter/csv/subject.rb
@@ -10,7 +10,7 @@ module Formatter
 
       def headers
         %w(subject_id project_id workflow_id subject_set_id metadata locations
-           classifications_count retired_at retirement_reason)
+           classifications_count retired_at retirement_reason created_at updated_at)
       end
 
       def to_rows(subject)
@@ -30,7 +30,9 @@ module Formatter
             locations: locations,
             classifications_count: classifications_count(workflow_id),
             retired_at: retired_at(workflow_id),
-            retirement_reason: retirement_reason(workflow_id)
+            retirement_reason: retirement_reason(workflow_id),
+            created_at: subject_workflow_set_link.subject.created_at,
+            updated_at: subject_workflow_set_link.subject.updated_at
           )
         end
 

--- a/spec/lib/formatter/csv/subject_spec.rb
+++ b/spec/lib/formatter/csv/subject_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe Formatter::Csv::Subject do
         locations: ordered_subject_locations.to_json,
         classifications_count: 10,
         retired_at: retirement_date,
-        retirement_reason: nil
+        retirement_reason: nil,
+        created_at: subject.created_at,
+        updated_at: subject.updated_at
       }
     end
 
@@ -53,7 +55,9 @@ RSpec.describe Formatter::Csv::Subject do
         locations: ordered_subject_locations.to_json,
         classifications_count: 5,
         retired_at: nil,
-        retirement_reason: nil
+        retirement_reason: nil,
+        created_at: subject.created_at,
+        updated_at: subject.updated_at
       }
     end
 
@@ -129,7 +133,9 @@ RSpec.describe Formatter::Csv::Subject do
           locations: ordered_subject_locations.to_json,
           classifications_count: 0,
           retired_at: nil,
-          retirement_reason: nil
+          retirement_reason: nil,
+          created_at: subject.created_at,
+          updated_at: subject.updated_at
         }
       end
 


### PR DESCRIPTION
Aiming at low hanging fruit in the issues list. This makes sense to include, and they're added at the end so this shouldn't affect scripts/automation. 

Resolves https://github.com/zooniverse/Panoptes/issues/1908. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
