### PR TITLE
add selected_at timestamp to track server side events

### DIFF
--- a/app/serializers/subject_selector_serializer.rb
+++ b/app/serializers/subject_selector_serializer.rb
@@ -3,7 +3,7 @@ class SubjectSelectorSerializer
   include NoCountSerializer
 
   attributes :id, :metadata, :locations, :zooniverse_id,
-    :created_at, :updated_at, :href
+    :created_at, :updated_at, :href, :selected_at
 
   optional :retired, :already_seen, :finished_workflow,
     :user_has_finished_workflow, :favorite, :selection_state
@@ -44,6 +44,10 @@ class SubjectSelectorSerializer
 
   def selection_state
     @context[:selection_state]
+  end
+
+  def selected_at
+    @context[:selected_at]
   end
 
   private

--- a/lib/subjects/selector_context.rb
+++ b/lib/subjects/selector_context.rb
@@ -1,11 +1,12 @@
 module Subjects
   class SelectorContext
-    attr_reader :selector, :subject_ids
+    attr_reader :selector, :subject_ids, :selected_at
     delegate :user, :workflow, to: :selector
 
-    def initialize(selector, subject_ids)
+    def initialize(selector, subject_ids, selected_at=Time.now.utc)
       @selector = selector
       @subject_ids = subject_ids
+      @selected_at = selected_at
     end
 
     def format
@@ -19,6 +20,7 @@ module Subjects
           user_has_finished_workflow: user_has_finished_workflow,
           finished_workflow: finished_workflow?,
           selection_state: selector.selection_state,
+          selected_at: selected_at,
           url_format: :get,
           select_context: true
         }.compact

--- a/spec/lib/subjects/selector_context_spec.rb
+++ b/spec/lib/subjects/selector_context_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Subjects::SelectorContext do
   let(:workflow) { project.workflows.first }
   let(:api_user) { ApiUser.new(user) }
   let(:subject_ids) { [1,2] }
+  let(:selected_at) { Time.now.utc }
   let(:expected_context) do
     {
       user_seen_subject_ids: [1],
@@ -14,6 +15,7 @@ RSpec.describe Subjects::SelectorContext do
       user_has_finished_workflow: false,
       finished_workflow: false,
       selection_state: :normal,
+      selected_at: selected_at,
       url_format: :get,
       select_context: true
     }
@@ -26,7 +28,7 @@ RSpec.describe Subjects::SelectorContext do
     selector
   end
 
-  subject { described_class.new(selector, subject_ids) }
+  subject { described_class.new(selector, subject_ids, selected_at) }
 
   it 'should return an empty object if skip flag is set' do
     Panoptes.flipper[:skip_subject_selection_context].enable
@@ -72,6 +74,7 @@ RSpec.describe Subjects::SelectorContext do
         user_has_finished_workflow: true,
         finished_workflow: false,
         selection_state: :normal,
+        selected_at: selected_at,
         url_format: :get,
         select_context: true
       }

--- a/spec/serializers/subject_selector_serializer_spec.rb
+++ b/spec/serializers/subject_selector_serializer_spec.rb
@@ -40,9 +40,24 @@ describe SubjectSelectorSerializer do
   end
 
   context "subject selection" do
-    let(:selection_context) { { select_context: true } }
+    let(:selection_context) do
+      {
+        select_context: true,
+        retired_subject_ids: [],
+        user_seen_subject_ids: [],
+        favorite_subject_ids: [],
+        finished_workflow: false,
+        user_has_finished_workflow: false,
+        selection_state: :normal,
+        selected_at: Time.now.utc
+       }
+    end
     let(:run_serializer) do
       SubjectSelectorSerializer.single({}, Subject.all, selection_context)
+    end
+
+    it "should return the selected_at timestamp" do
+      expect(run_serializer[:selected_at]).to eq(selection_context[:selected_at])
     end
 
     describe "seen, retired, finished selection contexts" do


### PR DESCRIPTION
embedd the timing of selection into the selector metadata to feed back to classification metadata, this will allow us to better debug the selection events that are causing the already seens issue

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
