### PR TITLE
allow cookie reuse across zooniverse subdomains

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,8 +1,14 @@
 # Be sure to restart your server when you modify this file.
 
+domain =
+  if %w(production staging).include?(Rails.env)
+    # allow zooniverse.org subdomains for staging & production
+    '.zooniverse.org'
+  else
+    # allow all subdomains for dev & test
+    :all
+  end
+
 Rails.application.config.session_store :cookie_store,
     key: '_Panoptes_session',
-    domain: {
-      production: '.zooniverse.org',
-      staging: '.zooniverse.org'
-    }.fetch(Rails.env.to_sym, :all)
+    domain: domain

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_Panoptes_session'
+Rails.application.config.session_store :cookie_store,
+    key: '_Panoptes_session',
+    domain: {
+      production: '.zooniverse.org',
+      staging: '.zooniverse.org'
+    }.fetch(Rails.env.to_sym, :all)


### PR DESCRIPTION
closes #3123 Allow cookies to be reused across subdomains as per https://github.com/plataformatec/devise/wiki/How-To:-Use-subdomains

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
