### PR TITLE
Scope SubjectMetadataWorker updates to know subjects and sets

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -104,7 +104,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
       end
 
       result = SetMemberSubject.import IMPORT_COLUMNS, new_sms_values, validate: false
-      SubjectMetadataWorker.perform_async(resource.id)
+      SubjectMetadataWorker.perform_async(subject_ids_to_link)
       result
     else
       super

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -104,7 +104,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
       end
 
       result = SetMemberSubject.import IMPORT_COLUMNS, new_sms_values, validate: false
-      SubjectMetadataWorker.perform_async(subject_ids_to_link)
+      SubjectMetadataWorker.perform_async(resource.id, subject_ids_to_link)
       result
     else
       super

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -104,7 +104,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
       end
 
       result = SetMemberSubject.import IMPORT_COLUMNS, new_sms_values, validate: false
-      SubjectMetadataWorker.perform_async(resource.id, subject_ids_to_link)
+      SubjectMetadataWorker.perform_async(result.ids)
       result
     else
       super

--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -15,7 +15,7 @@ class SubjectMetadataWorker
       SQL
       ActiveRecord::Base.connection.exec_update(
         update_sms_priority_sql,
-        "SQL",
+        'SQL',
         [[nil, subject_set_id], [nil, subject_ids]]
       )
     else
@@ -40,7 +40,7 @@ class SubjectMetadataWorker
       )
       ActiveRecord::Base.connection.exec_update(
         bound_update_sms_priority_sql,
-        "SQL",
+        'SQL',
         []
       )
     end

--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -11,7 +11,6 @@ class SubjectMetadataWorker
         FROM   subjects
         WHERE  subjects.id = set_member_subjects.subject_id
         AND    subjects.metadata ? '#priority'
-        AND    set_member_subjects.priority IS NULL
         AND    set_member_subjects.id IN $1
       SQL
       ActiveRecord::Base.connection.exec_update(
@@ -26,7 +25,6 @@ class SubjectMetadataWorker
         FROM   subjects
         WHERE  subjects.id = set_member_subjects.subject_id
         AND    subjects.metadata ? '#priority'
-        AND    set_member_subjects.priority IS NULL
         AND    set_member_subjects.id IN (:sms_ids)
       SQL
       # handle incorrect bind params for non preparted statements

--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -1,7 +1,7 @@
 class SubjectMetadataWorker
   include Sidekiq::Worker
 
-  def perform(subject_set_id)
+  def perform(subject_set_id, subject_ids)
     if ActiveRecord::VERSION::MAJOR == 5
       update_sms_priority_sql = <<-SQL
         UPDATE set_member_subjects
@@ -9,12 +9,14 @@ class SubjectMetadataWorker
         FROM   subjects
         WHERE  subjects.id = set_member_subjects.subject_id
         AND    subjects.metadata ? '#priority'
-        AND    set_member_subjects.subject_set_id = $1
+        AND    set_member_subjects.priority IS NULL
+        AND    set_member_subjects.subject_set_id IN $1
+        AND    set_member_subjects.subject_id IN $2
       SQL
       ActiveRecord::Base.connection.exec_update(
         update_sms_priority_sql,
         "SQL",
-        [[nil, subject_set_id]]
+        [[nil, subject_set_id], [nil, subject_ids]]
       )
     else
       update_sms_priority_sql = <<-SQL
@@ -23,7 +25,9 @@ class SubjectMetadataWorker
         FROM   subjects
         WHERE  subjects.id = set_member_subjects.subject_id
         AND    subjects.metadata ? '#priority'
+        AND    set_member_subjects.priority IS NULL
         AND    set_member_subjects.subject_set_id = :subject_set_id
+        AND    set_member_subjects.subject_id IN (:subject_ids)
       SQL
       # handle incorrect bind params for non preparted statements
       # in exec_update, fixed in rails 5
@@ -32,7 +36,7 @@ class SubjectMetadataWorker
       bound_update_sms_priority_sql = ActiveRecord::Base.send(
         :replace_named_bind_variables,
         update_sms_priority_sql,
-        {subject_set_id: subject_set_id}
+        subject_ids: subject_ids, subject_set_id: subject_set_id
       )
       ActiveRecord::Base.connection.exec_update(
         bound_update_sms_priority_sql,

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -157,7 +157,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
       it "should queue the SMS metadata worker" do
         expect(SubjectMetadataWorker)
           .to receive(:perform_async)
-          .with(kind_of(Numeric))
+          .with(subjects.map(&:id))
         run_update_links
       end
 

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -155,9 +155,16 @@ describe Api::V1::SubjectSetsController, type: :controller do
       end
 
       it "should queue the SMS metadata worker" do
+        fake_sms_ids = ["1318", "1319", "1320", "1321"]
+        import_result_double = instance_double(
+          'ActiveRecord::Import::Result',
+          num_inserts: 1,
+          ids: fake_sms_ids
+        )
+        allow(SetMemberSubject).to receive(:import).and_return(import_result_double)
         expect(SubjectMetadataWorker)
           .to receive(:perform_async)
-          .with(resource.id, subjects.map(&:id))
+          .with(fake_sms_ids)
         run_update_links
       end
 

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -157,7 +157,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
       it "should queue the SMS metadata worker" do
         expect(SubjectMetadataWorker)
           .to receive(:perform_async)
-          .with(subjects.map(&:id))
+          .with(resource.id, subjects.map(&:id))
         run_update_links
       end
 

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -154,7 +154,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
         run_update_links
       end
 
-      it "should queue the SMS metadata worker", :focus do
+      it "should queue the SMS metadata worker" do
         fake_sms_ids = %w[1318 1319 1320 1321]
         import_result_double = instance_double(
           'ActiveRecord::Import::Result',

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -154,8 +154,8 @@ describe Api::V1::SubjectSetsController, type: :controller do
         run_update_links
       end
 
-      it "should queue the SMS metadata worker" do
-        fake_sms_ids = ["1318", "1319", "1320", "1321"]
+      it "should queue the SMS metadata worker", :focus do
+        fake_sms_ids = %w[1318 1319 1320 1321]
         import_result_double = instance_double(
           'ActiveRecord::Import::Result',
           num_inserts: 1,

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe SubjectMetadataWorker do
       subjects: [subject_one, subject_two]
     )
   end
-  let(:subject_ids_from_set) do
-    subject_set.subject_ids
+  let(:set_member_subject_ids) do
+    subject_set.set_member_subject_ids
   end
 
   subject(:worker) { SubjectMetadataWorker.new }
@@ -39,13 +39,13 @@ RSpec.describe SubjectMetadataWorker do
         .with(
           instance_of(String),
           'SQL',
-          [[nil, subject_set.id], [nil, subject_ids_from_set]]
+          [[nil, set_member_subject_ids]]
         )
-      worker.perform(subject_set.id, subject_ids_from_set)
+      worker.perform(set_member_subject_ids)
     end
 
     it 'copies priority from metadata to SMS attribute' do
-      worker.perform(subject_set.id, subject_ids_from_set)
+      worker.perform(set_member_subject_ids)
       sms_one, sms_two, sms_three = SetMemberSubject.find(
         subject_set.set_member_subject_ids
       ).sort_by(&:id)

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe SubjectMetadataWorker do
       subjects: [subject_one, subject_two]
     )
   end
+  let(:subject_ids_from_set) do
+    subject_set.subject_ids
+  end
 
   subject(:worker) { SubjectMetadataWorker.new }
 
@@ -33,12 +36,16 @@ RSpec.describe SubjectMetadataWorker do
       stub_const("ActiveRecord::VERSION::MAJOR", 5)
       expect(ActiveRecord::Base.connection)
         .to receive(:exec_update)
-        .with(instance_of(String), "SQL",[[nil, subject_set.id]])
-      worker.perform(subject_set.id)
+        .with(
+          instance_of(String),
+          "SQL",
+          [[nil, subject_set.id], [nil, subject_ids_from_set]]
+        )
+      worker.perform(subject_set.id, subject_ids_from_set)
     end
 
     it 'copies priority from metadata to SMS attribute' do
-      worker.perform(subject_set.id)
+      worker.perform(subject_set.id, subject_ids_from_set)
       sms_one, sms_two, sms_three = SetMemberSubject.find(
         subject_set.set_member_subject_ids
       ).sort_by(&:id)

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SubjectMetadataWorker do
         .to receive(:exec_update)
         .with(
           instance_of(String),
-          "SQL",
+          'SQL',
           [[nil, subject_set.id], [nil, subject_ids_from_set]]
         )
       worker.perform(subject_set.id, subject_ids_from_set)


### PR DESCRIPTION
This PR changes the scope of each called worker to be idempotent and targets the update queries to known set_member_subject records. It will now also avoid clobbering any previously set priority values and thus avoid update rows where possible.

Current code flow means that anytime we add subjects to a set we queue a worker to update all the SMS records for the known set. For a large set upload this can leave us with blocking updates via concurrent workers. This PR should avoid these issues via more selective worker update queries.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
