### PR TITLE
add json encoding middleware for requests payloads to cellect client

### DIFF
--- a/app/services/cellect_client.rb
+++ b/app/services/cellect_client.rb
@@ -73,6 +73,7 @@ module CellectClient
 
     def connect!(adapter, host)
       Faraday.new(host, ssl: { verify: false }) do |faraday|
+        faraday.request :json
         faraday.response :json, content_type: /\bjson$/
         faraday.adapter(*adapter)
       end

--- a/spec/services/cellect_client_spec.rb
+++ b/spec/services/cellect_client_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe CellectClient::Request do
       }
     end
 
+    it 'adds connection middleware for json encoding and decoding' do
+      middleware = described_class.new.connection.builder.handlers
+      expected = [FaradayMiddleware::EncodeJson, FaradayMiddleware::ParseJson]
+      expect(middleware).to include(*expected)
+    end
+
     it 'sends get request to the remote host' do
       path = '/api/path/on/host'
       host_url_path = "#{url}#{path}"


### PR DESCRIPTION
ensure the cellect faraday client can encode the payload params to json correctly

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
