### PR TITLE
Add .to_i to ENV.fetch calls that should be ints

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -367,6 +367,6 @@ class User < ActiveRecord::Base
   end
 
   def subject_count_cache_expiry
-    ENV.fetch("UPLOADED_SUBJECTS_COUNT_CACHE_EXPIRY", 1.hour)
+    ENV.fetch("UPLOADED_SUBJECTS_COUNT_CACHE_EXPIRY", 1.hour).to_i.seconds
   end
 end

--- a/app/workers/concerns/rate_limit_dump_worker.rb
+++ b/app/workers/concerns/rate_limit_dump_worker.rb
@@ -4,9 +4,9 @@ module RateLimitDumpWorker
   included do
     sidekiq_options congestion:
       {
-        interval: ENV.fetch('DUMP_CONGESTION_OPTS_INTERVAL', 86400),
-        max_in_interval: ENV.fetch('DUMP_CONGESTION_OPTS_MAX_IN_INTERVAL', 1),
-        min_delay: ENV.fetch('DUMP_CONGESTION_OPTS_MIN_DELAY', 43200),
+        interval: ENV.fetch('DUMP_CONGESTION_OPTS_INTERVAL', 86400).to_i,
+        max_in_interval: ENV.fetch('DUMP_CONGESTION_OPTS_MAX_IN_INTERVAL', 1).to_i,
+        min_delay: ENV.fetch('DUMP_CONGESTION_OPTS_MIN_DELAY', 43200).to_i,
         reject_with: ENV.fetch('DUMP_CONGESTION_OPTS_REJECT_WITH', 'cancel').to_sym,
         key: ->(resource_id, resource_type, medium_id, _requester_id=nil) {
           "#{resource_type}_#{resource_id}_#{medium_id}_data_dump_worker"

--- a/app/workers/random_order_shuffle_worker.rb
+++ b/app/workers/random_order_shuffle_worker.rb
@@ -5,9 +5,9 @@ class RandomOrderShuffleWorker
     queue: :data_medium,
     congestion:
       {
-        interval: ENV.fetch('SELECTION_RANDOM_INTERVAL', 60),
-        max_in_interval: ENV.fetch('SELECTION_RANDOM_MAX_IN_INTERVAL', 1),
-        min_delay: ENV.fetch('SELECTION_RANDOM_MIN_DELAY', 30),
+        interval: ENV.fetch('SELECTION_RANDOM_INTERVAL', 60).to_i,
+        max_in_interval: ENV.fetch('SELECTION_RANDOM_MAX_IN_INTERVAL', 1).to_i,
+        min_delay: ENV.fetch('SELECTION_RANDOM_MIN_DELAY', 30).to_i,
         reject_with: :cancel
       }
   )

--- a/app/workers/reset_project_counters_worker.rb
+++ b/app/workers/reset_project_counters_worker.rb
@@ -6,9 +6,9 @@ class ResetProjectCountersWorker
     lock: :until_executing,
     congestion:
       {
-        interval: ENV.fetch('COUNTER_CONGESTION_OPTS_INTERVAL', 360),
-        max_in_interval: ENV.fetch('COUNTER_CONGESTION_OPTS_MAX_IN_INTERVAL', 10),
-        min_delay: ENV.fetch('COUNTER_CONGESTION_OPTS_MIN_DELAY', 180),
+        interval: ENV.fetch('COUNTER_CONGESTION_OPTS_INTERVAL', 360).to_i,
+        max_in_interval: ENV.fetch('COUNTER_CONGESTION_OPTS_MAX_IN_INTERVAL', 10).to_i,
+        min_delay: ENV.fetch('COUNTER_CONGESTION_OPTS_MIN_DELAY', 180).to_i,
         reject_with: :reschedule,
         key: ->(project_id) { "project_id_#{project_id}_count_worker" },
         enabled: ->(_project_id, rate_limit=true) { rate_limit }

--- a/app/workers/subject_set_subject_counter_worker.rb
+++ b/app/workers/subject_set_subject_counter_worker.rb
@@ -5,9 +5,9 @@ class SubjectSetSubjectCounterWorker
     queue: :data_high,
     congestion:
       {
-        interval: ENV.fetch('COUNTER_CONGESTION_OPTS_INTERVAL', 360),
-        max_in_interval: ENV.fetch('COUNTER_CONGESTION_OPTS_MAX_IN_INTERVAL', 10),
-        min_delay: ENV.fetch('COUNTER_CONGESTION_OPTS_MIN_DELAY', 180),
+        interval: ENV.fetch('COUNTER_CONGESTION_OPTS_INTERVAL', 360).to_i,
+        max_in_interval: ENV.fetch('COUNTER_CONGESTION_OPTS_MAX_IN_INTERVAL', 10).to_i,
+        min_delay: ENV.fetch('COUNTER_CONGESTION_OPTS_MIN_DELAY', 180).to_i,
         reject_with: :reschedule,
         key: ->(subject_set_id) { "subject_set_#{subject_set_id}_counter_worker" }
       },

--- a/config/cache_store.rb
+++ b/config/cache_store.rb
@@ -11,7 +11,7 @@ module Panoptes
     end
 
     def self.expires_in
-      ENV.fetch("CACHE_EXPIRES_IN", 5.minutes)
+      ENV.fetch("CACHE_EXPIRES_IN", 5.minutes).to_i.seconds
     end
 
     def self.compress
@@ -19,7 +19,7 @@ module Panoptes
     end
 
     def self.pool_size
-      ENV.fetch("CACHE_POOL_SIZE", 16)
+      ENV.fetch("CACHE_POOL_SIZE", 16).to_i
     end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,11 +2,11 @@ default: &default
   adapter: postgresql
   encoding: unicode
   url: <%= ENV.fetch('DATABASE_URL', 'postgresql://panoptes:panoptes@localhost') %>
-  pool: <%= ENV.fetch('PG_POOL_SIZE', 5) %>
+  pool: <%= ENV.fetch('PG_POOL_SIZE', 5).to_i %>
   prepared_statements: <%= ENV.fetch('PG_PREPARED_STATEMENTS', false) %>
   variables:
     # default 5 minutes for the query exectution (sidekiq uses default, API will set the env param match load balancer)
-    statement_timeout: <%= ENV.fetch('PG_STATEMENT_TIMEOUT', 300000) %>
+    statement_timeout: <%= ENV.fetch('PG_STATEMENT_TIMEOUT', 300000).to_i %>
 
 development:
   <<: *default

--- a/config/initializers/1_panoptes.rb
+++ b/config/initializers/1_panoptes.rb
@@ -1,6 +1,6 @@
 module Panoptes
   def self.lifecycled_live_window
-    ENV.fetch('LIVE_WINDOW', 15)
+    ENV.fetch('LIVE_WINDOW', 15).to_i
   end
 
   def self.disable_lifecycle_worker
@@ -8,10 +8,10 @@ module Panoptes
   end
 
   def self.pg_statement_timeout
-    ENV.fetch('PG_STATEMENT_TIMEOUT', 300000)
+    ENV.fetch('PG_STATEMENT_TIMEOUT', 300000).to_i
   end
 
   def self.max_page_size_limit
-    ENV.fetch('PAGE_SIZE_LIMIT', 100)
+    ENV.fetch('PAGE_SIZE_LIMIT', 100).to_i
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,7 +5,7 @@ module Panoptes
       headers: :any,
       request_methods: %w[delete get post options put head],
       expose: %w[ETag X-CSRF-Param X-CSRF-Token],
-      max_age: ENV.fetch('CORS_MAX_AGE', 300),
+      max_age: ENV.fetch('CORS_MAX_AGE', 300).to_i,
       allows: [
         { origins: '*', resource: '/api/*' },
         { origins: '*', resource: '/graphql' },

--- a/config/initializers/subject_selection_config.rb
+++ b/config/initializers/subject_selection_config.rb
@@ -3,11 +3,11 @@
 module Panoptes
   module SubjectSelection
     def self.focus_set_window_size
-      ENV.fetch('SELECTION_FOCUS_SET_WINDOW_SIZE', 1000)
+      ENV.fetch('SELECTION_FOCUS_SET_WINDOW_SIZE', 1000).to_i
     end
 
     def self.index_rebuild_rate
-      ENV.fetch('SELECTION_INDEX_REBUILD_RATE', 0.01)
+      ENV.fetch('SELECTION_INDEX_REBUILD_RATE', 0.01).to_f
     end
   end
 end

--- a/config/initializers/user_limits.rb
+++ b/config/initializers/user_limits.rb
@@ -2,6 +2,6 @@
 
 module Panoptes
   def self.max_subjects
-    ENV.fetch('USER_SUBJECT_LIMIT', 100)
+    ENV.fetch('USER_SUBJECT_LIMIT', 100).to_i
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,9 +5,9 @@
 :verbose: <%= ENV.fetch('SIDEKIQ_VERBOSE', false) %>
 :logfile: <%= ENV.fetch('SIDEKIQ_LOGFILE', './log/sidekiq.log') %>
 :pidfile: <%= ENV.fetch('SIDEKIQ_PIDFILE', './tmp/pids/sidekiq.pid') %>
-:concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 1) %>
+:concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 1).to_i %>
 # Set timeout to 8 on Heroku, longer if you manage your own systems.
-:timeout: <%= ENV.fetch('SIDEKIQ_TIMEOUT', 30) %>
+:timeout: <%= ENV.fetch('SIDEKIQ_TIMEOUT', 30).to_i %>
 :queues:
   - really_high
   - high

--- a/lib/http_cacheable.rb
+++ b/lib/http_cacheable.rb
@@ -37,7 +37,7 @@ class HttpCacheable
   end
 
   def max_age_directive
-    @max_age_directive ||= ENV.fetch("HTTP_#{resource_symbol.to_s.upcase}_MAX_AGE", 60)
+    @max_age_directive ||= ENV.fetch("HTTP_#{resource_symbol.to_s.upcase}_MAX_AGE", 60).to_i
   end
 
   def cacheable_resource?


### PR DESCRIPTION
Cast env var strings to integers so that Rails doesn't choke on comparisons. Also cast a few to time in seconds to match default types.

And one float.  🌬️ 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
