### PR TITLE
ensure user is logged in for submitting gs data

### DIFF
--- a/app/models/concerns/classification_validator.rb
+++ b/app/models/concerns/classification_validator.rb
@@ -6,7 +6,9 @@ class ClassificationValidator
 
   def validate_gold_standard
     if classification.gold_standard
-      unless project.expert_classifier?(user)
+      if user.nil?
+        add_error(:gold_standard, 'user must be logged in')
+      elsif !project.expert_classifier?(user)
         add_error(:gold_standard, 'classifier is not a project expert')
       end
     elsif classification.gold_standard == false

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -109,6 +109,11 @@ describe Classification, :type => :model do
     context "when the gold standard value is set to true" do
       let(:gold_standard) { true }
 
+      it "should be valid when the classification user is not supplied" do
+        classification.user = nil
+        expect(classification).to be_invalid
+      end
+
       context "when the classification user is not authorised for expert mode" do
 
         it "should not be valid" do

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -109,7 +109,7 @@ describe Classification, :type => :model do
     context "when the gold standard value is set to true" do
       let(:gold_standard) { true }
 
-      it "should be valid when the classification user is not supplied" do
+      it "should be invalid when the classification user is not supplied" do
         classification.user = nil
         expect(classification).to be_invalid
       end


### PR DESCRIPTION
Linked to https://app.honeybadger.io/projects/40595/faults/41349333#notice-summary

Gold standard classifications can only be made by logged in users (bots can) so to have them be unauthenticated when processing the payload is abnormal. This PR will reject as invalid records any gold standard classifications for users that have their tokens expire during classification submission. 

The invalid record will return a 400 response which will force the client to resubmit the data (with updated tokens) instead of erroring server side (which still would have resulted in the same outcome).
https://github.com/zooniverse/Panoptes/blob/3a573b65b1bf13e7c9632cd1e947d21b7fc338b7/app/controllers/api/api_controller.rb#L19

https://github.com/zooniverse/Panoptes/blob/3a573b65b1bf13e7c9632cd1e947d21b7fc338b7/app/controllers/concerns/json_api_responses.rb#L41

https://github.com/zooniverse/Panoptes-Front-End/blob/d6fda2f400f53b71bf05e8555c5be9f317e7f8c5/app/lib/classification-queue.js#L67

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
