### PR TITLE
update prod puma configs

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,15 +15,8 @@ bind "tcp://0.0.0.0:#{port}"
 
 threads_count = ENV.fetch('RAILS_MAX_THREADS', 2).to_i
 
-if rails_env == 'production'
-  stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true
-  # === Cluster mode ===
-  workers 2 # TODO: move from cluster mode once production is in K8s
-  threads 1, 8
-else
-  # === Non-Cluster mode (no worker / forking) ===
-  threads 1, threads_count
-end
+# === Non-Cluster mode (no worker / forking) ===
+threads 1, threads_count
 
 # Additional text to display in process listing
 tag 'panoptes_api'

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -132,6 +132,7 @@ data:
   PROJECT_REQUEST_RECIPIENTS: project-review@zooniverse.org
   PROJECT_REQUEST_BCC: i2h6y2f6a7o0x7i9@zooniverse.slack.com
   REDIS_URL: 'redis://panoptes-production-redis:6379/0'
+  RAILS_MAX_THREADS: 8
   SIDEKIQ_CONCURRENCY: '8'
   STORAGE_ADAPTER: aws
   STORAGE_BUCKET: zooniverse-static


### PR DESCRIPTION
Update the puma prod config from AWS to K8s

remove the STDOUT logging redirection and use RAILS_MAX_THREADS env var for puma thread count

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
