### PR TITLE
Sync only when strings change

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::OrganizationsController < Api::ApiController
   end
 
   def update
-    Organization.transaction(requires_new: true) do
+    @updated_resources = Organization.transaction(requires_new: true) do
       Array.wrap(resource_ids).zip(Array.wrap(params[:organizations])).map do |organization_id, organization_params|
         wrapper = { organization_params: organization_params }
         Organizations::Update.with(api_user: api_user, id: organization_id).run!(wrapper)

--- a/app/controllers/concerns/sync_resource_translation_strings.rb
+++ b/app/controllers/concerns/sync_resource_translation_strings.rb
@@ -18,8 +18,11 @@ module SyncResourceTranslationStrings
   end
 
   def translatable_resources
-    if action_name == "create"
+    case action_name
+    when "create"
       created_resources
+    when "update"
+      updated_resources
     else
       controlled_resources
     end

--- a/app/controllers/concerns/sync_resource_translation_strings.rb
+++ b/app/controllers/concerns/sync_resource_translation_strings.rb
@@ -9,11 +9,15 @@ module SyncResourceTranslationStrings
 
   def sync_translatable_resource_strings
     translatable_resources.each do |resource|
-      TranslationSyncWorker.perform_async(
-        resource.class.name,
-        resource.id,
-        resource.translatable_language
-      )
+      # NOTE: In Rails 5 this method is deprecated, and we should use
+      # resource.saved_changes instead.
+      if (resource.previous_changes.keys & resource.class.translatable_attributes.map(&:to_s)).present?
+        TranslationSyncWorker.perform_async(
+          resource.class.name,
+          resource.id,
+          resource.translatable_language
+        )
+      end
     end
   end
 

--- a/app/operations/organizations/update.rb
+++ b/app/operations/organizations/update.rb
@@ -25,13 +25,18 @@ module Organizations
         content_update.merge! content_params
         org_update.merge!(content_update.with_indifferent_access.except(:title, :language))
 
+        if org_update[:listed] == true
+          org_update[:listed_at] = Time.zone.now
+        else
+          org_update[:listed_at] = nil
+        end
+
         organization.update!(org_update.symbolize_keys)
+
         organization.organization_contents.find_or_initialize_by(language: language).tap do |content|
           content.update! content_update.symbolize_keys
         end
-        org_update[:listed] == true ? organization.touch(:listed_at) : organization[:listed_at] = nil
 
-        organization.save!
         organization
       end
     end

--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -9,20 +9,18 @@ module JsonApiController
     end
 
     def update
-      resource_class.transaction(requires_new: true) do
-        resources_with_updates = controlled_resources.zip(
-          Array.wrap(update_params)
-        )
-        resources_with_updates.each do |resource, update_hash|
-          resource.assign_attributes(
-            build_update_hash(update_hash, resource)
-          )
+      @updated_resources = resource_class.transaction(requires_new: true) do
+        resources_with_updates = controlled_resources.zip(Array.wrap(update_params))
+        resources_with_updates.map do |resource, update_hash|
+          resource.assign_attributes(build_update_hash(update_hash, resource))
 
           yield resource if block_given?
 
           resource.save!
+          resource
         end
       end
+
       updated_resource_response
     end
 
@@ -75,6 +73,10 @@ module JsonApiController
 
     def relation
       params[:link_relation].to_sym
+    end
+
+    def updated_resources
+      @updated_resources
     end
   end
 end

--- a/spec/controllers/api/v1/field_guides_controller_spec.rb
+++ b/spec/controllers/api/v1/field_guides_controller_spec.rb
@@ -91,14 +91,12 @@ describe Api::V1::FieldGuidesController, type: :controller do
 
     it_behaves_like "is creatable"
 
-    it_behaves_like "it syncs the resource translation strings" do
+    it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
       let(:translated_klass_name) { FieldGuide.name }
       let(:translated_resource_id) { be_kind_of(Integer) }
-      let(:translated_language) do
-        create_params.dig(:field_guides, :language)
-      end
+      let(:translated_language) { create_params.dig(:field_guides, :language) }
       let(:controller_action) { :create }
-      let(:controller_action_params) { create_params }
+      let(:translatable_action_params) { create_params }
     end
   end
 
@@ -118,12 +116,12 @@ describe Api::V1::FieldGuidesController, type: :controller do
 
     it_behaves_like "is updatable"
 
-    it_behaves_like "it syncs the resource translation strings" do
+    it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
       let(:translated_klass_name) { resource.class.name }
       let(:translated_resource_id) { resource.id }
       let(:translated_language) { resource.language }
       let(:controller_action) { :update }
-      let(:controller_action_params) { update_params.merge(id: resource.id) }
+      let(:translatable_action_params) { update_params.merge(id: resource.id) }
     end
   end
 

--- a/spec/controllers/api/v1/organization_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_pages_controller_spec.rb
@@ -110,14 +110,12 @@ describe Api::V1::OrganizationPagesController, type: :controller do
 
     it_behaves_like "is creatable"
 
-    it_behaves_like "it syncs the resource translation strings" do
+    it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
       let(:translated_klass_name) { OrganizationPage.name }
       let(:translated_resource_id) { be_kind_of(Integer) }
-      let(:translated_language) do
-        create_params.dig(:organization_pages, :language)
-      end
+      let(:translated_language) { create_params.dig(:organization_pages, :language) }
       let(:controller_action) { :create }
-      let(:controller_action_params) { create_params }
+      let(:translatable_action_params) { create_params }
     end
 
     it 'should set organization from the organization_id param' do
@@ -146,7 +144,8 @@ describe Api::V1::OrganizationPagesController, type: :controller do
       let(:translated_resource_id) { resource.id }
       let(:translated_language) { resource.language }
       let(:controller_action) { :update }
-      let(:controller_action_params) { update_params.merge(id: resource.id) }
+      let(:translatable_action_params) { update_params.merge(id: resource.id) }
+      let(:non_translatable_action_params) { {organization_id: organization.id, id: resource.id, organization_pages: {url_key: "foobar"}} }
     end
   end
 

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -33,7 +33,7 @@ describe Api::V1::OrganizationsController, type: :controller do
     end
   end
 
-  describe "when a logged in user" do
+  describe "with a logged in user" do
     describe "#index" do
       it_behaves_like "is indexable" do
         let(:private_resource) { unlisted_organization }
@@ -151,14 +151,12 @@ describe Api::V1::OrganizationsController, type: :controller do
         end
       end
 
-      it_behaves_like "it syncs the resource translation strings" do
+      it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
         let(:translated_klass_name) { Organization.name }
         let(:translated_resource_id) { be_kind_of(Integer) }
-        let(:translated_language) do
-          create_params.dig(:organizations, :primary_language)
-        end
+        let(:translated_language) { create_params.dig(:organizations, :primary_language) }
         let(:controller_action) { :create }
-        let(:controller_action_params) { create_params }
+        let(:translatable_action_params) { create_params }
       end
     end
 
@@ -200,7 +198,8 @@ describe Api::V1::OrganizationsController, type: :controller do
         let(:translated_resource_id) { resource.id }
         let(:translated_language) { resource.primary_language }
         let(:controller_action) { :update }
-        let(:controller_action_params) { update_params.merge(id: resource.id) }
+        let(:translatable_action_params) { update_params.merge(id: resource.id) }
+        let(:non_translatable_action_params) { {id: resource.id, organizations: {listed: true}} }
       end
 
       context "includes exceptional parameters" do

--- a/spec/controllers/api/v1/project_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/project_pages_controller_spec.rb
@@ -149,14 +149,12 @@ describe Api::V1::ProjectPagesController, type: :controller do
       expect(json_response[api_resource_name][0]["links"]["project"]).to eq(project.id.to_s)
     end
 
-    it_behaves_like "it syncs the resource translation strings" do
+    it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
       let(:translated_klass_name) { ProjectPage.name }
       let(:translated_resource_id) { be_kind_of(Integer) }
-      let(:translated_language) do
-        create_params.dig(:project_pages, :language)
-      end
+      let(:translated_language) { create_params.dig(:project_pages, :language) }
       let(:controller_action) { :create }
-      let(:controller_action_params) { create_params }
+      let(:translatable_action_params) { create_params }
     end
   end
 
@@ -179,7 +177,8 @@ describe Api::V1::ProjectPagesController, type: :controller do
       let(:translated_resource_id) { resource.id }
       let(:translated_language) { resource.language }
       let(:controller_action) { :update }
-      let(:controller_action_params) { update_params.merge(id: resource.id) }
+      let(:translatable_action_params) { update_params.merge(id: resource.id) }
+      let(:non_translatable_action_params) { {project_id: project.id, id: resource.id, project_pages: {url_key: "foo"}} }
     end
   end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -373,14 +373,12 @@ describe Api::V1::ProjectsController, type: :controller do
       ps
     end
 
-    it_behaves_like "it syncs the resource translation strings" do
+    it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
       let(:translated_klass_name) { Project.name }
       let(:translated_resource_id) { be_kind_of(Integer) }
-      let(:translated_language) do
-        default_create_params.dig(:projects, :primary_language)
-      end
+      let(:translated_language) { default_create_params.dig(:projects, :primary_language) }
       let(:controller_action) { :create }
-      let(:controller_action_params) { create_params }
+      let(:translatable_action_params) { create_params }
     end
 
     describe "redirect option" do
@@ -628,7 +626,8 @@ describe Api::V1::ProjectsController, type: :controller do
       let(:translated_resource_id) { resource.id }
       let(:translated_language) { resource.primary_language }
       let(:controller_action) { :update }
-      let(:controller_action_params) { update_params.merge(id: resource.id) }
+      let(:translatable_action_params) { update_params.merge(id: resource.id) }
+      let(:non_translatable_action_params) { {id: resource.id, projects: {tags: ["cats"]}} }
     end
 
     describe "launch_approved" do

--- a/spec/controllers/api/v1/tutorials_controller_spec.rb
+++ b/spec/controllers/api/v1/tutorials_controller_spec.rb
@@ -108,14 +108,12 @@ describe Api::V1::TutorialsController, type: :controller do
 
     it_behaves_like "is creatable"
 
-    it_behaves_like "it syncs the resource translation strings" do
+    it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
       let(:translated_klass_name) { Tutorial.name }
       let(:translated_resource_id) { be_kind_of(Integer) }
-      let(:translated_language) do
-        create_params.dig(:tutorials, :language)
-      end
+      let(:translated_language) { create_params.dig(:tutorials, :language) }
       let(:controller_action) { :create }
-      let(:controller_action_params) { create_params }
+      let(:translatable_action_params) { create_params }
     end
   end
 
@@ -138,7 +136,8 @@ describe Api::V1::TutorialsController, type: :controller do
       let(:translated_resource_id) { resource.id }
       let(:translated_language) { resource.language }
       let(:controller_action) { :update }
-      let(:controller_action_params) { update_params.merge(id: resource.id) }
+      let(:translatable_action_params) { update_params.merge(id: resource.id) }
+      let(:non_translatable_action_params) { {id: resource.id, tutorials: {kind: "something"}} }
     end
   end
 

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -156,7 +156,8 @@ describe Api::V1::WorkflowsController, type: :controller do
       let(:translated_resource_id) { resource.id }
       let(:translated_language) { resource.primary_language }
       let(:controller_action) { :update }
-      let(:controller_action_params) { update_params.merge(id: resource.id) }
+      let(:translatable_action_params) { update_params.merge(id: resource.id) }
+      let(:non_translatable_action_params) { {id: resource.id, workflows: {active: false}} }
     end
 
     context "workflow versions" do
@@ -556,14 +557,12 @@ describe Api::V1::WorkflowsController, type: :controller do
       }
     end
 
-    it_behaves_like "it syncs the resource translation strings" do
+    it_behaves_like "it syncs the resource translation strings", non_translatable_attributes_possible: false do
       let(:translated_klass_name) { Workflow.name }
       let(:translated_resource_id) { be_kind_of(Integer) }
-      let(:translated_language) do
-        create_params.dig(:workflows, :primary_language)
-      end
+      let(:translated_language) { create_params.dig(:workflows, :primary_language) }
       let(:controller_action) { :create }
-      let(:controller_action_params) { create_params }
+      let(:translatable_action_params) { create_params }
     end
 
     context "when the linked project is owned by a user" do

--- a/spec/support/syncs_resource_translation_strings.rb
+++ b/spec/support/syncs_resource_translation_strings.rb
@@ -1,12 +1,17 @@
-shared_examples "it syncs the resource translation strings" do
-  it 'should queue a translation sync worker' do
+shared_examples "it syncs the resource translation strings" do |non_translatable_attributes_possible: true|
+  it 'should queue a translation sync worker if translatable attributes change' do
     expect(TranslationSyncWorker)
       .to receive(:perform_async)
       .with(translated_klass_name, translated_resource_id, translated_language)
+    default_request scopes: scopes, user_id: authorized_user.id
+    post controller_action, translatable_action_params
   end
 
-  after do
-    default_request scopes: scopes, user_id: authorized_user.id
-    post controller_action, controller_action_params
+  if non_translatable_attributes_possible
+    it 'should not queue a worker when only other attributes change' do
+      expect(TranslationSyncWorker).not_to receive(:perform_async)
+      default_request scopes: scopes, user_id: authorized_user.id
+      post controller_action, non_translatable_action_params
+    end
   end
 end


### PR DESCRIPTION
Solves failing sync translations jobs, by not enqueuing them when they would fail.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
