### PR TITLE
remove jemalloc from dev docker file

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get -y upgrade && \
     libpq-dev \
     postgresql-client-9.4 \
     tmpreaper \
-    libjemalloc1 \
     && \
     apt-get clean
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,8 +19,6 @@ RUN apt-get update && apt-get -y upgrade && \
     && \
     apt-get clean
 
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
-
 ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 


### PR DESCRIPTION
closes #3197 we don't need the jemalloc memory allocator in the develoment mode

using the latest ruby image uses a different debian version (buster) and thus changes the underlying version of jemalloc (v5) so our install fails.

Pros: dev docker file works on latest debian, `docker-compose up` works again
Cons: underlying dev debian version differs from staging / production, and we use a different memory allocator (ruby default). 

see https://github.com/zooniverse/Panoptes/issues/3197#issuecomment-553839050 for links / more details on the allocator tradeoffs and performance of jemalloc versions in ruby.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
