### PR TITLE
avoid clobbering volume and mount declarations

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -121,16 +121,9 @@ spec:
       labels:
         app: panoptes-production-app
     spec:
-      volumes:
-        - name: jwt-production
-          secret:
-            secretName: panoptes-doorkeeper-jwt-production
       containers:
         - name: panoptes-production-app
           image: zooniverse/panoptes:__IMAGE_TAG__
-          volumeMounts:
-            - name: jwt-production
-              mountPath: "/rails_app/config/keys"
           resources:
             requests:
               memory: "1500Mi"
@@ -288,6 +281,9 @@ spec:
           volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"
+            - name: jwt-production
+              mountPath: "/rails_app/config/keys"
+              readOnly: true
           lifecycle:
             postStart:
               exec:
@@ -322,6 +318,9 @@ spec:
         - name: panoptes-nginx-config
           configMap:
             name: panoptes-nginx-conf-production
+        - name: jwt-production
+          secret:
+            secretName: panoptes-doorkeeper-jwt-production
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -72,16 +72,9 @@ spec:
       labels:
         app: panoptes-staging-app
     spec:
-      volumes:
-        - name: jwt-staging
-          secret:
-            secretName: panoptes-doorkeeper-jwt-staging
       containers:
         - name: panoptes-staging-app
           image: zooniverse/panoptes:__IMAGE_TAG__
-          volumeMounts:
-            - name: jwt-staging
-              mountPath: "/rails_app/config/keys"
           resources:
             requests:
               memory: "700Mi"
@@ -232,6 +225,9 @@ spec:
           volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"
+            - name: jwt-staging
+              mountPath: "/rails_app/config/keys"
+              readOnly: true
           lifecycle:
             postStart:
               exec:
@@ -266,6 +262,9 @@ spec:
         - name: panoptes-nginx-config
           configMap:
             name: panoptes-nginx-conf-staging
+        - name: jwt-staging
+          secret:
+            secretName: panoptes-doorkeeper-jwt-staging
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
consolidate the volume and mount declarations together, avoid clobbering details.

Debugged via `$ kubectl describe pod panoptes-staging-app-859c97896d-p26jf` and seeing the `jwt-*` volumes missing from the pods.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
