### PR TITLE
Reinstate AWS production deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,10 +42,149 @@ pipeline {
               newImage.push('latest')
             }
           }
+          if (env.TAG_NAME == 'production-release') {
+            stage('Update production release tag') {
+              newImage.push('production-release')
+            }
+          }
         }
       }
     }
 
+    stage('Build AMIs') {
+      when { tag 'production-release' }
+      failFast true
+      parallel {
+        stage('Production API') {
+          options {
+            skipDefaultCheckout true
+          }
+          agent {
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+            }
+          }
+          steps {
+            sh """#!/bin/bash -e
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./rebuild.sh -c panoptes-api
+              kill \${KEEP_ALIVE_ECHO_JOB}
+            """
+          }
+          post {
+            success {
+              slackSend (
+                  color: '#00FF00',
+                  message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+                  channel: "#ops"
+                  )
+            }
+            failure {
+              slackSend (
+                  color: '#FF0000',
+                  message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+                  channel: "#ops"
+                  )
+            }
+          }
+        }
+        stage('Production Dump workers') {
+          options {
+            skipDefaultCheckout true
+          }
+          agent {
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+            }
+          }
+          steps {
+            sh """#!/bin/bash -e
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./rebuild.sh -c panoptes-dumpworker
+              kill \${KEEP_ALIVE_ECHO_JOB}
+            """
+          }
+          post {
+            success {
+              slackSend (
+                  color: '#00FF00',
+                  message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+                  channel: "#ops"
+                  )
+            }
+            failure {
+              slackSend (
+                  color: '#FF0000',
+                  message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+                  channel: "#ops"
+                  )
+            }
+          }
+        }
+      }
+    }
+
+    stage('Deploy production AMIs') {
+      when { tag 'production-release' }
+      failFast true
+      parallel {
+        stage('Deploy API') {
+          options {
+            skipDefaultCheckout true
+          }
+          agent {
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+            }
+          }
+          steps {
+            sh """#!/bin/bash -e
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./deploy_latest.sh panoptes-api
+              kill \${KEEP_ALIVE_ECHO_JOB}
+            """
+          }
+        }
+        stage('Deploy Dump workers') {
+          options {
+            skipDefaultCheckout true
+          }
+          agent {
+            docker {
+              image 'zooniverse/operations:latest'
+              args '-v "$HOME/.ssh/:/home/ubuntu/.ssh" -v "$HOME/.aws/:/home/ubuntu/.aws"'
+            }
+          }
+          steps {
+            sh """#!/bin/bash -e
+              while true; do sleep 3; echo -n "."; done &
+              KEEP_ALIVE_ECHO_JOB=\$!
+              cd /operations
+              ./deploy_latest.sh panoptes-dumpworker
+              kill \${KEEP_ALIVE_ECHO_JOB}
+            """
+          }
+        }
+      }
+      post {
+        failure {
+          slackSend (
+              color: '#FF0000',
+              message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+              channel: "#ops"
+              )
+        }
+      }
+    }
     stage('Dry run deployments') {
       agent any
       steps {


### PR DESCRIPTION
When the `production-release` tag is pushed:
- Push `zooniverse/panoptes:production-release` to Docker Hub
- Build AMIs for panoptes-api and panoptes-dumpworker
- Deploy panoptes-api and panoptes-dumpworker

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
