### PR TITLE
Fix syntax on update_all

### DIFF
--- a/db/migrate/20190411125709_change_workflow_steps_default.rb
+++ b/db/migrate/20190411125709_change_workflow_steps_default.rb
@@ -5,7 +5,7 @@ class ChangeWorkflowStepsDefault < ActiveRecord::Migration
         change_column_default(:workflows, :steps, [])
         Workflow.select(:id).find_in_batches do |workflows|
           workflows_update_scope = Workflow.where(id: workflows)
-          workflows_update_scope.update_all(:steps, [])
+          workflows_update_scope.update_all(steps: [])
         end
       end
     end


### PR DESCRIPTION
Running the migration on an empty test db doesn't run the update_all line. Fixed the syntax.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
