### PR TITLE
Remove Designator strategy parameter

### DIFF
--- a/app/services/designator_client.rb
+++ b/app/services/designator_client.rb
@@ -49,7 +49,7 @@ class DesignatorClient
 
   def get_subjects(workflow_id, user_id, _group_id, limit)
     url = "/api/workflows/#{workflow_id}"
-    params = { strategy: :weighted, user_id: user_id, limit: limit }
+    params = { user_id: user_id, limit: limit }
     request(:get, [ url, params ])
   end
 

--- a/spec/services/designator_client_spec.rb
+++ b/spec/services/designator_client_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DesignatorClient do
     describe "#get_subjects" do
       it 'returns subject ids' do
         stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.get('/api/workflows/338?limit=5&strategy=weighted&user_id=1', headers) do |env|
+          stub.get('/api/workflows/338?limit=5&user_id=1', headers) do |env|
             [200, {'Content-Type' => 'application/json'}, [1,2,3,4].to_json]
           end
         end
@@ -62,7 +62,7 @@ RSpec.describe DesignatorClient do
       it_behaves_like "handles server errors" do
         let(:method) { :get_subjects }
         let(:params) { [ 338, 1, nil, 5 ] }
-        let(:url) { '/api/workflows/338?limit=5&strategy=weighted&user_id=1' }
+        let(:url) { '/api/workflows/338?limit=5&user_id=1' }
         let(:http_method) { :get }
       end
     end


### PR DESCRIPTION
This param wasn't actually used by Designator.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
