### PR TITLE
Add credentials to resource options when loading Rack::Cors middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,8 @@ module Panoptes
             headers: Panoptes.cors_config.headers,
             methods: Panoptes.cors_config.request_methods,
             expose: Panoptes.cors_config.expose,
-            max_age: Panoptes.cors_config.max_age
+            max_age: Panoptes.cors_config.max_age,
+            credentials: allow_config["credentials"]
         end
       end
     end


### PR DESCRIPTION
Adding `credentials: true` to the cors_config.yml doesn't mean much if it's ignored by Panoptes and Rack::Cors when Rails loads. Without trying to build that resources call conditionally, though, this will add `credentials: nil` to every allow that doesn't have it. But I think that'll translate to `credentials: false` (the new default), which is what it should be anyway.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
