### PR TITLE
run subject cleanup worker when unlinking subjects from a set

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -115,9 +115,12 @@ class Api::V1::SubjectSetsController < Api::ApiController
 
   def destroy_relation(resource, relation, value)
     if relation == :subjects
-      linked_sms_ids = value.split(',').map(&:to_i)
-      set_member_subjects = resource.set_member_subjects.where(subject_id: linked_sms_ids)
+      linked_subject_ids = value.split(',').map(&:to_i)
+      set_member_subjects = resource.set_member_subjects.where(subject_id: linked_subject_ids)
       remove_linked_set_member_subjects(set_member_subjects)
+      linked_subject_ids.each_with_index do |subject_id, index|
+        SubjectRemovalWorker.perform_in(index.seconds, subject_id)
+      end
     else
       super
     end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -381,6 +381,15 @@ describe Api::V1::SubjectSetsController, type: :controller do
       end
 
       it_behaves_like "cleans up the linked set member subjects"
+
+      it 'should call the subject removal worker' do
+        sms.map(&:subject_id).each_with_index do |subject_id, index|
+          expect(SubjectRemovalWorker)
+            .to receive(:perform_in)
+            .with(index.seconds, subject_id)
+        end
+        delete_resources
+      end
     end
   end
 end


### PR DESCRIPTION
Keep the API consistent with the UI, run the subject removal worker when unlinking subjects. Also internally consistent with the subject destroy and set_member_subject destroy operation.

If project owners have linked a subject across multiple sets and they unlink it from one, this may result in the subject being removed but still being referenced with a SetMemberSubject(SMS) record.

As subject reuse across sets isn't common** the orphaned SMS issue shouldn't come up much. We can revisit the cleanup operations if this becomes an issue.

** Caesar [add to subject set effect](https://github.com/zooniverse/panoptes-client.rb/blob/13b34ea1e0b66ceec147e20ffa699aa8e0a81bd6/lib/panoptes/client/subject_sets.rb#L22) being the exception and that is driven by classifications so any removal worker will leave the subject intact as it's been classified. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
