### PR TITLE
Switch from URL to pieces

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,9 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  url: <%= ENV.fetch('DATABASE_URL', 'postgresql://panoptes:panoptes@localhost') %>
+  host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
+  username: <%= ENV.fetch('DATABASE_USERNAME', 'panoptes' %>
+  password: <%= ENV.fetch('DATABASE_PASSWORD', 'panoptes' %>
   pool: <%= ENV.fetch('PG_POOL_SIZE', 5) %>
   prepared_statements: <%= ENV.fetch('PG_PREPARED_STATEMENTS', false) %>
   variables:
@@ -13,6 +15,10 @@ development:
   database: panoptes_development
 
 staging:
+  <<: *default
+  database: panoptes
+
+production:
   <<: *default
   database: panoptes
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,8 +2,8 @@ default: &default
   adapter: postgresql
   encoding: unicode
   host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
-  username: <%= ENV.fetch('DATABASE_USERNAME', 'panoptes' %>
-  password: <%= ENV.fetch('DATABASE_PASSWORD', 'panoptes' %>
+  username: <%= ENV.fetch('DATABASE_USERNAME', 'panoptes') %>
+  password: <%= ENV.fetch('DATABASE_PASSWORD', 'panoptes') %>
   pool: <%= ENV.fetch('PG_POOL_SIZE', 5) %>
   prepared_statements: <%= ENV.fetch('PG_PREPARED_STATEMENTS', false) %>
   variables:


### PR DESCRIPTION
Env vars can't contain `:`, as is required by a URL. A full URL, even as a quoted string, doesn't seem to make it as a set env var. 

Switching to pieces (host/username/password) bypasses this issue.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
