### PR TITLE
Fix ar connection timeouts through DB pool settings

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   url: <%= ENV.fetch('DATABASE_URL', 'postgresql://panoptes:panoptes@localhost') %>
-  pool: <%= ENV.fetch('PG_POOL_SIZE', 5).to_i %>
+  pool: <%= (ENV['PG_POOL_SIZE'] || ENV.fetch('RAILS_MAX_THREADS', 5)).to_i %>
   prepared_statements: <%= ENV.fetch('PG_PREPARED_STATEMENTS', false) %>
   variables:
     # default 5 minutes for the query exectution (sidekiq uses default, API will set the env param match load balancer)

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -78,6 +78,7 @@ data:
   NEW_RELIC_MONITOR_MODE: 'true'
   PAGE_SIZE_LIMIT: '100'
   REDIS_URL: 'redis://panoptes-staging-redis:6379/0'
+  RAILS_MAX_THREADS: '4'
   SIDEKIQ_CONCURRENCY: '4'
   STORAGE_ADAPTER: aws
   STORAGE_BUCKET: zooniverse-static


### PR DESCRIPTION
Ensure we have an AR connection pool of the appropriate size for the API and sidekiq nodes

New setting: 
#### Staging
- API Puma threads = 4
- Sidekiq = 4
- DB connection pool = 4 (set via RAILS_MAX_THREADS)
#### Production
- API Puma threads = 8
- Sidekiq = 8
- DB connection pool = 8 (set via RAILS_MAX_THREADS)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
