### PR TITLE
remove the SWS create worker locks

### DIFF
--- a/app/workers/subject_workflow_status_create_worker.rb
+++ b/app/workers/subject_workflow_status_create_worker.rb
@@ -1,8 +1,6 @@
 class SubjectWorkflowStatusCreateWorker
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed
-
   def perform(subject_id, workflow_id)
     return unless Panoptes.flipper[:subject_workflow_status_create_worker].enabled?
 


### PR DESCRIPTION
allow all these jobs to run as they shouldn't be enqueued multiple times.

If they are let the db unique index control state vs swamping redis with lock structures

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
