### PR TITLE
remove paper trail gem versions table

### DIFF
--- a/db/migrate/20200513124310_remove_paper_trail_gem_versions_table.rb
+++ b/db/migrate/20200513124310_remove_paper_trail_gem_versions_table.rb
@@ -1,0 +1,13 @@
+class RemovePaperTrailGemVersionsTable < ActiveRecord::Migration
+  def change
+    drop_table :versions do |t|
+      t.string   'item_type',      null: false
+      t.integer  'item_id',        null: false
+      t.string   'event',          null: false
+      t.string   'whodunnit'
+      t.text     'object'
+      t.datetime 'created_at'
+      t.text     'object_changes'
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,13 +2,18 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.5.21
+-- Dumped by pg_dump version 9.5.21
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -71,7 +76,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.access_control_lists (
@@ -105,7 +110,7 @@ ALTER SEQUENCE public.access_control_lists_id_seq OWNED BY public.access_control
 
 
 --
--- Name: aggregations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: aggregations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.aggregations (
@@ -138,7 +143,7 @@ ALTER SEQUENCE public.aggregations_id_seq OWNED BY public.aggregations.id;
 
 
 --
--- Name: authorizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: authorizations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.authorizations (
@@ -173,7 +178,7 @@ ALTER SEQUENCE public.authorizations_id_seq OWNED BY public.authorizations.id;
 
 
 --
--- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_export_rows; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.classification_export_rows (
@@ -218,7 +223,7 @@ ALTER SEQUENCE public.classification_export_rows_id_seq OWNED BY public.classifi
 
 
 --
--- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.classification_subjects (
@@ -228,7 +233,7 @@ CREATE TABLE public.classification_subjects (
 
 
 --
--- Name: classifications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: classifications; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.classifications (
@@ -270,7 +275,7 @@ ALTER SEQUENCE public.classifications_id_seq OWNED BY public.classifications.id;
 
 
 --
--- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: code_experiment_configs; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.code_experiment_configs (
@@ -301,7 +306,7 @@ ALTER SEQUENCE public.code_experiment_configs_id_seq OWNED BY public.code_experi
 
 
 --
--- Name: collections; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: collections; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.collections (
@@ -340,7 +345,7 @@ ALTER SEQUENCE public.collections_id_seq OWNED BY public.collections.id;
 
 
 --
--- Name: collections_projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.collections_projects (
@@ -350,7 +355,7 @@ CREATE TABLE public.collections_projects (
 
 
 --
--- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.collections_subjects (
@@ -380,7 +385,7 @@ ALTER SEQUENCE public.collections_subjects_id_seq OWNED BY public.collections_su
 
 
 --
--- Name: field_guide_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guide_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.field_guide_versions (
@@ -412,7 +417,7 @@ ALTER SEQUENCE public.field_guide_versions_id_seq OWNED BY public.field_guide_ve
 
 
 --
--- Name: field_guides; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guides; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.field_guides (
@@ -445,7 +450,7 @@ ALTER SEQUENCE public.field_guides_id_seq OWNED BY public.field_guides.id;
 
 
 --
--- Name: flipper_features; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_features; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.flipper_features (
@@ -476,7 +481,7 @@ ALTER SEQUENCE public.flipper_features_id_seq OWNED BY public.flipper_features.i
 
 
 --
--- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_gates; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.flipper_gates (
@@ -509,7 +514,7 @@ ALTER SEQUENCE public.flipper_gates_id_seq OWNED BY public.flipper_gates.id;
 
 
 --
--- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: gold_standard_annotations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.gold_standard_annotations (
@@ -546,7 +551,7 @@ ALTER SEQUENCE public.gold_standard_annotations_id_seq OWNED BY public.gold_stan
 
 
 --
--- Name: media; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: media; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.media (
@@ -588,7 +593,7 @@ ALTER SEQUENCE public.media_id_seq OWNED BY public.media.id;
 
 
 --
--- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: memberships; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.memberships (
@@ -623,7 +628,7 @@ ALTER SEQUENCE public.memberships_id_seq OWNED BY public.memberships.id;
 
 
 --
--- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.oauth_access_grants (
@@ -659,7 +664,7 @@ ALTER SEQUENCE public.oauth_access_grants_id_seq OWNED BY public.oauth_access_gr
 
 
 --
--- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.oauth_access_tokens (
@@ -696,7 +701,7 @@ ALTER SEQUENCE public.oauth_access_tokens_id_seq OWNED BY public.oauth_access_to
 
 
 --
--- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.oauth_applications (
@@ -736,7 +741,7 @@ ALTER SEQUENCE public.oauth_applications_id_seq OWNED BY public.oauth_applicatio
 
 
 --
--- Name: organization_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_contents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_contents (
@@ -773,7 +778,7 @@ ALTER SEQUENCE public.organization_contents_id_seq OWNED BY public.organization_
 
 
 --
--- Name: organization_page_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_page_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_page_versions (
@@ -807,7 +812,7 @@ ALTER SEQUENCE public.organization_page_versions_id_seq OWNED BY public.organiza
 
 
 --
--- Name: organization_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_pages; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_pages (
@@ -842,7 +847,7 @@ ALTER SEQUENCE public.organization_pages_id_seq OWNED BY public.organization_pag
 
 
 --
--- Name: organization_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organization_versions (
@@ -879,7 +884,7 @@ ALTER SEQUENCE public.organization_versions_id_seq OWNED BY public.organization_
 
 
 --
--- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.organizations (
@@ -921,7 +926,7 @@ ALTER SEQUENCE public.organizations_id_seq OWNED BY public.organizations.id;
 
 
 --
--- Name: project_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_contents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_contents (
@@ -959,7 +964,7 @@ ALTER SEQUENCE public.project_contents_id_seq OWNED BY public.project_contents.i
 
 
 --
--- Name: project_page_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_page_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_page_versions (
@@ -993,7 +998,7 @@ ALTER SEQUENCE public.project_page_versions_id_seq OWNED BY public.project_page_
 
 
 --
--- Name: project_pages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_pages; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_pages (
@@ -1028,7 +1033,7 @@ ALTER SEQUENCE public.project_pages_id_seq OWNED BY public.project_pages.id;
 
 
 --
--- Name: project_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_versions (
@@ -1071,7 +1076,7 @@ ALTER SEQUENCE public.project_versions_id_seq OWNED BY public.project_versions.i
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.projects (
@@ -1136,7 +1141,7 @@ ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 
 
 --
--- Name: recents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: recents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.recents (
@@ -1148,7 +1153,8 @@ CREATE TABLE public.recents (
     project_id integer,
     workflow_id integer,
     user_id integer,
-    user_group_id integer
+    user_group_id integer,
+    mark_remove boolean DEFAULT false
 );
 
 
@@ -1172,7 +1178,7 @@ ALTER SEQUENCE public.recents_id_seq OWNED BY public.recents.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.schema_migrations (
@@ -1181,7 +1187,7 @@ CREATE TABLE public.schema_migrations (
 
 
 --
--- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: set_member_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.set_member_subjects (
@@ -1216,7 +1222,7 @@ ALTER SEQUENCE public.set_member_subjects_id_seq OWNED BY public.set_member_subj
 
 
 --
--- Name: subject_set_imports; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_set_imports; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_set_imports (
@@ -1252,7 +1258,7 @@ ALTER SEQUENCE public.subject_set_imports_id_seq OWNED BY public.subject_set_imp
 
 
 --
--- Name: subject_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_sets (
@@ -1288,7 +1294,7 @@ ALTER SEQUENCE public.subject_sets_id_seq OWNED BY public.subject_sets.id;
 
 
 --
--- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets_workflows; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_sets_workflows (
@@ -1318,7 +1324,7 @@ ALTER SEQUENCE public.subject_sets_workflows_id_seq OWNED BY public.subject_sets
 
 
 --
--- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_workflow_counts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subject_workflow_counts (
@@ -1353,7 +1359,7 @@ ALTER SEQUENCE public.subject_workflow_counts_id_seq OWNED BY public.subject_wor
 
 
 --
--- Name: subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.subjects (
@@ -1391,7 +1397,7 @@ ALTER SEQUENCE public.subjects_id_seq OWNED BY public.subjects.id;
 
 
 --
--- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tagged_resources; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tagged_resources (
@@ -1422,7 +1428,7 @@ ALTER SEQUENCE public.tagged_resources_id_seq OWNED BY public.tagged_resources.i
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tags; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tags (
@@ -1454,7 +1460,7 @@ ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
 
 
 --
--- Name: translation_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: translation_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.translation_versions (
@@ -1487,7 +1493,7 @@ ALTER SEQUENCE public.translation_versions_id_seq OWNED BY public.translation_ve
 
 
 --
--- Name: translations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: translations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.translations (
@@ -1523,7 +1529,7 @@ ALTER SEQUENCE public.translations_id_seq OWNED BY public.translations.id;
 
 
 --
--- Name: tutorial_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorial_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tutorial_versions (
@@ -1557,7 +1563,7 @@ ALTER SEQUENCE public.tutorial_versions_id_seq OWNED BY public.tutorial_versions
 
 
 --
--- Name: tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorials; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tutorials (
@@ -1592,7 +1598,7 @@ ALTER SEQUENCE public.tutorials_id_seq OWNED BY public.tutorials.id;
 
 
 --
--- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_collection_preferences; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_collection_preferences (
@@ -1625,7 +1631,7 @@ ALTER SEQUENCE public.user_collection_preferences_id_seq OWNED BY public.user_co
 
 
 --
--- Name: user_groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_groups; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_groups (
@@ -1662,7 +1668,7 @@ ALTER SEQUENCE public.user_groups_id_seq OWNED BY public.user_groups.id;
 
 
 --
--- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_project_preferences; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_project_preferences (
@@ -1699,7 +1705,7 @@ ALTER SEQUENCE public.user_project_preferences_id_seq OWNED BY public.user_proje
 
 
 --
--- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: user_seen_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.user_seen_subjects (
@@ -1732,7 +1738,7 @@ ALTER SEQUENCE public.user_seen_subjects_id_seq OWNED BY public.user_seen_subjec
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.users (
@@ -1798,42 +1804,7 @@ ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE public.versions (
-    id integer NOT NULL,
-    item_type character varying NOT NULL,
-    item_id integer NOT NULL,
-    event character varying NOT NULL,
-    whodunnit character varying,
-    object text,
-    created_at timestamp without time zone,
-    object_changes text
-);
-
-
---
--- Name: versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.versions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.versions_id_seq OWNED BY public.versions.id;
-
-
---
--- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_contents; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflow_contents (
@@ -1867,7 +1838,7 @@ ALTER SEQUENCE public.workflow_contents_id_seq OWNED BY public.workflow_contents
 
 
 --
--- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_tutorials; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflow_tutorials (
@@ -1897,7 +1868,7 @@ ALTER SEQUENCE public.workflow_tutorials_id_seq OWNED BY public.workflow_tutoria
 
 
 --
--- Name: workflow_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflow_versions (
@@ -1936,7 +1907,7 @@ ALTER SEQUENCE public.workflow_versions_id_seq OWNED BY public.workflow_versions
 
 
 --
--- Name: workflows; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: workflows; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.workflows (
@@ -2323,13 +2294,6 @@ ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.versions ALTER COLUMN id SET DEFAULT nextval('public.versions_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY public.workflow_contents ALTER COLUMN id SET DEFAULT nextval('public.workflow_contents_id_seq'::regclass);
 
 
@@ -2355,7 +2319,7 @@ ALTER TABLE ONLY public.workflows ALTER COLUMN id SET DEFAULT nextval('public.wo
 
 
 --
--- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: access_control_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.access_control_lists
@@ -2363,7 +2327,7 @@ ALTER TABLE ONLY public.access_control_lists
 
 
 --
--- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.aggregations
@@ -2371,7 +2335,7 @@ ALTER TABLE ONLY public.aggregations
 
 
 --
--- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.authorizations
@@ -2379,7 +2343,7 @@ ALTER TABLE ONLY public.authorizations
 
 
 --
--- Name: classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_export_rows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.classification_export_rows
@@ -2387,7 +2351,7 @@ ALTER TABLE ONLY public.classification_export_rows
 
 
 --
--- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.classifications
@@ -2395,7 +2359,7 @@ ALTER TABLE ONLY public.classifications
 
 
 --
--- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: code_experiment_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.code_experiment_configs
@@ -2403,7 +2367,7 @@ ALTER TABLE ONLY public.code_experiment_configs
 
 
 --
--- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.collections
@@ -2411,7 +2375,7 @@ ALTER TABLE ONLY public.collections
 
 
 --
--- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: collections_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.collections_subjects
@@ -2419,7 +2383,7 @@ ALTER TABLE ONLY public.collections_subjects
 
 
 --
--- Name: field_guide_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guide_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.field_guide_versions
@@ -2427,7 +2391,7 @@ ALTER TABLE ONLY public.field_guide_versions
 
 
 --
--- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: field_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.field_guides
@@ -2435,7 +2399,7 @@ ALTER TABLE ONLY public.field_guides
 
 
 --
--- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.flipper_features
@@ -2443,7 +2407,7 @@ ALTER TABLE ONLY public.flipper_features
 
 
 --
--- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: flipper_gates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.flipper_gates
@@ -2451,7 +2415,7 @@ ALTER TABLE ONLY public.flipper_gates
 
 
 --
--- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: gold_standard_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.gold_standard_annotations
@@ -2459,7 +2423,7 @@ ALTER TABLE ONLY public.gold_standard_annotations
 
 
 --
--- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: media_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.media
@@ -2467,7 +2431,7 @@ ALTER TABLE ONLY public.media
 
 
 --
--- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.memberships
@@ -2475,7 +2439,7 @@ ALTER TABLE ONLY public.memberships
 
 
 --
--- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_access_grants
@@ -2483,7 +2447,7 @@ ALTER TABLE ONLY public.oauth_access_grants
 
 
 --
--- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_access_tokens
@@ -2491,7 +2455,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 
 
 --
--- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_applications
@@ -2499,7 +2463,7 @@ ALTER TABLE ONLY public.oauth_applications
 
 
 --
--- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_contents
@@ -2507,7 +2471,7 @@ ALTER TABLE ONLY public.organization_contents
 
 
 --
--- Name: organization_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_page_versions
@@ -2515,7 +2479,7 @@ ALTER TABLE ONLY public.organization_page_versions
 
 
 --
--- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_pages
@@ -2523,7 +2487,7 @@ ALTER TABLE ONLY public.organization_pages
 
 
 --
--- Name: organization_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organization_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_versions
@@ -2531,7 +2495,7 @@ ALTER TABLE ONLY public.organization_versions
 
 
 --
--- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organizations
@@ -2539,7 +2503,7 @@ ALTER TABLE ONLY public.organizations
 
 
 --
--- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_contents
@@ -2547,7 +2511,7 @@ ALTER TABLE ONLY public.project_contents
 
 
 --
--- Name: project_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_page_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_page_versions
@@ -2555,7 +2519,7 @@ ALTER TABLE ONLY public.project_page_versions
 
 
 --
--- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_pages
@@ -2563,7 +2527,7 @@ ALTER TABLE ONLY public.project_pages
 
 
 --
--- Name: project_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: project_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_versions
@@ -2571,7 +2535,7 @@ ALTER TABLE ONLY public.project_versions
 
 
 --
--- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects
@@ -2579,7 +2543,7 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: recents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.recents
@@ -2587,7 +2551,7 @@ ALTER TABLE ONLY public.recents
 
 
 --
--- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: set_member_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.set_member_subjects
@@ -2595,7 +2559,7 @@ ALTER TABLE ONLY public.set_member_subjects
 
 
 --
--- Name: subject_set_imports_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_set_imports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_set_imports
@@ -2603,7 +2567,7 @@ ALTER TABLE ONLY public.subject_set_imports
 
 
 --
--- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_sets
@@ -2611,7 +2575,7 @@ ALTER TABLE ONLY public.subject_sets
 
 
 --
--- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_sets_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_sets_workflows
@@ -2619,7 +2583,7 @@ ALTER TABLE ONLY public.subject_sets_workflows
 
 
 --
--- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subject_workflow_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subject_workflow_counts
@@ -2627,7 +2591,7 @@ ALTER TABLE ONLY public.subject_workflow_counts
 
 
 --
--- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subjects
@@ -2635,7 +2599,7 @@ ALTER TABLE ONLY public.subjects
 
 
 --
--- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tagged_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tagged_resources
@@ -2643,7 +2607,7 @@ ALTER TABLE ONLY public.tagged_resources
 
 
 --
--- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tags
@@ -2651,7 +2615,7 @@ ALTER TABLE ONLY public.tags
 
 
 --
--- Name: translation_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: translation_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.translation_versions
@@ -2659,7 +2623,7 @@ ALTER TABLE ONLY public.translation_versions
 
 
 --
--- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: translations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.translations
@@ -2667,7 +2631,7 @@ ALTER TABLE ONLY public.translations
 
 
 --
--- Name: tutorial_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorial_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tutorial_versions
@@ -2675,7 +2639,7 @@ ALTER TABLE ONLY public.tutorial_versions
 
 
 --
--- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tutorials
@@ -2683,7 +2647,7 @@ ALTER TABLE ONLY public.tutorials
 
 
 --
--- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_collection_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_collection_preferences
@@ -2691,7 +2655,7 @@ ALTER TABLE ONLY public.user_collection_preferences
 
 
 --
--- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_groups
@@ -2699,7 +2663,7 @@ ALTER TABLE ONLY public.user_groups
 
 
 --
--- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_project_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_project_preferences
@@ -2707,7 +2671,7 @@ ALTER TABLE ONLY public.user_project_preferences
 
 
 --
--- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: user_seen_subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.user_seen_subjects
@@ -2715,7 +2679,7 @@ ALTER TABLE ONLY public.user_seen_subjects
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users
@@ -2723,15 +2687,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY public.versions
-    ADD CONSTRAINT versions_pkey PRIMARY KEY (id);
-
-
---
--- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflow_contents
@@ -2739,7 +2695,7 @@ ALTER TABLE ONLY public.workflow_contents
 
 
 --
--- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_tutorials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflow_tutorials
@@ -2747,7 +2703,7 @@ ALTER TABLE ONLY public.workflow_tutorials
 
 
 --
--- Name: workflow_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflow_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflow_versions
@@ -2755,7 +2711,7 @@ ALTER TABLE ONLY public.workflow_versions
 
 
 --
--- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.workflows
@@ -2763,987 +2719,959 @@ ALTER TABLE ONLY public.workflows
 
 
 --
--- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: classification_subjects_pk; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX classification_subjects_pk ON public.classification_subjects USING btree (classification_id, subject_id);
 
 
 --
--- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: idx_lower_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_lower_email ON public.users USING btree (lower((email)::text));
 
 
 --
--- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: idx_translations_on_translated_type+id_and_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX "idx_translations_on_translated_type+id_and_language" ON public.translations USING btree (translated_type, translated_id, language);
 
 
 --
--- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_access_control_lists_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_access_control_lists_on_resource_id_and_resource_type ON public.access_control_lists USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_access_control_lists_on_user_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_access_control_lists_on_user_group_id ON public.access_control_lists USING btree (user_group_id);
 
 
 --
--- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_aggregations_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_aggregations_on_subject_id_and_workflow_id ON public.aggregations USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_aggregations_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_aggregations_on_workflow_id ON public.aggregations USING btree (workflow_id);
 
 
 --
--- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_authorizations_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_authorizations_on_user_id ON public.authorizations USING btree (user_id);
 
 
 --
--- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_export_rows_on_classification_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_classification_export_rows_on_classification_id ON public.classification_export_rows USING btree (classification_id);
 
 
 --
--- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_export_rows_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classification_export_rows_on_project_id ON public.classification_export_rows USING btree (project_id);
 
 
 --
--- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_export_rows_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classification_export_rows_on_workflow_id ON public.classification_export_rows USING btree (workflow_id);
 
 
 --
--- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classification_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classification_subjects_on_subject_id ON public.classification_subjects USING btree (subject_id);
 
 
 --
--- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_completed; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_completed ON public.classifications USING btree (completed) WHERE (completed IS FALSE);
 
 
 --
--- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_created_at ON public.classifications USING btree (created_at);
 
 
 --
--- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_gold_standard; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_gold_standard ON public.classifications USING btree (gold_standard) WHERE (gold_standard IS TRUE);
 
 
 --
--- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_lifecycled_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_lifecycled_at ON public.classifications USING btree (lifecycled_at) WHERE (lifecycled_at IS NULL);
 
 
 --
--- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_project_id_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_project_id_and_id ON public.classifications USING btree (project_id, id);
 
 
 --
--- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_user_id ON public.classifications USING btree (user_id);
 
 
 --
--- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_classifications_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_classifications_on_workflow_id ON public.classifications USING btree (workflow_id);
 
 
 --
--- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_code_experiment_configs_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_code_experiment_configs_on_name ON public.code_experiment_configs USING btree (name);
 
 
 --
--- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_display_name_trgrm ON public.collections USING gin ((COALESCE((display_name)::text, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_activated_state ON public.collections USING btree (activated_state);
 
 
 --
--- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_display_name ON public.collections USING btree (display_name);
 
 
 --
--- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_favorite; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_favorite ON public.collections USING btree (favorite);
 
 
 --
--- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_private; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_private ON public.collections USING btree (private);
 
 
 --
--- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_on_slug ON public.collections USING btree (slug);
 
 
 --
--- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_projects_on_collection_id ON public.collections_projects USING btree (collection_id);
 
 
 --
--- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_subjects_on_collection_id_and_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_collections_subjects_on_collection_id_and_subject_id ON public.collections_subjects USING btree (collection_id, subject_id);
 
 
 --
--- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_collections_subjects_on_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_collections_subjects_on_subject_id ON public.collections_subjects USING btree (subject_id);
 
 
 --
--- Name: index_field_guide_versions_on_field_guide_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_field_guide_versions_on_field_guide_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_field_guide_versions_on_field_guide_id ON public.field_guide_versions USING btree (field_guide_id);
 
 
 --
--- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_field_guides_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_field_guides_on_language ON public.field_guides USING btree (language);
 
 
 --
--- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_field_guides_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_field_guides_on_project_id ON public.field_guides USING btree (project_id);
 
 
 --
--- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_flipper_features_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_flipper_features_on_key ON public.flipper_features USING btree (key);
 
 
 --
--- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_flipper_gates_on_feature_key_and_key_and_value; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON public.flipper_gates USING btree (feature_key, key, value);
 
 
 --
--- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_gold_standard_annotations_on_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_gold_standard_annotations_on_subject_id ON public.gold_standard_annotations USING btree (subject_id);
 
 
 --
--- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_gold_standard_annotations_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_gold_standard_annotations_on_workflow_id ON public.gold_standard_annotations USING btree (workflow_id);
 
 
 --
--- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_media_on_linked_id_and_linked_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_media_on_linked_id_and_linked_type ON public.media USING btree (linked_id, linked_type);
 
 
 --
--- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_media_on_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_media_on_type ON public.media USING btree (type);
 
 
 --
--- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_memberships_on_user_group_id_and_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_memberships_on_user_group_id_and_user_id ON public.memberships USING btree (user_group_id, user_id);
 
 
 --
--- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_memberships_on_user_id ON public.memberships USING btree (user_id);
 
 
 --
--- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON public.oauth_access_grants USING btree (token);
 
 
 --
--- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_app_id_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_oauth_access_tokens_on_app_id_and_owner_id ON public.oauth_access_tokens USING btree (application_id, resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON public.oauth_access_tokens USING btree (refresh_token);
 
 
 --
--- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON public.oauth_access_tokens USING btree (resource_owner_id);
 
 
 --
--- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON public.oauth_access_tokens USING btree (token);
 
 
 --
--- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications USING btree (uid);
 
 
 --
--- Name: index_organization_page_versions_on_organization_page_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_page_versions_on_organization_page_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_page_versions_on_organization_page_id ON public.organization_page_versions USING btree (organization_page_id);
 
 
 --
--- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_pages_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_pages_on_language ON public.organization_pages USING btree (language);
 
 
 --
--- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_pages_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_pages_on_organization_id ON public.organization_pages USING btree (organization_id);
 
 
 --
--- Name: index_organization_versions_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organization_versions_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organization_versions_on_organization_id ON public.organization_versions USING btree (organization_id);
 
 
 --
--- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_activated_state ON public.organizations USING btree (activated_state);
 
 
 --
--- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_display_name ON public.organizations USING btree (display_name);
 
 
 --
--- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_listed; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_listed ON public.organizations USING btree (listed);
 
 
 --
--- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_listed_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_listed_at ON public.organizations USING btree (listed_at);
 
 
 --
--- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_organizations_on_slug ON public.organizations USING btree (slug);
 
 
 --
--- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_organizations_on_updated_at ON public.organizations USING btree (updated_at);
 
 
 --
--- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_contents_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_contents_on_project_id ON public.project_contents USING btree (project_id);
 
 
 --
--- Name: index_project_page_versions_on_project_page_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_page_versions_on_project_page_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_page_versions_on_project_page_id ON public.project_page_versions USING btree (project_page_id);
 
 
 --
--- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_pages_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_pages_on_language ON public.project_pages USING btree (language);
 
 
 --
--- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_pages_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_pages_on_project_id ON public.project_pages USING btree (project_id);
 
 
 --
--- Name: index_project_versions_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_project_versions_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_project_versions_on_project_id ON public.project_versions USING btree (project_id);
 
 
 --
--- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_display_name_trgrm ON public.projects USING gin ((COALESCE((display_name)::text, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_activated_state ON public.projects USING btree (activated_state);
 
 
 --
--- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_beta_approved; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_beta_approved ON public.projects USING btree (beta_approved);
 
 
 --
--- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_beta_requested; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_beta_requested ON public.projects USING btree (beta_requested) WHERE (beta_requested = true);
 
 
 --
--- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_beta_row_order; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_beta_row_order ON public.projects USING btree (beta_row_order);
 
 
 --
--- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_featured; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_featured ON public.projects USING btree (featured);
 
 
 --
--- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_launch_approved; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_launch_approved ON public.projects USING btree (launch_approved);
 
 
 --
--- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_launch_requested; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_launch_requested ON public.projects USING btree (launch_requested) WHERE (launch_requested = true);
 
 
 --
--- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_launched_row_order; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_launched_row_order ON public.projects USING btree (launched_row_order);
 
 
 --
--- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_live; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_live ON public.projects USING btree (live);
 
 
 --
--- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_migrated; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_migrated ON public.projects USING btree (migrated) WHERE (migrated = true);
 
 
 --
--- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_mobile_friendly ON public.projects USING btree (mobile_friendly);
 
 
 --
--- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_organization_id ON public.projects USING btree (organization_id);
 
 
 --
--- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_private; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_private ON public.projects USING btree (private);
 
 
 --
--- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_slug ON public.projects USING btree (slug);
 
 
 --
--- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_state ON public.projects USING btree (state) WHERE (state IS NOT NULL);
 
 
 --
--- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_projects_on_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_tsv ON public.projects USING gin (tsv);
 
 
 --
--- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_recents_on_created_at ON public.recents USING btree (created_at);
-
-
---
--- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_project_id ON public.recents USING btree (project_id);
 
 
 --
--- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_recents_on_subject_id ON public.recents USING btree (subject_id);
-
-
---
--- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_user_id ON public.recents USING btree (user_id);
 
 
 --
--- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_recents_on_workflow_id ON public.recents USING btree (workflow_id);
-
-
---
--- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_set_member_subjects_on_random; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_set_member_subjects_on_random ON public.set_member_subjects USING btree (random);
 
 
 --
--- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_set_member_subjects_on_subject_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_set_member_subjects_on_subject_id_and_subject_set_id ON public.set_member_subjects USING btree (subject_id, subject_set_id);
 
 
 --
--- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_set_member_subjects_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_set_member_subjects_on_subject_set_id ON public.set_member_subjects USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_set_imports_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_set_imports_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_set_imports_on_subject_set_id ON public.subject_set_imports USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_set_imports_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_set_imports_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_set_imports_on_user_id ON public.subject_set_imports USING btree (user_id);
 
 
 --
--- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_on_metadata; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_sets_on_metadata ON public.subject_sets USING gin (metadata);
 
 
 --
--- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_on_project_id_and_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_sets_on_project_id_and_display_name ON public.subject_sets USING btree (project_id, display_name);
 
 
 --
--- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_workflows_on_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_sets_workflows_on_subject_set_id ON public.subject_sets_workflows USING btree (subject_set_id);
 
 
 --
--- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_sets_workflows_on_workflow_id_and_subject_set_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_subject_sets_workflows_on_workflow_id_and_subject_set_id ON public.subject_sets_workflows USING btree (workflow_id, subject_set_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_workflow_counts_on_subject_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_subject_workflow_counts_on_subject_id_and_workflow_id ON public.subject_workflow_counts USING btree (subject_id, workflow_id);
 
 
 --
--- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subject_workflow_counts_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subject_workflow_counts_on_workflow_id ON public.subject_workflow_counts USING btree (workflow_id);
 
 
 --
--- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subjects_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subjects_on_project_id ON public.subjects USING btree (project_id);
 
 
 --
--- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subjects_on_upload_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subjects_on_upload_user_id ON public.subjects USING btree (upload_user_id);
 
 
 --
--- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tagged_resources_on_resource_id_and_resource_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tagged_resources_on_resource_id_and_resource_type ON public.tagged_resources USING btree (resource_id, resource_type);
 
 
 --
--- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tagged_resources_on_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tagged_resources_on_tag_id ON public.tagged_resources USING btree (tag_id);
 
 
 --
--- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tags_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tags_name_trgrm ON public.tags USING gin ((COALESCE(name, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_tags_on_name ON public.tags USING btree (name);
 
 
 --
--- Name: index_translation_versions_on_translation_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_translation_versions_on_translation_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_translation_versions_on_translation_id ON public.translation_versions USING btree (translation_id);
 
 
 --
--- Name: index_tutorial_versions_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorial_versions_on_tutorial_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorial_versions_on_tutorial_id ON public.tutorial_versions USING btree (tutorial_id);
 
 
 --
--- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorials_on_kind; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorials_on_kind ON public.tutorials USING btree (kind);
 
 
 --
--- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorials_on_language; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorials_on_language ON public.tutorials USING btree (language);
 
 
 --
--- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tutorials_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tutorials_on_project_id ON public.tutorials USING btree (project_id);
 
 
 --
--- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_collection_preferences_on_collection_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_collection_preferences_on_collection_id ON public.user_collection_preferences USING btree (collection_id);
 
 
 --
--- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_collection_preferences_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_collection_preferences_on_user_id ON public.user_collection_preferences USING btree (user_id);
 
 
 --
--- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_groups_display_name_trgrm ON public.user_groups USING gin ((COALESCE((display_name)::text, ''::text)) public.gin_trgm_ops);
 
 
 --
--- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_groups_on_activated_state ON public.user_groups USING btree (activated_state);
 
 
 --
--- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_user_groups_on_name ON public.user_groups USING btree (lower((name)::text));
 
 
 --
--- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_groups_on_private; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_groups_on_private ON public.user_groups USING btree (private);
 
 
 --
--- Name: index_user_project_preferences_on_project_id_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_project_preferences_on_project_id_and_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_user_project_preferences_on_project_id_and_user_id ON public.user_project_preferences USING btree (project_id, user_id);
 
 
 --
--- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_user_seen_subjects_on_user_id_and_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_user_seen_subjects_on_user_id_and_workflow_id ON public.user_seen_subjects USING btree (user_id, workflow_id);
 
 
 --
--- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_activated_state ON public.users USING btree (activated_state);
 
 
 --
--- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_beta_email_communication; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_beta_email_communication ON public.users USING btree (beta_email_communication) WHERE (beta_email_communication = true);
 
 
 --
--- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_display_name ON public.users USING btree (lower((display_name)::text));
 
 
 --
--- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 
 
 --
--- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_global_email_communication; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_global_email_communication ON public.users USING btree (global_email_communication) WHERE (global_email_communication = true);
 
 
 --
--- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_login ON public.users USING btree (lower((login)::text));
 
 
 --
--- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_login_with_case; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_login_with_case ON public.users USING btree (login);
 
 
 --
--- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_lower_names; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_lower_names ON public.users USING btree (lower((login)::text) text_pattern_ops, lower((display_name)::text) text_pattern_ops);
 
 
 --
--- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_private_profile; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_private_profile ON public.users USING btree (private_profile) WHERE (private_profile = false);
 
 
 --
--- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
 
 
 --
--- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_tsv ON public.users USING gin (tsv);
 
 
 --
--- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_unsubscribe_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_unsubscribe_token ON public.users USING btree (unsubscribe_token);
 
 
 --
--- Name: index_users_on_ux_testing_email_communication; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_ux_testing_email_communication; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_ux_testing_email_communication ON public.users USING btree (ux_testing_email_communication) WHERE (ux_testing_email_communication IS TRUE);
 
 
 --
--- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_zooniverse_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_zooniverse_id ON public.users USING btree (zooniverse_id);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_versions_on_item_type_and_item_id ON public.versions USING btree (item_type, item_id);
-
-
---
--- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_contents_on_workflow_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflow_contents_on_workflow_id ON public.workflow_contents USING btree (workflow_id);
 
 
 --
--- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_tutorials_on_tutorial_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflow_tutorials_on_tutorial_id ON public.workflow_tutorials USING btree (tutorial_id);
 
 
 --
--- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_tutorials_on_workflow_id_and_tutorial_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_workflow_tutorials_on_workflow_id_and_tutorial_id ON public.workflow_tutorials USING btree (workflow_id, tutorial_id);
 
 
 --
--- Name: index_workflow_versions_on_workflow_and_major_and_minor; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflow_versions_on_workflow_and_major_and_minor; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_workflow_versions_on_workflow_and_major_and_minor ON public.workflow_versions USING btree (workflow_id, major_number, minor_number);
 
 
 --
--- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_activated_state ON public.workflows USING btree (activated_state);
 
 
 --
--- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_aggregation ON public.workflows USING btree (((aggregation ->> 'public'::text)));
 
 
 --
--- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_display_order ON public.workflows USING btree (display_order);
 
 
 --
--- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_mobile_friendly; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_mobile_friendly ON public.workflows USING btree (mobile_friendly);
 
 
 --
--- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_project_id ON public.workflows USING btree (project_id);
 
 
 --
--- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_public_gold_standard; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_public_gold_standard ON public.workflows USING btree (public_gold_standard) WHERE (public_gold_standard IS TRUE);
 
 
 --
--- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_workflows_on_tutorial_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_workflows_on_tutorial_subject_id ON public.workflows USING btree (tutorial_subject_id);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
 
 
 --
--- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: users_idx_trgm_login; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX users_idx_trgm_login ON public.users USING gin ((COALESCE((login)::text, ''::text)) public.gin_trgm_ops);
@@ -3857,14 +3785,6 @@ ALTER TABLE ONLY public.collections_projects
 
 ALTER TABLE ONLY public.gold_standard_annotations
     ADD CONSTRAINT fk_rails_1d218ca624 FOREIGN KEY (workflow_id) REFERENCES public.workflows(id);
-
-
---
--- Name: fk_rails_1e54468460; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.recents
-    ADD CONSTRAINT fk_rails_1e54468460 FOREIGN KEY (classification_id) REFERENCES public.classifications(id);
 
 
 --
@@ -4279,7 +4199,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user",public;
+SET search_path TO "$user", public;
 
 INSERT INTO schema_migrations (version) VALUES ('20150210025312');
 
@@ -4776,4 +4696,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190507103007');
 INSERT INTO schema_migrations (version) VALUES ('20190524111214');
 
 INSERT INTO schema_migrations (version) VALUES ('20190624094308');
+
+INSERT INTO schema_migrations (version) VALUES ('20200327164455');
+
+INSERT INTO schema_migrations (version) VALUES ('20200513124310');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1153,8 +1153,7 @@ CREATE TABLE public.recents (
     project_id integer,
     workflow_id integer,
     user_id integer,
-    user_group_id integer,
-    mark_remove boolean DEFAULT false
+    user_group_id integer
 );
 
 
@@ -3265,6 +3264,13 @@ CREATE INDEX index_projects_on_tsv ON public.projects USING gin (tsv);
 
 
 --
+-- Name: index_recents_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_recents_on_created_at ON public.recents USING btree (created_at);
+
+
+--
 -- Name: index_recents_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3272,10 +3278,24 @@ CREATE INDEX index_recents_on_project_id ON public.recents USING btree (project_
 
 
 --
+-- Name: index_recents_on_subject_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_recents_on_subject_id ON public.recents USING btree (subject_id);
+
+
+--
 -- Name: index_recents_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recents_on_user_id ON public.recents USING btree (user_id);
+
+
+--
+-- Name: index_recents_on_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_recents_on_workflow_id ON public.recents USING btree (workflow_id);
 
 
 --
@@ -3785,6 +3805,14 @@ ALTER TABLE ONLY public.collections_projects
 
 ALTER TABLE ONLY public.gold_standard_annotations
     ADD CONSTRAINT fk_rails_1d218ca624 FOREIGN KEY (workflow_id) REFERENCES public.workflows(id);
+
+
+--
+-- Name: fk_rails_1e54468460; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recents
+    ADD CONSTRAINT fk_rails_1e54468460 FOREIGN KEY (classification_id) REFERENCES public.classifications(id);
 
 
 --
@@ -4696,8 +4724,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190507103007');
 INSERT INTO schema_migrations (version) VALUES ('20190524111214');
 
 INSERT INTO schema_migrations (version) VALUES ('20190624094308');
-
-INSERT INTO schema_migrations (version) VALUES ('20200327164455');
 
 INSERT INTO schema_migrations (version) VALUES ('20200513124310');
 


### PR DESCRIPTION
Drop the unused paper trail gem versions table to cleanup the schema, shrink the total db size and avoid migrating this data.

~NOTE: we must ensure we have a backup of the table data stored somewhere in case we need to restore data from it.~ Done

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
