### PR TITLE
Add missing serializer preload statements

### DIFF
--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -15,6 +15,7 @@ class CollectionSerializer
   preload [ owner: { identity_membership: :user } ],
     :collection_roles,
     :subjects,
+    :projects,
     default_subject: :locations
 
   def default_subject_src

--- a/app/serializers/field_guide_serializer.rb
+++ b/app/serializers/field_guide_serializer.rb
@@ -8,4 +8,6 @@ class FieldGuideSerializer
   can_include :project
   media_include :attached_images
   can_filter_by :language
+
+  preload :attached_images
 end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -13,6 +13,9 @@ class OrganizationSerializer
   can_filter_by :display_name, :slug, :listed
   can_include :organization_roles, :projects, :owners, :pages
 
+  preload :organization_roles, :projects, [ owner: { identity_membership: :user } ], :pages,
+          :avatar, :background, :attached_images
+
   def avatar_src
     if avatar = @model.avatar
       avatar.external_link ? avatar.external_link : avatar.src

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -33,7 +33,9 @@ class ProjectSerializer
     :attached_images,
     :avatar,
     :background,
-    :tags
+    :tags,
+    :classifications_export,
+    :subjects_export
 
   def self.page(params = {}, scope = nil, context = {})
     if Project.states.include?(params["state"])

--- a/app/serializers/set_member_subject_serializer.rb
+++ b/app/serializers/set_member_subject_serializer.rb
@@ -2,5 +2,5 @@ class SetMemberSubjectSerializer
   include Serialization::PanoptesRestpack
 
   attributes :id, :created_at, :updated_at, :priority, :href
-  can_include :subject_set, :subject, :retired_workflows
+  can_include :subject_set, :subject
 end

--- a/app/serializers/tutorial_serializer.rb
+++ b/app/serializers/tutorial_serializer.rb
@@ -5,8 +5,9 @@ class TutorialSerializer
 
   attributes :steps, :href, :id, :created_at, :updated_at, :language, :kind, :display_name
 
-  can_include :project
-  can_include :workflows
+  can_include :project, :workflows
   media_include :attached_images
   can_filter_by :language
+
+  preload :workflows, :attached_images
 end

--- a/app/serializers/user_group_serializer.rb
+++ b/app/serializers/user_group_serializer.rb
@@ -8,6 +8,8 @@ class UserGroupSerializer
               projects: { param: "owner", value: "name" },
               collections: { param: "owner", value: "name" }
 
+  preload :memberships, :users, :projects, :collections
+
   can_filter_by :name
 
   def type

--- a/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/set_member_subjects_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V1::SetMemberSubjectsController, type: :controller do
   let!(:set_member_subjects) { create_list(:set_member_subject, 2, subject_set: subject_set) }
   let(:api_resource_name) { 'set_member_subjects' }
   let(:api_resource_attributes) { %w(id priority) }
-  let(:api_resource_links) { %w(set_member_subjects.subject set_member_subjects.subject_set set_member_subjects.retired_workflows) }
+  let(:api_resource_links) { %w(set_member_subjects.subject set_member_subjects.subject_set) }
 
   let(:scopes) { %w(public project) }
   let(:resource) { set_member_subjects.first }

--- a/spec/serializers/collection_serializer_spec.rb
+++ b/spec/serializers/collection_serializer_spec.rb
@@ -11,6 +11,7 @@ describe CollectionSerializer do
         [ owner: { identity_membership: :user } ],
         :collection_roles,
         :subjects,
+        :projects,
         default_subject: :locations
       ]
     end

--- a/spec/serializers/organization_serializer_spec.rb
+++ b/spec/serializers/organization_serializer_spec.rb
@@ -15,6 +15,12 @@ describe OrganizationSerializer do
   let(:links) { [:avatar, :background] }
   let(:serialized) { OrganizationSerializer.resource({include: 'avatar,background,owners'}, Organization.where(id: organization_with_media.id), context) }
 
+  it_should_behave_like "a panoptes restpack serializer", "test_owner_include" do
+    let(:resource) { organization }
+    let(:includes) { %i(organization_roles projects pages) }
+    let(:preloads) { OrganizationSerializer.preloads }
+  end
+
   describe "includes avatar and background" do
     it "should include avatar" do
       expect(serialized[:linked][:avatars].map{ |r| r[:id] })

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -29,7 +29,7 @@ describe ProjectSerializer do
 
   it_should_behave_like "a panoptes restpack serializer", "test_owner_include", "test_blank_links" do
     let(:resource) { project }
-    let(:includes) { %i(workflows active_workflows subject_sets project_roles) }
+    let(:includes) { %i(workflows active_workflows subject_sets project_roles pages organization) }
     let(:preloads) { ProjectSerializer.preloads }
     let(:expected_links) do
       non_owners_includes = described_class.can_includes - [:owners]


### PR DESCRIPTION
Add in missing preload resource link relations that cause N+1 lookups on serializer page methods. This should speed up some end points. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
