### PR TITLE
Update WorkflowUnfinishWorker to update workflow's updated_at when updating workflow

### DIFF
--- a/app/workers/unfinish_workflow_worker.rb
+++ b/app/workers/unfinish_workflow_worker.rb
@@ -15,8 +15,6 @@ class UnfinishWorkflowWorker
 
   def perform(workflow_id)
     workflow = Workflow.find_without_json_attrs(workflow_id)
-    if workflow.finished_at
-      Workflow.where(id: workflow.id).update_all(finished_at: nil)
-    end
+    workflow.update_attribute(:finished_at, nil) if workflow.finished_at
   end
 end

--- a/spec/workers/unfinish_workflow_worker_spec.rb
+++ b/spec/workers/unfinish_workflow_worker_spec.rb
@@ -9,11 +9,17 @@ RSpec.describe UnfinishWorkflowWorker do
       expect { worker.perform(workflow.id) }.not_to change{ workflow.reload.finished_at }
     end
 
-    context "with a finished worklfow" do
+    context "with a finished workflow" do
       let(:workflow) { create(:workflow, finished_at: DateTime.now) }
 
       it "should remove the finished flag if the workflow is finished" do
         expect { worker.perform(workflow.id) }.to change{ workflow.reload.finished_at }
+      end
+
+      it "should touch the updated_at timestamp" do
+        workflow.updated_at = Time.now - 1.hour
+        workflow.save!
+        expect { worker.perform(workflow.id) }.to change{ workflow.reload.updated_at}
       end
     end
   end

--- a/spec/workers/unfinish_workflow_worker_spec.rb
+++ b/spec/workers/unfinish_workflow_worker_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe UnfinishWorkflowWorker do
       end
 
       it "should touch the updated_at timestamp" do
-        workflow.updated_at = Time.now - 1.hour
-        workflow.save!
+        workflow.update(updated_at: Time.now - 1.hour)
         expect { worker.perform(workflow.id) }.to change{ workflow.reload.updated_at}
       end
     end


### PR DESCRIPTION
Low hanging 🍎🍊, fixes https://github.com/zooniverse/Panoptes/issues/2146 

Use `update_attribute` instead of an extra query and update_all when querying by id. `update_attribute` bypasses validation because the RetirementValidator complains about the JSON attribute-less workflow object, but it's always nil, so it doesn't matter.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
