### PR TITLE
Revert "run subject cleanup worker when unlinking subjects from a set…

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -113,12 +113,9 @@ class Api::V1::SubjectSetsController < Api::ApiController
 
   def destroy_relation(resource, relation, value)
     if relation == :subjects
-      linked_subject_ids = value.split(',').map(&:to_i)
-      set_member_subjects = resource.set_member_subjects.where(subject_id: linked_subject_ids)
+      linked_sms_ids = value.split(',').map(&:to_i)
+      set_member_subjects = resource.set_member_subjects.where(subject_id: linked_sms_ids)
       remove_linked_set_member_subjects(set_member_subjects)
-      linked_subject_ids.each_with_index do |subject_id, index|
-        SubjectRemovalWorker.perform_in(index.seconds, subject_id)
-      end
     else
       super
     end

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -381,15 +381,6 @@ describe Api::V1::SubjectSetsController, type: :controller do
       end
 
       it_behaves_like "cleans up the linked set member subjects"
-
-      it 'should call the subject removal worker' do
-        sms.map(&:subject_id).each_with_index do |subject_id, index|
-          expect(SubjectRemovalWorker)
-            .to receive(:perform_in)
-            .with(index.seconds, subject_id)
-        end
-        delete_resources
-      end
     end
   end
 end


### PR DESCRIPTION
… (#3143)"

This reverts commit 426f33c42916706a40c923ba02b319b563bca15b.

closes #3181

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
