### PR TITLE
more robust dropdown annotation conversion

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -99,18 +99,20 @@ module Formatter
       end
 
       def dropdown_process_selects(selects, index)
-        answer = @current['value'][index]
+        answer_value = nil
+        if answer = @current['value'][index]
+          answer_value = answer['value']
+        end
 
         {}.tap do |drop_anno|
           drop_anno['select_label'] = selects['title']
 
           if selects['allowCreate']
             drop_anno['option'] = false
-            drop_anno['value'] = @current['value'][index]['value']
+            drop_anno['value'] = answer_value
           end
 
-          selected_option = dropdown_find_selected_option(selects, answer)
-          if selected_option
+          if selected_option = dropdown_find_selected_option(selects, answer_value)
             drop_anno['option'] = true
             drop_anno['value'] = selected_option['value']
             drop_anno['label'] = translate(selected_option['label'])
@@ -118,10 +120,10 @@ module Formatter
         end
       end
 
-      def dropdown_find_selected_option(selects, answer)
+      def dropdown_find_selected_option(selects, answer_value)
         selects['options'].each do |key, options|
           options.each do |option|
-            return option if option['value'] == answer['value']
+            return option if option['value'] == answer_value
           end
         end
         nil

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -264,6 +264,28 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
           formatted = described_class.new(dd_classification, dd_classification.annotations[0], dd_cache).to_h
           expect(formatted).to eq(codex)
         end
+
+        context "with a empty array value (found in production db)" do
+          let(:annotation) do
+            {"task"=>"T7", "value"=>[]}
+          end
+
+          let(:codex) do
+            {
+              "task"=>"T7",
+              "value"=> [
+                {"select_label"=>"Country"},
+                {"select_label"=>"State", "option"=>false, "value"=>nil},
+                {"select_label"=>"City", "option"=>false, "value"=>nil}
+              ]
+            }
+          end
+
+          it 'should add the correct answer labels' do
+            formatted = described_class.new(dd_classification, dd_classification.annotations[0], dd_cache).to_h
+            expect(formatted).to eq(codex)
+          end
+        end
       end
 
       context "with a survey task" do


### PR DESCRIPTION
handle strange dropdown select payloads found in real exports - fixes https://app.honeybadger.io/projects/40595/faults/36814777

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
