### PR TITLE
add pg_stat_statements extension

### DIFF
--- a/db/migrate/20190524111214_add_pg_stats_statements_extension.rb
+++ b/db/migrate/20190524111214_add_pg_stats_statements_extension.rb
@@ -1,0 +1,5 @@
+class AddPgStatsStatementsExtension < ActiveRecord::Migration
+  def change
+    enable_extension "pg_stat_statements"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -39,6 +39,20 @@ COMMENT ON EXTENSION intarray IS 'functions, operators, and index support for 1-
 
 
 --
+-- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
+
+
+--
 -- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -4757,4 +4771,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190307141138');
 INSERT INTO schema_migrations (version) VALUES ('20190411125709');
 
 INSERT INTO schema_migrations (version) VALUES ('20190507103007');
+
+INSERT INTO schema_migrations (version) VALUES ('20190524111214');
 


### PR DESCRIPTION
Record the API database queries to gain more insight into the db performance. This extension looks to be available in both staging & production RDS instance.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
