### PR TITLE
Revert "Bump rack from 2.0.7 to 2.2.3 in /docs"

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.12.1)
     public_suffix (3.0.3)
-    rack (2.2.3)
+    rack (2.0.7)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)


### PR DESCRIPTION
Reverts zooniverse/panoptes#3355

this breaks the doc builds due to `Content-Length header was 10952, but should be 10964` - downgrading the gem is the only solution i could find quickly. 

Looks likely related to `Change MockRequest#env_for to rely on the input optionally responding to #size instead of #length` 

```
 error  build/stylesheets/screen.css
Content-Length header was 10952, but should be 10964
/usr/local/bundle/gems/rack-2.1.4/lib/rack/lint.rb:22:in `assert'
/usr/local/bundle/gems/rack-2.1.4/lib/rack/lint.rb:695:in `verify_content_length'
/usr/local/bundle/gems/rack-2.1.4/lib/rack/lint.rb:719:in `each'
/usr/local/bundle/gems/rack-2.1.4/lib/rack/response.rb:236:in `buffered_body!'
/usr/local/bundle/gems/rack-2.1.4/lib/rack/mock.rb:173:in `initialize'
/usr/local/bundle/gems/rack-2.1.4/lib/rack/mock.rb:78:in `new'
/usr/local/bundle/gems/rack-2.1.4/lib/rack/mock.rb:78:in `request'
/usr/local/bundle/gems/rack-2.1.4/lib/rack/mock.rb:59:in `get'
/usr/local/bundle/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:232:in `block in output_resource'
/usr/local/bundle/gems/activesupport-5.0.7.2/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/bundle/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
/usr/local/bundle/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:225:in `output_resource'
/usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
/usr/local/bundle/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
/usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
/usr/local/bundle/gems/parallel-1.19.2/lib/parallel.rb:508:in `call_with_index'
```