### PR TITLE
Add Configuration Blob to Tutorial

### DIFF
--- a/app/schemas/tutorial_create_schema.rb
+++ b/app/schemas/tutorial_create_schema.rb
@@ -49,5 +49,9 @@ class TutorialCreateSchema < JsonSchema
       end
 
     end
+
+    property "configuration" do
+      type "object"
+    end
   end
 end

--- a/app/schemas/tutorial_create_schema.rb
+++ b/app/schemas/tutorial_create_schema.rb
@@ -50,8 +50,8 @@ class TutorialCreateSchema < JsonSchema
 
     end
 
-    property "configuration" do
-      type "object"
+    property 'configuration' do
+      type 'object'
     end
   end
 end

--- a/app/schemas/tutorial_update_schema.rb
+++ b/app/schemas/tutorial_update_schema.rb
@@ -24,8 +24,8 @@ class TutorialUpdateSchema < JsonSchema
       end
     end
 
-    property "configuration" do
-      type "object"
+    property 'configuration' do
+      type 'object'
     end
   end
 end

--- a/app/schemas/tutorial_update_schema.rb
+++ b/app/schemas/tutorial_update_schema.rb
@@ -23,5 +23,9 @@ class TutorialUpdateSchema < JsonSchema
         end
       end
     end
+
+    property "configuration" do
+      type "object"
+    end
   end
 end

--- a/app/serializers/tutorial_serializer.rb
+++ b/app/serializers/tutorial_serializer.rb
@@ -3,7 +3,7 @@ class TutorialSerializer
   include MediaLinksSerializer
   include CachedSerializer
 
-  attributes :steps, :href, :id, :created_at, :updated_at, :language, :kind, :display_name
+  attributes :steps, :href, :id, :created_at, :updated_at, :language, :kind, :display_name, :configuration
 
   can_include :project, :workflows
   media_include :attached_images

--- a/db/migrate/20200717155424_add_configuration_to_tutorials.rb
+++ b/db/migrate/20200717155424_add_configuration_to_tutorials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConfigurationToTutorials < ActiveRecord::Migration
   def change
     add_column :tutorials, :configuration, :jsonb

--- a/db/migrate/20200717155424_add_configuration_to_tutorials.rb
+++ b/db/migrate/20200717155424_add_configuration_to_tutorials.rb
@@ -1,0 +1,5 @@
+class AddConfigurationToTutorials < ActiveRecord::Migration
+  def change
+    add_column :tutorials, :configuration, :jsonb
+  end
+end

--- a/db/migrate/20200717155424_add_configuration_to_tutorials.rb
+++ b/db/migrate/20200717155424_add_configuration_to_tutorials.rb
@@ -2,6 +2,6 @@
 
 class AddConfigurationToTutorials < ActiveRecord::Migration
   def change
-    add_column :tutorials, :configuration, :jsonb
+    safety_assured { add_column :tutorials, :configuration, :jsonb, default: {} }
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1529,7 +1529,8 @@ CREATE TABLE public.tutorials (
     updated_at timestamp without time zone NOT NULL,
     project_id integer NOT NULL,
     kind character varying,
-    display_name text DEFAULT ''::text
+    display_name text DEFAULT ''::text,
+    configuration jsonb
 );
 
 
@@ -4661,3 +4662,4 @@ INSERT INTO schema_migrations (version) VALUES ('20200716170833');
 
 INSERT INTO schema_migrations (version) VALUES ('20200720125246');
 
+INSERT INTO schema_migrations (version) VALUES ('20200717155424');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.22
+-- Dumped from database version 9.5.20
 -- Dumped by pg_dump version 9.5.22
 
 SET statement_timeout = 0;
@@ -1530,7 +1530,7 @@ CREATE TABLE public.tutorials (
     project_id integer NOT NULL,
     kind character varying,
     display_name text DEFAULT ''::text,
-    configuration jsonb
+    configuration jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -4660,6 +4660,7 @@ INSERT INTO schema_migrations (version) VALUES ('20200714191914');
 
 INSERT INTO schema_migrations (version) VALUES ('20200716170833');
 
+INSERT INTO schema_migrations (version) VALUES ('20200717155424');
+
 INSERT INTO schema_migrations (version) VALUES ('20200720125246');
 
-INSERT INTO schema_migrations (version) VALUES ('20200717155424');

--- a/spec/controllers/api/v1/tutorials_controller_spec.rb
+++ b/spec/controllers/api/v1/tutorials_controller_spec.rb
@@ -101,6 +101,9 @@ describe Api::V1::TutorialsController, type: :controller do
           links: {
             project: project.id.to_s,
             workflows: [workflow.id]
+          },
+          configuration: {
+            an_option: "a setting"
           }
         }
       }
@@ -125,6 +128,9 @@ describe Api::V1::TutorialsController, type: :controller do
       {
         tutorials: {
           steps: [{"media" => "asdf", "content" => "asdf"}]
+        },
+        configuration: {
+          an_option: "a setting"
         }
       }
     end

--- a/spec/controllers/api/v1/tutorials_controller_spec.rb
+++ b/spec/controllers/api/v1/tutorials_controller_spec.rb
@@ -103,7 +103,7 @@ describe Api::V1::TutorialsController, type: :controller do
             workflows: [workflow.id]
           },
           configuration: {
-            an_option: "a setting"
+            an_option: 'a setting'
           }
         }
       }
@@ -130,7 +130,7 @@ describe Api::V1::TutorialsController, type: :controller do
           steps: [{"media" => "asdf", "content" => "asdf"}]
         },
         configuration: {
-          an_option: "a setting"
+          an_option: 'a setting'
         }
       }
     end


### PR DESCRIPTION
Describe your change here.

Closes #3296 

This PR adds the configuration JSON blob to tutorial resources. No changes here to the apiary file, as it looks like there is not a section there for the Tutorial resource.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
