### PR TITLE
only retire subjects that are linked to the workflow

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -142,7 +142,7 @@ class Api::V1::WorkflowsController < Api::ApiController
 
   def add_relation(resource, relation, value)
     if relation == :retired_subjects && value.is_a?(Array)
-      value.each {|id| resource.retire_subject(id) }
+      new_items(resource, relation, value)
     else
       super
     end
@@ -151,7 +151,10 @@ class Api::V1::WorkflowsController < Api::ApiController
   def new_items(resource, relation, value)
     case relation
     when :retired_subjects, 'retired_subjects'
-      value.flat_map {|id| resource.retire_subject(id) }
+      retirable_subjects = super(resource, relation, value)
+      retirable_subjects.pluck(:id) do |subject_id|
+        resource.retire_subject(subject_id)
+      end
     when :subject_sets, 'subject_sets'
       items = construct_new_items(super(resource, relation, value), resource.project_id)
       if items.any? { |item| item.is_a?(SubjectSet) }


### PR DESCRIPTION
Make sure only linked subjects are retired for a workflow. Use the relation manager methods to access the linkable resources for a given policy object / scope. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
