### PR TITLE
change assets pipeline prefix path

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,10 @@ Rails.application.configure do
   config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
+  # use a non-default path to provide unique paths for use behind CDNs
+  # E.g. avoid clashes with the PFE UI code uses as it uses '/assets'
+  config.assets.prefix = '/api-assets'
+
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -26,6 +26,10 @@ Rails.application.configure do
   config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
+  # use a non-default path to provide unique paths for use behind CDNs
+  # E.g. avoid clashes with the PFE UI code uses as it uses '/assets'
+  config.assets.prefix = '/api-assets'
+
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
Linked to https://github.com/zooniverse/operations/pull/295 and https://github.com/zooniverse/operations/pull/296 

Use a different asset prefix to avoid clashes with PFE UI assets paths. This can then be used behind a CDN to appear as hosted on the origin domain

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
