### PR TITLE
check the sms resources exist attempting an update

### DIFF
--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -10,7 +10,7 @@ class SubjectMetadataWorker
     if ActiveRecord::VERSION::MAJOR == 5
       run_ar5_update
     else
-      run_ar_4_update
+      run_ar4_update
     end
   end
 
@@ -42,7 +42,7 @@ class SubjectMetadataWorker
     )
   end
 
-  def run_ar_4_update
+  def run_ar4_update
     update_sms_priority_sql =
       <<-SQL
         UPDATE set_member_subjects

--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -1,11 +1,33 @@
 class SubjectMetadataWorker
   include Sidekiq::Worker
+  attr_reader :sms_ids
 
   def perform(sms_ids)
     return if Panoptes.flipper[:skip_subject_metadata_worker].enabled?
 
+    @sms_ids = sms_ids
+    check_sms_resources_exist
     if ActiveRecord::VERSION::MAJOR == 5
-      update_sms_priority_sql = <<-SQL
+      run_ar5_update
+    else
+      run_ar_4_update
+    end
+  end
+
+  private
+
+  def check_sms_resources_exist
+    return if SetMemberSubject.exists?(id: sms_ids)
+
+    raise(
+      ActiveRecord::RecordNotFound,
+      "Couldn't find all SetMemberSubjects with 'id': (#{sms_ids.join(',')})"
+    )
+  end
+
+  def run_ar5_update
+    update_sms_priority_sql =
+      <<-SQL
         UPDATE set_member_subjects
         SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
         FROM   subjects
@@ -13,13 +35,16 @@ class SubjectMetadataWorker
         AND    subjects.metadata ? '#priority'
         AND    set_member_subjects.id IN $1
       SQL
-      ActiveRecord::Base.connection.exec_update(
-        update_sms_priority_sql,
-        'SQL',
-        [[nil, sms_ids]]
-      )
-    else
-      update_sms_priority_sql = <<-SQL
+    ActiveRecord::Base.connection.exec_update(
+      update_sms_priority_sql,
+      'SQL',
+      [[nil, sms_ids]]
+    )
+  end
+
+  def run_ar_4_update
+    update_sms_priority_sql =
+      <<-SQL
         UPDATE set_member_subjects
         SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
         FROM   subjects
@@ -27,20 +52,19 @@ class SubjectMetadataWorker
         AND    subjects.metadata ? '#priority'
         AND    set_member_subjects.id IN (:sms_ids)
       SQL
-      # handle incorrect bind params for non preparted statements
-      # in exec_update, fixed in rails 5
-      # https://github.com/rails/rails/issues/24893
-      # https://github.com/rails/rails/issues/34183
-      bound_update_sms_priority_sql = ActiveRecord::Base.send(
-        :replace_named_bind_variables,
-        update_sms_priority_sql,
-        sms_ids: sms_ids
-      )
-      ActiveRecord::Base.connection.exec_update(
-        bound_update_sms_priority_sql,
-        'SQL',
-        []
-      )
-    end
+    # handle incorrect bind params for non preparted statements
+    # in exec_update, fixed in rails 5
+    # https://github.com/rails/rails/issues/24893
+    # https://github.com/rails/rails/issues/34183
+    bound_update_sms_priority_sql = ActiveRecord::Base.send(
+      :replace_named_bind_variables,
+      update_sms_priority_sql,
+      sms_ids: sms_ids
+    )
+    ActiveRecord::Base.connection.exec_update(
+      bound_update_sms_priority_sql,
+      'SQL',
+      []
+    )
   end
 end

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -60,5 +60,12 @@ RSpec.describe SubjectMetadataWorker do
       expect(sms_two.priority).to eq(2)
       expect(sms_three.priority).to be_nil
     end
+
+    it 'raises not found if the SMS resources do not exist' do
+      non_existant_ids = (1..3).to_a - set_member_subject_ids
+      expect {
+        worker.perform(non_existant_ids)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 end


### PR DESCRIPTION
SetMemberSubject (sms) resources are created in a transaction via [add_relation](https://github.com/zooniverse/Panoptes/blob/1fbc53d2ca2feddf14f24437fe5babd69ebd2507/app/controllers/api/v1/subject_sets_controller.rb#L106) and straight after this worker is fired. 

DB isolation levels mean that this worker will most likely run before the transaction is committed, thus the sms record won't be visible to the update statement resulting in no actual updates and the priority field not propagating to the sms record or the selector services. Thanks to @hughdickinson for finding this bug.

This PR will ensure we raise the error and use sidekiqs retry attempts to re-reun the update after transaction commit.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
