### PR TITLE
Add readiness probes for rollout traffic routing

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -386,6 +386,7 @@ spec:
       containers:
         - name: panoptes-production-redis
           image: redis:6.0.5
+          args: ['--save ""', '--appendonly no']
           resources:
             requests:
               memory: "2500Mi"

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -175,6 +175,14 @@ spec:
               httpHeaders:
                  - name: X-Forwarded-Proto
                    value: https
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
           env:
           - name: PG_STATEMENT_TIMEOUT
             value: '65000'
@@ -212,6 +220,14 @@ spec:
                  - name: X-Forwarded-Proto
                    value: https
             initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
           lifecycle:
             preStop:
               exec:
@@ -386,7 +402,6 @@ spec:
       containers:
         - name: panoptes-production-redis
           image: redis:6.0.5
-          args: ['--save ""', '--appendonly no']
           resources:
             requests:
               memory: "2500Mi"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -330,6 +330,7 @@ spec:
       containers:
         - name: panoptes-staging-redis
           image: redis:6.0.5
+          args: ['--save ""', '--appendonly no']
           resources:
             requests:
               memory: "100Mi"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -119,6 +119,14 @@ spec:
               httpHeaders:
                  - name: X-Forwarded-Proto
                    value: https
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
           env:
           - name: PG_STATEMENT_TIMEOUT
             value: '65000'
@@ -156,6 +164,14 @@ spec:
                  - name: X-Forwarded-Proto
                    value: https
             initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
           lifecycle:
             preStop:
               exec:
@@ -330,7 +346,6 @@ spec:
       containers:
         - name: panoptes-staging-redis
           image: redis:6.0.5
-          args: ['--save ""', '--appendonly no']
           resources:
             requests:
               memory: "100Mi"


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes

only route traffic to the new pods once they are ready to accept it. I tested boot on my dev machine and it was ~25s so going with 20 for production.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
