### PR TITLE
add RAILS_ENV to prod & staging Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ RUN apt-get update && \
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 
+# set a default RAILS_ENV for the build scripts
+# this is required for the `rake assets:precompile` script
+# to write assets to target dir set in `config.assets.prefix`
+ARG RAILS_ENV=production
+ENV RAILS_ENV=$RAILS_ENV
+
 RUN mkdir config && curl "https://ip-ranges.amazonaws.com/ip-ranges.json" > config/aws_ips.json
 
 ADD ./Gemfile /rails_app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ADD ./ /rails_app
 
 RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt)
 RUN (cd /rails_app && mkdir -p tmp/pids && rm -f tmp/pids/*.pid)
-RUN (cd /rails_app && SECRET_KEY_BASE=1 bundle exec rake assets:precompile)
+RUN (cd /rails_app && SECRET_KEY_BASE=1a bundle exec rake assets:precompile)
 
 EXPOSE 81
 


### PR DESCRIPTION
Add a RAILS_ENV argument to production and staging Dockerfile to ensure at build time the asset pipeline correctly wires up the assets in the expected dir** 

The Dockerfile ARG will allow us to modify the RAILS_ENV environment variable at build time if we chose to (via jenkins etc). Noting that as staging and production produce the same underlying image we don't need this right now but it's better than inlining the RAILS_ENV to the rake assets:precompile CMD.

**modified in https://github.com/zooniverse/panoptes/pull/3249 to accomodate both PFE assets and panoptes assets on www.zooniverser.org domain.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
