### PR TITLE
remove reference to Cellect::Client gem

### DIFF
--- a/config/initializers/cellect.rb
+++ b/config/initializers/cellect.rb
@@ -1,4 +1,0 @@
-cellect_timeout = ENV["CELLECT_HTTP_TIMEOUT"].to_f
-if cellect_timeout != 0.0
-  Cellect::Client::Connection.timeout = cellect_timeout
-end


### PR DESCRIPTION
missed this in #3259 remove the initializer ref to the cellect client gem

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
