### PR TITLE
create a project's missing primary language translations

### DIFF
--- a/lib/tasks/translations.rake
+++ b/lib/tasks/translations.rake
@@ -12,7 +12,7 @@ namespace :translations do
       # get the current resource primary language strings
       translated_strings = TranslationStrings.new(resource).extract
       # make sure they end up in a translation model with the correct version resources
-      translation.update_strings_and_versions(translated_strings, translated_resource.latest_version_id)
+      translation.update_strings_and_versions(translated_strings, resource.latest_version_id)
       translation.save!
     else
       false

--- a/lib/tasks/translations.rake
+++ b/lib/tasks/translations.rake
@@ -1,50 +1,72 @@
+# frozen_string_literal: true
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
 namespace :translations do
 
-  def create_or_update_translation_strings(resource, language)
+  def create_missing_translation_strings(resource, language)
+    # do we have any existing translation for the project's primary language
     translation = Translation.find_or_initialize_by(translated: resource, language: language)
-    translated_strings = TranslationStrings.new(resource).extract
-    translation.strings = translated_strings
-    translation.save!
+    if translation.new_record?
+      # get the current resource primary language strings
+      translated_strings = TranslationStrings.new(resource).extract
+      # make sure they end up in a translation model with the correct version resources
+      translation.update_strings_and_versions(translated_strings, translated_resource.latest_version_id)
+      translation.save!
+    else
+      false
+    end
   end
 
-  desc "Sync existing translatable resources with new translations data model"
-  task :sync_resource_strings, [:project_id] => [:environment] do |task, args|
-    project = Project.find(args[:project_id])
-    language = project.primary_language
+  desc "Sync a project's missing primary language translations"
+  # call this with param sytnax
+  # rake translations:sync_projects_missing_primary_lanugage_translations['1 2 3 4']
+  # or
+  # rake translations:sync_projects_missing_primary_lanugage_translations[1,2,3,4]
+  # or
+  # rake translations:sync_projects_missing_primary_lanugage_translations['1 2',3,4]
+  task :sync_projects_missing_primary_lanugage_translations, [:project_ids] => [:environment] do |task, args|
+    space_format_ids = args.project_ids.split
+    extra_format_ids = args.extras
+    project_ids = space_format_ids | extra_format_ids
 
-    puts "Syncing project - #{project.id} strings to translations"
-    create_or_update_translation_strings(project, language)
+    project_ids.each do |project_id|
+      project = Project.find(project_id)
 
-    puts "Syncing all project workflow strings to translations"
-    project.workflows.each do |workflow|
-      create_or_update_translation_strings(workflow, language)
-    end
+      primary_language = project.primary_language
 
-    puts "Syncing all project field guide strings to translations"
-    project.field_guides.each do |field_guide|
-      create_or_update_translation_strings(field_guide, language)
-    end
+      puts "Syncing project - #{project.id} strings to translations"
+      puts create_missing_translation_strings(project, primary_language)
 
-    puts "Syncing all project tutorial strings to translations"
-    project.tutorials.each do |tutorial|
-      create_or_update_translation_strings(tutorial, language)
-    end
+      puts 'Syncing all project workflow strings to translations'
+      project.workflows.each do |workflow|
+        puts create_missing_translation_strings(workflow, primary_language)
+      end
 
-    puts "Syncing all project page strings to translations"
-    project.pages.each do |page|
-      create_or_update_translation_strings(page, language)
-    end
+      puts 'Syncing all project field guide strings to translations'
+      project.field_guides.each do |field_guide|
+        puts create_missing_translation_strings(field_guide, primary_language)
+      end
 
-    if organization = project.organization
-      puts "Syncing project organization strings to translations"
-      create_or_update_translation_strings(organization, language)
+      puts 'Syncing all project tutorial strings to translations'
+      project.tutorials.each do |tutorial|
+        puts create_missing_translation_strings(tutorial, primary_language)
+      end
 
-      puts "Syncing project organization page strings to translations"
-      organization.pages.each do |page|
-        create_or_update_translation_strings(page, language)
+      puts 'Syncing all project page strings to translations'
+      project.pages.each do |page|
+        puts create_missing_translation_strings(page, primary_language)
+      end
+
+      if organization = project.organization
+        puts 'Syncing project organization strings to translations'
+        puts create_missing_translation_strings(organization, primary_language)
+
+        puts 'Syncing project organization page strings to translations'
+        organization.pages.each do |page|
+          puts create_missing_translation_strings(page, primary_language)
+        end
       end
     end
   end

--- a/lib/tasks/translations.rake
+++ b/lib/tasks/translations.rake
@@ -59,14 +59,15 @@ namespace :translations do
         puts create_missing_translation_strings(page, primary_language)
       end
 
-      if organization = project.organization
-        puts 'Syncing project organization strings to translations'
-        puts create_missing_translation_strings(organization, primary_language)
+      organization = project.organization
+      next unless organization
 
-        puts 'Syncing project organization page strings to translations'
-        organization.pages.each do |page|
-          puts create_missing_translation_strings(page, primary_language)
-        end
+      puts 'Syncing project organization strings to translations'
+      puts create_missing_translation_strings(organization, primary_language)
+
+      puts 'Syncing project organization page strings to translations'
+      organization.pages.each do |page|
+        puts create_missing_translation_strings(page, primary_language)
       end
     end
   end


### PR DESCRIPTION
modify translations rake task to setup any missing primary language translation resources for project and linked resources (field guides, tutorials, workflows, pages, etc)

Some projects have not been edited in the project builder and we've never backfilled the primary language translation resources, this rake task will help fill them in.

Call the rake task with the offending project ids like so:
```
rake translations:sync_projects_missing_primary_lanugage_translations['1 2 3 4']
# or
rake translations:sync_projects_missing_primary_lanugage_translations[1,2,3,4]
# or
rake translations:sync_projects_missing_primary_lanugage_translations['1 2',3,4]
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
