### PR TITLE
Improve container startup times 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ ADD supervisord.conf /etc/supervisor/conf.d/panoptes.conf
 ADD ./ /rails_app
 
 RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt)
+RUN (cd /rails_app && mkdir -p tmp/pids && rm -f tmp/pids/*.pid)
+RUN (cd /rails_app && SECRET_KEY_BASE=1 bundle exec rake assets:precompile)
 
 EXPOSE 81
 

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -2,24 +2,13 @@
 
 cd /rails_app
 
-if [ -d "/rails_conf/" ]
-then
-    ln -sf /rails_conf/* ./config/
-fi
-
 tmpreaper 7d /tmp/
 
-mkdir -p tmp/pids/
-rm -f tmp/pids/*.pid
-
 if [ "$RAILS_ENV" == "development" ]; then
+  mkdir -p tmp/pids/
+  rm -f tmp/pids/*.pid
   exec bundle exec foreman start
 else
-  if [ ! -d public/assets ]
-  then
-      bundle exec rake assets:precompile
-  fi
-
   if [ -f "commit_id.txt" ]
   then
     cp commit_id.txt public/


### PR DESCRIPTION
Improve container startup times: 
1. avoid building at startup of the container
0. setup the tmp pid dirs at build time

## TODO
- [x] test this builds and works correctly locally

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
