### PR TITLE
Revert "allow azure zooniverse.org subdomain"

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -129,7 +129,7 @@ spec:
             - name: DUMP_CONGESTION_OPTS_MIN_DELAY
               value: "60"
             - name: CORS_ORIGIN
-              value: /^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|[a-z0-9-]+(\.azure)?\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$/
+              value: /^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|[a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$/
             - name: DESIGNATOR_API_HOST
               value: https://designator-staging.zooniverse.org/
             - name: DESIGNATOR_API_USERNAME


### PR DESCRIPTION
Reverts zooniverse/panoptes#3341 - remove this addition once we switch staging to azure k8s cluster