### PR TITLE
raise errors for 4xx and 5xx HTTP status codes for talk api

### DIFF
--- a/app/services/talk_api_client.rb
+++ b/app/services/talk_api_client.rb
@@ -65,6 +65,7 @@ class TalkApiClient
     @connection = Faraday.new host do |faraday|
       faraday.response :json, content_type: /\bjson$/
       faraday.use :http_cache, store: Rails.cache, logger: Rails.logger
+      faraday.use Faraday::Response::RaiseError
       faraday.adapter(*adapter)
     end
   end

--- a/spec/services/talk_api_client_spec.rb
+++ b/spec/services/talk_api_client_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TalkApiClient do
   context "instance methods" do
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.get('/error') do env
+        stub.get('/error') do |env|
           [404,
            {'Content-Type' => 'application/vnd.api+json'},
            {errors: [message: "Not Found"]}.to_json
@@ -71,7 +71,7 @@ RSpec.describe TalkApiClient do
       end
 
       it 'should raise an error on failure' do
-        expect{subject.request('get', '/error')}.to raise_error(NameError)
+        expect{subject.request('get', '/error')}.to raise_error(Faraday::ResourceNotFound)
       end
     end
 


### PR DESCRIPTION
Get error reports and retries via sidekiq when HTTP connection errors for project talk role creation.

This should ensure we don't leave project teams without talk roles

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
