### PR TITLE
lock debian to stretch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.4-stretch
 
 WORKDIR /rails_app
 


### PR DESCRIPTION
linked to #3088 ensure we don't update the libjemalloc1 package accidently, debian won't release a major update for this version

Note: Dockerfile.dev isn't being locked to stretch and can be used to test any debian upgrades to the official ruby versions.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
