### PR TITLE
Primary language translations only via lab

### DIFF
--- a/app/controllers/api/v1/translations_controller.rb
+++ b/app/controllers/api/v1/translations_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Api::V1::TranslationsController < Api::ApiController
   include JsonApiController::PunditPolicy
   include PolymorphicResourceScope
@@ -6,29 +7,28 @@ class Api::V1::TranslationsController < Api::ApiController
 
   require_authentication :create, :update, :destroy, scopes: [:translation]
 
-  # TODO: add in destroy action
   resource_actions :show, :index, :create, :update
 
   schema_type :json_schema
 
   before_action :downcase_language_param, except: :create
-  before_action :non_primary_language, only: :update
 
   def create
     check_polymorphic_controller_resources
 
-    translation = Translation.transaction(requires_new: true) do
+    # push these scope params into create payload to validate using the create schema
+    params[:translations][:translated_type] = params[:translated_type].classify
+    params[:translations][:translated_id] = params[:translated_id]
 
-      # push these scope params into create payload
-      # to validate using the create schema
-      params[:translations][:translated_type] = params[:translated_type].classify
-      params[:translations][:translated_id] = params[:translated_id]
+    ensure_non_primary_language_request(create_params[:language])
 
-      resource = Translation.new(create_params)
-      resource.save!
-      resource
-    end
-    created_resource_response(translation)
+    super
+  end
+
+  def update
+    ensure_non_primary_language_request(controlled_resource.language)
+
+    super
   end
 
   def serializer
@@ -60,18 +60,40 @@ class Api::V1::TranslationsController < Api::ApiController
 
   # Owners & collaborators should update the primary langauge through the lab app
   # translators should not be allowed to modify a primary language via the API
-  def non_primary_language
-    translated_resource = controlled_resource.translated
-    # handle the difference between resources like projects & field guides
-    translated_resource_primary_language =
-      if translated_resource.respond_to?(:primary_language)
-        translated_resource.primary_language
-      else
-        translated_resource.language
-      end
+  def ensure_non_primary_language_request(language=nil)
+    checker = TranslationChecker.new(
+      polymorphic_controlled_resourse,
+      action_name,
+      language
+    )
 
-    if translated_resource_primary_language == controlled_resource.language
+    if checker.for_primary_language?
       raise JsonApiController::AccessDenied, no_resources_error_message
+    end
+  end
+
+  class TranslationChecker
+    attr_reader :translated_resource, :action_name, :language
+
+    def initialize(resource, action_name, language)
+      @translated_resource = resource
+      @action_name = action_name
+      @language = language
+    end
+
+    def for_primary_language?
+      primary_language(translated_resource) == language
+    end
+
+    private
+
+    def primary_language(resource)
+      # handle the difference between resources like projects & field guides
+      if resource.respond_to?(:primary_language)
+        resource.primary_language
+      else
+        resource.language
+      end
     end
   end
 end

--- a/app/controllers/concerns/polymorphic_resource_scope.rb
+++ b/app/controllers/concerns/polymorphic_resource_scope.rb
@@ -52,7 +52,7 @@ module PolymorphicResourceScope
   end
 
   def polymorphic_controlled_resourse
-    @polymorphic_controlled_resourse ||= @polymorphic_controlled_resourses.first
+    @polymorphic_controlled_resourse ||= polymorphic_controlled_resourses.first
   end
 
   def polymorphic_klass_name

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -11,8 +11,6 @@ class Translation < ActiveRecord::Base
 
   before_validation :downcase_language, on: :create
 
-  # TODO: Versioning and maintaining a live, published version
-
   def self.translated_model_names
     @translated_model_names ||= %w(
       project

--- a/spec/controllers/api/v1/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/translations_controller_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Api::V1::TranslationsController, type: :controller do
   %i(project).each do |resource_type|
     let(:resource_class) { Translation }
     let(:translated_resource) { create(resource_type) }
-    let(:resource) { create(:translation, translated: translated_resource) }
+    let(:resource) do
+      create(:translation, language: 'es', translated: translated_resource)
+    end
     let(:api_resource_name) { "translations" }
     let(:api_resource_attributes) { %w(id strings language) }
     let(:api_resource_links) { %w(translations.project) }
@@ -139,31 +141,59 @@ RSpec.describe Api::V1::TranslationsController, type: :controller do
     end
 
     describe "#update" do
+      let(:translation_strings) do
+        {
+          title: "Un buen proyecto",
+          description: "Esto es increíble",
+          introduction: "Este proyecto tiene como objetivo encontrar",
+          workflow_description: "¿Se ha utilizado este campo?",
+          researcher_quote: "Posiblemente el cuarto proyecto más grande jamás",
+          urls: [
+            {label: "Blog", url: "http://blog.example.com/"},
+            {label: "El Gorjeo", url: "http://twitter.com/example"}
+          ]
+        }
+      end
+      let(:update_params) do
+        {
+          translations: {
+            strings: translation_strings
+          },
+          translated_type: resource_type.to_s
+        }
+      end
+
       it_behaves_like "is updatable" do
         before { user_translator_role }
-
-        let(:translation_strings) do
-          {
-            title: "Un buen proyecto",
-            description: "Esto es increíble",
-            introduction: "Este proyecto tiene como objetivo encontrar",
-            workflow_description: "¿Se ha utilizado este campo?",
-            researcher_quote: "Posiblemente el cuarto proyecto más grande jamás",
-            urls: [
-              {label: "Blog", url: "http://blog.example.com/"},
-              {label: "El Gorjeo", url: "http://twitter.com/example"}
-            ]
-          }
-        end
         let(:test_attr) { :strings }
         let(:test_attr_value)  { JSON.parse(translation_strings.to_json) }
-        let(:update_params) do
-          {
-            translations: {
-              strings: translation_strings
-            },
-            translated_type: resource_type.to_s
-          }
+      end
+
+      describe "updates to the primary language" do
+        let(:resource) do
+          create(:translation, translated: translated_resource)
+        end
+
+        context "with a translator role" do
+          before { user_translator_role }
+
+          it "it should not allow changes to primary language translations" do
+            default_request scopes: scopes, user_id: authorized_user.id
+            params = update_params.merge(id: resource.id)
+            put :update, params
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+
+        context "with an owner role" do
+          let(:authorized_user) { translated_resource.owner }
+
+          it "it should not allow changes to primary language translations" do
+            default_request scopes: scopes, user_id: authorized_user.id
+            params = update_params.merge(id: resource.id)
+            put :update, params
+            expect(response).to have_http_status(:not_found)
+          end
         end
       end
     end

--- a/spec/requests/v1/translation_route_constraint_spec.rb
+++ b/spec/requests/v1/translation_route_constraint_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "translation api custom route constraints", type: :request do
   include APIRequestHelpers
-  let(:translation) { create(:project_translation) }
+  let(:translation) { create(:project_translation, language: 'en-NZ') }
   let(:user) { translation.translated.owner }
   let(:query_params) do
     "translated_type=#{translation.translated_type}&translated_id=#{translation.translated_id}"


### PR DESCRIPTION
Only allow updates to translations that are not the translated resources primary language. I.e. If my `project.primary_language == 'en'` then i should not be able to update a translation resource for that project with the 'en' language. All other language translation updates are fine. 

This applies to all users owners included as owners should be updating the translations via the originating resources to keep the string keys in sync. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
