### PR TITLE
Update _links.erb

### DIFF
--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -8,16 +8,6 @@
     <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
       <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: 'devise-shared-link' %>
     <% end -%>
-
-    <%- if devise_mapping.omniauthable? %>
-      <%- resource_class.omniauth_providers.each do |provider| %>
-        <%- if provider.to_s == 'facebook' %>
-          <%= link_to ("<i class='fa fa-facebook-official fa-lg'></i> Sign in").html_safe, user_facebook_omniauth_authorize_path, class: "devise-shared-link #{provider.to_s}-link" %>
-        <%- elsif provider.to_s == 'google_oauth2' %>
-          <%= link_to ("<i class='fa fa-google fa-lg'></i> Sign in").html_safe, user_google_oauth2_omniauth_authorize_path, class: "devise-shared-link #{provider.to_s}-link" %>
-        <% end -%>
-      <% end -%>
-    <% end -%>
   </div>
 
   <div class="action-links">


### PR DESCRIPTION
This removes the links to the sign in with Facebook and Google options. I'm pretty sure these don't fully work and there's a requested change for my Google Drive API verification request with Google to update this to use the latest brand requirements. It's easier for us to just remove it especially if it's not working anyway.

The reason for the verification request is that I've integrated Google Drive API with Zooniverse Classrooms just to make exports easier to load up with Sheets and use the plugin I built for the Galaxy Zoo activities. Depending on the Google domain settings, sometimes the export to Google Drive fails because we don't have the API key usage verified by Google and the Drive API is considered to be a sensitive scope. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
