### PR TITLE
extend designator client with add_seen method

### DIFF
--- a/app/services/designator_client.rb
+++ b/app/services/designator_client.rb
@@ -28,8 +28,12 @@ class DesignatorClient
   end
 
   def add_seen(workflow_id, user_id, subject_id)
-    # not needed right now
-    true
+    request(:put, "/api/users/#{user_id}/add_seen_subject") do |req|
+      req.body = {
+        workflow_id: workflow_id,
+        subject_id: subject_id
+      }.to_json
+    end
   end
 
   def load_user(workflow_id, user_id)
@@ -51,15 +55,6 @@ class DesignatorClient
     url = "/api/workflows/#{workflow_id}"
     params = { user_id: user_id, limit: limit }
     request(:get, [ url, params ])
-  end
-
-  def add_seen_subjects(subject_ids, workflow_id, user_id)
-    request(:put, "/api/users/#{user_id}/add_seen_subjects") do |req|
-      req.body = {
-        workflow_id: workflow_id,
-        subject_ids: Array.wrap(subject_ids)
-      }.to_json
-    end
   end
 
   private

--- a/app/services/designator_client.rb
+++ b/app/services/designator_client.rb
@@ -53,6 +53,15 @@ class DesignatorClient
     request(:get, [ url, params ])
   end
 
+  def add_seen_subjects(subject_ids, workflow_id, user_id)
+    request(:put, "/api/users/#{user_id}/add_seen_subjects") do |req|
+      req.body = {
+        workflow_id: workflow_id,
+        subject_ids: Array.wrap(subject_ids)
+      }.to_json
+    end
+  end
+
   private
 
   def request(http_method, params)

--- a/spec/services/designator_client_spec.rb
+++ b/spec/services/designator_client_spec.rb
@@ -107,37 +107,25 @@ RSpec.describe DesignatorClient do
       end
     end
 
-    describe "#add_seen_subjects" do
+    describe "#add_seen" do
       let(:params) do
-        { workflow_id: 338, subject_ids: [1,2,3] }
+        { workflow_id: 338, subject_id: 99 }
       end
       it 'returns a no-content response' do
         stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.put('/api/users/1/add_seen_subjects', params.to_json, headers) do |env|
+          stub.put('/api/users/1/add_seen_subject', params.to_json, headers) do |env|
             [204, {'Content-Type' => 'application/json'}, nil]
           end
         end
 
-        response = described_class.new([:test, stubs]).add_seen_subjects([1,2,3], 338, 1)
-        expect(response).to eq(nil)
-      end
-
-      it 'array wraps an integer subject_ids input' do
-        single_int_params = params.merge(subject_ids: [1])
-        stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.put('/api/users/1/add_seen_subjects', single_int_params.to_json, headers) do |env|
-            [204, {'Content-Type' => 'application/json'}, nil]
-          end
-        end
-
-        response = described_class.new([:test, stubs]).add_seen_subjects(1, 338, 1)
+        response = described_class.new([:test, stubs]).add_seen(338, 1, 99)
         expect(response).to eq(nil)
       end
 
       it_behaves_like "handles server errors" do
-        let(:method) { :add_seen_subjects }
-        let(:params) { [ [1,2,3], 338, 1] }
-        let(:url) { '/api/users/1/add_seen_subjects' }
+        let(:method) { :add_seen }
+        let(:params) { [338, 1, 99] }
+        let(:url) { '/api/users/1/add_seen_subject' }
         let(:http_method) { :put }
       end
     end

--- a/spec/services/designator_client_spec.rb
+++ b/spec/services/designator_client_spec.rb
@@ -106,5 +106,40 @@ RSpec.describe DesignatorClient do
         let(:http_method) { :post }
       end
     end
+
+    describe "#add_seen_subjects" do
+      let(:params) do
+        { workflow_id: 338, subject_ids: [1,2,3] }
+      end
+      it 'returns a no-content response' do
+        stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.put('/api/users/1/add_seen_subjects', params.to_json, headers) do |env|
+            [204, {'Content-Type' => 'application/json'}, nil]
+          end
+        end
+
+        response = described_class.new([:test, stubs]).add_seen_subjects([1,2,3], 338, 1)
+        expect(response).to eq(nil)
+      end
+
+      it 'array wraps an integer subject_ids input' do
+        single_int_params = params.merge(subject_ids: [1])
+        stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.put('/api/users/1/add_seen_subjects', single_int_params.to_json, headers) do |env|
+            [204, {'Content-Type' => 'application/json'}, nil]
+          end
+        end
+
+        response = described_class.new([:test, stubs]).add_seen_subjects(1, 338, 1)
+        expect(response).to eq(nil)
+      end
+
+      it_behaves_like "handles server errors" do
+        let(:method) { :add_seen_subjects }
+        let(:params) { [ [1,2,3], 338, 1] }
+        let(:url) { '/api/users/1/add_seen_subjects' }
+        let(:http_method) { :put }
+      end
+    end
   end
 end


### PR DESCRIPTION
Depends on https://github.com/zooniverse/designator/pull/86

This will allow a user's seen subjects for a workflow to sync between the panoptes and designator APIs. This works by extending the designator client `add_seen` API to match the public designator API added in https://github.com/zooniverse/designator/pull/86

This will be called each time a classification is received by worker https://github.com/zooniverse/Panoptes/blob/f039669292a9709ca83a9e7e382b6ce3c8da2c6b/app/workers/notify_subject_selector_of_seen_worker.rb which in turn calls the designator selector https://github.com/zooniverse/Panoptes/blob/f039669292a9709ca83a9e7e382b6ce3c8da2c6b/lib/subjects/designator_selector.rb#L15 to call this client method to call the remote API. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
