### PR TITLE
remove flipper experiment for project workflow association pre-loading

### DIFF
--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -29,7 +29,6 @@ describe ProjectSerializer do
     end
 
     it 'manually preloads the workflow associations' do
-      Panoptes.flipper[:test_preload_workflow_associations].enable
       project
       expect(described_class)
         .to receive(:preload_workflows)
@@ -39,7 +38,6 @@ describe ProjectSerializer do
     end
 
     it 'handles includes correctly' do
-      Panoptes.flipper[:test_preload_workflow_associations].enable
       project
       expected_workflow_ids = project.workflows.pluck(:id).map(&:to_s)
       params = { include: 'workflows,active_workflows' }


### PR DESCRIPTION
Remove the test introduced for #3280, this was successful and reduced the loading times of project workflow resources

custom workflow(s) preloading for project serializer paging is a win, keeping this around.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
