### PR TITLE
avoid serializing worklfow versions

### DIFF
--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -12,13 +12,13 @@ class WorkflowSerializer
              :retirement, :retired_set_member_subjects_count, :href, :active, :mobile_friendly,
              :aggregation, :configuration, :public_gold_standard, :completeness
 
-  can_include :project, :subject_sets, :tutorial_subject, :workflow_versions, :published_version
+  can_include :project, :subject_sets, :tutorial_subject, :published_version
 
   media_include :attached_images, classifications_export: { include: false }
 
   can_filter_by :active, :mobile_friendly
 
-  preload :subject_sets, :attached_images
+  preload :subject_sets, :attached_images, :classifications_export, :published_version
 
   def version
     "#{@model.major_version}.#{content_version}"

--- a/spec/serializers/workflow_serializer_spec.rb
+++ b/spec/serializers/workflow_serializer_spec.rb
@@ -13,7 +13,9 @@ describe WorkflowSerializer do
   it_should_behave_like "a panoptes restpack serializer" do
     let(:resource) { workflow }
     let(:includes) { %i(project subject_sets tutorial_subject) }
-    let(:preloads) { %i(subject_sets attached_images) }
+    let(:preloads) do
+      %i(subject_sets attached_images classifications_export published_version)
+    end
   end
 
   it_should_behave_like "a filter has many serializer" do


### PR DESCRIPTION
Why serialize them if they are not used? These relations will quickly become hundreds to thousands.

Allow the lookup of workflow versions via the workflow_versions controller instead.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
