### PR TITLE
switch worker to until_executing locking strategy

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -15,7 +15,7 @@ class CalculateProjectCompletenessWorker
     }
   }
 
-  sidekiq_options queue: :data_medium, lock: :until_executed
+  sidekiq_options queue: :data_medium, lock: :until_executing
 
   def perform(project_id)
     @project = Project.find(project_id)

--- a/app/workers/project_classifications_count_worker.rb
+++ b/app/workers/project_classifications_count_worker.rb
@@ -13,7 +13,7 @@ class ProjectClassificationsCountWorker
     }
   }
 
-  sidekiq_options lock: :until_executed
+  sidekiq_options lock: :until_executing
 
   def perform(project_id)
     project = Project.find(project_id)

--- a/app/workers/workflow_classifications_count_worker.rb
+++ b/app/workers/workflow_classifications_count_worker.rb
@@ -13,7 +13,7 @@ class WorkflowClassificationsCountWorker
     }
   }
 
-  sidekiq_options lock: :until_executed
+  sidekiq_options lock: :until_executing
 
   def perform(workflow_id)
     workflow = Workflow.find_without_json_attrs(workflow_id)

--- a/app/workers/workflow_retired_count_worker.rb
+++ b/app/workers/workflow_retired_count_worker.rb
@@ -11,7 +11,7 @@ class WorkflowRetiredCountWorker
     key: ->(workflow_id) { "workflow_#{workflow_id}_retired_count_worker" }
   }
 
-  sidekiq_options lock: :until_executed
+  sidekiq_options lock: :until_executing
 
   def perform(workflow_id)
     workflow = Workflow.find_without_json_attrs(workflow_id)


### PR DESCRIPTION
until_executed combined with congestion we needs the job to complete to  remove the lock, if congestion rate limits the job then the lock is  never removed.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
