### PR TITLE
ignore training subject sets for counters and selection

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2129,6 +2129,18 @@ the strategy. There are 2 valid criteria:
 If retirement is left blank Panoptes defaults to the `classification_count`
 strategy with 15 classifications per subject.
 
+A Workflow has a _configuration_ object that is used to store client configuration details.
+Three attributes in this object are reserved: _training_set_ids_, _training_chances_ and _training_default_chance_,
+_training_set_ids_ are used to choose training data from in the subject selectors
+and to tell the counting systems which subjects to ignore as training subjects do not retire.
+_training_default_chance_ is the fallback chance a user will see a training subject and also applies if _training_chances_ are not set
+_training_chances_ are used to determine when to show a training subject and each index reflects a seen subject by the user.
+E.g [ 1, 0.5, 0.1 ] reflects when i have seen 0 subjects (first element) on your workflow i will have a 100% chance of selecting a training subject.
+After seeing 1 subject, I will have a 50% chance, on the second subject i will have a 10% chance, after that the default chance applies.
+
+Normally when setting training subject selection you would set the retirement
+config to "never_retire" and use another system (e.g. Caesar) to handle retirement.
+
 + Request
 
     + Headers

--- a/app/counters/workflow_counter.rb
+++ b/app/counters/workflow_counter.rb
@@ -27,9 +27,6 @@ class WorkflowCounter
   private
 
   def non_training_subject_set_ids_scope
-    workflow
-    .subject_sets
-    .where("NOT subject_sets.metadata ? 'training'")
-    .select(:id)
+    workflow.non_training_subject_sets.select(:id)
   end
 end

--- a/app/counters/workflow_counter.rb
+++ b/app/counters/workflow_counter.rb
@@ -17,12 +17,19 @@ class WorkflowCounter
     SubjectWorkflowStatus
     .where(workflow_id: workflow.id)
     .joins("INNER JOIN set_member_subjects ON set_member_subjects.subject_id = subject_workflow_counts.subject_id")
-    .where(set_member_subjects: { subject_set_id: subject_set_ids })
+    .where(
+      set_member_subjects: {
+        subject_set_id: non_training_subject_set_ids_scope
+      }
+    )
   end
 
   private
 
-  def subject_set_ids
-    workflow.subject_sets.pluck(:id)
+  def non_training_subject_set_ids_scope
+    workflow
+    .subject_sets
+    .where("NOT subject_sets.metadata ? 'training'")
+    .select(:id)
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -13,7 +13,7 @@ class Workflow < ActiveRecord::Base
   has_many :subject_sets_workflows, dependent: :destroy
   has_many :subject_sets, through: :subject_sets_workflows
   has_many :non_training_subject_sets,
-    -> { where("NOT subject_sets.metadata ? 'training'") },
+    ->(workflow) { where.not(subject_sets_workflows: { subject_set_id: workflow.training_set_ids }) },
     through: :subject_sets_workflows,
     source: :subject_set
   has_many :set_member_subjects, through: :subject_sets
@@ -162,5 +162,9 @@ class Workflow < ActiveRecord::Base
 
   def retirement_config
     RetirementValidator.new(self).validate
+  end
+
+  def training_set_ids
+    Array.wrap(configuration.dig("training_set_ids"))
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -12,6 +12,15 @@ class Workflow < ActiveRecord::Base
   has_many :subject_workflow_statuses, dependent: :destroy
   has_many :subject_sets_workflows, dependent: :destroy
   has_many :subject_sets, through: :subject_sets_workflows
+  # TODO: this is looking like a good reason
+  # to move away from the NOT json attribute present ?
+  # instead add an indexed (binrary) column on the subject_set resource
+  # and search on that instead
+  # DO NOT ALLOW MERGE WITHOUT FIXING THIS
+  has_many :non_training_subject_sets,
+    -> { where("NOT subject_sets.metadata ? 'training'") },
+    through: :subject_sets_workflows,
+    source: :subject_set
   has_many :set_member_subjects, through: :subject_sets
   has_many :subjects, through: :set_member_subjects
   has_many :classifications, dependent: :restrict_with_exception

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -166,8 +166,6 @@ class Workflow < ActiveRecord::Base
 
   def training_set_ids
     config_training_set_ids = Array.wrap(configuration.dig("training_set_ids"))
-    config_training_set_ids.select do |id|
-      !id.to_i.zero?
-    end
+    config_training_set_ids.reject { |id| id.to_i.zero? }
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -12,11 +12,6 @@ class Workflow < ActiveRecord::Base
   has_many :subject_workflow_statuses, dependent: :destroy
   has_many :subject_sets_workflows, dependent: :destroy
   has_many :subject_sets, through: :subject_sets_workflows
-  # TODO: this is looking like a good reason
-  # to move away from the NOT json attribute present ?
-  # instead add an indexed (binrary) column on the subject_set resource
-  # and search on that instead
-  # DO NOT ALLOW MERGE WITHOUT FIXING THIS
   has_many :non_training_subject_sets,
     -> { where("NOT subject_sets.metadata ? 'training'") },
     through: :subject_sets_workflows,

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -42,7 +42,7 @@ class Workflow < ActiveRecord::Base
     'options' => {'count' => 15}
   }.freeze
 
-  JSON_ATTRIBUTES = %w(tasks retirement aggregation configuration strings steps).freeze
+  JSON_ATTRIBUTES = %w(tasks retirement aggregation strings steps).freeze
 
   # Used by HttpCacheable
   scope :private_scope, -> { where(project_id: Project.private_scope) }

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -165,6 +165,9 @@ class Workflow < ActiveRecord::Base
   end
 
   def training_set_ids
-    Array.wrap(configuration.dig("training_set_ids"))
+    config_training_set_ids = Array.wrap(configuration.dig("training_set_ids"))
+    config_training_set_ids.select do |id|
+      !id.to_i.zero?
+    end
   end
 end

--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -26,14 +26,14 @@ module Subjects
 
     def available
       query = Subjects::SetMemberSubjectSelector.new(workflow, user).set_member_subjects
-      subject_set_scope = if workflow.grouped
-                            # respect the user wishes if they want to selection from a training set
+      subject_set_ids = if workflow.grouped
+                            # respect the user if they want to select from a training set
                             opts[:subject_set_id]
                           else
-                            # by default do not select data from training sets
+                            # default mode: do not select from training sets
                             workflow.non_training_subject_sets.pluck(:id)
                           end
-      query.where(subject_set_id: subject_set_scope)
+      query.where(subject_set_id: subject_set_ids)
     end
 
     def limit

--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -26,10 +26,14 @@ module Subjects
 
     def available
       query = Subjects::SetMemberSubjectSelector.new(workflow, user).set_member_subjects
-      if workflow.grouped
-        query = query.where(subject_set_id: opts[:subject_set_id])
-      end
-      query
+      subject_set_scope = if workflow.grouped
+                            # respect the user wishes if they want to selection from a training set
+                            opts[:subject_set_id]
+                          else
+                            # by default do not select data from training sets
+                            workflow.non_training_subject_sets.pluck(:id)
+                          end
+      query.where(subject_set_id: subject_set_scope)
     end
 
     def limit

--- a/spec/counters/workflow_counter_spec.rb
+++ b/spec/counters/workflow_counter_spec.rb
@@ -47,8 +47,8 @@ describe WorkflowCounter do
         let(:training_set) { workflow.subject_sets.first }
         let(:real_set) { workflow.subject_sets.last }
         before do
-          new_metadata = training_set.metadata.merge("training" => true)
-          training_set.update_column(:metadata, new_metadata)
+          real_set_ar_collection_proxy = SubjectSet.where(id: real_set)
+          allow(workflow).to receive(:non_training_subject_sets).and_return(real_set_ar_collection_proxy)
         end
 
         it "should return non training data classification count only" do
@@ -94,8 +94,8 @@ describe WorkflowCounter do
         let(:training_set) { workflow.subject_sets.first }
         let(:real_set) { workflow.subject_sets.last }
         before do
-          new_metadata = training_set.metadata.merge("training" => true)
-          training_set.update_column(:metadata, new_metadata)
+          real_set_ar_collection_proxy = SubjectSet.where(id: real_set)
+          allow(workflow).to receive(:non_training_subject_sets).and_return(real_set_ar_collection_proxy)
         end
 
         it "should return non training data retired count only" do

--- a/spec/counters/workflow_counter_spec.rb
+++ b/spec/counters/workflow_counter_spec.rb
@@ -41,6 +41,20 @@ describe WorkflowCounter do
           expect(counter.classifications).to eq(2)
         end
       end
+
+      context "with subject sets marked as training data" do
+        let(:workflow) { create(:workflow_with_subjects, num_sets: 2) }
+        let(:training_set) { workflow.subject_sets.first }
+        let(:real_set) { workflow.subject_sets.last }
+        before do
+          new_metadata = training_set.metadata.merge("training" => true)
+          training_set.update_column(:metadata, new_metadata)
+        end
+
+        it "should return non training data classification count only" do
+          expect(counter.classifications).to eq(2)
+        end
+      end
     end
   end
 
@@ -73,6 +87,20 @@ describe WorkflowCounter do
       it "should return 0 when a subject set was unlinked" do
         workflow.subject_sets = []
         expect(counter.retired_subjects).to eq(0)
+      end
+
+      context "with subject sets marked as training data" do
+        let(:workflow) { create(:workflow_with_subjects, num_sets: 2) }
+        let(:training_set) { workflow.subject_sets.first }
+        let(:real_set) { workflow.subject_sets.last }
+        before do
+          new_metadata = training_set.metadata.merge("training" => true)
+          training_set.update_column(:metadata, new_metadata)
+        end
+
+        it "should return non training data retired count only" do
+          expect(counter.retired_subjects).to eq(2)
+        end
       end
     end
   end

--- a/spec/lib/formatter/csv/workflow_spec.rb
+++ b/spec/lib/formatter/csv/workflow_spec.rb
@@ -49,21 +49,6 @@ RSpec.describe Formatter::Csv::Workflow do
     it { is_expected.to match_array(rows) }
   end
 
-  describe "#non_training_subject_sets" do
-    let(:workflow) { create(:workflow_with_subject_sets) }
-    let(:training_set) { workflow.subject_sets.first }
-    let(:real_set) { workflow.subject_sets.last }
-    before do
-      training_set.update_column(
-        :metadata,
-        training_set.metadata.merge("training" => true)
-      )
-    end
-    it "should only return subjects sets that are not marked as training" do
-      expect(workflow.non_training_subject_sets).to match_array([real_set])
-    end
-  end
-
   context "with a versioned workflow" do
     let(:q_workflow) { build(:workflow, :question_task) }
     let(:tasks) { q_workflow.tasks }

--- a/spec/lib/formatter/csv/workflow_spec.rb
+++ b/spec/lib/formatter/csv/workflow_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe Formatter::Csv::Workflow do
     it { is_expected.to match_array(rows) }
   end
 
+  describe "#non_training_subject_sets" do
+    let(:workflow) { create(:workflow_with_subject_sets) }
+    let(:training_set) { workflow.subject_sets.first }
+    let(:real_set) { workflow.subject_sets.last }
+    before do
+      training_set.update_column(
+        :metadata,
+        training_set.metadata.merge("training" => true)
+      )
+    end
+    it "should only return subjects sets that are not marked as training" do
+      expect(workflow.non_training_subject_sets).to match_array([real_set])
+    end
+  end
+
   context "with a versioned workflow" do
     let(:q_workflow) { build(:workflow, :question_task) }
     let(:tasks) { q_workflow.tasks }

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -10,20 +10,19 @@ RSpec.describe Subjects::PostgresqlSelection do
 
   describe "selection" do
     let(:user) { User.first }
-    let(:workflow) { Workflow.first }
+    let(:workflow) { create(:workflow_with_subject_sets) }
     let(:sms) { SetMemberSubject.all }
     let(:opts) { {} }
     let(:sms_count) { 25 }
+    let(:uploader) { create(:user) }
     subject { Subjects::PostgresqlSelection.new(workflow, user, opts) }
 
     before do
-      uploader = create(:user)
-      created_workflow = create(:workflow_with_subject_sets)
-      create_list(:subject, sms_count, project: created_workflow.project, uploader: uploader).each do |subject|
+      create_list(:subject, sms_count, project: workflow.project, uploader: uploader).each do |subject|
         create(:set_member_subject,
           setup_subject_workflow_statuses: true,
           subject: subject,
-          subject_set: created_workflow.subject_sets.first
+          subject_set: workflow.subject_sets.first
         )
       end
     end
@@ -33,6 +32,32 @@ RSpec.describe Subjects::PostgresqlSelection do
         it_behaves_like "select for incomplete_project" do
           let(:sms_scope) do
             SetMemberSubject.all
+          end
+        end
+
+        context "with a training set and a real set with data" do
+          let(:sms_count) { 2 }
+          let(:training_set) { workflow.subject_sets.first }
+          let(:real_set) { workflow.subject_sets.last }
+
+          before do
+            training_set.update_column(
+              :metadata,
+              training_set.metadata.merge("training" => true)
+            )
+            create(:subject, project: workflow.project, uploader: uploader) do |subject|
+              create(:set_member_subject,
+                setup_subject_workflow_statuses: true,
+                subject: subject,
+                subject_set: real_set
+              )
+            end
+          end
+
+          it "should not include training subject sets in the results" do
+            result_ids = subject.select
+            non_training_subject_ids = real_set.subjects.pluck(:id)
+            expect(result_ids).to match_array(non_training_subject_ids)
           end
         end
       end

--- a/spec/lib/subjects/postgresql_selection_spec.rb
+++ b/spec/lib/subjects/postgresql_selection_spec.rb
@@ -41,10 +41,7 @@ RSpec.describe Subjects::PostgresqlSelection do
           let(:real_set) { workflow.subject_sets.last }
 
           before do
-            training_set.update_column(
-              :metadata,
-              training_set.metadata.merge("training" => true)
-            )
+            workflow.configuration['training_set_ids'] = training_set.id
             create(:subject, project: workflow.project, uploader: uploader) do |subject|
               create(:set_member_subject,
                 setup_subject_workflow_statuses: true,

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -424,6 +424,21 @@ describe Workflow, type: :model do
     end
   end
 
+  describe "#training_subject_sets" do
+    let(:training_ids) { ["1"] }
+
+    it "should return the data in the config object" do
+
+      workflow.configuration["training_set_ids"] = training_ids
+      expect(workflow.training_set_ids).to match_array(training_ids)
+    end
+
+    it "should sanitize the return values to known integer values" do
+      workflow.configuration["training_set_ids"] = training_ids | ["test"]
+      expect(workflow.training_set_ids).to match_array(training_ids)
+    end
+  end
+
   describe "#non_training_subject_sets" do
     let(:workflow) { create(:workflow_with_subject_sets) }
     let(:training_set) { workflow.subject_sets.first }
@@ -436,6 +451,11 @@ describe Workflow, type: :model do
 
     it "should always return all real sets with empty training sets config" do
       workflow.configuration["training_set_ids"] = []
+      expect(workflow.non_training_subject_sets).to match_array(workflow.subject_sets)
+    end
+
+    it "should always return all real sets with an unkonwn set id" do
+      workflow.configuration["training_set_ids"] = "test"
       expect(workflow.non_training_subject_sets).to match_array(workflow.subject_sets)
     end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -427,14 +427,19 @@ describe Workflow, type: :model do
     let(:workflow) { create(:workflow_with_subject_sets) }
     let(:training_set) { workflow.subject_sets.first }
     let(:real_set) { workflow.subject_sets.last }
-    before do
-      training_set.update_column(
-        :metadata,
-        training_set.metadata.merge("training" => true)
-      )
-    end
+
     it "should only return subjects sets that are not marked as training" do
+      workflow.configuration["training_set_ids"] = [training_set.id]
       expect(workflow.non_training_subject_sets).to match_array([real_set])
+    end
+
+    it "should always return all real sets with empty training sets config" do
+      workflow.configuration["training_set_ids"] = []
+      expect(workflow.non_training_subject_sets).to match_array(workflow.subject_sets)
+    end
+
+    it "should always return all real sets with no training sets config" do
+      expect(workflow.non_training_subject_sets).to match_array(workflow.subject_sets)
     end
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -428,7 +428,10 @@ describe Workflow, type: :model do
     let(:training_set) { workflow.subject_sets.first }
     let(:real_set) { workflow.subject_sets.last }
     before do
-      training_set.update_column(:training, true)
+      training_set.update_column(
+        :metadata,
+        training_set.metadata.merge("training" => true)
+      )
     end
     it "should only return subjects sets that are not marked as training" do
       expect(workflow.non_training_subject_sets).to match_array([real_set])

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -39,11 +39,12 @@ describe Workflow, type: :model do
 
   describe "::find_without_json_attrs" do
     let(:workflow) { create(:workflow) }
+    let(:whitelist_json_attrs) { %w(configuration) }
     let(:json_attrs) do
       col_information = Workflow.columns_hash.select do |name, col|
         /\Ajson.*/.match?(col.sql_type)
       end
-      col_information.keys
+      col_information.keys - whitelist_json_attrs
     end
 
     it "should load the workflow without the json attributes" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -422,4 +422,16 @@ describe Workflow, type: :model do
       end
     end
   end
+
+  describe "#non_training_subject_sets" do
+    let(:workflow) { create(:workflow_with_subject_sets) }
+    let(:training_set) { workflow.subject_sets.first }
+    let(:real_set) { workflow.subject_sets.last }
+    before do
+      training_set.update_column(:training, true)
+    end
+    it "should only return subjects sets that are not marked as training" do
+      expect(workflow.non_training_subject_sets).to match_array([real_set])
+    end
+  end
 end


### PR DESCRIPTION
towards #2795 - Ignore all subject sets that are marked as training sets on the workflow configuration when counting the workflows retired and classification counts.  These counts propagate up to project counts via the workflow resource.

And When selecting data due internally from postgres, avoid selecting from training sets.

Thanks to @amyrebecca and @eatyourgreens for the idea to use subject sets markers to determine which records are included in the counts.

~~Benchmarking the query to filter the subject sets on metadata attribute presence / absence to determine the training sets look like a simple filter on the index scan for workflow -> subject sets. I think this is ok even though it's a `NOT` query. Thoughts welcome.~~

Modified the AR association scope query to reflect on the marked configuration object ids and filter on the `subject_sets_workflows.subject_set_id` after doing it's index scan. The number of linked sets to workflows should always be a fairly small set being filtered (page fetching) on so shouldn't impact on the query time with the combined index scan.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
