### PR TITLE
remove featured uniqueness constraint on projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,8 +54,6 @@ class Project < ActiveRecord::Base
 
   validates_inclusion_of :private, :live, in: [true, false], message: "must be true or false"
 
-  validates :featured, uniqueness: {conditions: -> { featured } }
-
   ## TODO: This potential has locking issues
   validates_with UniqueForOwnerValidator
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -69,7 +69,6 @@ describe Project, type: :model do
     end
 
     it 'can be featured' do
-      create :project, featured: true
       expect(described_class.featured).to eq([featured_project])
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -64,16 +64,18 @@ describe Project, type: :model do
   end
 
   describe 'featured projects' do
+    let(:featured_project) do
+      create :project, featured: true
+    end
     it 'can be featured' do
-      project = create :project, featured: true
-      expect(Project.featured).to eq([project])
+      create :project, featured: true
+      expect(Project.featured).to eq([featured_project])
     end
 
-    it 'only allows one featured project at a time' do
-      featured_project = create :project, featured: true
+    it 'allows more than one featured project at a time' do
+      featured_project
       other_project = build :project, featured: true
-      expect(other_project).not_to be_valid
-      expect(other_project.errors[:featured]).to be_present
+      expect(other_project).to be_valid
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -67,9 +67,10 @@ describe Project, type: :model do
     let(:featured_project) do
       create :project, featured: true
     end
+
     it 'can be featured' do
       create :project, featured: true
-      expect(Project.featured).to eq([featured_project])
+      expect(described_class.featured).to eq([featured_project])
     end
 
     it 'allows more than one featured project at a time' do


### PR DESCRIPTION
support more featured projects, specifically by allowing more than 1 project to be featured at the API

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
