### PR TITLE
Add staging adapter to database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,10 @@ development:
   <<: *default
   database: panoptes_development
 
+staging:
+  <<: *default
+  database: panoptes
+
 development_standby:
   <<: *default
   database: panoptes_development


### PR DESCRIPTION
* `DATABASE_URL` was missing from the secret. Added it with full creds and included `/panoptes` at the end to specify database.
* staging adapter was missing from database.yml. Included `database: panoptes` at the risk of being redundant with the URL above.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
