### PR TITLE
allow user intervention column name change

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::UsersController < Api::ApiController
    :global_email_communication, :project_email_communication,
    :beta_email_communication, :languages, :subject_limit, :upload_whitelist,
    :banned, :valid_email, :ux_testing_email_communication,
-   :intervention_notifications
+   :interventions, :intervention_notifications
 
   alias_method :user, :controlled_resource
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -360,16 +360,32 @@ class User < ActiveRecord::Base
   # REMOVE THE FOLLOWING ACCESSOR OVERRIDES AFTER COLUMN RENAMING DEPLOYS
   # https://github.com/zooniverse/Panoptes/pull/3010
   # Allow column rename to serialize the correct attribute
+  def intervention_notifications=(value)
+    if attributes.key?('intervention_notifications')
+      super(value)
+    else
+      write_attribute(:interventions, value)
+    end
+  end
+
   def intervention_notifications
-    if attributes['intervention_notifications']
+    if attributes.key?('intervention_notifications')
       super
     else
       read_attribute(:interventions)
     end
   end
 
+  def interventions=(value)
+    if attributes.key?('interventions')
+      super(value)
+    else
+      write_attribute(:intervention_notifications, value)
+    end
+  end
+
   def interventions
-    if attributes['interventions']
+    if attributes.key?('interventions')
       super
     else
       read_attribute(:intervention_notifications)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -357,6 +357,26 @@ class User < ActiveRecord::Base
     collections.joins(:projects).where(favorite: true, projects: {id: project_id})
   end
 
+  # REMOVE THE FOLLOWING ACCESSOR OVERRIDES AFTER COLUMN RENAMING DEPLOYS
+  # https://github.com/zooniverse/Panoptes/pull/3010
+  # Allow column rename to serialize the correct attribute
+  def intervention_notifications
+    if attributes['intervention_notifications']
+      super
+    else
+      read_attribute(:interventions)
+    end
+  end
+
+  def interventions
+    if attributes['interventions']
+      super
+    else
+      read_attribute(:intervention_notifications)
+    end
+  end
+  # REMOVE THE ABOVE ACCESSOR OVERRIDES AFTER COLUMN RENAMING DEPLOYS
+
   private
 
   def subjects_count_cache_key

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,7 +9,7 @@ class UserSerializer
     project_email_communication beta_email_communication
     uploaded_subjects_count subject_limit admin login_prompt zooniverse_id
     upload_whitelist valid_email ux_testing_email_communication
-    intervention_notifications banned
+    interventions intervention_notifications banned
   ).freeze
 
   attributes :id, :login, :display_name, :credited_name, :email, :languages,
@@ -17,8 +17,8 @@ class UserSerializer
     :project_email_communication, :beta_email_communication,
     :subject_limit, :uploaded_subjects_count, :admin, :href, :login_prompt,
     :private_profile, :zooniverse_id, :upload_whitelist, :avatar_src,
-    :valid_email, :ux_testing_email_communication, :intervention_notifications,
-    :banned
+    :valid_email, :ux_testing_email_communication, :interventions,
+    :intervention_notifications, :banned
 
   can_include :classifications, :project_preferences, :collection_preferences,
     projects: { param: "owner", value: "login" },


### PR DESCRIPTION
closes #3007 - The users `intervention_notifications` attribute changes to `interventions` in #3010

This is a pre-deploy commit to allow the atttributes to serialize with  the correct value until the column name, code and user serializer schema is changed. The plan is to deploy this to the API, migrate the db, deploy the new code and serializer schema and update the front end to use the new attributes (noting any updates to this column will 500 unless I add in setter overrides on the user model as well)

This code will be removed in a future PR.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
