### PR TITLE
revoke access tokens on password change

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ require:
 Style/NumericLiterals:
   Enabled: false
 
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*'
+
 Layout/LineLength:
   Max: 160
 Layout/SpaceAroundEqualsInParameterDefault:
@@ -15,4 +19,9 @@ Metrics/BlockLength:
   Exclude:
     - '**/*_spec.rb'
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
 
+RSpec/ExampleLength:
+  Max: 10

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -88,16 +88,11 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def oauth_application_ids_to_revoke
-    oauth_application_ids = [doorkeeper_token&.application_id]
-
     if params.key?(:revoke_all_tokens)
-      # revoke all user owned oauth application tokens
-      oauth_application_ids <<
-        Doorkeeper::Application
-        .where(owner_id: resource.id, owner_type: resource.class.name)
-        .pluck(:id)
+      # revoke tokens for ALL known oauth applications in the system
+      Doorkeeper::Application.pluck(:id)
+    else
+      [doorkeeper_token&.application_id]
     end
-
-    oauth_application_ids.compact.uniq
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -97,13 +97,20 @@ describe RegistrationsController, type: :controller do
           end
 
           context 'when supplying a revoke_all_apps param' do
+            let(:non_owned_oauth_app) { create(:application) }
+            let(:non_owned_app_token) do
+              create(:access_token, application_id: non_owned_oauth_app.id, resource_owner_id: user.id)
+            end
+
+            before { non_owned_app_token }
+
             it 'revokes access tokens for all client apps' do
               request.env['HTTP_AUTHORIZATION'] = "Bearer #{user_token.token}"
               expect {
                 put :update, user: params, revoke_all_tokens: 1
               }.to change {
                 Doorkeeper::AccessToken.where(resource_owner_id: user.id, revoked_at: nil).count
-              }.from(3).to(0)
+              }.from(4).to(0)
             end
           end
         end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -69,7 +69,7 @@ describe RegistrationsController, type: :controller do
           end
 
           it 'revokes all access tokens for the relevant client app' do
-            request.env["HTTP_AUTHORIZATION"] = "Bearer #{user_token.token}"
+            request.env['HTTP_AUTHORIZATION'] = "Bearer #{user_token.token}"
             expect {
               put :update, user: params
             }.to change {
@@ -86,7 +86,7 @@ describe RegistrationsController, type: :controller do
           end
 
           it 'does not revoke access tokens for other client apps' do
-            request.env["HTTP_AUTHORIZATION"] = "Bearer #{user_token.token}"
+            request.env['HTTP_AUTHORIZATION'] = "Bearer #{user_token.token}"
             expect {
               put :update, user: params
             }.not_to change {


### PR DESCRIPTION
when a user changes a password, invalidate the access tokens for the user and the associated oauth application

Note: this will only revoke the tokens for the requesting oauth application. tokens for another oauth application will not be revoked. We may want to consider revoking all tokens for security purposes (i.e. account takeover and password was reset to fix it) but this may break some workflows like subject uploading. I wasn't really sure the best way to go with this tradeoff.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
