### PR TITLE
Workflow version number fixes

### DIFF
--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -22,7 +22,7 @@ class WorkflowSerializer
   preload :subject_sets, :attached_images
 
   def version
-    "#{@model.current_version_number}.#{content_version}"
+    "#{@model.major_version}.#{content_version}"
   end
 
   def content_language

--- a/lib/classification_dump_cache.rb
+++ b/lib/classification_dump_cache.rb
@@ -37,11 +37,18 @@ class ClassificationDumpCache
   def workflow_at_version(workflow, major_version, minor_version)
     @workflows[workflow.id] ||= {}
     @workflows[workflow.id][major_version] ||= {}
-    @workflows[workflow.id][major_version][minor_version] ||=
-      workflow.workflow_versions.find_by!(major_number: major_version, minor_number: minor_version)
+    @workflows[workflow.id][major_version][minor_version] ||= find_workflow_at_version(workflow, major_version, minor_version)
   end
 
   def secure_user_ip(ip_string)
     @secure_ip_lookup[ip_string] ||= SecureRandom.hex(10)
+  end
+
+  private
+
+  def find_workflow_at_version(workflow, major_version, minor_version)
+    workflow.workflow_versions.where("major_number >= ? AND minor_number >= ?", major_version, minor_version).order("major_number ASC, minor_number ASC").first!
+  rescue ActiveRecord::RecordNotFound
+    workflow.workflow_versions.order("major_number ASC, minor_number ASC").last
   end
 end

--- a/spec/lib/classification_dump_cache_spec.rb
+++ b/spec/lib/classification_dump_cache_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe ClassificationDumpCache do
+  describe '#workflow_at_version' do
+    let(:workflow_version_1_1) { build(:workflow_version, major_number: 1, minor_number: 1) }
+    let(:workflow_version_1_2) { build(:workflow_version, major_number: 1, minor_number: 2) }
+    let(:workflow_version_2_2) { build(:workflow_version, major_number: 2, minor_number: 2) }
+    let(:workflow_version_3_3) { build(:workflow_version, major_number: 3, minor_number: 3) }
+
+    let(:workflow) do
+      create :workflow, workflow_versions: [
+        workflow_version_1_2,
+        workflow_version_2_2,
+        workflow_version_3_3
+      ]
+    end
+
+    it 'finds the workflow at the specific version' do
+      cache = described_class.new
+      expect(cache.workflow_at_version(workflow, 1, 2)).to eq(workflow_version_1_2)
+    end
+
+    it 'finds a newer version if requested version does not exist' do
+      cache = described_class.new
+      expect(cache.workflow_at_version(workflow, 2, 3)).to eq(workflow_version_3_3)
+    end
+
+    it 'finds the latest version if requested version is newer than anything that exists' do
+      cache = described_class.new
+      expect(cache.workflow_at_version(workflow, 4, 5)).to eq(workflow_version_3_3)
+    end
+  end
+end


### PR DESCRIPTION
This makes it so that we can export classifications when they refer to a workflow version that we don't have in the database. Best effort guess is to use the next one-higher workflow version, but if all else fails, just use the latest.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
