### PR TITLE
add custom workflows preloading project serializer

### DIFF
--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -66,23 +66,31 @@ class ProjectSerializer
   # instead load the data required for serializing
   # the project and links
   def self.serialize_page(page, options)
-    project_ids = page.pluck(:id)
-    preloadable_workflows = preload_workflows(project_ids)
-    page.map do |project_model|
-      # select the model relations for assigning to the workflow associations
-      project_model_workflows = preloadable_workflows.select do |workflow|
-        workflow.project_id == project_model.id
-      end
-      project_model_active_workflows = preloadable_workflows.select do |workflow|
-        workflow.active && workflow.project_id == project_model.id
-      end
-      # assign the preloaded workflow records to the model associations targets
-      # use .target here to avoid loading the association before assignment
-      # and thus undoing all the hard work to load only what we need
-      project_model.association(:workflows).target = project_model_workflows
-      project_model.association(:active_workflows).target = project_model_active_workflows
+    # this is an experiement to see how we can manually preload
+    # project's workflow associations to avoid loading large json data
+    # and thus high DB CPI
+    # if this lingers past mid April 2020 - remove it and the flipper key
+    if Panoptes.flipper[:test_preload_workflow_associations].enabled?
+      project_ids = page.pluck(:id)
+      preloadable_workflows = preload_workflows(project_ids)
+      page.map do |project_model|
+        # select the model relations for assigning to the workflow associations
+        project_model_workflows = preloadable_workflows.select do |workflow|
+          workflow.project_id == project_model.id
+        end
+        project_model_active_workflows = preloadable_workflows.select do |workflow|
+          workflow.active && workflow.project_id == project_model.id
+        end
+        # assign the preloaded workflow records to the model associations targets
+        # use .target here to avoid loading the association before assignment
+        # and thus undoing all the hard work to load only what we need
+        project_model.association(:workflows).target = project_model_workflows
+        project_model.association(:active_workflows).target = project_model_active_workflows
 
-      self.as_json(project_model, options.context)
+        self.as_json(project_model, options.context)
+      end
+    else
+      super(page, options)
     end
   end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -29,6 +29,7 @@ describe ProjectSerializer do
     end
 
     it 'manually preloads the workflow associations' do
+      Panoptes.flipper[:test_preload_workflow_associations].enable
       project
       expect(described_class)
         .to receive(:preload_workflows)
@@ -38,6 +39,7 @@ describe ProjectSerializer do
     end
 
     it 'handles includes correctly' do
+      Panoptes.flipper[:test_preload_workflow_associations].enable
       project
       expected_workflow_ids = project.workflows.pluck(:id).map(&:to_s)
       params = { include: 'workflows,active_workflows' }


### PR DESCRIPTION
avoid loading all the json attributes (some very large) for project workflow associations. As the links only need to lookup the association id we can use a custom preloader to select only the required data for serializing the association links

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
