### PR TITLE
Update Registration Form with Underage Text

### DIFF
--- a/app/assets/javascripts/forms.js
+++ b/app/assets/javascripts/forms.js
@@ -4,7 +4,7 @@ $(function () {
   var DEFAULT_SUBSCRIPTION_TEXT = "It’s okay to send me email every once in a while.";
 
   function changeRegistrationFormWording() {
-    if ($("#under_age").is(':checked')) {
+    if ($("#minor_age").is(':checked')) {
       $("#privacy_text").text("I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the");
       $("#agreement_text").text("If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes.");
       $("#anonymous_text").text("Don't use your real name");
@@ -21,10 +21,10 @@ $(function () {
     $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
     $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
     $("#email_text label").text(DEFAULT_EMAIL_TEXT);
-    // ensure the form changes on re-load if the under_age checkbox is set
+    // ensure the form changes on re-load if the minor_age checkbox is set
     changeRegistrationFormWording();
   });
-  $("#under_age").change(function() {
+  $("#minor_age").change(function() {
     changeRegistrationFormWording();
   });
 });

--- a/app/assets/javascripts/forms.js
+++ b/app/assets/javascripts/forms.js
@@ -1,0 +1,24 @@
+$(function () {
+  var DEFAULT_PRIVACY_TEXT = "I have read and agreed to the";
+  var DEFAULT_EMAIL_TEXT = "Email (required)";
+  var DEFAULT_SUBSCRIPTION_TEXT = "It’s okay to send me email every once in a while.";
+
+  $(document).ready(function() {
+    $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
+    $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
+    $("#email_text label").text(DEFAULT_EMAIL_TEXT);
+  });
+  $("#under_age").change(function() {
+    if ($("#under_age").is(':checked')) {
+      $("#privacy_text").text("I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the");
+      $("#agreement_text").text("If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes.");
+      $("#anonymous_text").text("Don't use your real name");
+      $("#email_text label").text("Parent/Guardian's Email (required)");
+    } else {
+      $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
+      $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
+      $("#anonymous_text").text("");
+      $("#email_text label").text(DEFAULT_EMAIL_TEXT);
+    }
+    });
+  });

--- a/app/assets/javascripts/forms.js
+++ b/app/assets/javascripts/forms.js
@@ -3,12 +3,7 @@ $(function () {
   var DEFAULT_EMAIL_TEXT = "Email (required)";
   var DEFAULT_SUBSCRIPTION_TEXT = "It’s okay to send me email every once in a while.";
 
-  $(document).ready(function() {
-    $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
-    $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
-    $("#email_text label").text(DEFAULT_EMAIL_TEXT);
-  });
-  $("#under_age").change(function() {
+  function changeRegistrationFormWording() {
     if ($("#under_age").is(':checked')) {
       $("#privacy_text").text("I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the");
       $("#agreement_text").text("If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes.");
@@ -20,5 +15,16 @@ $(function () {
       $("#anonymous_text").text("");
       $("#email_text label").text(DEFAULT_EMAIL_TEXT);
     }
-    });
+  }
+
+  $(document).ready(function() {
+    $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
+    $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
+    $("#email_text label").text(DEFAULT_EMAIL_TEXT);
+    // ensure the form changes on re-load if the under_age checkbox is set
+    changeRegistrationFormWording();
   });
+  $("#under_age").change(function() {
+    changeRegistrationFormWording();
+  });
+});

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -88,21 +88,21 @@
 
 /* Styles for form errors messages */
 
-.form .field_with_errors {
+.field_with_errors {
     display: inline;
 }
 
-.form .field_with_errors label {
+.field_with_errors label {
     color: red;
 }
 
-.form .field_with_errors input {
+.field_with_errors input {
     border: 1px solid red;
 }
 
 /* Styles for new user form */
 
-.form small.errored {
+small.errored {
     color: red;
     padding-left: 1em;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
       u.permit(:email, :password, :password_confirmation, :login, :display_name,
                :credited_name, :global_email_communication,
                :project_email_communication, :beta_email_communication,
-               :project_id)
+               :project_id, :under_age)
     end
 
     devise_parameter_sanitizer.permit(:account_update) do |u|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
       u.permit(:email, :password, :password_confirmation, :login, :display_name,
                :credited_name, :global_email_communication,
                :project_email_communication, :beta_email_communication,
-               :project_id, :under_age)
+               :project_id, :minor_age)
     end
 
     devise_parameter_sanitizer.permit(:account_update) do |u|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ActiveRecord::Base
   include Activatable
   include PgSearch
   include ExtendedCacheKey
-  attr_accessor :under_age
 
   ALLOWED_LOGIN_CHARACTERS = '[\w\-\.]'
   USER_LOGIN_REGEX = /\A#{ ALLOWED_LOGIN_CHARACTERS }+\z/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ActiveRecord::Base
   USER_LOGIN_REGEX = /\A#{ ALLOWED_LOGIN_CHARACTERS }+\z/
   DUP_LOGIN_SANITATION_ATTEMPTS = 20
 
-  # virtual attribute used on registration form
-  attr_accessor :under_age
+  # virtual attribute used on registration form for minors
+  attr_accessor :minor_age
 
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :trackable, :validatable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,9 @@ class User < ActiveRecord::Base
   USER_LOGIN_REGEX = /\A#{ ALLOWED_LOGIN_CHARACTERS }+\z/
   DUP_LOGIN_SANITATION_ATTEMPTS = 20
 
+  # virtual attribute used on registration form
+  attr_accessor :under_age
+
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :trackable, :validatable,
     :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
@@ -53,7 +56,7 @@ class User < ActiveRecord::Base
   validates_with IdentityGroupNameValidator
 
   after_create :set_zooniverse_id
-  after_create :send_welcome_email, unless: :migrated
+  # after_create :send_welcome_email, unless: :migrated
   before_create :set_ouroboros_api_key
 
   delegate :projects, to: :identity_group

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
   include Activatable
   include PgSearch
   include ExtendedCacheKey
+  attr_accessor :under_age
 
   ALLOWED_LOGIN_CHARACTERS = '[\w\-\.]'
   USER_LOGIN_REGEX = /\A#{ ALLOWED_LOGIN_CHARACTERS }+\z/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ActiveRecord::Base
   validates_with IdentityGroupNameValidator
 
   after_create :set_zooniverse_id
-  # after_create :send_welcome_email, unless: :migrated
+  after_create :send_welcome_email, unless: :migrated
   before_create :set_ouroboros_api_key
 
   delegate :projects, to: :identity_group

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -38,7 +38,7 @@
 
       <div class="checkbox" >
         <label for="privacy">
-          <input name="privacy" id="privacy" type="checkbox" />
+          <input name="privacy" id="privacy" type="checkbox" required/>
           <span id="privacy_text"></span>
           <a href="https://www.zooniverse.org/privacy">Privacy Policy</a>
         </label>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,30 +1,3 @@
-<script>
-  var DEFAULT_PRIVACY_TEXT = "I have read and agreed to the";
-  var DEFAULT_EMAIL_TEXT = "Email (required)";
-  var DEFAULT_SUBSCRIPTION_TEXT = "It’s okay to send me email every once in a while.";
-
-  $(function () {
-    $(document).ready(function() {
-      $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
-      $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
-      $("#email_text label").text(DEFAULT_EMAIL_TEXT);
-    });
-    $("#under_age").change(function() {
-      if ($("#under_age").is(':checked')) {
-        $("#privacy_text").text("I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the");
-        $("#agreement_text").text("If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes.");
-        $("#anonymous_text").text("Don't use your real name");
-        $("#email_text label").text("Parent/Guardian's Email (required)");
-      } else {
-        $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
-        $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
-        $("#anonymous_text").text("");
-        $("#email_text label").text(DEFAULT_EMAIL_TEXT);
-      }
-      });
-    });
-</script>
-
 <div class="form-container panel panel-default">
   <div class="panel-body">
     <h2>Create account</h2>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,8 +5,8 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
 
       <div class="checkbox">
-          <%= f.label :under_age do %>
-            <%= f.check_box :under_age, id: 'under_age' %>
+          <%= f.label :minor_age do %>
+            <%= f.check_box :minor_age, id: 'minor_age' %>
             If you are under 16 years old, tick this box and complete the form with your parent/guardian.
           <% end %>
         </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,9 +4,19 @@
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
 
+      <div class="checkbox">
+        <%= f.label :under_age do %>
+          <%= f.check_box :under_age, checked: false %>
+          If you are under 16 years old, tick this box and complete the form with your parent/guardian.
+        <% end %>
+      </div>
+
       <div class="form-group <%= "has-errors" if resource.errors[:login].present? %>">
         <%= f.label :login, "Username (required)" %><small class="errored"><%= resource.errors[:login].join(', ')%></small><br />
         <%= f.text_field :login, autofocus: true, required: true, class: 'form-control' %>
+        <% if @under_age %>
+          <small>Don't use your real name.</small>
+        <% end %>
       </div>
 
       <div class="form-group <%= "has-errors" if resource.errors[:credited_name].present? %>">
@@ -16,7 +26,7 @@
       </div>
 
       <div class="form-group <%= "has-errors" if resource.errors[:email].present? %>">
-        <%= f.label :email, "Email (required)"%><small class="errored"><%= resource.errors[:email].join(', ')%></small><br />
+        <%= f.label :email, @under_age ? "Parent/Guardian's Email (required)" : "Email (required)" %><small class="errored"><%= resource.errors[:email].join(', ')%></small><br />
         <%= f.email_field :email, required: true, class: 'form-control' %>
       </div>
 
@@ -31,14 +41,30 @@
       <div class="checkbox" >
         <label for="privacy">
           <input name="privacy" id="privacy" type="checkbox" />
-          I have read and agreed to the <a href="https://www.zooniverse.org/privacy">Privacy Policy</a>
+            <span>
+              <% if @under_age %>
+                I confirm I am the parent/guardian and give permission for my child to register by providing my
+                email address as the main contact address. Both I and my child understand and agree to the
+              <% else %>
+                  I have read and agreed to the
+              <% end %>
+            </span>
+          <a href="https://www.zooniverse.org/privacy">Privacy Policy</a>
         </label>
       </div>
 
         <div class="checkbox">
           <%= f.label :global_email_communication do %>
             <%= f.check_box :global_email_communication, checked: true %>
-            It’s okay to send me email every once in a while.
+            <span>
+              <% if @under_age %>
+                If you agree, we will periodically send email promoting new research-related
+                projects or other information relating to our research. We will not use your
+                contact information for commercial purposes.
+              <% else %>
+                It’s okay to send me email every once in a while.
+              <% end %>
+            </span>
           <% end %>
         </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,30 @@
+<script>
+  var DEFAULT_PRIVACY_TEXT = "I have read and agreed to the";
+  var DEFAULT_EMAIL_TEXT = "Email (required)";
+  var DEFAULT_SUBSCRIPTION_TEXT = "It’s okay to send me email every once in a while.";
+
+  $(function () {
+    $(document).ready(function() {
+      $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
+      $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
+      $("#email_text label").text(DEFAULT_EMAIL_TEXT);
+    });
+    $("#under_age").change(function() {
+      if ($("#under_age").is(':checked')) {
+        $("#privacy_text").text("I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the");
+        $("#agreement_text").text("If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes.");
+        $("#anonymous_text").text("Don't use your real name");
+        $("#email_text label").text("Parent/Guardian's Email (required)");
+      } else {
+        $("#privacy_text").text(DEFAULT_PRIVACY_TEXT);
+        $("#agreement_text").text(DEFAULT_SUBSCRIPTION_TEXT);
+        $("#anonymous_text").text("");
+        $("#email_text label").text(DEFAULT_EMAIL_TEXT);
+      }
+      });
+    });
+</script>
+
 <div class="form-container panel panel-default">
   <div class="panel-body">
     <h2>Create account</h2>
@@ -5,18 +32,16 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
 
       <div class="checkbox">
-        <%= f.label :under_age do %>
-          <%= f.check_box :under_age, checked: false %>
-          If you are under 16 years old, tick this box and complete the form with your parent/guardian.
-        <% end %>
+          <label for="under_age">
+            <input name="under_age" id="under_age" type="checkbox"/>
+            If you are under 16 years old, tick this box and complete the form with your parent/guardian.
+          </label>
       </div>
 
       <div class="form-group <%= "has-errors" if resource.errors[:login].present? %>">
         <%= f.label :login, "Username (required)" %><small class="errored"><%= resource.errors[:login].join(', ')%></small><br />
         <%= f.text_field :login, autofocus: true, required: true, class: 'form-control' %>
-        <% if @under_age %>
-          <small>Don't use your real name.</small>
-        <% end %>
+        <small id="anonymous_text"></small>
       </div>
 
       <div class="form-group <%= "has-errors" if resource.errors[:credited_name].present? %>">
@@ -25,8 +50,8 @@
         <small>We’ll use this to give you credit in scientific papers, posters, etc</small>
       </div>
 
-      <div class="form-group <%= "has-errors" if resource.errors[:email].present? %>">
-        <%= f.label :email, @under_age ? "Parent/Guardian's Email (required)" : "Email (required)" %><small class="errored"><%= resource.errors[:email].join(', ')%></small><br />
+      <div class="form-group <%= "has-errors" if resource.errors[:email].present? %>" id="email_text">
+        <%= f.label :email%><small class="errored"><%= resource.errors[:email].join(', ')%></small><br />
         <%= f.email_field :email, required: true, class: 'form-control' %>
       </div>
 
@@ -41,14 +66,7 @@
       <div class="checkbox" >
         <label for="privacy">
           <input name="privacy" id="privacy" type="checkbox" />
-            <span>
-              <% if @under_age %>
-                I confirm I am the parent/guardian and give permission for my child to register by providing my
-                email address as the main contact address. Both I and my child understand and agree to the
-              <% else %>
-                  I have read and agreed to the
-              <% end %>
-            </span>
+          <span id="privacy_text"></span>
           <a href="https://www.zooniverse.org/privacy">Privacy Policy</a>
         </label>
       </div>
@@ -56,15 +74,7 @@
         <div class="checkbox">
           <%= f.label :global_email_communication do %>
             <%= f.check_box :global_email_communication, checked: true %>
-            <span>
-              <% if @under_age %>
-                If you agree, we will periodically send email promoting new research-related
-                projects or other information relating to our research. We will not use your
-                contact information for commercial purposes.
-              <% else %>
-                It’s okay to send me email every once in a while.
-              <% end %>
-            </span>
+            <span id="agreement_text"></span>
           <% end %>
         </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,11 +5,11 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
 
       <div class="checkbox">
-          <label for="under_age">
-            <input name="under_age" id="under_age" type="checkbox"/>
+          <%= f.label :under_age do %>
+            <%= f.check_box :under_age, id: 'under_age' %>
             If you are under 16 years old, tick this box and complete the form with your parent/guardian.
-          </label>
-      </div>
+          <% end %>
+        </div>
 
       <div class="form-group <%= "has-errors" if resource.errors[:login].present? %>">
         <%= f.label :login, "Username (required)" %><small class="errored"><%= resource.errors[:login].join(', ')%></small><br />
@@ -44,19 +44,19 @@
         </label>
       </div>
 
-        <div class="checkbox">
-          <%= f.label :global_email_communication do %>
-            <%= f.check_box :global_email_communication, checked: true %>
-            <span id="agreement_text"></span>
-          <% end %>
-        </div>
+      <div class="checkbox">
+        <%= f.label :global_email_communication do %>
+          <%= f.check_box :global_email_communication, checked: true %>
+          <span id="agreement_text"></span>
+        <% end %>
+      </div>
 
-        <div class="checkbox">
-          <%= f.label :beta_email_communication do %>
-            <%= f.check_box :beta_email_communication, checked: false %>
-            I’d like to help test new projects, and be emailed when they’re available.
-          <% end %>
-        </div>
+      <div class="checkbox">
+        <%= f.label :beta_email_communication do %>
+          <%= f.check_box :beta_email_communication, checked: false %>
+          I’d like to help test new projects, and be emailed when they’re available.
+        <% end %>
+      </div>
 
       <%= f.submit "Create account", class: 'btn btn-primary' %>
     <% end %>


### PR DESCRIPTION
Describe your change here.
This PR adds under age conditional strings to the registration form. Initially, I need some feedback on what I'm doing wrong. The conditions and strings are set, but I can't get the virtual attributes to work with toggling to `under_age` attribute.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
