### PR TITLE
remove unsued db compose file

### DIFF
--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -1,9 +1,0 @@
-postgres:
-  image: postgres:9.4
-  environment:
-    - "POSTGRES_USER=panoptes"
-    - "POSTGRES_PASSWORD=panoptes"
-  ports:
-    - "5432:5432"
-
-


### PR DESCRIPTION
Remove the old compose file for running just the db. This is out of date with the pg version and i don't think anyone uses it. An alternative way to run the db is specified in the readme, 
```
Run docker-compose run -d --name postgres --service-ports postgres to start the postgres container
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
