### PR TITLE
Export catch nomethoderror

### DIFF
--- a/app/models/concerns/versioning.rb
+++ b/app/models/concerns/versioning.rb
@@ -34,10 +34,14 @@ module Versioning
     end
 
     if (changes.keys & self.class.versioned_attributes).present?
-      send(self.class.versioned_association).create!(
-        attributes.slice(*self.class.versioned_attributes)
-      )
+      build_version.save!
     end
+  end
+
+  def build_version
+    send(self.class.versioned_association).build(
+      attributes.slice(*self.class.versioned_attributes)
+    )
   end
 
   # take the highest associated version_id

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -189,6 +189,8 @@ module Formatter
          key == annotation["task"]
         end
         @task = task_annotation.try(:last) || {}
+      rescue NoMethodError
+        @task = {}
       end
     end
   end

--- a/lib/formatter/csv/annotation_for_csv.rb
+++ b/lib/formatter/csv/annotation_for_csv.rb
@@ -25,6 +25,9 @@ module Formatter
         else
           @annotation
         end
+      rescue ClassificationDumpCache::MissingWorkflowVersion => error
+        Honeybadger.notify(error, context: {classification_id: classification.id})
+        @annotation
       end
 
       private
@@ -189,8 +192,6 @@ module Formatter
          key == annotation["task"]
         end
         @task = task_annotation.try(:last) || {}
-      rescue NoMethodError
-        @task = {}
       end
     end
   end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -336,6 +336,15 @@ namespace :migrate do
       end
     end
 
+    desc 'backfill workflow versions for those workflows that have none'
+    task :backfill_missing_workflow_versions => :environment do
+      Workflow.find_each do |workflow|
+        if workflow.workflow_versions.count == 0
+          workflow.build_version.save!
+        end
+      end
+    end
+
     desc "Backfill org page versions"
     task :backfill_organization_page_versions => :environment do
       OrganizationPage.find_each do |org_page|

--- a/spec/lib/classification_dump_cache_spec.rb
+++ b/spec/lib/classification_dump_cache_spec.rb
@@ -6,13 +6,18 @@ describe ClassificationDumpCache do
     let(:workflow_version_1_2) { build(:workflow_version, major_number: 1, minor_number: 2) }
     let(:workflow_version_2_2) { build(:workflow_version, major_number: 2, minor_number: 2) }
     let(:workflow_version_3_3) { build(:workflow_version, major_number: 3, minor_number: 3) }
+    let(:workflow_version_6_6) { build(:workflow_version, major_number: 6, minor_number: 6) }
 
     let(:workflow) do
-      create :workflow, workflow_versions: [
-        workflow_version_1_2,
-        workflow_version_2_2,
-        workflow_version_3_3
-      ]
+      create :workflow,
+        major_version: 3,
+        minor_version: 3,
+        workflow_versions: [
+          workflow_version_1_2,
+          workflow_version_2_2,
+          workflow_version_3_3,
+          workflow_version_6_6
+        ]
     end
 
     it 'finds the workflow at the specific version' do
@@ -27,7 +32,16 @@ describe ClassificationDumpCache do
 
     it 'finds the latest version if requested version is newer than anything that exists' do
       cache = described_class.new
-      expect(cache.workflow_at_version(workflow, 4, 5)).to eq(workflow_version_3_3)
+      expect(cache.workflow_at_version(workflow, 7, 7)).to eq(workflow_version_6_6)
+    end
+
+    it 'returns the workflow itself if the requested version is the latest, but no WorkflowVersion record exists' do
+      workflow.workflow_versions.delete_all
+      cache = described_class.new
+      workflow_at_version = cache.workflow_at_version(workflow, 4, 4)
+      expect(workflow_at_version).to be_instance_of(WorkflowVersion)
+      expect(workflow_at_version.major_number).to eq(4)
+      expect(workflow_at_version.minor_number).to eq(4)
     end
   end
 end

--- a/spec/lib/formatter/csv/annotation_for_csv_spec.rb
+++ b/spec/lib/formatter/csv/annotation_for_csv_spec.rb
@@ -321,5 +321,21 @@ RSpec.describe Formatter::Csv::AnnotationForCsv do
         expect(formatted["value"]).to eq(["yes"])
       end
     end
+
+    context 'when the version cannot be loaded' do
+      before do
+        allow(cache).to receive(:workflow_at_version).and_raise(ClassificationDumpCache::MissingWorkflowVersion)
+      end
+
+      it 'should return the annotation without additional formatting' do
+        formatted = described_class.new(classification, annotation, cache).to_h
+        expect(formatted).to eq(annotation)
+      end
+
+      it 'should report to honeybadger' do
+        expect(Honeybadger).to receive(:notify).with(an_instance_of(ClassificationDumpCache::MissingWorkflowVersion), context: {classification_id: classification.id})
+        described_class.new(classification, annotation, cache).to_h
+      end
+    end
   end
 end


### PR DESCRIPTION
Continuing on @adammcmaster's work in https://github.com/zooniverse/Panoptes/pull/3161/files in addition to letting an export proceed in case the version can't be found, this branch will create a version on the fly if the requested version is the latest, but the WorkflowVersion for it doesn't exist. It will also ensure that Honeybadger is still notified in case of issues, even though we continue with the export.

I'm also adding a rake task to make sure that every workflow has at least a version for the current state (which would otherwise not be captured anywhere if someone classifies and then a project owner makes a change). **We should be run this as soon as possible.**

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
