### PR TITLE
perform_in instead of perform_async

### DIFF
--- a/app/controllers/api/v1/set_member_subjects_controller.rb
+++ b/app/controllers/api/v1/set_member_subjects_controller.rb
@@ -12,11 +12,9 @@ class Api::V1::SetMemberSubjectsController < Api::ApiController
     super do |sms|
       set_id = sms.subject_set_id
       update_set_counts(set_id)
-      set_ids = linked_workflow_ids(set_id)
-      duration = set_ids.length * 4 # Pad times to prevent backlogs
-      set_ids.each do |workflow_id|
+      linked_workflow_ids(set_id).each do |workflow_id|
         SubjectWorkflowStatusCreateWorker.perform_in(
-          duration.seconds*rand,
+          1.minute*rand,
           sms.subject_id,
           workflow_id
         )

--- a/app/controllers/api/v1/set_member_subjects_controller.rb
+++ b/app/controllers/api/v1/set_member_subjects_controller.rb
@@ -12,8 +12,11 @@ class Api::V1::SetMemberSubjectsController < Api::ApiController
     super do |sms|
       set_id = sms.subject_set_id
       update_set_counts(set_id)
-      linked_workflow_ids(set_id).each do |workflow_id|
-        SubjectWorkflowStatusCreateWorker.perform_async(
+      set_ids = linked_workflow_ids(set_id)
+      duration = set_ids.length * 4 # Pad times to prevent backlogs
+      set_ids.each do |workflow_id|
+        SubjectWorkflowStatusCreateWorker.perform_in(
+          duration.seconds*rand,
           sms.subject_id,
           workflow_id
         )

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -29,8 +29,9 @@ class Api::V1::SubjectSetsController < Api::ApiController
 
       subject_set.subject_sets_workflows.pluck(:workflow_id).each do |workflow_id|
         UnfinishWorkflowWorker.perform_async(workflow_id)
+        duration = params[:subjects].length * 4 # Pad times to prevent backlogs
         params[:subjects].each do |subject_id|
-          SubjectWorkflowStatusCreateWorker.perform_async(subject_id, workflow_id)
+          SubjectWorkflowStatusCreateWorker.perform_in(duration.seconds*rand, subject_id, workflow_id)
         end
 
       end

--- a/app/workers/subject_set_statuses_create_worker.rb
+++ b/app/workers/subject_set_statuses_create_worker.rb
@@ -12,9 +12,11 @@ class SubjectSetStatusesCreateWorker
     ).exists?
     return unless set_is_linked_to_workflow
 
-    linked_subject_select_scope = SetMemberSubject.where(subject_set_id: subject_set_id)
-    duration = linked_subject_select_scope.count * 4
+    linked_subject_select_scope = SetMemberSubject
+      .where(subject_set_id: subject_set_id)
+      .select(:id,:subject_id)
 
+    duration = linked_subject_select_scope.count(:id) * 4
     linked_subject_select_scope.find_each do |sms|
       SubjectWorkflowStatusCreateWorker.perform_in(
         duration.seconds*rand,

--- a/app/workers/subject_set_statuses_create_worker.rb
+++ b/app/workers/subject_set_statuses_create_worker.rb
@@ -16,7 +16,7 @@ class SubjectSetStatusesCreateWorker
       .where(subject_set_id: subject_set_id)
       .select(:id,:subject_id)
 
-    duration = linked_subject_select_scope.length * 4
+    duration = linked_subject_select_scope.scope * 4
     linked_subject_select_scope.find_each do |sms|
       SubjectWorkflowStatusCreateWorker.perform_in(
         duration.seconds*rand,

--- a/app/workers/subject_set_statuses_create_worker.rb
+++ b/app/workers/subject_set_statuses_create_worker.rb
@@ -12,11 +12,9 @@ class SubjectSetStatusesCreateWorker
     ).exists?
     return unless set_is_linked_to_workflow
 
-    linked_subject_select_scope = SetMemberSubject
-      .where(subject_set_id: subject_set_id)
-      .select(:id,:subject_id)
+    linked_subject_select_scope = SetMemberSubject.where(subject_set_id: subject_set_id)
+    duration = linked_subject_select_scope.count * 4
 
-    duration = linked_subject_select_scope.scope * 4
     linked_subject_select_scope.find_each do |sms|
       SubjectWorkflowStatusCreateWorker.perform_in(
         duration.seconds*rand,

--- a/app/workers/subject_set_statuses_create_worker.rb
+++ b/app/workers/subject_set_statuses_create_worker.rb
@@ -16,8 +16,10 @@ class SubjectSetStatusesCreateWorker
       .where(subject_set_id: subject_set_id)
       .select(:id,:subject_id)
 
+    duration = linked_subject_select_scope.length * 4
     linked_subject_select_scope.find_each do |sms|
-      SubjectWorkflowStatusCreateWorker.perform_async(
+      SubjectWorkflowStatusCreateWorker.perform_in(
+        duration.seconds*rand,
         sms.subject_id,
         workflow_id
       )

--- a/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Api::V1::SetMemberSubjectsController, type: :controller do
       linked_workflow_ids = subject_set.subject_sets_workflows.pluck(:workflow_id)
       linked_workflow_ids.each do |workflow_id|
         expect(SubjectWorkflowStatusCreateWorker)
-        .to receive(:perform_async)
-        .with(linked_subject.id, workflow_id)
+        .to receive(:perform_in)
+        .with(kind_of(Numeric), linked_subject.id, workflow_id)
       end
       default_request user_id: authorized_user.id, scopes: scopes
       post :create, create_params

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -165,8 +165,8 @@ describe Api::V1::SubjectSetsController, type: :controller do
         resource.workflows.each do |workflow|
           test_relation_ids.each do |subject_id|
             expect(SubjectWorkflowStatusCreateWorker)
-            .to receive(:perform_async)
-            .with(subject_id, workflow.id)
+            .to receive(:perform_in)
+            .with(kind_of(Numeric), subject_id, workflow.id)
           end
         end
         run_update_links

--- a/spec/workers/subject_set_statuses_create_worker_spec.rb
+++ b/spec/workers/subject_set_statuses_create_worker_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe SubjectSetStatusesCreateWorker do
     it "should call a SubjectWorkflowStatusCreateWorker for each subject" do
       subject_ids.each do |subject_id|
         expect(SubjectWorkflowStatusCreateWorker)
-          .to receive(:perform_async)
-          .with(subject_id, workflow_id)
+          .to receive(:perform_in)
+          .with(kind_of(Numeric), subject_id, workflow_id)
       end
       worker.perform(subject_set.id, workflow_id)
     end


### PR DESCRIPTION
Switches SubjectWorkflowStatusCreateWorkers to use `perform_in` instead of `perform_async`. The duration is just `number of elements * 4` to pad it out a bit. Perform times for each job are a chosen randomly from within that duration.

Not a genius-at-work situation over here but it's better than locking the database. Better ideas encouraged.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
