### PR TITLE
add flipper experiement for db preloading on project

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -24,18 +24,16 @@ class ProjectSerializer
   can_sort_by :launch_date, :activity, :completeness, :classifiers_count,
     :updated_at, :display_name
 
-  preload :workflows,
-    :active_workflows,
-    :subject_sets,
-    :project_roles,
-    [ owner: { identity_membership: :user } ],
-    :pages,
-    :attached_images,
-    :avatar,
-    :background,
-    :tags,
-    :classifications_export,
-    :subjects_export
+  preload :subject_sets,
+          :project_roles,
+          [owner: { identity_membership: :user }],
+          :pages,
+          :attached_images,
+          :avatar,
+          :background,
+          :tags,
+          :classifications_export,
+          :subjects_export
 
   def self.page(params = {}, scope = nil, context = {})
     if Project.states.include?(params["state"])
@@ -56,6 +54,12 @@ class ProjectSerializer
     if context[:cards]
       scope.preload(:avatar)
     else
+      # this is an experiement to see if the workflow association
+      # preload is causing high CPU
+      # if this lingers past 2nd April 2020 - remove it and the flipper key
+      if Panoptes.flipper[:test_preload_workflow_associations].enabled?
+        scope = scope.preload(:workflows, :active_workflows)
+      end
       super(params, scope, context)
     end
   end


### PR DESCRIPTION
fallback to N+1 loading the workflow* association ids vs preloading the workflow data to then throw it away. this should allow us to test the association pressure on the db using flipper and view the results in new relic etc

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
