### PR TITLE
Revert "decrease the HPA cpu target to 50%"

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -264,7 +264,7 @@ spec:
     name: panoptes-production-app
   minReplicas: 2
   maxReplicas: 8
-  targetCPUUtilizationPercentage: 50
+  targetCPUUtilizationPercentage: 80
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Reverts zooniverse/panoptes#3380

We can switch this back to see how it performs at 80% cpu target. 

Re reading the docs https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#how-does-the-horizontal-pod-autoscaler-work

It appears that it will take the 80% of the resource request limit, so 800 as the denominator in the calcs. so ~650m cpu average for the API pod containers before a scale up event occurs. 650/800=0.8125 or 81.25%

That scaling threshold should provide good CPU use on each API container node before a scale up event, while leaving a little headroom before maxing out if we reach our HPA scale max limit. Running less API nodes will also be more efficient on RAM resources in the k8s cluster. 