### PR TITLE
allow selector page size to be set from workflow configuration

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -44,7 +44,7 @@ class Workflow < ActiveRecord::Base
 
   JSON_ATTRIBUTES = %w(tasks retirement aggregation strings steps).freeze
 
-  SELECTOR_PAGE_SIZE_KEY = 'selector_page_size'.freeze
+  SELECTOR_PAGE_SIZE_KEY = 'subject_queue_page_size'.freeze
 
   # Used by HttpCacheable
   scope :private_scope, -> { where(project_id: Project.private_scope) }

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -44,6 +44,8 @@ class Workflow < ActiveRecord::Base
 
   JSON_ATTRIBUTES = %w(tasks retirement aggregation strings steps).freeze
 
+  SELECTOR_PAGE_SIZE_KEY = 'selector_page_size'.freeze
+
   # Used by HttpCacheable
   scope :private_scope, -> { where(project_id: Project.private_scope) }
 
@@ -161,5 +163,9 @@ class Workflow < ActiveRecord::Base
   def training_set_ids
     config_training_set_ids = Array.wrap(configuration.dig("training_set_ids"))
     config_training_set_ids.reject { |id| id.to_i.zero? }
+  end
+
+  def selector_page_size(default_page_size=10)
+    configuration.fetch(SELECTOR_PAGE_SIZE_KEY, default_page_size)
   end
 end

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -123,9 +123,12 @@ module Subjects
       MissingSubjects.new("No data available for selection")
     end
 
-    def subjects_page_size
-      page_size = params[:page_size] ? params[:page_size].to_i : 10
-      params.merge!(page_size: page_size)
+    def subjects_page_size(default_page_size=10)
+      page_size = (params[:page_size] || workflow.selector_page_size).to_i
+
+      # update the params as they flow through the system, i.e. to the serializer
+      params[:page_size] ||= page_size
+
       page_size
     end
 

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -124,7 +124,7 @@ module Subjects
     end
 
     def subjects_page_size(default_page_size=10)
-      page_size = (params[:page_size] || workflow.selector_page_size).to_i
+      page_size = (params[:page_size] || workflow.selector_page_size(default_page_size)).to_i
 
       # update the params as they flow through the system, i.e. to the serializer
       params[:page_size] ||= page_size

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -62,16 +62,49 @@ RSpec.describe Subjects::Selector do
         expect(subjects.length).to eq(10)
       end
 
-      context "when the params page size is set as a string" do
-        let(:size) { 2 }
-        subject do
-          params = { page_size: size, workflow_id: workflow.id }
-          described_class.new(user, params)
+      describe "page_size" do
+        context "when params is set as a string" do
+          let(:size) { 2 }
+          subject do
+            params = { page_size: size, workflow_id: workflow.id }
+            described_class.new(user, params)
+          end
+
+          it 'should return the page_size number of subjects' do
+            subjects = subject.get_subject_ids
+            expect(subjects.length).to eq(size)
+          end
         end
 
-        it 'should return the page_size number of subjects' do
-          subjects = subject.get_subject_ids
-          expect(subjects.length).to eq(size)
+        context "when the worfklow config has selector_page_size set" do
+          let(:params_page_size) { 2 }
+          let(:selector_page_size) { 1 }
+          let(:config) { { selector_page_size: selector_page_size }}
+          let(:workflow) do
+            create(:workflow_with_subject_set, configuration: config)
+          end
+
+          subject do
+            described_class.new(user, params)
+          end
+
+          context "when params page_size is missing" do
+            let(:params) { { workflow_id: workflow.id } }
+
+            it 'should respect the config page_size value' do
+              subjects = subject.get_subject_ids
+              expect(subjects.length).to eq(selector_page_size)
+            end
+          end
+
+          context "when params page_size is set" do
+            let(:params) { { page_size: params_page_size, workflow_id: workflow.id } }
+
+            it 'should respect the params page_size value' do
+              subjects = subject.get_subject_ids
+              expect(subjects.length).to eq(params_page_size)
+            end
+          end
         end
       end
     end

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe Subjects::Selector do
           end
         end
 
-        context "when the worfklow config has selector_page_size set" do
+        context "when the workflow config has subject_queue_page_size set" do
           let(:params_page_size) { 2 }
-          let(:selector_page_size) { 1 }
-          let(:config) { { selector_page_size: selector_page_size }}
+          let(:subject_queue_page_size) { 1 }
+          let(:config) { { subject_queue_page_size: subject_queue_page_size }}
           let(:workflow) do
             create(:workflow_with_subject_set, configuration: config)
           end
@@ -93,7 +93,7 @@ RSpec.describe Subjects::Selector do
 
             it 'should respect the config page_size value' do
               subjects = subject.get_subject_ids
-              expect(subjects.length).to eq(selector_page_size)
+              expect(subjects.length).to eq(subject_queue_page_size)
             end
           end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -474,7 +474,7 @@ describe Workflow, type: :model do
     end
 
     it "should respect the selector_page_size value in configuration" do
-      workflow.configuration['selector_page_size'] = 1
+      workflow.configuration['subject_queue_page_size'] = 1
       expect(workflow.selector_page_size).to eq(1)
     end
   end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -467,4 +467,15 @@ describe Workflow, type: :model do
       expect(workflow.non_training_subject_sets).to match_array(workflow.subject_sets)
     end
   end
+
+  describe "#selector_page_size" do
+    it "should default to 10" do
+      expect(workflow.selector_page_size).to eq(10)
+    end
+
+    it "should respect the selector_page_size value in configuration" do
+      workflow.configuration['selector_page_size'] = 1
+      expect(workflow.selector_page_size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Allow the selector page_size to be derived from the `workflow.configuration` object.

default is to respect the incoming `page_size` param value, then if `workflow.configuration['subject_queue_page_size']` and then a default value of 10 (current). 

The use case is from @hughdickinson, specifically some workflows need to select less than the default to ensure their expected training ratios are met.

this will allow a workflow configuration setting to set a default page size when requesting subjects.

The only issue i can see with this is more round trips to the selector for that workflow, especially once the user has seen past the point where they would receive training subjects. Perhaps we could do more introspection on the user seens but that would add more work into a critical path of the API. I'd appreciate folks thoughts on this.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
