### PR TITLE
Add horizontal pod autoscaler

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -113,7 +113,6 @@ metadata:
   labels:
     app: panoptes-production-app
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: panoptes-production-app
@@ -323,6 +322,19 @@ spec:
         - name: panoptes-nginx-config
           configMap:
             name: panoptes-nginx-conf-production
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: panoptes-production-app
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: panoptes-production-app
+  minReplicas: 2
+  maxReplicas: 8
+  targetCPUUtilizationPercentage: 80
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -64,7 +64,6 @@ metadata:
   labels:
     app: panoptes-staging-app
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: panoptes-staging-app
@@ -267,6 +266,19 @@ spec:
         - name: panoptes-nginx-config
           configMap:
             name: panoptes-nginx-conf-staging
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: panoptes-staging-app
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: panoptes-staging-app
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 80
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Adding one for staging too so we can test applying the K8 config. Prod will scale between 2 and 8 pods, targeting 80% CPU utilisation (based on the resource limit we've set, so 80% of one core in this case).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
