### PR TITLE
avoid count queries on the recent serializer

### DIFF
--- a/app/serializers/recent_serializer.rb
+++ b/app/serializers/recent_serializer.rb
@@ -1,6 +1,7 @@
 class RecentSerializer
   include Serialization::PanoptesRestpack
   include CachedSerializer
+  include NoCountSerializer
 
   attributes :id, :created_at, :updated_at, :locations, :href
   can_include :project, :workflow, :subject

--- a/spec/serializers/recent_serializer_spec.rb
+++ b/spec/serializers/recent_serializer_spec.rb
@@ -1,17 +1,22 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RecentSerializer do
+  let(:recent) { create(:recent) }
   let(:prefix) { "users/1" }
   let(:context) do
     { url_prefix: prefix }
   end
 
-  it "should preload the serialized associations" do
-    expect_any_instance_of(Recent::ActiveRecord_Relation)
-      .to receive(:preload)
-      .with(:locations)
-      .and_call_original
-    RecentSerializer.page({}, Recent.all, context)
+  it_behaves_like 'a panoptes restpack serializer' do
+    let(:resource) { recent }
+    let(:includes) { [] }
+    let(:preloads) { [:locations] }
+  end
+
+  it_behaves_like 'a no count serializer' do
+    let(:resource) { recent }
   end
 
   describe "#locations" do


### PR DESCRIPTION
these are expensive queries and we don't need them

this work can be augemented by the turning recents into a capped collection for users, e.g. each user has 100 recents each, the rest are deleted

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
