### PR TITLE
Fix race condition when setting up assets

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -222,11 +222,7 @@ spec:
               value: '10000'
           volumeMounts:
             - name: static-assets
-              mountPath: "/static-assets"
-          lifecycle:
-            postStart:
-              exec:
-                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
+              mountPath: "/rails_app/public/api-assets"
         - name: panoptes-staging-nginx
           image: zooniverse/apps-nginx:xenial
           ports:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -215,11 +215,7 @@ spec:
               value: '100'
           volumeMounts:
             - name: static-assets
-              mountPath: "/static-assets"
-          lifecycle:
-            postStart:
-              exec:
-                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
+              mountPath: "/rails_app/public/api-assets"
         - name: panoptes-staging-nginx
           image: zooniverse/apps-nginx:xenial
           ports:

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -15,7 +15,7 @@ rm -f tmp/pids/*.pid
 if [ "$RAILS_ENV" == "development" ]; then
   exec bundle exec foreman start
 else
-  if [ ! -d public/assets ]
+  if [ ! -d public/api-assets ] || [ "$(ls -A public/api-assets)" == "" ]
   then
       bundle exec rake assets:precompile
   fi


### PR DESCRIPTION
The "cp" command runs before the assets finish compiling.

Mount the api-assets directory directly as a volume, and precompile
assets on start if the directory is empty.


Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
