### PR TITLE
setup the test explicitly

### DIFF
--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -4,16 +4,26 @@ RSpec.describe SubjectMetadataWorker do
   let(:user) { create :user }
   let(:project) { create :project_with_workflow, owner: user }
   let(:workflow) { project.workflows.first }
+  let(:subject_one) do
+    create(:subject, project: project, uploader: project.owner, metadata: {'#priority'=>1/3.0})
+  end
+  let(:subject_two) do
+    create(:subject, project: project, uploader: project.owner, metadata: {'#priority'=>'2'})
+  end
   let(:subject_set) do
-    create(:subject_set_with_subjects, num_subjects: 3, project: project, workflows: [workflow])
+    create(
+      :subject_set_with_subjects,
+      num_subjects: 1,
+      project: project,
+      workflows: [workflow],
+      subjects: [subject_one, subject_two]
+    )
   end
 
   subject(:worker) { SubjectMetadataWorker.new }
 
   before do
-    subject_set.subjects[0].metadata['#priority'] = 1/3.0
-    subject_set.subjects[1].metadata['#priority'] = "2"
-    subject_set.subjects.map(&:save)
+    subject_set.subjects.reload
   end
 
   describe "#perform" do


### PR DESCRIPTION
try to avoid tranasction races for intermittent failing specs. 

I'm not sure this will fix it but i can't see how the `ActiveRecord::Base.connection.exec_update` statement doesn't block to get the return val of num rows updated, hence i've tried to ensure the tests have the state setup when creating the subject resources before running each test.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
