### PR TITLE
remove old authorization code

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -17,10 +17,6 @@ class Membership < ActiveRecord::Base
     joins(@parent).where(state: states[:active]).merge(parent_class.public_scope)
   }
 
-  def self.joins_for
-    @parent
-  end
-
   def disable!
     inactive!
   end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -32,25 +32,6 @@ class UserGroup < ActiveRecord::Base
     using: :trigram,
     ranked_by: ":trigram"
 
-  def self.memberships_query(action, target)
-    target.memberships_for(action)
-  end
-
-  def self.joins_for
-    :memberships
-  end
-
-  def self.private_query(action, target, roles)
-    joins(:memberships).merge(target.memberships_for(action, self))
-      .where(memberships: { identity: false })
-  end
-
-  def self.user_can_access_scope(private_query, public_flag)
-    scope = where(id: private_query.select(:id))
-    scope = scope.or(public_scope) if public_flag
-    scope
-  end
-
   def self.roles_allowed_to_access(action, klass=nil)
     roles = case action
             when :show, :index


### PR DESCRIPTION
Remove dead authorization code - some of this is very old, others has moved to *_policy.rb code. I found this code when reviewing the state of #3165 for merge.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
