### PR TITLE
Use build number rather than commit ID for migration jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,20 +198,21 @@ pipeline {
           message: "Starting Panoptes production DB migration - Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
           channel: "#ops"
         )
+        def jobName = "panoptes-migrate-db-production-$env.BUILD_NUMBER"
         sh """
           sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-production.tmpl \
             | sed 's/__BUILD_NUMBER__/${env.BUILD_NUMBER}/g'
             | kubectl --context azure apply --record -f -
 
-          kubectl wait --for=condition=complete --timeout=86400s job/panoptes-migrate-db-production-$env.BUILD_NUMBER
+          kubectl wait --for=condition=complete --timeout=86400s job/$jobName
           SUCCESS=\$?
 
-          kubectl describe job/panoptes-migrate-db-production-$env.BUILD_NUMBER
-          kubectl logs \$(kubectl get pods --selector=job-name=panoptes-migrate-db-production-$env.BUILD_NUMBER --output=jsonpath='{.items[*].metadata.name}')
+          kubectl describe job/$jobName
+          kubectl logs \$(kubectl get pods --selector=job-name=$jobName --output=jsonpath='{.items[*].metadata.name}')
 
           if [ \$SUCCESS -eq 0 ]
           then
-            kubectl delete job panoptes-migrate-db-production-$env.BUILD_NUMBER
+            kubectl delete job $jobName
           fi
 
           exit \$SUCCESS
@@ -228,20 +229,21 @@ pipeline {
           message: "Starting Panoptes staging DB migration - Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
           channel: "#ops"
         )
+        def jobName = "panoptes-migrate-db-staging-$env.BUILD_NUMBER"
         sh """
           sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-staging.tmpl \
             | sed 's/__BUILD_NUMBER__/${env.BUILD_NUMBER}/g'
             | kubectl --context azure apply --record -f -
 
-          kubectl wait --for=condition=complete --timeout=86400s job/panoptes-migrate-db-staging-$env.BUILD_NUMBER
+          kubectl wait --for=condition=complete --timeout=86400s job/$jobName
           SUCCESS=\$?
 
-          kubectl describe job/panoptes-migrate-db-staging-$env.BUILD_NUMBER
-          kubectl logs \$(kubectl get pods --selector=job-name=panoptes-migrate-db-staging-$env.BUILD_NUMBER --output=jsonpath='{.items[*].metadata.name}')
+          kubectl describe job/$jobName
+          kubectl logs \$(kubectl get pods --selector=job-name=$jobName --output=jsonpath='{.items[*].metadata.name}')
 
           if [ \$SUCCESS -eq 0 ]
           then
-            kubectl delete job panoptes-migrate-db-staging-$env.BUILD_NUMBER
+            kubectl delete job $jobName
           fi
 
           exit \$SUCCESS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,17 +199,19 @@ pipeline {
           channel: "#ops"
         )
         sh """
-          sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-production.tmpl | kubectl --context azure apply --record -f -
+          sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-production.tmpl \
+            | sed 's/__BUILD_NUMBER__/${env.BUILD_NUMBER}/g'
+            | kubectl --context azure apply --record -f -
 
-          kubectl wait --for=condition=complete --timeout=86400s job/panoptes-migrate-db-production-$GIT_COMMIT
+          kubectl wait --for=condition=complete --timeout=86400s job/panoptes-migrate-db-production-$env.BUILD_NUMBER
           SUCCESS=\$?
 
-          kubectl describe job/panoptes-migrate-db-production-$GIT_COMMIT
-          kubectl logs \$(kubectl get pods --selector=job-name=panoptes-migrate-db-production-$GIT_COMMIT --output=jsonpath='{.items[*].metadata.name}')
+          kubectl describe job/panoptes-migrate-db-production-$env.BUILD_NUMBER
+          kubectl logs \$(kubectl get pods --selector=job-name=panoptes-migrate-db-production-$env.BUILD_NUMBER --output=jsonpath='{.items[*].metadata.name}')
 
           if [ \$SUCCESS -eq 0 ]
           then
-            kubectl delete job panoptes-migrate-db-production-$GIT_COMMIT
+            kubectl delete job panoptes-migrate-db-production-$env.BUILD_NUMBER
           fi
 
           exit \$SUCCESS
@@ -227,17 +229,19 @@ pipeline {
           channel: "#ops"
         )
         sh """
-          sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-staging.tmpl | kubectl --context azure apply --record -f -
+          sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-staging.tmpl \
+            | sed 's/__BUILD_NUMBER__/${env.BUILD_NUMBER}/g'
+            | kubectl --context azure apply --record -f -
 
-          kubectl wait --for=condition=complete --timeout=86400s job/panoptes-migrate-db-staging-$GIT_COMMIT
+          kubectl wait --for=condition=complete --timeout=86400s job/panoptes-migrate-db-staging-$env.BUILD_NUMBER
           SUCCESS=\$?
 
-          kubectl describe job/panoptes-migrate-db-staging-$GIT_COMMIT
-          kubectl logs \$(kubectl get pods --selector=job-name=panoptes-migrate-db-staging-$GIT_COMMIT --output=jsonpath='{.items[*].metadata.name}')
+          kubectl describe job/panoptes-migrate-db-staging-$env.BUILD_NUMBER
+          kubectl logs \$(kubectl get pods --selector=job-name=panoptes-migrate-db-staging-$env.BUILD_NUMBER --output=jsonpath='{.items[*].metadata.name}')
 
           if [ \$SUCCESS -eq 0 ]
           then
-            kubectl delete job panoptes-migrate-db-staging-$GIT_COMMIT
+            kubectl delete job panoptes-migrate-db-staging-$env.BUILD_NUMBER
           fi
 
           exit \$SUCCESS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,21 +198,21 @@ pipeline {
           message: "Starting Panoptes production DB migration - Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
           channel: "#ops"
         )
-        def jobName = "panoptes-migrate-db-production-$env.BUILD_NUMBER"
         sh """
+          export JOB_NAME="panoptes-migrate-db-production-$env.BUILD_NUMBER"
           sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-production.tmpl \
-            | sed 's/__BUILD_NUMBER__/${env.BUILD_NUMBER}/g'
+            | sed 's/__JOB_NAME__/\$JOB_NAME/g'
             | kubectl --context azure apply --record -f -
 
-          kubectl wait --for=condition=complete --timeout=86400s job/$jobName
+          kubectl wait --for=condition=complete --timeout=86400s job/\$JOB_NAME
           SUCCESS=\$?
 
-          kubectl describe job/$jobName
-          kubectl logs \$(kubectl get pods --selector=job-name=$jobName --output=jsonpath='{.items[*].metadata.name}')
+          kubectl describe job/\$JOB_NAME
+          kubectl logs \$(kubectl get pods --selector=job-name=\$JOB_NAME --output=jsonpath='{.items[*].metadata.name}')
 
           if [ \$SUCCESS -eq 0 ]
           then
-            kubectl delete job $jobName
+            kubectl delete job \$JOB_NAME
           fi
 
           exit \$SUCCESS
@@ -229,21 +229,21 @@ pipeline {
           message: "Starting Panoptes staging DB migration - Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
           channel: "#ops"
         )
-        def jobName = "panoptes-migrate-db-staging-$env.BUILD_NUMBER"
         sh """
+          export JOB_NAME="panoptes-migrate-db-staging-$env.BUILD_NUMBER"
           sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/job-db-migrate-staging.tmpl \
-            | sed 's/__BUILD_NUMBER__/${env.BUILD_NUMBER}/g'
+            | sed 's/__JOB_NAME__/\$JOB_NAME/g'
             | kubectl --context azure apply --record -f -
 
-          kubectl wait --for=condition=complete --timeout=86400s job/$jobName
+          kubectl wait --for=condition=complete --timeout=86400s job/\$JOB_NAME
           SUCCESS=\$?
 
-          kubectl describe job/$jobName
-          kubectl logs \$(kubectl get pods --selector=job-name=$jobName --output=jsonpath='{.items[*].metadata.name}')
+          kubectl describe job/\$JOB_NAME
+          kubectl logs \$(kubectl get pods --selector=job-name=\$JOB_NAME --output=jsonpath='{.items[*].metadata.name}')
 
           if [ \$SUCCESS -eq 0 ]
           then
-            kubectl delete job $jobName
+            kubectl delete job \$JOB_NAME
           fi
 
           exit \$SUCCESS

--- a/kubernetes/job-db-migrate-production.tmpl
+++ b/kubernetes/job-db-migrate-production.tmpl
@@ -1,12 +1,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: panoptes-migrate-db-production
+  name: panoptes-migrate-db-production-__BUILD_NUMBER__
 spec:
   template:
     spec:
       containers:
-      - name: panoptes-migrate-db-production-__IMAGE_TAG__
+      - name: panoptes-migrate-db-production
         image: zooniverse/panoptes:__IMAGE_TAG__
         command: ["/rails_app/migrate.sh"]
         envFrom:

--- a/kubernetes/job-db-migrate-production.tmpl
+++ b/kubernetes/job-db-migrate-production.tmpl
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: panoptes-migrate-db-production-__BUILD_NUMBER__
+  name: __JOB_NAME__
 spec:
   template:
     spec:

--- a/kubernetes/job-db-migrate-staging.tmpl
+++ b/kubernetes/job-db-migrate-staging.tmpl
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: panoptes-migrate-db-staging-__BUILD_NUMBER__
+  name: __JOB_NAME__
 spec:
   template:
     spec:

--- a/kubernetes/job-db-migrate-staging.tmpl
+++ b/kubernetes/job-db-migrate-staging.tmpl
@@ -1,12 +1,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: panoptes-migrate-db-staging
+  name: panoptes-migrate-db-staging-__BUILD_NUMBER__
 spec:
   template:
     spec:
       containers:
-      - name: panoptes-migrate-db-staging-__IMAGE_TAG__
+      - name: panoptes-migrate-db-staging
         image: zooniverse/panoptes:__IMAGE_TAG__
         command: ["/rails_app/migrate.sh"]
         envFrom:


### PR DESCRIPTION
Commit ID seems to be too long.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
