### PR TITLE
Update validation to account for when validated record is not new

### DIFF
--- a/lib/validators/one_favorite_per_owner_validator.rb
+++ b/lib/validators/one_favorite_per_owner_validator.rb
@@ -6,18 +6,19 @@ module Validators
   # and the fact our validations exist in ruby land and not strictly enforced at the database layer
   # it's low probablity but worth noting here if folks wonder how it can happen
   class OneFavoritePerOwnerValidator < ActiveModel::Validator
-    def validate(new_record)
-      return unless new_record.owner && new_record.favorite
+    def validate(record)
+      return unless record.owner && record.favorite
 
-      owner_fav_collections = new_record.owner.collections.where(favorite: true)
+      owner_fav_collections = record.owner.collections.where(favorite: true)
+      owner_fav_collections = owner_fav_collections.where.not(id: record.id) if record.persisted?
       owner_has_existing_fav_for_project = owner_fav_collections
         .joins(:projects)
-        .where(projects: { id: new_record.project_ids })
+        .where(projects: { id: record.project_ids })
         .exists?
 
       return unless owner_has_existing_fav_for_project
 
-      new_record.errors[:favorite] = 'An owner can only have one favorite collection per project'
+      record.errors[:favorite] = 'An owner can only have one favorite collection per project'
     end
   end
 end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -142,6 +142,27 @@ describe Api::V1::CollectionsController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context 'when favorite collection has existing subjects' do
+      let(:additional_subject) { create(:subject) }
+      let(:params) do
+        {
+          link_relation: 'subjects',
+          subjects: [additional_subject.id],
+          collection_id: collection.id
+        }
+      end
+
+      before do
+        collection.favorite = true
+        collection.save!
+      end
+
+      it 'allows another subject to be added' do
+        post :update_links, params
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -154,6 +154,8 @@ describe Api::V1::CollectionsController, type: :controller do
       end
 
       before do
+        default_request scopes: scopes, user_id: authorized_user.id
+
         collection.favorite = true
         collection.save!
       end


### PR DESCRIPTION
Existing issue that this PR is fixing:
The `OneFavoritePerOwnerValidator` was throwing a validation error when an existing collection record was being updated, e.g. to add a new subject to the favorites collection. For example, the validation would fail when "favorite" collection id 7 was updated, since it would pass through the OneFavoritePerOwnerValidator, the validator would say "we already have a favorite collection for this owner/project", and then the validation would fail. This PR updates the validator such that if the record being validated is not a new record (`record.persisted?`), filter out collections with the same id as the current record when checking for favorite collections for the current owner/project.

Worth noting that this failure mostly due to the fact that I wrote the validator under the (false) impression that it'd only run the validation on newly created records (hence why I renamed the param from `new_record` to `record`).

--------------

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
