### PR TITLE
update sidekiq-congestion and congestion gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'active_model_serializers', '0.10.0.rc2' # Event stream
 gem 'active_record_union', '~> 1.3.0'
 gem 'activerecord-import', '~> 1.0'
 gem 'aws-sdk', '~> 2.10'
-gem 'congestion', git: 'https://github.com/camallen/Congestion.git', branch: 'ttl-freshly-added-keys', ref: '6bf0ffa7b2'
 gem 'dalli'
 gem 'deep_cloneable', '~> 2.3.2'
 gem 'devise', '~> 4.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/camallen/Congestion.git
-  revision: 6bf0ffa7b206b8d5723042e724b4c6953f3233fd
-  ref: 6bf0ffa7b2
-  branch: ttl-freshly-added-keys
-  specs:
-    congestion (0.0.3)
-      connection_pool (>= 2.0)
-      redis (>= 3.1)
-
-GIT
   remote: https://github.com/zooniverse/restpack_serializer.git
   revision: cef0969cef79a31de774e71c63de2a934c9e9f7f
   ref: cef0969cef
@@ -101,7 +91,10 @@ GEM
       timers (>= 4.1.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
-    connection_pool (2.2.2)
+    congestion (0.1.0)
+      connection_pool (>= 2.0)
+      redis (>= 3.1)
+    connection_pool (2.2.3)
     crass (1.0.6)
     dalli (2.7.10)
     database_cleaner (1.8.5)
@@ -332,7 +325,7 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rdoc (6.0.1)
-    redis (4.1.3)
+    redis (4.2.1)
     ref (2.0.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -405,8 +398,8 @@ GEM
       rack (< 2.1.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
-    sidekiq-congestion (0.1.0)
-      congestion (~> 0.0.3)
+    sidekiq-congestion (0.1.1)
+      congestion (~> 0.1)
       sidekiq (>= 3.0)
     sidekiq-unique-jobs (6.0.20)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -462,7 +455,6 @@ DEPENDENCIES
   active_record_union (~> 1.3.0)
   activerecord-import (~> 1.0)
   aws-sdk (~> 2.10)
-  congestion!
   dalli
   database_cleaner (~> 1.8.5)
   deep_cloneable (~> 2.3.2)


### PR DESCRIPTION
linked to #3397 - switch Gemfile to the newly released gems instead of the manual git settings
https://github.com/parrish/Sidekiq-Congestion/pull/3#event-3531826075

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
