### PR TITLE
[WIP] rename intervention_notifications to interventions

### DIFF
--- a/db/migrate/20181123100145_change_intervention_notifications_to_interventions.rb
+++ b/db/migrate/20181123100145_change_intervention_notifications_to_interventions.rb
@@ -1,0 +1,5 @@
+class ChangeInterventionNotificationsToInterventions < ActiveRecord::Migration
+  def change
+    rename_column :users, :intervention_notifications, :interventions
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1590,7 +1590,7 @@ CREATE TABLE public.users (
     tsv tsvector,
     upload_whitelist boolean DEFAULT false NOT NULL,
     ux_testing_email_communication boolean DEFAULT false,
-    intervention_notifications boolean DEFAULT true
+    interventions boolean DEFAULT true
 );
 
 
@@ -4391,4 +4391,6 @@ INSERT INTO schema_migrations (version) VALUES ('20181015112421');
 INSERT INTO schema_migrations (version) VALUES ('20181022172507');
 
 INSERT INTO schema_migrations (version) VALUES ('20181023130028');
+
+INSERT INTO schema_migrations (version) VALUES ('20181123100145');
 

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -24,14 +24,14 @@ namespace :user do
     end
   end
 
-  desc "Backfill intervention_notifications field in batches (restartable)"
-  task backfill_intervention_notifications_field: :environment do
+  desc "Backfill interventions field in batches (restartable)"
+  task backfill_interventions_field: :environment do
     User.select(:id).find_in_batches do |users|
       non_backfilled_users = User.where(
         id: users.map(&:id),
-        intervention_notifications: nil
+        interventions: nil
       )
-      non_backfilled_users.update_all(intervention_notifications: true)
+      non_backfilled_users.update_all(interventions: true)
     end
   end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -501,7 +501,7 @@ describe Api::V1::UsersController, type: :controller do
       let(:new_pec) { false }
       let(:new_bec) { false }
       let(:new_ux_testing) { false }
-      let(:new_intervention_notifications) { false }
+      let(:new_interventions) { false }
       let(:put_operations) do
         {
           users: {
@@ -510,7 +510,7 @@ describe Api::V1::UsersController, type: :controller do
             project_email_communication: new_pec,
             beta_email_communication: new_bec,
             ux_testing_email_communication: new_ux_testing,
-            intervention_notifications: new_intervention_notifications
+            interventions: new_interventions
           }
         }
       end
@@ -539,8 +539,8 @@ describe Api::V1::UsersController, type: :controller do
         expect(user.reload.ux_testing_email_communication).to eq(new_bec)
       end
 
-      it "should have updated the intervention notifications attribute" do
-        expect(user.reload.intervention_notifications).to eq(new_bec)
+      it "should have updated the interventions attribute" do
+        expect(user.reload.interventions).to eq(new_bec)
       end
 
       it "should have a single group" do


### PR DESCRIPTION
Rename the `intervention_notifications` column to handle all `interventions`.

Ensure that #3011 is merged and deployed before this migration and change goes out. Will need a rebase over master as well to include the changes in #3011 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
