### PR TITLE
increase the CPU limits

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -76,10 +76,10 @@ spec:
           resources:
             requests:
               memory: "1500Mi"
-              cpu: "50m"
+              cpu: "500m"
             limits:
               memory: "1500Mi"
-              cpu: "500m"
+              cpu: "1000m"
           env:
             - name: RAILS_ENV
               value: production

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -79,7 +79,7 @@ spec:
               cpu: "50m"
             limits:
               memory: "700Mi"
-              cpu: "500m"
+              cpu: "1000m"
           env:
             - name: RAILS_ENV
               value: staging


### PR DESCRIPTION
allow the API containers to consume 1vcpu as the puma web server will most likely need 1vcpu for processing the incoming requests. 

Running more pods will increase the RAM pressure on the K8s system. So we've got to find a balance between the number of threads a puma server (share the same RAM cost) can handle before we scale via pods to handle the traffic. 

FWIW on each ec2 instance, we ran 2 puma processes, each with 4(staging)/8(production) threads.

The puma web server will have at least 2 threads running (more in production, https://github.com/zooniverse/panoptes/blob/33c3475a885da0821a2336f55485703b7ef055d2/config/puma.rb#L16). 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
