### PR TITLE
Catch NoMethodError when generating export

### DIFF
--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -189,6 +189,8 @@ module Formatter
          key == annotation["task"]
         end
         @task = task_annotation.try(:last) || {}
+      rescue NoMethodError
+        @task = {}
       end
     end
   end


### PR DESCRIPTION
`workflow_at_version` can be nil. I assume there is an underlying issue
that causes that, but this does not attempt to fix it.

Regardless of the underlying problem, the export should not silently
fail.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
