### PR TITLE
allow externally hosted media resources on create

### DIFF
--- a/app/schemas/medium_create_schema.rb
+++ b/app/schemas/medium_create_schema.rb
@@ -13,6 +13,10 @@ class MediumCreateSchema < JsonSchema
       type "boolean"
     end
 
+    property "src" do
+      type "string"
+    end
+
     property "metadata" do
       type "object"
     end

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
           expect(json_response["media"][0]["src"]).to eq(new_resource.put_url)
         end
 
-        describe "uploding externally hosted media resources" do
+        describe 'uploading externally hosted media resources' do
           let(:external_media_payload) do
             {
               media: {

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -251,6 +251,30 @@ RSpec.describe Api::V1::MediaController, type: :controller do
           expect(json_response["media"][0]["src"]).to eq(new_resource.put_url)
         end
 
+        describe "uploding externally hosted media resources" do
+          let(:external_media_payload) do
+            {
+              media: {
+                content_type: "image/jpeg",
+                external_link: true,
+                src: 'https://example.com/test.jpeg',
+                metadata: { filename: "image.png" }
+              },
+              :"#{parent_name}_id" => parent.id,
+              media_name: media_type
+            }
+          end
+
+          it "should create an externally hosted media resource" do
+            default_request user_id: authorized_user.id, scopes: scopes
+            post :create, external_media_payload
+            media_location = json_response["media"][0]["src"]
+            expect(media_location).to eq(
+              external_media_payload.dig(:media, :src)
+            )
+          end
+        end
+
         describe "updates relationship" do
           before(:each) do
             default_request user_id: authorized_user.id, scopes: scopes


### PR DESCRIPTION
Allow externally hosted media resources to specify their src URL on create actions. Pinging @adammcmaster 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
