### PR TITLE
Remove s3 download export link

### DIFF
--- a/app/views/classification_data_mailer/classification_data.html.erb
+++ b/app/views/classification_data_mailer/classification_data.html.erb
@@ -1,3 +1,3 @@
 <p>Classification data for <%= @resource.display_name %> is ready</p>
 
-<p><a href="<%= @url %>">Click to download your data</a>. This link will be valid for 24 hours.</p>
+<p><a href="<%= @url %>">Download from your lab data exports page</a>.</p>

--- a/app/views/classification_data_mailer/classification_data.text.erb
+++ b/app/views/classification_data_mailer/classification_data.text.erb
@@ -1,3 +1,3 @@
 Classification data for <%= @resource.display_name %> is ready
 
-Download at <%= @url %>. This link will be valid for 24 hours.
+Download from your lab data exports page <%= @url %>.

--- a/app/views/subject_data_mailer/subject_data.html.erb
+++ b/app/views/subject_data_mailer/subject_data.html.erb
@@ -1,3 +1,3 @@
 <p>Subject data for <%= @project.display_name %> is ready</p>
 
-<p><a href="<%= @url %>">Click to download your data</a>. This link will be valid for 24 hours.</p>
+<p><a href="<%= @url %>">Download from your lab data exports page</a>.</p>

--- a/app/views/subject_data_mailer/subject_data.text.erb
+++ b/app/views/subject_data_mailer/subject_data.text.erb
@@ -1,3 +1,3 @@
 Subject data for <%= @project.display_name %> is ready
 
-Download at <%= @url %>. This link will be valid for 24 hours.
+Download from your lab data exports page <%= @url %>.

--- a/app/views/workflow_data_mailer/workflow_data.html.erb
+++ b/app/views/workflow_data_mailer/workflow_data.html.erb
@@ -1,3 +1,3 @@
 <p>Workflow data for <%= @project.display_name %> is ready</p>
 
-<p><a href="<%= @url %>">Click to download your data</a>. This link will be valid for 24 hours.</p>
+<p><a href="<%= @url %>">Download from your lab data exports page</a>.</p>

--- a/app/views/workflow_data_mailer/workflow_data.text.erb
+++ b/app/views/workflow_data_mailer/workflow_data.text.erb
@@ -1,3 +1,3 @@
 Workflow data for <%= @project.display_name %> is ready
 
-Download at <%= @url %>. This link will be valid for 24 hours.
+Download from your lab data exports page <%= @url %>.

--- a/app/workers/classification_data_mailer_worker.rb
+++ b/app/workers/classification_data_mailer_worker.rb
@@ -3,11 +3,11 @@ class ClassificationDataMailerWorker
 
   sidekiq_options queue: :data_high
 
-  def perform(resource_id, resource_type, s3_url, emails)
+  def perform(resource_id, resource_type, url, emails)
     return unless emails.present?
     ClassificationDataMailer.classification_data(
       resource_type.camelize.constantize.find(resource_id),
-      s3_url.to_s,
+      url.to_s,
       emails
     ).deliver
   end

--- a/app/workers/concerns/dump_mailer.rb
+++ b/app/workers/concerns/dump_mailer.rb
@@ -40,7 +40,7 @@ class DumpMailer
         resource.id
       end
 
-    "#{Panoptes.frontend_url}/lab/#{project_id}"
+    "#{Panoptes.frontend_url}/lab/#{project_id}/data-exports"
   end
 
   private

--- a/app/workers/concerns/dump_mailer.rb
+++ b/app/workers/concerns/dump_mailer.rb
@@ -9,7 +9,13 @@ class DumpMailer
 
   def send_email
     return unless emails.present?
-    mailer.perform_async(resource.id, resource.class.to_s.downcase, media_get_url, emails)
+
+    mailer.perform_async(
+      resource.id,
+      resource.class.to_s.downcase,
+      lab_export_url,
+      emails
+    )
   end
 
   def mailer
@@ -25,8 +31,16 @@ class DumpMailer
     end
   end
 
-  def media_get_url(expires=24*60)
-    medium.get_url(get_expires: expires)
+  def lab_export_url
+    # resources from export operations are projects but may not be
+    project_id =
+      if resource.is_a?(Workflow)
+        resource.project_id
+      else
+        resource.id
+      end
+
+    "#{Panoptes.frontend_url}/lab/#{project_id}"
   end
 
   private

--- a/app/workers/subject_data_mailer_worker.rb
+++ b/app/workers/subject_data_mailer_worker.rb
@@ -3,8 +3,8 @@ class SubjectDataMailerWorker
 
   sidekiq_options queue: :data_high
 
-  def perform(resource_id, resource_type, s3_url, emails)
+  def perform(resource_id, resource_type, url, emails)
     return unless emails.present?
-    SubjectDataMailer.subject_data(Project.find(resource_id), s3_url.to_s, emails).deliver
+    SubjectDataMailer.subject_data(Project.find(resource_id), url.to_s, emails).deliver
   end
 end

--- a/app/workers/workflow_data_mailer_worker.rb
+++ b/app/workers/workflow_data_mailer_worker.rb
@@ -3,8 +3,8 @@ class WorkflowDataMailerWorker
 
   sidekiq_options queue: :data_high
 
-  def perform(resource_id, resource_type, s3_url, emails)
+  def perform(resource_id, resource_type, url, emails)
     return unless emails.present?
-    WorkflowDataMailer.workflow_data(Project.find(resource_id), s3_url.to_s, emails).deliver
+    WorkflowDataMailer.workflow_data(Project.find(resource_id), url.to_s, emails).deliver
   end
 end

--- a/spec/workers/classification_data_mailer_worker_spec.rb
+++ b/spec/workers/classification_data_mailer_worker_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe ClassificationDataMailerWorker do
-  let(:s3_url) { "https://fake.s3.url.example.com" }
+  let(:url) { "https://www.zooniverse.org/lab/123" }
 
   shared_examples 'is a classification data mailer' do
     it 'should deliver the mail' do
-      expect{ subject.perform(resource.id, resource.class.to_s.downcase, s3_url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+      expect{ subject.perform(resource.id, resource.class.to_s.downcase, url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
     end
 
-    context 'when there are no recipients' do
+    context 'when there are no recipients'  do
       it 'does not call the mailer' do
         expect(ClassificationDataMailer).to receive(:classification_data).never
-        subject.perform(resource.id, resource.class.to_s.downcase, s3_url, [])
+        subject.perform(resource.id, resource.class.to_s.downcase, url, [])
       end
     end
   end

--- a/spec/workers/concerns/dump_mailer_spec.rb
+++ b/spec/workers/concerns/dump_mailer_spec.rb
@@ -40,7 +40,7 @@ describe DumpMailer do
   describe 'lab_export_url' do
     let(:resource) { Project.new(id: 1) }
     let(:project_id) { resource.id }
-    let(:lab_url) { "#{Panoptes.frontend_url}/lab/#{project_id}" }
+    let(:lab_url) { "#{Panoptes.frontend_url}/lab/#{project_id}/data-exports" }
 
     it 'corretly determines the lab url' do
       expect(dump_mailer.lab_export_url).to eq(lab_url)

--- a/spec/workers/concerns/dump_mailer_spec.rb
+++ b/spec/workers/concerns/dump_mailer_spec.rb
@@ -4,10 +4,10 @@ describe DumpMailer do
   let(:users) { create_list(:user, 2) }
   let(:owner) { users.sample }
   let(:resource) do
-    double(id: 1, class: Workflow, communication_emails: [owner.email])
+    double(id: 1, class: Project, communication_emails: [owner.email])
   end
   let(:metadata) { {"recipients" => users.map(&:id) } }
-  let(:medium) { double(id: 2, get_url: nil, metadata: metadata) }
+  let(:medium) { instance_double("Medium", id: 2, metadata: metadata) }
   let(:dump_mailer) { described_class.new(resource, medium, "classifications") }
 
   describe 'queueing notification emails' do
@@ -16,7 +16,7 @@ describe DumpMailer do
     before do
       expect(ClassificationDataMailerWorker)
       .to receive(:perform_async)
-      .with(resource.id, "workflow", nil, expected_emails)
+      .with(resource.id, "project", instance_of(String), expected_emails)
       .once
       .and_call_original
     end
@@ -33,6 +33,25 @@ describe DumpMailer do
 
       it 'queues an email to the owner' do
         dump_mailer.send_email
+      end
+    end
+  end
+
+  describe 'lab_export_url' do
+    let(:resource) { Project.new(id: 1) }
+    let(:project_id) { resource.id }
+    let(:lab_url) { "#{Panoptes.frontend_url}/lab/#{project_id}" }
+
+    it 'corretly determines the lab url' do
+      expect(dump_mailer.lab_export_url).to eq(lab_url)
+    end
+
+    context "when the resource is a workflow" do
+      let(:resource) { Workflow.new(project_id: 2) }
+      let(:project_id) { resource.project_id }
+
+      it 'corretly determines the lab url' do
+        expect(dump_mailer.lab_export_url).to eq(lab_url)
       end
     end
   end

--- a/spec/workers/subject_data_mailer_worker_spec.rb
+++ b/spec/workers/subject_data_mailer_worker_spec.rb
@@ -2,16 +2,16 @@ require "spec_helper"
 
 RSpec.describe SubjectDataMailerWorker do
   let(:project) { create(:project) }
-  let(:s3_url) { "https://fake.s3.url.example.com" }
+  let(:url) { "https://www.zooniverse.org/lab/123" }
 
   it 'should deliver the mail' do
-    expect{ subject.perform(project.id, "project", s3_url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    expect{ subject.perform(project.id, "project", url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
 
   context 'when there are no recipients' do
     it 'does not call the mailer' do
       expect(SubjectDataMailer).to receive(:subject_data).never
-      subject.perform(project.id, "project", s3_url, [])
+      subject.perform(project.id, "project", url, [])
     end
   end
 end

--- a/spec/workers/workflow_data_mailer_worker_spec.rb
+++ b/spec/workers/workflow_data_mailer_worker_spec.rb
@@ -2,16 +2,16 @@ require "spec_helper"
 
 RSpec.describe WorkflowDataMailerWorker do
   let(:project) { create(:project) }
-  let(:s3_url) { "https://fake.s3.url.example.com" }
+  let(:url) { "https://www.zooniverse.org/lab/123" }
 
   it 'should deliver the mail' do
-    expect{ subject.perform(project.id, "project", s3_url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    expect{ subject.perform(project.id, "project", url, ["zach@zooniverse.org"]) }.to change{ ActionMailer::Base.deliveries.count }.by(1)
   end
 
   context 'when there are no recipients' do
     it 'does not call the mailer' do
       expect(WorkflowDataMailer).to receive(:subject_data).never
-      subject.perform(project.id, "project", s3_url, [])
+      subject.perform(project.id, "project", url, [])
     end
   end
 end


### PR DESCRIPTION
fixes #1871 #2830 closes https://github.com/zooniverse/Panoptes-Front-End/issues/5241 

Remove the s3 URL from the data export emails, instead replace it with a link to the project lab data exports page where the link will be generated properly.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
