### PR TITLE
use tmp disk for dumpworker tmp files

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -252,7 +252,10 @@ spec:
             readOnly: true
       volumes:
         - name: panoptes-staging-dumpworker-data
-          emptyDir: {}
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/panoptes-staging-dumpworker-data
+            type: DirectoryOrCreate
         - name: jwt-staging
           secret:
             secretName: panoptes-doorkeeper-jwt-staging


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/storage/volumes/#hostpath

From my reading this should use the mounted temp disk on the node host FS to map the dump workers scratch space and avoid IOPS on the `/` OS disk. Trying in staging and if it works then i will roll out to production

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
