### PR TITLE
allow azure zooniverse.org subdomain

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -129,7 +129,7 @@ spec:
             - name: DUMP_CONGESTION_OPTS_MIN_DELAY
               value: "60"
             - name: CORS_ORIGIN
-              value: /^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|[a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$/
+              value: /^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|[a-z0-9-]+(\.azure)?\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$/
             - name: DESIGNATOR_API_HOST
               value: https://designator-staging.zooniverse.org/
             - name: DESIGNATOR_API_USERNAME


### PR DESCRIPTION
allow testing of azure deployed staging API via PFE & CORS, e.g. https://master.pfe-preview.zooniverse.org/?panoptes-api-host=https://panoptes-staging.azure.zooniverse.org

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
