### PR TITLE
Fix dump worker sql statement timeouts

### DIFF
--- a/app/models/csv_dumps/dump_scope.rb
+++ b/app/models/csv_dumps/dump_scope.rb
@@ -9,7 +9,7 @@ module CsvDumps
     private
 
     def read_from_database(&block)
-      DatabaseReplica.read_longer('dump_data_from_read_replica', &block)
+      DatabaseReplica.read_without_timeout('dump_data_from_read_replica', &block)
     end
   end
 end

--- a/app/models/csv_dumps/dump_scope.rb
+++ b/app/models/csv_dumps/dump_scope.rb
@@ -9,7 +9,7 @@ module CsvDumps
     private
 
     def read_from_database(&block)
-      DatabaseReplica.read("dump_data_from_read_replica", &block)
+      DatabaseReplica.read_longer("dump_data_from_read_replica", &block)
     end
   end
 end

--- a/app/models/csv_dumps/dump_scope.rb
+++ b/app/models/csv_dumps/dump_scope.rb
@@ -9,7 +9,7 @@ module CsvDumps
     private
 
     def read_from_database(&block)
-      DatabaseReplica.read_longer("dump_data_from_read_replica", &block)
+      DatabaseReplica.read_longer('dump_data_from_read_replica', &block)
     end
   end
 end

--- a/config/initializers/panoptes.rb
+++ b/config/initializers/panoptes.rb
@@ -8,4 +8,8 @@ module Panoptes
   def self.disable_lifecycle_worker
     Panoptes.flipper[:disable_lifecycle_worker].enabled?
   end
+
+  def self.pg_statement_timeout
+    ENV.fetch('PG_STATEMENT_TIMEOUT', 300000)
+  end
 end

--- a/lib/database_replica.rb
+++ b/lib/database_replica.rb
@@ -1,11 +1,32 @@
 class DatabaseReplica
-  def self.read(feature_flag_key)
+  def self.read(feature_flag_key, &block)
     if Panoptes.flipper.enabled?(feature_flag_key)
+      # read via the replica settings using Standby gem
       Standby.on_standby do
-        yield
+        read_with_timeouts(&block)
       end
     else
+      read_with_timeouts(&block)
+    end
+  end
+
+  # allow dump workers to have twice the length of time to query data from
+  # the database vs the defaults for long running query times
+  # introduce in https://github.com/zooniverse/Panoptes/pull/3278
+  def self.read_with_timeouts
+    begin
+      # double the statement timeout for dump workers
+      ActiveRecord::Base.connection.execute(
+        "SET statement_timeout = #{(Panoptes.pg_statement_timeout * 2).to_i}"
+      )
+
       yield
+
+    ensure
+      # reset back to the default for subsequent connection re-use
+      ActiveRecord::Base.connection.execute(
+        "SET statement_timeout = #{Panoptes.pg_statement_timeout}"
+      )
     end
   end
 end

--- a/lib/database_replica.rb
+++ b/lib/database_replica.rb
@@ -1,32 +1,39 @@
 class DatabaseReplica
-  def self.read(feature_flag_key, &block)
+  def self.read(feature_flag_key)
     if Panoptes.flipper.enabled?(feature_flag_key)
       # read via the replica settings using Standby gem
-      Standby.on_standby do
-        read_with_timeouts(&block)
-      end
+      Standby.on_standby { yield }
     else
-      read_with_timeouts(&block)
+      yield
     end
   end
 
   # allow dump workers to have twice the length of time to query data from
   # the database vs the defaults for long running query times
   # introduce in https://github.com/zooniverse/Panoptes/pull/3278
-  def self.read_with_timeouts
-    begin
-      # double the statement timeout for dump workers
-      ActiveRecord::Base.connection.execute(
-        "SET statement_timeout = #{(Panoptes.pg_statement_timeout * 2).to_i}"
-      )
-
-      yield
-
-    ensure
-      # reset back to the default for subsequent connection re-use
-      ActiveRecord::Base.connection.execute(
-        "SET statement_timeout = #{Panoptes.pg_statement_timeout}"
-      )
+  def self.read_longer(feature_flag_key, &block)
+    if Panoptes.flipper.enabled?(feature_flag_key)
+      # read via the replica settings using Standby gem
+      Standby.on_standby do
+        read_with_doubled_timeouts(&block)
+      end
+    else
+      read_with_doubled_timeouts(&block)
     end
   end
+
+  def self.read_with_doubled_timeouts
+    # double the statement timeout for dump workers
+    ActiveRecord::Base.connection.execute(
+      "SET statement_timeout = #{(Panoptes.pg_statement_timeout * 2).to_i}"
+    )
+
+    yield
+  ensure
+    # reset back to the default for subsequent connection re-use
+    ActiveRecord::Base.connection.execute(
+      "SET statement_timeout = #{Panoptes.pg_statement_timeout}"
+    )
+  end
+  private_class_method :read_with_doubled_timeouts
 end

--- a/spec/lib/database_replica_spec.rb
+++ b/spec/lib/database_replica_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe DatabaseReplica do
+  let(:flipper_key) { 'test_read_from_read_replica' }
+
+  before do
+    allow(Standby).to receive(:on_standby)
+  end
+
+  it 'defaults to reading from the primary db' do
+    described_class.read(flipper_key) do
+      User.count
+    end
+    expect(Standby).not_to have_received(:on_standby)
+  end
+
+  context 'with read replica feature flag on' do
+    before do
+      Panoptes.flipper.enable(flipper_key)
+    end
+
+    it 'uses standby gem to read from replica' do
+      described_class.read(flipper_key) do
+        User.count
+      end
+      expect(Standby).to have_received(:on_standby)
+    end
+  end
+end

--- a/spec/lib/database_replica_spec.rb
+++ b/spec/lib/database_replica_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 
 describe DatabaseReplica do
   let(:flipper_key) { 'test_read_from_read_replica' }
+  let(:connection_double) do
+    connection_double = instance_double('ActiveRecord::ConnectionAdapters::PostgreSQLAdapter')
+    allow(connection_double).to receive(:execute)
+    connection_double
+  end
+  let(:pg_statment_timeout) { Panoptes.pg_statement_timeout }
+  let(:default_set_timeout) { "SET statement_timeout = #{pg_statment_timeout}" }
+  let(:double_set_timeout) { "SET statement_timeout = #{(pg_statment_timeout * 2).to_i}" }
 
   before do
     allow(Standby).to receive(:on_standby)
@@ -14,6 +22,16 @@ describe DatabaseReplica do
     end
     expect(Standby).not_to have_received(:on_standby)
   end
+
+  # rubocop:disable RSpec/MultipleExpectations
+  it 'sets the pg statement timeouts to allow long running dump queries' do
+    allow(ActiveRecord::Base).to receive(:connection).and_return(connection_double)
+    described_class.read(flipper_key) { nil }
+
+    expect(connection_double).to have_received(:execute).with(double_set_timeout).ordered
+    expect(connection_double).to have_received(:execute).with(default_set_timeout).ordered
+  end
+  # rubocop:enable RSpec/MultipleExpectations
 
   context 'with read replica feature flag on' do
     before do

--- a/spec/lib/database_replica_spec.rb
+++ b/spec/lib/database_replica_spec.rb
@@ -1,48 +1,76 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe DatabaseReplica do
   let(:flipper_key) { 'test_read_from_read_replica' }
-  let(:connection_double) do
-    connection_double = instance_double('ActiveRecord::ConnectionAdapters::PostgreSQLAdapter')
-    allow(connection_double).to receive(:execute)
-    connection_double
-  end
-  let(:pg_statment_timeout) { Panoptes.pg_statement_timeout }
-  let(:default_set_timeout) { "SET statement_timeout = #{pg_statment_timeout}" }
-  let(:double_set_timeout) { "SET statement_timeout = #{(pg_statment_timeout * 2).to_i}" }
 
   before do
-    allow(Standby).to receive(:on_standby)
+    allow(Standby).to receive(:on_standby).and_call_original
   end
 
-  it 'defaults to reading from the primary db' do
-    described_class.read(flipper_key) do
-      User.count
-    end
-    expect(Standby).not_to have_received(:on_standby)
-  end
-
-  # rubocop:disable RSpec/MultipleExpectations
-  it 'sets the pg statement timeouts to allow long running dump queries' do
-    allow(ActiveRecord::Base).to receive(:connection).and_return(connection_double)
-    described_class.read(flipper_key) { nil }
-
-    expect(connection_double).to have_received(:execute).with(double_set_timeout).ordered
-    expect(connection_double).to have_received(:execute).with(default_set_timeout).ordered
-  end
-  # rubocop:enable RSpec/MultipleExpectations
-
-  context 'with read replica feature flag on' do
-    before do
-      Panoptes.flipper.enable(flipper_key)
+  describe '::read' do
+    it 'defaults to reading from the primary db' do
+      described_class.read(flipper_key) { nil }
+      expect(Standby).not_to have_received(:on_standby)
     end
 
-    it 'uses standby gem to read from replica' do
-      described_class.read(flipper_key) do
-        User.count
+    context 'with read replica feature flag on' do
+      before do
+        Panoptes.flipper.enable(flipper_key)
       end
-      expect(Standby).to have_received(:on_standby)
+
+      it 'uses standby gem to read from replica' do
+        described_class.read(flipper_key) { nil }
+        expect(Standby).to have_received(:on_standby)
+      end
+    end
+  end
+
+  describe '::read_longer' do
+    let(:pg_statment_timeout) { Panoptes.pg_statement_timeout }
+    let(:default_set_timeout) { "SET statement_timeout = #{pg_statment_timeout}" }
+    let(:double_set_timeout) { "SET statement_timeout = #{(pg_statment_timeout * 2).to_i}" }
+    let(:connection_double) do
+      connection_double = instance_double('ActiveRecord::ConnectionAdapters::PostgreSQLAdapter')
+      allow(connection_double).to receive(:execute)
+      connection_double
+    end
+
+    it 'defaults to reading from the primary db' do
+      described_class.read_longer(flipper_key) { nil }
+      expect(Standby).not_to have_received(:on_standby)
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'sets the pg statement timeouts for longer queries' do
+      allow(ActiveRecord::Base).to receive(:connection).and_return(connection_double)
+      described_class.read_longer(flipper_key) { nil }
+
+      expect(connection_double).to have_received(:execute).with(double_set_timeout).ordered
+      expect(connection_double).to have_received(:execute).with(default_set_timeout).ordered
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    context 'with read replica feature flag on' do
+      before do
+        Panoptes.flipper.enable(flipper_key)
+      end
+
+      it 'uses standby gem to read from replica' do
+        described_class.read_longer(flipper_key) { nil }
+        expect(Standby).to have_received(:on_standby)
+      end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'sets the pg statement timeouts for longer queries' do
+        allow(ActiveRecord::Base).to receive(:connection).and_return(connection_double)
+        described_class.read_longer(flipper_key) { nil }
+
+        expect(connection_double).to have_received(:execute).with(double_set_timeout).ordered
+        expect(connection_double).to have_received(:execute).with(default_set_timeout).ordered
+      end
+      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 end


### PR DESCRIPTION
~allow the dump workers to have twice as long to run than normal sidekiq queries~
remove query timeouts for the  the dump workers and ensure we reset the default timeout after dump query execution

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
