### PR TITLE
refactor and spec resource link relations

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -152,8 +152,7 @@ class Api::V1::ProjectsController < Api::ApiController
       resource.launch_date ||= Time.zone.now
     end
 
-    update_attributes = super(update_params, resource)
-    update_attributes.except(:tags)
+    update_params.except(:tags)
   end
 
   def new_items(resource, relation, value)

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -91,11 +91,11 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def build_update_hash(update_params, resource)
-    locations = update_params.delete(:locations)
-    new_locations = add_locations(locations, resource)
-    subject.save!
-    subject.locations = new_locations if new_locations
-    super(update_params, resource)
+    if locations = update_params.delete(:locations)
+      add_locations(locations, resource)
+    end
+
+    update_params
   end
 
   def add_locations(locations, subject)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -71,7 +71,8 @@ class Api::V1::UsersController < Api::ApiController
   def build_update_hash(update_params, id)
     admin_allowed(update_params, :subject_limit, :upload_whitelist, :banned,
                   :valid_email)
-    super
+
+    update_params
   end
 
   private

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -117,7 +117,7 @@ class Api::V1::WorkflowsController < Api::ApiController
     end
 
     reject_live_project_changes(resource, update_params)
-    super(update_params, resource)
+    update_params
   end
 
   def build_resource_for_create(create_params)

--- a/lib/json_api_controller/relation_manager.rb
+++ b/lib/json_api_controller/relation_manager.rb
@@ -1,5 +1,6 @@
 module JsonApiController
   module RelationManager
+    # use this method to retrieve the updatable relation
     def update_relation(resource, relation, value)
       case value
       when Hash
@@ -13,6 +14,7 @@ module JsonApiController
       end
     end
 
+    # use this method to modify the resource relations
     def add_relation(resource, relation, value)
       added_relation = update_relation(resource, relation, value)
       case value

--- a/lib/json_api_controller/relation_manager.rb
+++ b/lib/json_api_controller/relation_manager.rb
@@ -14,11 +14,12 @@ module JsonApiController
     end
 
     def add_relation(resource, relation, value)
+      added_relation = update_relation(resource, relation, value)
       case value
       when Array
-        resource.send(relation).concat(new_items(resource, relation, value))
+        resource.send(relation) << added_relation
       else
-        resource.send("#{relation}=", update_relation(resource, relation, value))
+        resource.send("#{relation}=", added_relation)
       end
     end
 

--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -15,7 +15,11 @@ module JsonApiController
 
           if update_links = update_params.delete(:links)
             update_links.each do |relation, value|
-              add_relation(resource, relation.to_sym, value)
+              update_params[relation] = update_relation(
+                resource,
+                relation.to_sym,
+                value
+              )
             end
           end
 

--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -53,7 +53,7 @@ module JsonApiController
     def build_update_hash(update_params, resource)
       if links = update_params.delete(:links)
         links.try(:reduce, update_params) do |params, (k, v)|
-          params[k] = update_relation(resource, k.to_sym, v)
+          params[k] = add_relation(resource, k.to_sym, v)
           params
         end
       else

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -586,10 +586,6 @@ describe Api::V1::ProjectsController, type: :controller do
   describe "#update" do
     let(:workflow) { create(:workflow) }
     let(:subject_set) { create(:subject_set, workflows: [workflow]) }
-    # let(:tutorial) do
-    #   workflow = create(:workflow, project: resource)
-    #   create(:tutorial, workflow: workflow)
-    # end
     let(:resource) { create(:project_with_contents, owner: authorized_user) }
     let(:test_attr) { :display_name }
     let(:test_attr_value) { "A Better Name" }

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -694,6 +694,21 @@ describe Api::V1::WorkflowsController, type: :controller do
           expect(still_linked_sets).to match_array([])
         end
       end
+
+      context 'with a subject_set not linked to the workflow' do
+        let(:other_subject_set) { create(:subject_set) }
+        let(:link_ids) { other_subject_set.id.to_s }
+
+        it "should not unlink" do
+          delete :destroy_links, destroy_link_params
+          expect(still_linked_sets).to match_array(linked_resources)
+        end
+
+        it "should respond with not_found" do
+          delete :destroy_links, destroy_link_params
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
linked to #3040 #2031 - refactor and spec out how link relations work. this should remove a few super calls and extra db round trips when updating a resource and relations via a PUT e.g. subject locations.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
