### PR TITLE
update puma configs for K8s deployments

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,20 +9,19 @@ port = rails_env == dev_env ? 3000 : 81
 environment rails_env
 state_path "#{app_path}/tmp/pids/puma.state"
 
-if rails_env == "production"
-  stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true
-end
-
 bind "tcp://0.0.0.0:#{port}"
 
-# === Cluster mode ===
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 2 }.to_i
+
 case rails_env
 when "production"
-  workers 2
-  threads 0,8
+  stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true
+  # === Cluster mode ===
+  workers 2 # TODO: move from cluster mode once production is in K8s
+  threads 1,8
 when "staging"
-  workers 2
-  threads 0,4
+  # === Non-Cluster mode (no worker / forking) ===
+  threads 1,threads_count
 end
 
 # Additional text to display in process listing

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -13,13 +13,12 @@ bind "tcp://0.0.0.0:#{port}"
 
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 2 }.to_i
 
-case rails_env
-when "production"
+if rails_env == "production"
   stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true
   # === Cluster mode ===
   workers 2 # TODO: move from cluster mode once production is in K8s
   threads 1,8
-when "staging"
+else
   # === Non-Cluster mode (no worker / forking) ===
   threads 1,threads_count
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # For more information: https://github.com/puma/puma/blob/master/examples/config.rb
 app_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
 
@@ -13,14 +15,14 @@ bind "tcp://0.0.0.0:#{port}"
 
 threads_count = ENV.fetch('RAILS_MAX_THREADS', 2).to_i
 
-if rails_env == "production"
+if rails_env == 'production'
   stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true
   # === Cluster mode ===
   workers 2 # TODO: move from cluster mode once production is in K8s
-  threads 1,8
+  threads 1, 8
 else
   # === Non-Cluster mode (no worker / forking) ===
-  threads 1,threads_count
+  threads 1, threads_count
 end
 
 # Additional text to display in process listing

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,7 +11,7 @@ state_path "#{app_path}/tmp/pids/puma.state"
 
 bind "tcp://0.0.0.0:#{port}"
 
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 2 }.to_i
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 2).to_i
 
 if rails_env == "production"
   stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true


### PR DESCRIPTION
scale via k8s pods and reduce the CPU / RAM load in the web server container

As per docs here, https://github.com/puma/puma#thread-pool

THIS needs to be tested locally, i haven't done this yet. `docker-compose build` then `docker-compose up` would do it for non production setup

### TODO
- [x] Look at how the puma restart script will work, https://github.com/zooniverse/Panoptes/blob/5cbaf621f99799880112e7304e9b4016ff78343d/scripts/docker/restart_puma.sh#L5 docs here https://github.com/puma/puma/blob/master/docs/restart.md

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
