### PR TITLE
Add memcached

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'active_model_serializers', '0.10.0.rc2' # Event stream
 gem 'active_record_union', '~> 1.3.0'
 gem 'activerecord-import', '~> 1.0'
 gem 'aws-sdk', '~> 2.10'
-gem 'dalli-elasticache'
+gem 'dalli'
 gem 'deep_cloneable', '~> 2.3.2'
 gem 'devise', '~> 4.7'
 gem 'doorkeeper', '~> 4.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,7 @@ GEM
       redis (>= 3.1)
     connection_pool (2.2.2)
     crass (1.0.6)
-    dalli (2.7.6)
-    dalli-elasticache (0.2.0)
-      dalli (>= 1.0.0)
+    dalli (2.7.10)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     deep_cloneable (2.3.2)
@@ -460,7 +458,7 @@ DEPENDENCIES
   active_record_union (~> 1.3.0)
   activerecord-import (~> 1.0)
   aws-sdk (~> 2.10)
-  dalli-elasticache
+  dalli
   database_cleaner (~> 1.7.0)
   deep_cloneable (~> 2.3.2)
   devise (~> 4.7)

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,8 +46,8 @@ module Panoptes
     config.middleware.use Flipper::Middleware::SetupEnv, -> { Panoptes.flipper }
     config.middleware.use Flipper::Middleware::Memoizer
 
-    if cache_client = Panoptes::ElastiCache.client
-      config.cache_store = :dalli_store, cache_client.servers, Panoptes::ElastiCache.options
+    if cache_client = Panoptes::Cache.client
+      config.cache_store = :dalli_store, cache_client.servers, Panoptes::Cache.options
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,8 +46,10 @@ module Panoptes
     config.middleware.use Flipper::Middleware::SetupEnv, -> { Panoptes.flipper }
     config.middleware.use Flipper::Middleware::Memoizer
 
-    if cache_client = Panoptes::Cache.client
-      config.cache_store = :dalli_store, cache_client.servers, Panoptes::Cache.options
+    if Panoptes::Cache.enabled?
+      # use ENV MEMCACHE_SERVERS var to configure the servers
+      # https://github.com/petergoldstein/dalli#usage-with-rails-3x-and-4x
+      config.cache_store = :dalli_store, nil, Panoptes::Cache.options
     end
   end
 end

--- a/config/cache_store.rb
+++ b/config/cache_store.rb
@@ -1,9 +1,7 @@
 module Panoptes
   module Cache
-    def self.client
-      if cluster_name = ENV["CACHE_SERVER"]
-        Dalli::Client.new("#{cluster_name}:11211")
-      end
+    def self.enabled?
+      ENV.key?('MEMCACHE_SERVERS')
     end
 
     def self.options
@@ -11,15 +9,15 @@ module Panoptes
     end
 
     def self.expires_in
-      ENV.fetch("CACHE_EXPIRES_IN", 5.minutes).to_i.seconds
+      ENV.fetch('CACHE_EXPIRES_IN', 5.minutes).to_i.seconds
     end
 
     def self.compress
-      ENV.fetch("CACHE_COMPRESS", true)
+      ENV.fetch('CACHE_COMPRESS', true)
     end
 
     def self.pool_size
-      ENV.fetch("CACHE_POOL_SIZE", 16).to_i
+      ENV.fetch('RAILS_MAX_THREADS', 8).to_i
     end
   end
 end

--- a/config/cache_store.rb
+++ b/config/cache_store.rb
@@ -1,8 +1,8 @@
 module Panoptes
-  module ElastiCache
+  module Cache
     def self.client
-      if cluster_name = ENV["ELASTIC_CACHE"]
-        Dalli::ElastiCache.new("#{cluster_name}:11211")
+      if cluster_name = ENV["CACHE_SERVER"]
+        Dalli::Client.new("#{cluster_name}:11211")
       end
     end
 

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -170,8 +170,8 @@ spec:
                 secretKeyRef:
                   name: panoptes-common-env-vars
                   key: AWS_SECRET_ACCESS_KEY
-            - name: CACHE_SERVER
-              value: panoptes-production-memcached
+            - name: MEMCACHE_SERVERS
+              value: 'panoptes-production-memcached:11211'
             - name: CORS_ORIGINS_REGEX
               value: '^https?:\/\/((www|staging)\.antislaverymanuscripts\.org|(www|staging)?\.?heirtagger\.ox\.ac\.uk|(www|lab|learn)\.wildcamgorongosa\.org|www\.diagnosislondon\.org|anno\.tate\.org\.uk|(www|relaunch|field-book)\.notesfromnature\.org|[a-z0-9-]+\.oldweather\.org|www\.scribesofthecairogeniza\.org|([a-z0-9-]+\.)?zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
             - name: DESIGNATOR_API_HOST
@@ -391,4 +391,4 @@ spec:
     - protocol: TCP
       port: 11211
       targetPort: 11211
-  type: NodePort 
+  type: NodePort

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -170,6 +170,8 @@ spec:
                 secretKeyRef:
                   name: panoptes-common-env-vars
                   key: AWS_SECRET_ACCESS_KEY
+            - name: CACHE_SERVER
+              value: panoptes-production-memcached
             - name: CORS_ORIGINS_REGEX
               value: '^https?:\/\/((www|staging)\.antislaverymanuscripts\.org|(www|staging)?\.?heirtagger\.ox\.ac\.uk|(www|lab|learn)\.wildcamgorongosa\.org|www\.diagnosislondon\.org|anno\.tate\.org\.uk|(www|relaunch|field-book)\.notesfromnature\.org|[a-z0-9-]+\.oldweather\.org|www\.scribesofthecairogeniza\.org|([a-z0-9-]+\.)?zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
             - name: DESIGNATOR_API_HOST
@@ -347,3 +349,46 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: panoptes-production-memcached
+  labels:
+    app: panoptes-production-memcached
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: panoptes-production-memcached
+  template:
+    metadata:
+      labels:
+        app: panoptes-production-memcached
+    spec:
+      containers:
+        - name: panoptes-production-memcached
+          image: memcached:1.6.6
+          args: ['-m 90']
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: panoptes-production-memcached
+spec:
+  selector:
+    app: panoptes-production-memcached
+  ports:
+    - protocol: TCP
+      port: 11211
+      targetPort: 11211
+  type: NodePort 

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -120,6 +120,8 @@ spec:
               value: "60"
             - name: DUMP_CONGESTION_OPTS_MIN_DELAY
               value: "60"
+            - name: CACHE_SERVER
+              value: panoptes-staging-memcached
             - name: CORS_ORIGINS_REGEX
               value: '^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|[a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
             - name: DESIGNATOR_API_HOST
@@ -291,3 +293,46 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: panoptes-staging-memcached
+  labels:
+    app: panoptes-staging-memcached
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: panoptes-staging-memcached
+  template:
+    metadata:
+      labels:
+        app: panoptes-staging-memcached
+    spec:
+      containers:
+        - name: panoptes-staging-memcached
+          image: memcached:1.6.6
+          args: ['-m 90']
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: panoptes-staging-memcached
+spec:
+  selector:
+    app: panoptes-staging-memcached
+  ports:
+    - protocol: TCP
+      port: 11211
+      targetPort: 11211
+  type: NodePort 

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -120,8 +120,8 @@ spec:
               value: "60"
             - name: DUMP_CONGESTION_OPTS_MIN_DELAY
               value: "60"
-            - name: CACHE_SERVER
-              value: panoptes-staging-memcached
+            - name: MEMCACHE_SERVERS
+              value: 'panoptes-staging-memcached:11211'
             - name: CORS_ORIGINS_REGEX
               value: '^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local|10\.[0-9]+\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|[a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
             - name: DESIGNATOR_API_HOST
@@ -335,4 +335,4 @@ spec:
     - protocol: TCP
       port: 11211
       targetPort: 11211
-  type: NodePort 
+  type: NodePort


### PR DESCRIPTION
Adds a memcached service, renames the cache class and config env var to not mention ElastiCache.

I've set the container's memory limit to 100 MB, and the runtime memory limit in memcached to 90 MB. The current production cache seems to be consistently using less than half this amount:

![Screenshot 2020-06-16 at 16 36 26](https://user-images.githubusercontent.com/428423/84796823-012e1d80-aff1-11ea-9582-5be451ed872a.png)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
