### PR TITLE
Descrease sidekiq hpa cpu target

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -346,7 +346,7 @@ spec:
     name: panoptes-production-sidekiq
   minReplicas: 2
   maxReplicas: 6
-  targetCPUUtilizationPercentage: 95
+  targetCPUUtilizationPercentage: 80
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -291,7 +291,7 @@ spec:
     name: panoptes-staging-sidekiq
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 95
+  targetCPUUtilizationPercentage: 80
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1


### PR DESCRIPTION
95% cpu target is causing pods x 2 to come into and out of service. It appears that the high cpu target is causing the sidekiq nodes to get busy for longer and thus they activate pods in groups due to servicing the sidekiq queues. 

Decreasing this cpu target should allow the nodes to scale up and respond to the queue pressure and then down when the queue is alleviated.

```
Type    Reason             Age                   From                       Message
  ----    ------             ----                  ----                       -------
  Normal  SuccessfulRescale  12m (x2 over 3d2h)    horizontal-pod-autoscaler  New size: 3; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  11m                   horizontal-pod-autoscaler  New size: 4; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  3m34s (x2 over 3d2h)  horizontal-pod-autoscaler  New size: 2; reason: All metrics below target
....
Normal  SuccessfulRescale  15m (x2 over 3d2h)    horizontal-pod-autoscaler  New size: 2; reason: All metrics below target
  Normal  SuccessfulRescale  6m37s (x3 over 3d2h)  horizontal-pod-autoscaler  New size: 3; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  5m36s (x2 over 23m)   horizontal-pod-autoscaler  New size: 4; reason: cpu resource utilization (percentage of request) above target
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
