### PR TITLE
Revert "Bump graphql from 1.9.15 to 1.11.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     graphiql-rails (1.7.0)
       railties
       sprockets-rails
-    graphql (1.11.1)
+    graphql (1.9.15)
     guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)


### PR DESCRIPTION
Reverts zooniverse/panoptes#3356

so many breaking changes in minor gem versions, WAT!?