### PR TITLE
Increment major version if first_task changes

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -73,7 +73,7 @@ class Workflow < ActiveRecord::Base
   before_save :update_version
 
   def update_version
-    if (changes.keys & %w(tasks grouped pairwise prioritized)).present?
+    if (changes.keys & %w(tasks grouped pairwise prioritized first_task)).present?
       self.major_version += 1
     end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -184,6 +184,12 @@ describe Workflow, type: :model do
       expect(workflow.previous_version.tasks).to_not eq(new_tasks)
     end
 
+    it 'should track changes to first_task' do
+      expect do
+        workflow.update!(first_task: "T4")
+      end.to change(workflow, :major_version).from(1).to(2)
+    end
+
     it 'should not track changes to primary_language' do
       new_lang = 'en'
       workflow.update!(primary_language: new_lang)


### PR DESCRIPTION
This field is tracked by the new versioning, and thus should also be in either major or minor version numbering calculation. 

It wasn't included in Papertrail, but that seems like an oversight. When adding WorkflowVersion, I fixed that without realising the implication of not adding it to the version numbering. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
