### PR TITLE
Revert "allow cookie reuse across zooniverse subdomains"

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,14 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-domain =
-  if %w(production staging).include?(Rails.env)
-    # allow zooniverse.org subdomains for staging & production
-    '.zooniverse.org'
-  else
-    # allow all subdomains for dev & test
-    :all
-  end
-
-Rails.application.config.session_store :cookie_store,
-    key: '_Panoptes_session',
-    domain: domain
+Rails.application.config.session_store :cookie_store, key: '_Panoptes_session'


### PR DESCRIPTION
Reverts zooniverse/Panoptes#3176

With this change when using staging API i get a cookie with domain `.zooniverse.org`, i then try to log into the production API and the browser sends both cookies due to the `.zooniverse.org`  domain matches and the server doesn't process them in any order, thus wiping any known state of the production session.

This is due to setting the cookie domain value to conflated value of `.zooniverse.org` for both staging and production domains. 

More details about this here
https://xebia.com/blog/caveats-and-pitfalls-of-cookie-domains/

Our current setup is conflated for domains. It may be that we can isolate our staging API and app subdomains completely but this might have other impacts, e.g. `.preview-zooniverse.org` or `zooniverse.dev`?

FWIW i considered isolating the API and staging apps to perhaps run on `*.preview.zooniverse.org` but I assume that will suffer the same issue where the subdomain cookies will also be sent.
