### PR TITLE
disable kernel THP for redis nodes

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -336,6 +336,13 @@ spec:
       labels:
         app: panoptes-production-redis
     spec:
+      initContainers:
+        - name: disable-thp
+          image: busybox
+          volumeMounts:
+            - name: host-sys
+              mountPath: /host-sys
+          command: ["sh", "-c", "echo never >/host-sys/kernel/mm/transparent_hugepage/enabled"]
       containers:
         - name: panoptes-production-redis
           image: redis:6.0.5

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -361,6 +361,10 @@ spec:
         - name: panoptes-production-redis-data
           persistentVolumeClaim:
             claimName: panoptes-production-redis
+        - name: host-sys
+          hostPath:
+            path: /sys
+
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -311,6 +311,9 @@ spec:
         - name: panoptes-staging-redis-data
           persistentVolumeClaim:
             claimName: panoptes-staging-redis
+        - name: host-sys
+          hostPath:
+            path: /sys
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -286,6 +286,13 @@ spec:
       labels:
         app: panoptes-staging-redis
     spec:
+      initContainers:
+        - name: disable-thp
+          image: busybox
+          volumeMounts:
+            - name: host-sys
+              mountPath: /host-sys
+          command: ["sh", "-c", "echo never >/host-sys/kernel/mm/transparent_hugepage/enabled"]
       containers:
         - name: panoptes-staging-redis
           image: redis:6.0.5


### PR DESCRIPTION
disable linux kernel transparent huge pages feature to avoid latency spikes in redis, http://antirez.com/news/84

use `initcontainers` to disable on the underlying k8s node, note this setting is permanent on the nodes so it may impact other apps. If we need isolation we can have another node pool for containers that need / do not need this setting, https://stackoverflow.com/questions/45279477/disable-transparent-huge-pages-from-kubernetes

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
