### PR TITLE
Fix env var value loading in configurable

### DIFF
--- a/lib/configurable.rb
+++ b/lib/configurable.rb
@@ -23,7 +23,8 @@ module Configurable
     def load_configuration
       @fields.each do |key, options|
         field_key = options[:key] || key
-        value = env_vars["#{@api_prefix}_#{field_key.upcase}"]
+        env_key = "#{@api_prefix}_#{field_key}".upcase
+        value = env_vars[env_key]
         value ||= config_from_file[field_key]
         value = value.to_i if options[:type] == :integer
 


### PR DESCRIPTION
ensure we load from UPCASE env var names, e.g. https://github.com/zooniverse/panoptes/blob/700d65c883b6590fc96ded48da74f6cacf14d980/kubernetes/deployment-production.tmpl#L140

before this was looking for key `TALK_API_host` after change it's looking for `TALK_API_HOST`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
