### PR TITLE
Fix missing first_task attribute in spec

### DIFF
--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -198,7 +198,7 @@ describe Workflow, type: :model do
     end
 
     it 'defaults version numbers to 1' do
-      workflow = Workflow.new(project: create(:project), display_name: "FOO", primary_language: 'en-us')
+      workflow = Workflow.new(project: create(:project), display_name: "FOO", primary_language: 'en-us', first_task: 'init')
       workflow_content = workflow.workflow_contents.build(language: 'en-us')
       workflow.save!
       expect(workflow.major_version).to eq(1)


### PR DESCRIPTION
Not sure how we managed to get this broken on master, but it was.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
