### PR TITLE
optimize the latest_version_id lookup

### DIFF
--- a/app/models/concerns/versioning.rb
+++ b/app/models/concerns/versioning.rb
@@ -40,8 +40,10 @@ module Versioning
     end
   end
 
+  # take the highest associated version_id
+  # via the autoincrementing PK of the versioned_association
   def latest_version_id
-    send(self.class.versioned_association).order(id: :desc).select(:id).first.id
+    version_ids.max
   end
 
   def version_ids

--- a/spec/support/shared_specs_for_versioning.rb
+++ b/spec/support/shared_specs_for_versioning.rb
@@ -14,4 +14,14 @@ RSpec.shared_examples "a versioned model" do
       model.save!
     end.to change { model.send(model.class.versioned_association).count }.by(1)
   end
+
+  it 'lists the version ids' do
+    expected_ids = model.send(model.class.versioned_association).pluck(:id)
+    expect(model.version_ids).to match_array(expected_ids)
+  end
+
+  it 'records the lastest version id' do
+    expected_id = model.send(model.class.versioned_association).last.id
+    expect(model.latest_version_id).to eq(expected_id)
+  end
 end


### PR DESCRIPTION
avoid a costly order on possibly large tables to then select a subset of filtered rows.

Instead take the max id from the optimal version_ids to find the latest known version association via the auto-incrementing PK.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
