### PR TITLE
Inject bind variables in rails 4 with prepared_statements set to false

### DIFF
--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -8,16 +8,18 @@ class SubjectMetadataWorker
       FROM   subjects
       WHERE  subjects.id = set_member_subjects.subject_id
       AND    subjects.metadata ? '#priority'
-      AND    set_member_subjects.subject_set_id = ?
+      AND    set_member_subjects.subject_set_id = :subject_set_id
     SQL
+    # replace the above SQL :subject_set_id named bind var with $1
+    #
     # handle incorrect bind params for non preparted statements
     # in exec_update, fixed in rails 5
     # https://github.com/rails/rails/issues/24893
     # https://github.com/rails/rails/issues/34183
     bound_update_sms_priority_sql = ActiveRecord::Base.send(
-      :replace_bind_variables,
+      :replace_named_bind_variables,
       update_sms_priority_sql,
-      [subject_set_id]
+      {subject_set_id: subject_set_id}
     )
 
     # Note: In Rails 5 use bound params, [[nil,subject_set_id]]
@@ -26,6 +28,5 @@ class SubjectMetadataWorker
       "SQL",
       []
     )
-binding.pry
   end
 end

--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -2,31 +2,48 @@ class SubjectMetadataWorker
   include Sidekiq::Worker
 
   def perform(subject_set_id)
-    update_sms_priority_sql = <<-SQL
-      UPDATE set_member_subjects
-      SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
-      FROM   subjects
-      WHERE  subjects.id = set_member_subjects.subject_id
-      AND    subjects.metadata ? '#priority'
-      AND    set_member_subjects.subject_set_id = :subject_set_id
-    SQL
-    # replace the above SQL :subject_set_id named bind var with $1
-    #
-    # handle incorrect bind params for non preparted statements
-    # in exec_update, fixed in rails 5
-    # https://github.com/rails/rails/issues/24893
-    # https://github.com/rails/rails/issues/34183
-    bound_update_sms_priority_sql = ActiveRecord::Base.send(
-      :replace_named_bind_variables,
-      update_sms_priority_sql,
-      {subject_set_id: subject_set_id}
-    )
+    if Panoptes.rails5?
+      update_sms_priority_sql = <<-SQL
+        UPDATE set_member_subjects
+        SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
+        FROM   subjects
+        WHERE  subjects.id = set_member_subjects.subject_id
+        AND    subjects.metadata ? '#priority'
+        AND    set_member_subjects.subject_set_id = $1
+      SQL
 
-    # Note: In Rails 5 use bound params, [[nil,subject_set_id]]
-    ActiveRecord::Base.connection.exec_update(
-      bound_update_sms_priority_sql,
-      "SQL",
-      []
-    )
+      ActiveRecord::Base.connection.exec_update(
+        update_sms_priority_sql,
+        "SQL",
+        [[nil, subject_set_id]]
+      )
+    else
+      update_sms_priority_sql = <<-SQL
+        UPDATE set_member_subjects
+        SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
+        FROM   subjects
+        WHERE  subjects.id = set_member_subjects.subject_id
+        AND    subjects.metadata ? '#priority'
+        AND    set_member_subjects.subject_set_id = :subject_set_id
+      SQL
+      # replace the above SQL :subject_set_id named bind var with $1
+      #
+      # handle incorrect bind params for non preparted statements
+      # in exec_update, fixed in rails 5
+      # https://github.com/rails/rails/issues/24893
+      # https://github.com/rails/rails/issues/34183
+      bound_update_sms_priority_sql = ActiveRecord::Base.send(
+        :replace_named_bind_variables,
+        update_sms_priority_sql,
+        {subject_set_id: subject_set_id}
+      )
+
+      # Note: In Rails 5 use bound params, [[nil,subject_set_id]]
+      ActiveRecord::Base.connection.exec_update(
+        bound_update_sms_priority_sql,
+        "SQL",
+        []
+      )
+    end
   end
 end

--- a/config/database.yml.hudson
+++ b/config/database.yml.hudson
@@ -7,6 +7,7 @@ default: &default
   host: pg
   pool: 5
   port: 5432
+  prepared_statements: false
 
 development:
   <<: *default

--- a/config/initializers/panoptes.rb
+++ b/config/initializers/panoptes.rb
@@ -8,8 +8,4 @@ module Panoptes
   def self.disable_lifecycle_worker
     Panoptes.flipper[:disable_lifecycle_worker].enabled?
   end
-
-  def self.rails5?
-    Rails.version[0] == "5"
-  end
 end

--- a/config/initializers/panoptes.rb
+++ b/config/initializers/panoptes.rb
@@ -8,4 +8,8 @@ module Panoptes
   def self.disable_lifecycle_worker
     Panoptes.flipper[:disable_lifecycle_worker].enabled?
   end
+
+  def self.rails5?
+    Rails.version[0] == "5"
+  end
 end

--- a/lib/tasks/configure.rake
+++ b/lib/tasks/configure.rake
@@ -31,6 +31,7 @@ test:
   adapter: postgresql
   database: travis_ci_test
   username: postgres
+  prepared_statements: false
 YAML
 
     File.open('config/redis.yml', 'w') { |f| f.write(<<YAML) }

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe SubjectMetadataWorker do
   end
 
   describe "#perform" do
+    # TODO: Rails 5 combine the tests to one
+    # to test behaviour not AR calling interface
+    it 'calls the correct RAILS 5 AR methods' do
+      stub_const("ActiveRecord::VERSION::MAJOR", 5)
+      expect(ActiveRecord::Base.connection)
+        .to receive(:exec_update)
+        .with(instance_of(String), "SQL",[[nil, subject_set.id]])
+      worker.perform(subject_set.id)
+    end
+
     it 'copies priority from metadata to SMS attribute' do
       worker.perform(subject_set.id)
       sms_one, sms_two, sms_three = SetMemberSubject.find(


### PR DESCRIPTION
In non local envs disable prepared statements, manual SQL work relies on testing these code paths.

Allow Rails 4 to correctly inject the bind vars for the raw SQL

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
