### PR TITLE
Mark recents for deletion with hourly sweeper workers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,4 +15,8 @@ Metrics/BlockLength:
   Exclude:
     - '**/*_spec.rb'
 
+Rails/SkipsModelValidations:
+  Whitelist:
+  - update_all
+
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ require:
 
 Style/NumericLiterals:
   Enabled: false
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*'
 
 Layout/LineLength:
   Max: 160
@@ -22,3 +25,6 @@ Lint/AmbiguousBlockAssociation:
 Rails/SkipsModelValidations:
   Whitelist:
   - update_all
+
+RSpec/ExampleLength:
+  Max: 10

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,8 +15,10 @@ Metrics/BlockLength:
   Exclude:
     - '**/*_spec.rb'
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Rails/SkipsModelValidations:
   Whitelist:
   - update_all
-
-

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -6,7 +6,7 @@ class Classification < ActiveRecord::Base
 
   has_one :export_row, class_name: "ClassificationExportRow"
 
-  has_many :recents, -> { where(mark_remove: false) }
+  has_many :recents, -> { where(mark_remove: false) }, inverse_of: :classification
 
   has_and_belongs_to_many :subjects,
     join_table: :classification_subjects,

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -21,6 +21,14 @@ class Recent < ActiveRecord::Base
     end
   end
 
+  # find the first known recent older than 2 week (defaul)
+  def self.first_older_than(period=14.days)
+    where('created_at < ?', Time.now.utc - period)
+      .order(id: 'desc')
+      .limit(1)
+      .first
+  end
+
   private
 
   def copy_classification_fkeys

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -14,7 +14,7 @@ class Subject < ActiveRecord::Base
     -> { where(type: 'subject_location') },
     class_name: "Medium",
     as: :linked
-  has_many :recents, dependent: :destroy
+  has_many :recents
   has_many :aggregations, dependent: :destroy
   has_many :tutorial_workflows,
     class_name: 'Workflow',

--- a/app/workers/recent_create_worker.rb
+++ b/app/workers/recent_create_worker.rb
@@ -4,5 +4,18 @@ class RecentCreateWorker
   def perform(classification_id)
     classification = Classification.find(classification_id)
     Recent.create_from_classification(classification)
+
+    # TODO: move this to the Recent class
+    # TODO: provide a constant / env var to modify
+    #       the capped collection size
+    # find the latest 50(default) classifications
+    # and mark any with an id > the last one
+    # for removal and thus cleanup
+    user_project_recent_scope = Recent.where(
+      project_id: classification.project_id,
+      user_id: classification.user_id
+    ).order(id: 'ASC')
+    last_id = user_project_recent_scope.limit(1).pluck(:id)
+    user_project_recent_scope.where("id > ?", last_id).update_all(mark_remove: true)
   end
 end

--- a/app/workers/recent_create_worker.rb
+++ b/app/workers/recent_create_worker.rb
@@ -8,14 +8,14 @@ class RecentCreateWorker
     # TODO: move this to the Recent class
     # TODO: provide a constant / env var to modify
     #       the capped collection size
-    # find the latest 50(default) classifications
-    # and mark any with an id > the last one
+    # find the most recent 50(default) classifications
+    # and mark any with an id < the last one
     # for removal and thus cleanup
     user_project_recent_scope = Recent.where(
       project_id: classification.project_id,
       user_id: classification.user_id
-    ).order(id: 'ASC')
+    ).order(id: 'DESC')
     last_id = user_project_recent_scope.limit(1).pluck(:id)
-    user_project_recent_scope.where("id > ?", last_id).update_all(mark_remove: true)
+    user_project_recent_scope.where("id < ?", last_id).update_all(mark_remove: true)
   end
 end

--- a/app/workers/recent_create_worker.rb
+++ b/app/workers/recent_create_worker.rb
@@ -6,22 +6,43 @@ class RecentCreateWorker
     recents = Recent.create_from_classification(classification)
     latest_recent_id = recents.last.id
 
-    # TODO: move this to the Recent class
-    # TODO: provide a constant / env var to modify
-    #       the capped collection size
-    # find the most recent 50(default) classifications
-    # and mark any with an id < the last one
-    # for removal and thus cleanup
-    user_project_recent_scope = Recent.where(
+    # find the latest set of user / project recents
+    # and make sure we order them descending on the PK (i.e. latest are first)
+    latest_ordered_user_project_recents = Recent.where(
       project_id: classification.project_id,
       user_id: classification.user_id
     ).order(id: 'DESC')
-    # ensure we specify the ID here as the recents table can be big
-    # use the recent id in the creation above to seed the search point
-    # in the recents table
-    oldest_allowed_recent_id = user_project_recent_scope.where('id < ?', latest_recent_id).limit(1).pluck(:id)
-    # then seed the update_all mark query to search the recents table
-    # by the capped collection id offset
-    user_project_recent_scope.where('id < ?', oldest_allowed_recent_id).update_all(mark_remove: true)
+
+    mark_remove_recents_past_limit(
+      latest_ordered_user_project_recents,
+      latest_recent_id
+    )
+  end
+
+  private
+
+  def mark_remove_recents_past_limit(latest_ordered_user_project_recents, latest_recent_id)
+    # find the latest recent id up to the limit of stored recents
+    # taking care to set a starting point to search the PK index
+    # using the created recent id from this worker
+    # this will help avoid traversing the possibly large table space of recents
+    oldest_allowed_recent_id =
+      latest_ordered_user_project_recents
+      .where('id <= ?', latest_recent_id)
+      .offset(Panoptes.user_project_recents_limit)
+      .limit(1)
+      .pluck(:id)
+      .last
+
+    # gaurd against recents coming in under the limit
+    return unless oldest_allowed_recent_id
+
+    # search and mark_remove all the the recents
+    # that are over the allowed limit of records
+    # taking care to update only older recents smaller than (older)
+    # the known recent id at the limit boundary
+    latest_ordered_user_project_recents
+      .where('id < ?', oldest_allowed_recent_id)
+      .update_all(mark_remove: true)
   end
 end

--- a/app/workers/recent_sweeper_worker.rb
+++ b/app/workers/recent_sweeper_worker.rb
@@ -27,7 +27,10 @@ class RecentSweeperWorker
     old_recents = Recent.where('id <= ?', old_recent.id).select(:id)
 
     old_recents.find_in_batches do |recents|
-      Recent.where(id: recents).update_all(mark_remove: true)
+      Recent.where(
+        id: recents,
+        mark_remove: false
+      ).update_all(mark_remove: true)
     end
   end
 end

--- a/app/workers/recent_sweeper_worker.rb
+++ b/app/workers/recent_sweeper_worker.rb
@@ -10,11 +10,24 @@ class RecentSweeperWorker
   recurrence { hourly }
 
   def perform
+    # mark any recents older than 14 days, keep the recents table clean
+    mark_old_recents(Recent.first_older_than(14.days))
+
     # https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-in_batches
     # move this method to in_batches when migrating past rails 4
     recent_ids_to_delete = Recent.where(mark_remove: true).select(:id)
     recent_ids_to_delete.find_in_batches do |recents|
       Recent.where(id: recents).destroy_all
+    end
+  end
+
+  def mark_old_recents(old_recent)
+    return unless old_recent
+
+    old_recents = Recent.where('id <= ?', old_recent.id).select(:id)
+
+    old_recents.find_in_batches do |recents|
+      Recent.where(id: recents).update_all(mark_remove: true)
     end
   end
 end

--- a/app/workers/recent_sweeper_worker.rb
+++ b/app/workers/recent_sweeper_worker.rb
@@ -1,0 +1,18 @@
+class RecentSweeperWorker
+  include Sidekiq::Worker
+
+  include Sidetiq::Schedulable
+
+  sidekiq_options queue: :data_low
+
+  recurrence { hourly }
+
+  def perform
+    # https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-in_batches
+    # move this method to in_batches when migrating past rails 4
+    recent_ids_to_delete = Recent.where(mark_remove: true).select(:id)
+    recent_ids_to_delete.find_in_batches do |recents|
+      Recent.where(id: recents).destroy_all
+    end
+  end
+end

--- a/app/workers/recent_sweeper_worker.rb
+++ b/app/workers/recent_sweeper_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RecentSweeperWorker
   include Sidekiq::Worker
 

--- a/config/initializers/panoptes.rb
+++ b/config/initializers/panoptes.rb
@@ -12,4 +12,8 @@ module Panoptes
   def self.pg_statement_timeout
     ENV.fetch('PG_STATEMENT_TIMEOUT', 300000)
   end
+
+  def self.user_project_recents_limit
+    ENV.fetch('USER_PROJECT_RECENTS_LIMIT', 50)
+  end
 end

--- a/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
+++ b/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
@@ -8,13 +8,8 @@ class AddMarkRemoveColumnToRecents < ActiveRecord::Migration
     remove_foreign_key :recents, :classifications
 
     # find the first known recent older than 2 week
-    recent_older_than_2_weeks = Recent.where(
-      'created_at < ?',
-      Time.now.utc - 14.days
-    ).order(id: 'desc').limit(1).first
-
-    if recent_older_than_2_weeks
-      # use the oldest recent id to find and remove old recents
+    if recent_older_than_2_weeks = Recent.first_older_than(14.days)
+      # use the oldest recent id to destroy old recents
       old_recents_to_remove = Recent.where(
         'id <= ?',
         recent_older_than_2_weeks.id

--- a/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
+++ b/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
@@ -28,7 +28,7 @@ class AddMarkRemoveColumnToRecents < ActiveRecord::Migration
 
     # remove recents bloated indexes after data cleanup
     %i[project_id subject_id user_id workflow_id created_at].each do |col|
-      remove_index :recents, column: col
+      remove_index :recents, column: col if index_exists?(:recents, col)
     end
     # rebuild only recent indexes we use to access data
     add_index :recents, :project_id, algorithm: :concurrently

--- a/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
+++ b/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMarkRemoveColumnToRecents < ActiveRecord::Migration
   disable_ddl_transaction!
   def up

--- a/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
+++ b/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
@@ -7,36 +7,53 @@ class AddMarkRemoveColumnToRecents < ActiveRecord::Migration
     change_column_default :recents, :mark_remove, false
     remove_foreign_key :recents, :classifications
 
-    # find the first known recent older than 2 week
-    if recent_older_than_2_weeks = Recent.first_older_than(14.days)
-      # use the oldest recent id to destroy old recents
-      old_recents_to_remove = Recent.where(
-        'id <= ?',
-        recent_older_than_2_weeks.id
-      ).select(:id)
-
-      old_recents_to_remove.find_in_batches do |recents|
-        Recent.where(id: recents).destroy_all
-      end
-    end
-
-    # as all remaining recents in the table are less
-    # than 14 days old, mark them as ok to keep
-    Recent.select(:id).find_in_batches do |recents|
-      Recent.where(id: recents).update_all(mark_remove: false)
-    end
-
-    # remove recents bloated indexes after data cleanup
-    %i[project_id subject_id user_id workflow_id created_at].each do |col|
-      remove_index :recents, column: col if index_exists?(:recents, col)
-    end
-    # rebuild only recent indexes we use to access data
-    add_index :recents, :project_id, algorithm: :concurrently
-    add_index :recents, :user_id, algorithm: :concurrently
+    remove_old_recents
+    mark_all_remaining_recents_as_good
+    remove_bloated_indexes
+    rebuild_used_indexes
   end
 
   def down
     remove_column :recents, :mark_remove
     add_foreign_key :recents, :classifications
+  end
+
+  private
+
+  def remove_old_recents
+    # find the first known recent older than 2 week
+    recent_older_than_2_weeks = Recent.first_older_than(14.days)
+    return unless recent_older_than_2_weeks
+
+    # use the oldest recent id to destroy old recents
+    old_recents_to_remove = Recent.where(
+      'id <= ?',
+      recent_older_than_2_weeks.id
+    ).select(:id)
+
+    old_recents_to_remove.find_in_batches do |recents|
+      Recent.where(id: recents).destroy_all
+    end
+  end
+
+  def mark_all_remaining_recents_as_good
+    # as all remaining recents in the table are less
+    # than 14 days old, mark them as ok to keep
+    Recent.select(:id).find_in_batches do |recents|
+      Recent.where(id: recents).update_all(mark_remove: false)
+    end
+  end
+
+  # remove recents bloated indexes after data cleanup
+  def remove_bloated_indexes
+    %i[project_id subject_id user_id workflow_id created_at].each do |col|
+      remove_index :recents, column: col if index_exists?(:recents, col)
+    end
+  end
+
+  # rebuild only recent indexes we use to access data
+  def rebuild_used_indexes
+    add_index :recents, :project_id, algorithm: :concurrently
+    add_index :recents, :user_id, algorithm: :concurrently
   end
 end

--- a/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
+++ b/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
@@ -7,13 +7,41 @@ class AddMarkRemoveColumnToRecents < ActiveRecord::Migration
     change_column_default :recents, :mark_remove, false
     remove_foreign_key :recents, :classifications
 
-    Recent.find_in_batches do |recents|
-      recents.update_all(mark_remove: false)
-      sleep(0.01) # throttle the updates to the table
+    # find the first known recent older than 2 week
+    recent_older_than_2_weeks = Recent.where(
+      'created_at < ?',
+      Time.now.utc - 14.days
+    ).order(id: 'desc').limit(1).first
+
+    if recent_older_than_2_weeks
+      # use the oldest recent id to find and remove old recents
+      old_recents_to_remove = Recent.where(
+        'id <= ?',
+        recent_older_than_2_weeks.id
+      ).select(:id)
+
+      old_recents_to_remove.find_in_batches do |recents|
+        Recent.where(id: recents).destroy_all
+      end
     end
+
+    # as all remaining recents in the table are less
+    # than 14 days old, mark them as ok to keep
+    Recent.select(:id).find_in_batches do |recents|
+      Recent.where(id: recents).update_all(mark_remove: false)
+    end
+
+    # remove recents bloated indexes after data cleanup
+    %i[project_id subject_id user_id workflow_id created_at].each do |col|
+      remove_index :recents, column: col
+    end
+    # rebuild only recent indexes we use to access data
+    add_index :recents, :project_id, algorithm: :concurrently
+    add_index :recents, :user_id, algorithm: :concurrently
   end
 
   def down
     remove_column :recents, :mark_remove
+    add_foreign_key :recents, :classifications
   end
 end

--- a/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
+++ b/db/migrate/20200327164455_add_mark_remove_column_to_recents.rb
@@ -1,0 +1,17 @@
+class AddMarkRemoveColumnToRecents < ActiveRecord::Migration
+  disable_ddl_transaction!
+  def up
+    add_column :recents, :mark_remove, :boolean
+    change_column_default :recents, :mark_remove, false
+    remove_foreign_key :recents, :classifications
+
+    Recent.find_in_batches do |recents|
+      recents.update_all(mark_remove: false)
+      sleep(0.01) # throttle the updates to the table
+    end
+  end
+
+  def down
+    remove_column :recents, :mark_remove
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,13 +2,18 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.5.21
+-- Dumped by pg_dump version 9.5.21
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -71,7 +76,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.access_control_lists (
@@ -105,7 +110,7 @@ ALTER SEQUENCE public.access_control_lists_id_seq OWNED BY public.access_control
 
 
 --
--- Name: aggregations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: aggregations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.aggregations (
@@ -138,7 +143,7 @@ ALTER SEQUENCE public.aggregations_id_seq OWNED BY public.aggregations.id;
 
 
 --
--- Name: authorizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: authorizations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.authorizations (
@@ -173,7 +178,7 @@ ALTER SEQUENCE public.authorizations_id_seq OWNED BY public.authorizations.id;
 
 
 --
--- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.classification_export_rows (
@@ -218,7 +223,7 @@ ALTER SEQUENCE public.classification_export_rows_id_seq OWNED BY public.classifi
 
 
 --
--- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.classification_subjects (
@@ -228,7 +233,7 @@ CREATE TABLE public.classification_subjects (
 
 
 --
--- Name: classifications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: classifications; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.classifications (
@@ -270,7 +275,7 @@ ALTER SEQUENCE public.classifications_id_seq OWNED BY public.classifications.id;
 
 
 --
--- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.code_experiment_configs (
@@ -301,7 +306,7 @@ ALTER SEQUENCE public.code_experiment_configs_id_seq OWNED BY public.code_experi
 
 
 --
--- Name: collections; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: collections; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.collections (
@@ -340,7 +345,7 @@ ALTER SEQUENCE public.collections_id_seq OWNED BY public.collections.id;
 
 
 --
--- Name: collections_projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.collections_projects (
@@ -350,7 +355,7 @@ CREATE TABLE public.collections_projects (
 
 
 --
--- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.collections_subjects (
@@ -380,7 +385,7 @@ ALTER SEQUENCE public.collections_subjects_id_seq OWNED BY public.collections_su
 
 
 --
--- Name: field_guide_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guide_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.field_guide_versions (
@@ -412,7 +417,7 @@ ALTER SEQUENCE public.field_guide_versions_id_seq OWNED BY public.field_guide_ve
 
 
 --
--- Name: field_guides; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guides; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.field_guides (
@@ -445,7 +450,7 @@ ALTER SEQUENCE public.field_guides_id_seq OWNED BY public.field_guides.id;
 
 
 --
--- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_features; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.flipper_features (
@@ -476,7 +481,7 @@ ALTER SEQUENCE public.flipper_features_id_seq OWNED BY public.flipper_features.i
 
 
 --
--- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.flipper_gates (
@@ -509,7 +514,7 @@ ALTER SEQUENCE public.flipper_gates_id_seq OWNED BY public.flipper_gates.id;
 
 
 --
--- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.gold_standard_annotations (
@@ -546,7 +551,7 @@ ALTER SEQUENCE public.gold_standard_annotations_id_seq OWNED BY public.gold_stan
 
 
 --
--- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: media; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.media (
@@ -588,7 +593,7 @@ ALTER SEQUENCE public.media_id_seq OWNED BY public.media.id;
 
 
 --
--- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: memberships; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.memberships (
@@ -623,7 +628,7 @@ ALTER SEQUENCE public.memberships_id_seq OWNED BY public.memberships.id;
 
 
 --
--- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.oauth_access_grants (
@@ -659,7 +664,7 @@ ALTER SEQUENCE public.oauth_access_grants_id_seq OWNED BY public.oauth_access_gr
 
 
 --
--- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.oauth_access_tokens (
@@ -696,7 +701,7 @@ ALTER SEQUENCE public.oauth_access_tokens_id_seq OWNED BY public.oauth_access_to
 
 
 --
--- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.oauth_applications (
@@ -736,7 +741,7 @@ ALTER SEQUENCE public.oauth_applications_id_seq OWNED BY public.oauth_applicatio
 
 
 --
--- Name: organization_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_contents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_contents (
@@ -773,7 +778,7 @@ ALTER SEQUENCE public.organization_contents_id_seq OWNED BY public.organization_
 
 
 --
--- Name: organization_page_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_page_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_page_versions (
@@ -807,7 +812,7 @@ ALTER SEQUENCE public.organization_page_versions_id_seq OWNED BY public.organiza
 
 
 --
--- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_pages; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_pages (
@@ -842,7 +847,7 @@ ALTER SEQUENCE public.organization_pages_id_seq OWNED BY public.organization_pag
 
 
 --
--- Name: organization_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_versions (
@@ -879,7 +884,7 @@ ALTER SEQUENCE public.organization_versions_id_seq OWNED BY public.organization_
 
 
 --
--- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organizations (
@@ -921,7 +926,7 @@ ALTER SEQUENCE public.organizations_id_seq OWNED BY public.organizations.id;
 
 
 --
--- Name: project_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_contents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_contents (
@@ -959,7 +964,7 @@ ALTER SEQUENCE public.project_contents_id_seq OWNED BY public.project_contents.i
 
 
 --
--- Name: project_page_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_page_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_page_versions (
@@ -993,7 +998,7 @@ ALTER SEQUENCE public.project_page_versions_id_seq OWNED BY public.project_page_
 
 
 --
--- Name: project_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_pages; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_pages (
@@ -1028,7 +1033,7 @@ ALTER SEQUENCE public.project_pages_id_seq OWNED BY public.project_pages.id;
 
 
 --
--- Name: project_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_versions (
@@ -1071,7 +1076,7 @@ ALTER SEQUENCE public.project_versions_id_seq OWNED BY public.project_versions.i
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.projects (
@@ -1136,7 +1141,7 @@ ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 
 
 --
--- Name: recents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: recents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.recents (
@@ -1148,7 +1153,8 @@ CREATE TABLE public.recents (
     project_id integer,
     workflow_id integer,
     user_id integer,
-    user_group_id integer
+    user_group_id integer,
+    mark_remove boolean DEFAULT false
 );
 
 
@@ -1172,7 +1178,7 @@ ALTER SEQUENCE public.recents_id_seq OWNED BY public.recents.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.schema_migrations (
@@ -1181,7 +1187,7 @@ CREATE TABLE public.schema_migrations (
 
 
 --
--- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.set_member_subjects (
@@ -1216,7 +1222,7 @@ ALTER SEQUENCE public.set_member_subjects_id_seq OWNED BY public.set_member_subj
 
 
 --
--- Name: subject_set_imports; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_set_imports; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_set_imports (
@@ -1252,7 +1258,7 @@ ALTER SEQUENCE public.subject_set_imports_id_seq OWNED BY public.subject_set_imp
 
 
 --
--- Name: subject_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_sets (
@@ -1288,7 +1294,7 @@ ALTER SEQUENCE public.subject_sets_id_seq OWNED BY public.subject_sets.id;
 
 
 --
--- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_sets_workflows (
@@ -1318,7 +1324,7 @@ ALTER SEQUENCE public.subject_sets_workflows_id_seq OWNED BY public.subject_sets
 
 
 --
--- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_workflow_counts (
@@ -1353,7 +1359,7 @@ ALTER SEQUENCE public.subject_workflow_counts_id_seq OWNED BY public.subject_wor
 
 
 --
--- Name: subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subjects (
@@ -1391,7 +1397,7 @@ ALTER SEQUENCE public.subjects_id_seq OWNED BY public.subjects.id;
 
 
 --
--- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tagged_resources (
@@ -1422,7 +1428,7 @@ ALTER SEQUENCE public.tagged_resources_id_seq OWNED BY public.tagged_resources.i
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tags; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tags (
@@ -1454,7 +1460,7 @@ ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
 
 
 --
--- Name: translation_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: translation_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.translation_versions (
@@ -1487,7 +1493,7 @@ ALTER SEQUENCE public.translation_versions_id_seq OWNED BY public.translation_ve
 
 
 --
--- Name: translations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: translations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.translations (
@@ -1523,7 +1529,7 @@ ALTER SEQUENCE public.translations_id_seq OWNED BY public.translations.id;
 
 
 --
--- Name: tutorial_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorial_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tutorial_versions (
@@ -1557,7 +1563,7 @@ ALTER SEQUENCE public.tutorial_versions_id_seq OWNED BY public.tutorial_versions
 
 
 --
--- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorials; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tutorials (
@@ -1592,7 +1598,7 @@ ALTER SEQUENCE public.tutorials_id_seq OWNED BY public.tutorials.id;
 
 
 --
--- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_collection_preferences (
@@ -1625,7 +1631,7 @@ ALTER SEQUENCE public.user_collection_preferences_id_seq OWNED BY public.user_co
 
 
 --
--- Name: user_groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_groups; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_groups (
@@ -1662,7 +1668,7 @@ ALTER SEQUENCE public.user_groups_id_seq OWNED BY public.user_groups.id;
 
 
 --
--- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_project_preferences (
@@ -1699,7 +1705,7 @@ ALTER SEQUENCE public.user_project_preferences_id_seq OWNED BY public.user_proje
 
 
 --
--- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_seen_subjects (
@@ -1732,7 +1738,7 @@ ALTER SEQUENCE public.user_seen_subjects_id_seq OWNED BY public.user_seen_subjec
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.users (
@@ -1798,7 +1804,7 @@ ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.versions (
@@ -1833,7 +1839,7 @@ ALTER SEQUENCE public.versions_id_seq OWNED BY public.versions.id;
 
 
 --
--- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflow_contents (
@@ -1867,7 +1873,7 @@ ALTER SEQUENCE public.workflow_contents_id_seq OWNED BY public.workflow_contents
 
 
 --
--- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflow_tutorials (
@@ -1897,7 +1903,7 @@ ALTER SEQUENCE public.workflow_tutorials_id_seq OWNED BY public.workflow_tutoria
 
 
 --
--- Name: workflow_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflow_versions (
@@ -1936,7 +1942,7 @@ ALTER SEQUENCE public.workflow_versions_id_seq OWNED BY public.workflow_versions
 
 
 --
--- Name: workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflows; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflows (
@@ -2355,7 +2361,7 @@ ALTER TABLE ONLY public.workflows ALTER COLUMN id SET DEFAULT nextval('public.wo
 
 
 --
--- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.access_control_lists
@@ -2363,7 +2369,7 @@ ALTER TABLE ONLY public.access_control_lists
 
 
 --
--- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.aggregations
@@ -2371,7 +2377,7 @@ ALTER TABLE ONLY public.aggregations
 
 
 --
--- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.authorizations
@@ -2379,7 +2385,7 @@ ALTER TABLE ONLY public.authorizations
 
 
 --
--- Name: classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.classification_export_rows
@@ -2387,7 +2393,7 @@ ALTER TABLE ONLY public.classification_export_rows
 
 
 --
--- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.classifications
@@ -2395,7 +2401,7 @@ ALTER TABLE ONLY public.classifications
 
 
 --
--- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.code_experiment_configs
@@ -2403,7 +2409,7 @@ ALTER TABLE ONLY public.code_experiment_configs
 
 
 --
--- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.collections
@@ -2411,7 +2417,7 @@ ALTER TABLE ONLY public.collections
 
 
 --
--- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.collections_subjects
@@ -2419,7 +2425,7 @@ ALTER TABLE ONLY public.collections_subjects
 
 
 --
--- Name: field_guide_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guide_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.field_guide_versions
@@ -2427,7 +2433,7 @@ ALTER TABLE ONLY public.field_guide_versions
 
 
 --
--- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.field_guides
@@ -2435,7 +2441,7 @@ ALTER TABLE ONLY public.field_guides
 
 
 --
--- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.flipper_features
@@ -2443,7 +2449,7 @@ ALTER TABLE ONLY public.flipper_features
 
 
 --
--- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.flipper_gates
@@ -2451,7 +2457,7 @@ ALTER TABLE ONLY public.flipper_gates
 
 
 --
--- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.gold_standard_annotations
@@ -2459,7 +2465,7 @@ ALTER TABLE ONLY public.gold_standard_annotations
 
 
 --
--- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.media
@@ -2467,7 +2473,7 @@ ALTER TABLE ONLY public.media
 
 
 --
--- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.memberships
@@ -2475,7 +2481,7 @@ ALTER TABLE ONLY public.memberships
 
 
 --
--- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_access_grants
@@ -2483,7 +2489,7 @@ ALTER TABLE ONLY public.oauth_access_grants
 
 
 --
--- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_access_tokens
@@ -2491,7 +2497,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 
 
 --
--- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_applications
@@ -2499,7 +2505,7 @@ ALTER TABLE ONLY public.oauth_applications
 
 
 --
--- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_contents
@@ -2507,7 +2513,7 @@ ALTER TABLE ONLY public.organization_contents
 
 
 --
--- Name: organization_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_page_versions
@@ -2515,7 +2521,7 @@ ALTER TABLE ONLY public.organization_page_versions
 
 
 --
--- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_pages
@@ -2523,7 +2529,7 @@ ALTER TABLE ONLY public.organization_pages
 
 
 --
--- Name: organization_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_versions
@@ -2531,7 +2537,7 @@ ALTER TABLE ONLY public.organization_versions
 
 
 --
--- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organizations
@@ -2539,7 +2545,7 @@ ALTER TABLE ONLY public.organizations
 
 
 --
--- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_contents
@@ -2547,7 +2553,7 @@ ALTER TABLE ONLY public.project_contents
 
 
 --
--- Name: project_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_page_versions
@@ -2555,7 +2561,7 @@ ALTER TABLE ONLY public.project_page_versions
 
 
 --
--- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_pages
@@ -2563,7 +2569,7 @@ ALTER TABLE ONLY public.project_pages
 
 
 --
--- Name: project_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_versions
@@ -2571,7 +2577,7 @@ ALTER TABLE ONLY public.project_versions
 
 
 --
--- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects
@@ -2579,7 +2585,7 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.recents
@@ -2587,7 +2593,7 @@ ALTER TABLE ONLY public.recents
 
 
 --
--- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.set_member_subjects
@@ -2595,7 +2601,7 @@ ALTER TABLE ONLY public.set_member_subjects
 
 
 --
--- Name: subject_set_imports_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_set_imports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_set_imports
@@ -2603,7 +2609,7 @@ ALTER TABLE ONLY public.subject_set_imports
 
 
 --
--- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_sets
@@ -2611,7 +2617,7 @@ ALTER TABLE ONLY public.subject_sets
 
 
 --
--- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_sets_workflows
@@ -2619,7 +2625,7 @@ ALTER TABLE ONLY public.subject_sets_workflows
 
 
 --
--- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_workflow_counts
@@ -2627,7 +2633,7 @@ ALTER TABLE ONLY public.subject_workflow_counts
 
 
 --
--- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subjects
@@ -2635,7 +2641,7 @@ ALTER TABLE ONLY public.subjects
 
 
 --
--- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tagged_resources
@@ -2643,7 +2649,7 @@ ALTER TABLE ONLY public.tagged_resources
 
 
 --
--- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tags
@@ -2651,7 +2657,7 @@ ALTER TABLE ONLY public.tags
 
 
 --
--- Name: translation_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: translation_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.translation_versions
@@ -2659,7 +2665,7 @@ ALTER TABLE ONLY public.translation_versions
 
 
 --
--- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.translations
@@ -2667,7 +2673,7 @@ ALTER TABLE ONLY public.translations
 
 
 --
--- Name: tutorial_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorial_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tutorial_versions
@@ -2675,7 +2681,7 @@ ALTER TABLE ONLY public.tutorial_versions
 
 
 --
--- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tutorials
@@ -2683,7 +2689,7 @@ ALTER TABLE ONLY public.tutorials
 
 
 --
--- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_collection_preferences
@@ -2691,7 +2697,7 @@ ALTER TABLE ONLY public.user_collection_preferences
 
 
 --
--- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_groups
@@ -2699,7 +2705,7 @@ ALTER TABLE ONLY public.user_groups
 
 
 --
--- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_project_preferences
@@ -2707,7 +2713,7 @@ ALTER TABLE ONLY public.user_project_preferences
 
 
 --
--- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_seen_subjects
@@ -2715,7 +2721,7 @@ ALTER TABLE ONLY public.user_seen_subjects
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users
@@ -2723,7 +2729,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.versions
@@ -2731,7 +2737,7 @@ ALTER TABLE ONLY public.versions
 
 
 --
--- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflow_contents
@@ -2739,7 +2745,7 @@ ALTER TABLE ONLY public.workflow_contents
 
 
 --
--- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflow_tutorials
@@ -2747,7 +2753,7 @@ ALTER TABLE ONLY public.workflow_tutorials
 
 
 --
--- Name: workflow_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflow_versions
@@ -2755,7 +2761,7 @@ ALTER TABLE ONLY public.workflow_versions
 
 
 --
--- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflows
@@ -2763,987 +2769,987 @@ ALTER TABLE ONLY public.workflows
 
 
 --
--- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX classification_subjects_pk ON public.classification_subjects USING btree (classification_id, subject_id);
 
 
 --
--- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_lower_email ON public.users USING btree (lower((email)::text));
 
 
 --
--- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX "idx_translations_on_translated_type+id_and_language" ON public.translations USING btree (translated_type, translated_id, language);
 
 
 --
--- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_access_control_lists_on_resource_id_and_resource_type ON public.access_control_lists USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_access_control_lists_on_user_group_id ON public.access_control_lists USING btree (user_group_id);
 
 
 --
--- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_aggregations_on_subject_id_and_workflow_id ON public.aggregations USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_aggregations_on_workflow_id ON public.aggregations USING btree (workflow_id);
 
 
 --
--- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_authorizations_on_user_id ON public.authorizations USING btree (user_id);
 
 
 --
--- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_classification_export_rows_on_classification_id ON public.classification_export_rows USING btree (classification_id);
 
 
 --
--- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classification_export_rows_on_project_id ON public.classification_export_rows USING btree (project_id);
 
 
 --
--- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classification_export_rows_on_workflow_id ON public.classification_export_rows USING btree (workflow_id);
 
 
 --
--- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classification_subjects_on_subject_id ON public.classification_subjects USING btree (subject_id);
 
 
 --
--- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_completed ON public.classifications USING btree (completed) WHERE (completed IS FALSE);
 
 
 --
--- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_created_at ON public.classifications USING btree (created_at);
 
 
 --
--- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_gold_standard ON public.classifications USING btree (gold_standard) WHERE (gold_standard IS TRUE);
 
 
 --
--- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_lifecycled_at ON public.classifications USING btree (lifecycled_at) WHERE (lifecycled_at IS NULL);
 
 
 --
--- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_project_id_and_id ON public.classifications USING btree (project_id, id);
 
 
 --
--- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_user_id ON public.classifications USING btree (user_id);
 
 
 --
--- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_workflow_id ON public.classifications USING btree (workflow_id);
 
 
 --
--- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_code_experiment_configs_on_name ON public.code_experiment_configs USING btree (name);
 
 
 --
--- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_display_name_trgrm ON public.collections USING gin ((COALESCE((display_name)::text, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_activated_state ON public.collections USING btree (activated_state);
 
 
 --
--- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_display_name ON public.collections USING btree (display_name);
 
 
 --
--- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_favorite ON public.collections USING btree (favorite);
 
 
 --
--- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_private ON public.collections USING btree (private);
 
 
 --
--- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_slug ON public.collections USING btree (slug);
 
 
 --
--- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_projects_on_collection_id ON public.collections_projects USING btree (collection_id);
 
 
 --
--- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_collections_subjects_on_collection_id_and_subject_id ON public.collections_subjects USING btree (collection_id, subject_id);
 
 
 --
--- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_subjects_on_subject_id ON public.collections_subjects USING btree (subject_id);
 
 
 --
--- Name: index_field_guide_versions_on_field_guide_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_field_guide_versions_on_field_guide_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_field_guide_versions_on_field_guide_id ON public.field_guide_versions USING btree (field_guide_id);
 
 
 --
--- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_field_guides_on_language ON public.field_guides USING btree (language);
 
 
 --
--- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_field_guides_on_project_id ON public.field_guides USING btree (project_id);
 
 
 --
--- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_flipper_features_on_key ON public.flipper_features USING btree (key);
 
 
 --
--- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON public.flipper_gates USING btree (feature_key, key, value);
 
 
 --
--- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_gold_standard_annotations_on_subject_id ON public.gold_standard_annotations USING btree (subject_id);
 
 
 --
--- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_gold_standard_annotations_on_workflow_id ON public.gold_standard_annotations USING btree (workflow_id);
 
 
 --
--- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_media_on_linked_id_and_linked_type ON public.media USING btree (linked_id, linked_type);
 
 
 --
--- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_media_on_type ON public.media USING btree (type);
 
 
 --
--- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_memberships_on_user_group_id_and_user_id ON public.memberships USING btree (user_group_id, user_id);
 
 
 --
--- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_memberships_on_user_id ON public.memberships USING btree (user_id);
 
 
 --
--- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON public.oauth_access_grants USING btree (token);
 
 
 --
--- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_oauth_access_tokens_on_app_id_and_owner_id ON public.oauth_access_tokens USING btree (application_id, resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON public.oauth_access_tokens USING btree (refresh_token);
 
 
 --
--- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON public.oauth_access_tokens USING btree (resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON public.oauth_access_tokens USING btree (token);
 
 
 --
--- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications USING btree (uid);
 
 
 --
--- Name: index_organization_page_versions_on_organization_page_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_page_versions_on_organization_page_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_page_versions_on_organization_page_id ON public.organization_page_versions USING btree (organization_page_id);
 
 
 --
--- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_pages_on_language ON public.organization_pages USING btree (language);
 
 
 --
--- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_pages_on_organization_id ON public.organization_pages USING btree (organization_id);
 
 
 --
--- Name: index_organization_versions_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_versions_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_versions_on_organization_id ON public.organization_versions USING btree (organization_id);
 
 
 --
--- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_activated_state ON public.organizations USING btree (activated_state);
 
 
 --
--- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_display_name ON public.organizations USING btree (display_name);
 
 
 --
--- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_listed ON public.organizations USING btree (listed);
 
 
 --
--- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_listed_at ON public.organizations USING btree (listed_at);
 
 
 --
--- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_organizations_on_slug ON public.organizations USING btree (slug);
 
 
 --
--- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_updated_at ON public.organizations USING btree (updated_at);
 
 
 --
--- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_contents_on_project_id ON public.project_contents USING btree (project_id);
 
 
 --
--- Name: index_project_page_versions_on_project_page_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_page_versions_on_project_page_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_page_versions_on_project_page_id ON public.project_page_versions USING btree (project_page_id);
 
 
 --
--- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_pages_on_language ON public.project_pages USING btree (language);
 
 
 --
--- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_pages_on_project_id ON public.project_pages USING btree (project_id);
 
 
 --
--- Name: index_project_versions_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_versions_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_versions_on_project_id ON public.project_versions USING btree (project_id);
 
 
 --
--- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_display_name_trgrm ON public.projects USING gin ((COALESCE((display_name)::text, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_activated_state ON public.projects USING btree (activated_state);
 
 
 --
--- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_beta_approved ON public.projects USING btree (beta_approved);
 
 
 --
--- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_beta_requested ON public.projects USING btree (beta_requested) WHERE (beta_requested = true);
 
 
 --
--- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_beta_row_order ON public.projects USING btree (beta_row_order);
 
 
 --
--- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_featured ON public.projects USING btree (featured);
 
 
 --
--- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_launch_approved ON public.projects USING btree (launch_approved);
 
 
 --
--- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_launch_requested ON public.projects USING btree (launch_requested) WHERE (launch_requested = true);
 
 
 --
--- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_launched_row_order ON public.projects USING btree (launched_row_order);
 
 
 --
--- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_live ON public.projects USING btree (live);
 
 
 --
--- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_migrated ON public.projects USING btree (migrated) WHERE (migrated = true);
 
 
 --
--- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_mobile_friendly ON public.projects USING btree (mobile_friendly);
 
 
 --
--- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_organization_id ON public.projects USING btree (organization_id);
 
 
 --
--- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_private ON public.projects USING btree (private);
 
 
 --
--- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_slug ON public.projects USING btree (slug);
 
 
 --
--- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_state ON public.projects USING btree (state) WHERE (state IS NOT NULL);
 
 
 --
--- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_tsv ON public.projects USING gin (tsv);
 
 
 --
--- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_created_at ON public.recents USING btree (created_at);
 
 
 --
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_project_id ON public.recents USING btree (project_id);
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_subject_id ON public.recents USING btree (subject_id);
 
 
 --
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_user_id ON public.recents USING btree (user_id);
 
 
 --
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_workflow_id ON public.recents USING btree (workflow_id);
 
 
 --
--- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_set_member_subjects_on_random ON public.set_member_subjects USING btree (random);
 
 
 --
--- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_set_member_subjects_on_subject_id_and_subject_set_id ON public.set_member_subjects USING btree (subject_id, subject_set_id);
 
 
 --
--- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_set_member_subjects_on_subject_set_id ON public.set_member_subjects USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_set_imports_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_set_imports_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_set_imports_on_subject_set_id ON public.subject_set_imports USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_set_imports_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_set_imports_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_set_imports_on_user_id ON public.subject_set_imports USING btree (user_id);
 
 
 --
--- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_sets_on_metadata ON public.subject_sets USING gin (metadata);
 
 
 --
--- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_sets_on_project_id_and_display_name ON public.subject_sets USING btree (project_id, display_name);
 
 
 --
--- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_sets_workflows_on_subject_set_id ON public.subject_sets_workflows USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_subject_sets_workflows_on_workflow_id_and_subject_set_id ON public.subject_sets_workflows USING btree (workflow_id, subject_set_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_subject_workflow_counts_on_subject_id_and_workflow_id ON public.subject_workflow_counts USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_workflow_counts_on_workflow_id ON public.subject_workflow_counts USING btree (workflow_id);
 
 
 --
--- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subjects_on_project_id ON public.subjects USING btree (project_id);
 
 
 --
--- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subjects_on_upload_user_id ON public.subjects USING btree (upload_user_id);
 
 
 --
--- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tagged_resources_on_resource_id_and_resource_type ON public.tagged_resources USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tagged_resources_on_tag_id ON public.tagged_resources USING btree (tag_id);
 
 
 --
--- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tags_name_trgrm ON public.tags USING gin ((COALESCE(name, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_tags_on_name ON public.tags USING btree (name);
 
 
 --
--- Name: index_translation_versions_on_translation_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_translation_versions_on_translation_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_translation_versions_on_translation_id ON public.translation_versions USING btree (translation_id);
 
 
 --
--- Name: index_tutorial_versions_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorial_versions_on_tutorial_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorial_versions_on_tutorial_id ON public.tutorial_versions USING btree (tutorial_id);
 
 
 --
--- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorials_on_kind ON public.tutorials USING btree (kind);
 
 
 --
--- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorials_on_language ON public.tutorials USING btree (language);
 
 
 --
--- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorials_on_project_id ON public.tutorials USING btree (project_id);
 
 
 --
--- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_collection_preferences_on_collection_id ON public.user_collection_preferences USING btree (collection_id);
 
 
 --
--- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_collection_preferences_on_user_id ON public.user_collection_preferences USING btree (user_id);
 
 
 --
--- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_groups_display_name_trgrm ON public.user_groups USING gin ((COALESCE((display_name)::text, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_groups_on_activated_state ON public.user_groups USING btree (activated_state);
 
 
 --
--- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_user_groups_on_name ON public.user_groups USING btree (lower((name)::text));
 
 
 --
--- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_groups_on_private ON public.user_groups USING btree (private);
 
 
 --
--- Name: index_user_project_preferences_on_project_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_project_preferences_on_project_id_and_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_user_project_preferences_on_project_id_and_user_id ON public.user_project_preferences USING btree (project_id, user_id);
 
 
 --
--- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON public.user_seen_subjects USING btree (user_id, workflow_id);
 
 
 --
--- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_activated_state ON public.users USING btree (activated_state);
 
 
 --
--- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_beta_email_communication ON public.users USING btree (beta_email_communication) WHERE (beta_email_communication = true);
 
 
 --
--- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_display_name ON public.users USING btree (lower((display_name)::text));
 
 
 --
--- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 
 
 --
--- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_global_email_communication ON public.users USING btree (global_email_communication) WHERE (global_email_communication = true);
 
 
 --
--- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_login ON public.users USING btree (lower((login)::text));
 
 
 --
--- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_login_with_case ON public.users USING btree (login);
 
 
 --
--- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_lower_names ON public.users USING btree (lower((login)::text) text_pattern_ops, lower((display_name)::text) text_pattern_ops);
 
 
 --
--- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_private_profile ON public.users USING btree (private_profile) WHERE (private_profile = false);
 
 
 --
--- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
 
 
 --
--- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_tsv ON public.users USING gin (tsv);
 
 
 --
--- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_unsubscribe_token ON public.users USING btree (unsubscribe_token);
 
 
 --
--- Name: index_users_on_ux_testing_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_ux_testing_email_communication; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_ux_testing_email_communication ON public.users USING btree (ux_testing_email_communication) WHERE (ux_testing_email_communication IS TRUE);
 
 
 --
--- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_zooniverse_id ON public.users USING btree (zooniverse_id);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_versions_on_item_type_and_item_id ON public.versions USING btree (item_type, item_id);
 
 
 --
--- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflow_contents_on_workflow_id ON public.workflow_contents USING btree (workflow_id);
 
 
 --
--- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflow_tutorials_on_tutorial_id ON public.workflow_tutorials USING btree (tutorial_id);
 
 
 --
--- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_workflow_tutorials_on_workflow_id_and_tutorial_id ON public.workflow_tutorials USING btree (workflow_id, tutorial_id);
 
 
 --
--- Name: index_workflow_versions_on_workflow_and_major_and_minor; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_versions_on_workflow_and_major_and_minor; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_workflow_versions_on_workflow_and_major_and_minor ON public.workflow_versions USING btree (workflow_id, major_number, minor_number);
 
 
 --
--- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_activated_state ON public.workflows USING btree (activated_state);
 
 
 --
--- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_aggregation ON public.workflows USING btree (((aggregation ->> 'public'::text)));
 
 
 --
--- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_display_order ON public.workflows USING btree (display_order);
 
 
 --
--- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_mobile_friendly ON public.workflows USING btree (mobile_friendly);
 
 
 --
--- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_project_id ON public.workflows USING btree (project_id);
 
 
 --
--- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_public_gold_standard ON public.workflows USING btree (public_gold_standard) WHERE (public_gold_standard IS TRUE);
 
 
 --
--- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_tutorial_subject_id ON public.workflows USING btree (tutorial_subject_id);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
 
 
 --
--- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX users_idx_trgm_login ON public.users USING gin ((COALESCE((login)::text, ''::text)) public.gin_trgm_ops);
@@ -3857,14 +3863,6 @@ ALTER TABLE ONLY public.collections_projects
 
 ALTER TABLE ONLY public.gold_standard_annotations
     ADD CONSTRAINT fk_rails_1d218ca624 FOREIGN KEY (workflow_id) REFERENCES public.workflows(id);
-
-
---
--- Name: fk_rails_1e54468460; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.recents
-    ADD CONSTRAINT fk_rails_1e54468460 FOREIGN KEY (classification_id) REFERENCES public.classifications(id);
 
 
 --
@@ -4279,7 +4277,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user",public;
+SET search_path TO "$user", public;
 
 INSERT INTO schema_migrations (version) VALUES ('20150210025312');
 
@@ -4776,4 +4774,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190507103007');
 INSERT INTO schema_migrations (version) VALUES ('20190524111214');
 
 INSERT INTO schema_migrations (version) VALUES ('20190624094308');
+
+INSERT INTO schema_migrations (version) VALUES ('20200327164455');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3315,13 +3315,6 @@ CREATE INDEX index_projects_on_tsv ON public.projects USING gin (tsv);
 
 
 --
--- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_recents_on_created_at ON public.recents USING btree (created_at);
-
-
---
 -- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3329,24 +3322,10 @@ CREATE INDEX index_recents_on_project_id ON public.recents USING btree (project_
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_recents_on_subject_id ON public.recents USING btree (subject_id);
-
-
---
 -- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_user_id ON public.recents USING btree (user_id);
-
-
---
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_recents_on_workflow_id ON public.recents USING btree (workflow_id);
 
 
 --

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -206,4 +206,19 @@ describe Classification, :type => :model do
       expect(build(:classification).seen_before?).to be_falsey
     end
   end
+
+  describe '#destroy' do
+    let(:classification) { create(:classification_with_recents) }
+
+    it 'marks the linked recents for removal' do
+      expect {
+        classification.destroy
+      }.to change {
+        Recent.where(
+          classification_id: classification.id,
+          mark_remove: true
+        ).count
+      }.from(0).to(2)
+    end
+  end
 end

--- a/spec/models/recent_spec.rb
+++ b/spec/models/recent_spec.rb
@@ -53,6 +53,35 @@ RSpec.describe Recent, :type => :model do
     end
   end
 
+  describe ':first_older_than' do
+    let(:old_period) { 15.days }
+    let(:old_recent) do
+      create(:recent) do |r|
+        r.update_attribute(:created_at, Time.now.utc - old_period)
+      end
+    end
+    let(:create_attrs) do
+      {
+        classification: old_recent.classification,
+        subject: old_recent.subject
+      }
+    end
+    let(:new_recent) { create(:recent, create_attrs) }
+
+    it 'returns nothing if no recents to find' do
+      expect(described_class.first_older_than).to be_nil
+    end
+
+    # avoid factories taking seconds to setup, collapsing to one test
+    it 'finds the correct records based on default and supplied periods' do # rubocop:disable RSpec/MultipleExpectations
+      # ensure these are created in this order
+      old_recent
+      new_recent
+      expect(described_class.first_older_than.id).to eq(old_recent.id)
+      expect(described_class.first_older_than(0.days).id).to eq(new_recent.id)
+    end
+  end
+
   describe "ordered_locations" do
     it_behaves_like "it has ordered locations" do
       let(:resource) { create(:recent) }

--- a/spec/workers/recent_create_worker_spec.rb
+++ b/spec/workers/recent_create_worker_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 RSpec.describe RecentCreateWorker do
   subject(:recent_create_worker) { described_class.new }
 
-  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
-    @classification = create(:classification)
-  end
-
-  let(:classification) { @classification } # rubocop:disable RSpec/InstanceVariable
+  let(:classification) { create(:classification) }
 
   it 'should call create_from_classification' do
     expect(Recent)

--- a/spec/workers/recent_create_worker_spec.rb
+++ b/spec/workers/recent_create_worker_spec.rb
@@ -9,4 +9,21 @@ RSpec.describe RecentCreateWorker do
       .with(classification)
     subject.perform(classification.id)
   end
+
+  it 'should mark all recents past the capped ammount for deletion' do
+    # TODO: allow the capped collection size
+    # to be stubbed to only have to cleanup 1 out of 2
+    classification = create(:classification_with_recents)
+    classification.recents.last.id
+    recent_to_be_marked = classification.recents.last.id
+    expect {
+      subject.perform(classification.id)
+    }.to change {
+        Recent.where(
+          id: recent_to_be_marked,
+          mark_remove: true
+        ).count
+      }.from(0).to(1)
+  end
+
 end

--- a/spec/workers/recent_create_worker_spec.rb
+++ b/spec/workers/recent_create_worker_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RecentCreateWorker do
     expect(Recent)
       .to receive(:create_from_classification)
       .with(classification)
+      .and_call_original
     subject.perform(classification.id)
   end
 

--- a/spec/workers/recent_create_worker_spec.rb
+++ b/spec/workers/recent_create_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RecentCreateWorker do
     # to be stubbed to only have to cleanup 1 out of 2
     classification = create(:classification_with_recents)
     classification.recents.last.id
-    recent_to_be_marked = classification.recents.last.id
+    recent_to_be_marked = classification.recents.first.id
     expect {
       subject.perform(classification.id)
     }.to change {

--- a/spec/workers/recent_sweeper_worker_spec.rb
+++ b/spec/workers/recent_sweeper_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RecentSweeperWorker do

--- a/spec/workers/recent_sweeper_worker_spec.rb
+++ b/spec/workers/recent_sweeper_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RecentSweeperWorker do
     expect(worker.class.schedule.to_s).to eq('Hourly')
   end
 
-   it 'removes all recents marked for removal' do
+  it 'removes all recents marked for removal' do
     expect {
       worker.perform
     }.to change {

--- a/spec/workers/recent_sweeper_worker_spec.rb
+++ b/spec/workers/recent_sweeper_worker_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe RecentSweeperWorker do
+  subject(:worker) { described_class.new }
+
+  let(:marked_recent) { create(:recent, mark_remove: true) }
+  let(:recent) { create(:recent) }
+
+  before do
+    marked_recent
+    recent
+  end
+
+  it 'is scheduled to run hourly' do
+    expect(worker.class.schedule.to_s).to eq('Hourly')
+  end
+
+  it 'removes all recents marked for removal' do
+    expect {
+      worker.perform
+    }.to change {
+      Recent.where(mark_remove: true).count
+    }.from(1).to(0)
+  end
+
+  it 'leaves all recents not marked for removal' do
+    expect {
+      worker.perform
+    }.not_to change {
+      Recent.where(mark_remove: false).count
+    }
+  end
+end

--- a/spec/workers/recent_sweeper_worker_spec.rb
+++ b/spec/workers/recent_sweeper_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RecentSweeperWorker do
     expect(worker.class.schedule.to_s).to eq('Hourly')
   end
 
-  it 'removes all recents marked for removal' do
+   it 'removes all recents marked for removal' do
     expect {
       worker.perform
     }.to change {
@@ -31,5 +31,15 @@ RSpec.describe RecentSweeperWorker do
     }.not_to change {
       Recent.where(mark_remove: false).count
     }
+  end
+
+  context 'with a recent older than 14 days' do
+    it 'sweeps it up' do
+      old_recent = create(:recent) do |r|
+        r.update_column(:created_at, Time.now.utc - 15.days)
+      end
+      worker.perform
+      expect { old_recent.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 end


### PR DESCRIPTION
classification deletes are cascading down to recents which is a very slow removal and is now erroring due the the pg statement timeouts

instead of `dependent :destroy` on the classification->recents relation, move to a mark and sweep system where we use a background worker on a schedule to remove the recents. The advantage of this technique is: 
1. it's quick and will not impact the classifcation destroy
2. it allows us to have implement a simple capped collection for recents (max 50 or so) which will be updated when new classifications come in.

The removal worker will cleanup any marked recents and any old recents past 14 days by default.

The migration will remove recents older than 14 days, leave the rest and remove the bloated indexes and rebuild the only ones we use for the API.

## Todo
- [ ] Rebase / merge with schema changes in #3424 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
