### PR TITLE
filter the paused and finished project states correctly

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -46,7 +46,11 @@ class ProjectSerializer
       params["state"] = Project.states[params["state"]]
     elsif params["state"] == "live"
       params["live"] = true
+      # ensure we only look for projects missing the paused, finished enum states
+      # this indicates we missed the true state of a project in the enum
+      # we should have an active state instead of checking if state is null
       params.delete("state")
+      scope = scope.where(state: nil)
     end
 
     super(params, scope, context)

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -58,6 +58,7 @@ describe ProjectSerializer do
       let(:live_project) { create(:full_project, state: nil, live: true) }
 
       before do
+        paused_live_project.save
         live_project.save
         paused_project.save
         project.save
@@ -65,8 +66,9 @@ describe ProjectSerializer do
 
       it 'includes filtered projects' do
         results = described_class.page({"state" => "paused"}, Project.all)
-        expect(results[:projects].map { |p| p[:id] }).to include(paused_project.id.to_s)
-        expect(results[:projects].count).to eq(1)
+        found_project_ids = results[:projects].map { |p| p[:id] }
+        expected_project_ids = [ paused_project.id, paused_live_project.id].map(&:to_s)
+        expect(found_project_ids).to match_array(expected_project_ids)
       end
 
       it 'includes non-enum states' do


### PR DESCRIPTION
fixes an issue reported where paused / finished projects are showing on the active list. 

This happens as the state enum only has paused & finished so we have to manually check the null (active) state. Ideally this would be migrated to a new enum value of active

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
