### PR TITLE
Add project status to the cards route

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -25,6 +25,8 @@ class Api::V1::ProjectsController < Api::ApiController
                  :avatar_src,
                  :classifications_count,
                  :updated_at,
+                 :state,
+                 :completeness,
                  :launch_approved].freeze
 
   prepend_before_action :require_login,

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -106,7 +106,7 @@ describe Api::V1::ProjectsController, type: :controller do
         describe "cards only" do
           let(:index_options) { { cards: true } }
           let(:card_attrs) do
-            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at", "classifications_count", "launch_approved"]
+            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at", "classifications_count", "launch_approved", "state", "completeness"]
           end
 
           it "should return only serialise the card data" do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -106,7 +106,7 @@ describe Api::V1::ProjectsController, type: :controller do
         describe "cards only" do
           let(:index_options) { { cards: true } }
           let(:card_attrs) do
-            ["id", "display_name", "description", "slug", "redirect", "avatar_src", "links", "updated_at", "classifications_count", "launch_approved", "state", "completeness"]
+            %w(id display_name description slug redirect avatar_src links updated_at classifications_count launch_approved state completeness)
           end
 
           it "should return only serialise the card data" do


### PR DESCRIPTION
Add `project.status` and `project.completeness` to the fields returned by `/projects?cards=true`.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
