### PR TITLE
Ensure sync works when translated resource doesnt have versions

### DIFF
--- a/app/models/concerns/versioning.rb
+++ b/app/models/concerns/versioning.rb
@@ -41,7 +41,8 @@ module Versioning
   end
 
   def latest_version_id
-    send(self.class.versioned_association).order(id: :desc).select(:id).first.id
+    latest_version = send(self.class.versioned_association).order(id: :desc).select(:id).first
+    latest_version&.id
   end
 
   def version_ids

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -67,7 +67,7 @@ class Translation < ActiveRecord::Base
     return unless translated.present? # This is a different validation error
 
     known_version_ids = translated.version_ids
-    referenced_version_ids = string_versions.values.uniq
+    referenced_version_ids = string_versions.values.compact.uniq
     unknown_version_ids = referenced_version_ids - known_version_ids
 
     if unknown_version_ids.present?

--- a/spec/workers/translation_sync_worker_spec.rb
+++ b/spec/workers/translation_sync_worker_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe TranslationSyncWorker do
           translation.reload.strings["title"]
         }.from(old_title).to(new_title)
       end
+
+      it 'updates strings if workflow has no versions yet' do
+        workflow = create :workflow
+        translation = create :translation, translated: workflow
+        old_string = translation.strings["tasks.shape.question"]
+        workflow.primary_content.strings["shape.question"] = "asdf"
+        workflow.save!
+        workflow.workflow_versions.delete_all
+
+        expect {
+          worker.perform(workflow.class.to_s, workflow.id, workflow.primary_language)
+        }.to change {
+          translation.reload.strings["tasks.shape.question"]
+        }.from(old_string).to("asdf")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://app.honeybadger.io/projects/40595/faults/40428061

It wouldn't be able to reference the `.id` in case no WorkflowVersion existed yet (not yet backfilled). This makes it more robust against that case.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
