### PR TITLE
add statement_timeout to db template

### DIFF
--- a/config/database.yml.hudson
+++ b/config/database.yml.hudson
@@ -8,6 +8,9 @@ default: &default
   pool: 5
   port: 5432
   prepared_statements: false
+  variables:
+    # default 5 minutes for the query exectution (sidekiq uses default, API will set the env param match load balancer)
+    statement_timeout: <%= ENV.fetch('PG_STATEMENT_TIMEOUT', 300000) %>
 
 development:
   <<: *default


### PR DESCRIPTION
record the config we are using to timeout long sql queries at the db connection layer

I'm going to update our system database.yaml to include this config. The plan is to set the ENV variable for API nodes to just longer than the load balancer (60s). As the loadbalancer will terminate connections that surpass the timeout, we can safely cancel the db queries as the results won't make it to the client.

The 5min (300000ms) value here is for sidekiq and should handle any long running queries in this env. This default can be changed via ENV vars if needed.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
