### PR TITLE
Upgrade ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,22 +17,25 @@ before_script: &before_script
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - rvm: 2.6
   include:
-    - rvm: 2.4
+    - rvm: 2.5
       env:
         - SPECS=spec/controllers/api/v1/[a-m]*.rb
-    - rvm: 2.4
+    - rvm: 2.5
       env:
         - SPECS=spec/controllers/api/v1/[n-s]*.rb
-    - rvm: 2.4
+    - rvm: 2.5
       env:
         - SPECS=spec/controllers/api/v1/[t-z]*.rb
-    - rvm: 2.4
+    - rvm: 2.5
       env:
         - SPECS="spec/controllers/**.rb spec/controllers/api/*.rb spec/models spec/operations spec/counters spec/routes"
-    - rvm: 2.4
+    - rvm: 2.5
       env:
         - SPECS="spec/lib spec/workers spec/serializers spec/services spec/requests spec/middleware spec/mailers spec/policies"
+    - rvm: 2.6
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_install:
   - find spec -maxdepth 1 -type d | grep spec/ > tmp/curr_spec_dirs.txt
   - if grep -Fxvc -f spec/known_dirs.txt tmp/curr_spec_dirs.txt; then echo 'Detected unkown Spec directories, check the spec/known_dirs.txt!'; exit 1; fi
   - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 
 before_script: &before_script
   - psql -c 'create database travis_ci_test;' -U postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-stretch
+FROM ruby:2.5-stretch
 
 WORKDIR /rails_app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.5
 
 WORKDIR /rails_app
 

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.5
 
 EXPOSE 4567
 WORKDIR /src

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.5
 
 EXPOSE 4567
 WORKDIR /usr/src/docs


### PR DESCRIPTION
Bump next ruby version 2.5 for testing and running the system. Also test ruby 2.6 which has some failures we need to upgrade on.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
