### PR TITLE
Canary deployment setup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,7 @@ pipeline {
       agent any
       steps {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --record -f -"
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging-azure-canary.tmpl | kubectl --context azure apply --record -f -"
       }
     }
   }

--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -41,13 +41,19 @@ spec:
           env:
           - name: PG_STATEMENT_TIMEOUT
             value: '65000'
+          - name: AZURE_STORAGE_ACCOUNT
+            value: panoptes
+          - name: AZURE_STORAGE_CONTAINER_PUBLIC
+            value: public
+          - name: AZURE_STORAGE_CONTAINER_PRIVATE
+            value: private
           envFrom:
           - secretRef:
               name: panoptes-common-env-vars
           - secretRef:
               name: panoptes-staging-env-vars
           - configMapRef:
-              name: panoptes-staging-azure-canary-shared
+              name: panoptes-staging-shared
           volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"
@@ -107,46 +113,6 @@ spec:
         - name: jwt-staging
           secret:
             secretName: panoptes-doorkeeper-jwt-staging
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: panoptes-staging-azure-canary-shared
-data:
-  RAILS_ENV: staging
-  ZOO_STREAM_KINESIS_STREAM_NAME: zooniverse-staging
-  ZOO_STREAM_SOURCE: panoptes
-  DUMP_CONGESTION_OPTS_INTERVAL: "60"
-  DUMP_CONGESTION_OPTS_MIN_DELAY: "60"
-  CORS_ORIGINS_REGEX: '^https?:\/\/([a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
-  DESIGNATOR_API_HOST: https://designator-staging.zooniverse.org/
-  DESIGNATOR_API_USERNAME: staging
-  EMAIL_EXPORT_S3_BUCKET: zooniverse-exports
-  EVENTS_API_USERNAME: staging_api
-  REDIRECTS_BASE: https://master.pfe-preview.zooniverse.org
-  REDIRECTS_PASSWORD_RESET: /#/reset-password
-  REDIRECTS_UNSUBSCRIBE: /#/unsubscribe
-  MAILER_ADDRESS: email-smtp.us-east-1.amazonaws.com
-  MAILER_DOMAIN: zooniverse.org
-  MEMCACHE_SERVERS: 'panoptes-staging-memcached:11211'
-  NEW_RELIC_APP_NAME: Panoptes Staging
-  NEW_RELIC_LOG_LEVEL: info
-  NEW_RELIC_MONITOR_MODE: 'true'
-  PAGE_SIZE_LIMIT: '100'
-  REDIS_URL: 'redis://panoptes-staging-redis:6379/0'
-  RAILS_MAX_THREADS: '4'
-  SIDEKIQ_CONCURRENCY: '4'
-  STORAGE_ADAPTER: aws
-  STORAGE_BUCKET: zooniverse-static
-  STORAGE_PREFIX: panoptes-uploads.zooniverse.org/staging/
-  AZURE_STORAGE_ACCOUNT: panoptes
-  AZURE_STORAGE_CONTAINER_PUBLIC: public
-  AZURE_STORAGE_CONTAINER_PRIVATE: private
-  TALK_API_HOST: https://talk-staging.zooniverse.org
-  TALK_API_USER: '1'
-  TALK_API_APPLICATION: '1'
-  USER_SUBJECT_LIMIT: '100'
----
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -155,7 +155,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "0"
-    nginx.ingress.kubernetes.io/canary-by-cookie: "use-azure-storage"
+    nginx.ingress.kubernetes.io/canary-by-cookie: "canary-api-testing-opt-in"
 spec:
   tls:
   - hosts:

--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -1,0 +1,171 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: panoptes-staging-azure-canary-app
+  labels:
+    app: panoptes-staging-azure-canary-app
+spec:
+  selector:
+    matchLabels:
+      app: panoptes-staging-azure-canary-app
+  template:
+    metadata:
+      labels:
+        app: panoptes-staging-azure-canary-app
+    spec:
+      containers:
+        - name: panoptes-staging-azure-canary-app
+          image: zooniverse/panoptes:__IMAGE_TAG__
+          resources:
+            requests:
+              memory: "700Mi"
+              cpu: "50m"
+            limits:
+              memory: "700Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
+          env:
+          - name: PG_STATEMENT_TIMEOUT
+            value: '65000'
+          envFrom:
+          - secretRef:
+              name: panoptes-common-env-vars
+          - secretRef:
+              name: panoptes-staging-env-vars
+          - configMapRef:
+              name: panoptes-staging-azure-canary-shared
+          volumeMounts:
+            - name: static-assets
+              mountPath: "/static-assets"
+            - name: jwt-staging
+              mountPath: "/rails_app/config/keys"
+              readOnly: true
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
+        - name: panoptes-staging-nginx
+          image: zooniverse/nginx:1.19.0
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
+          lifecycle:
+            preStop:
+              exec:
+                # SIGTERM triggers a quick exit; gracefully terminate instead
+                command: ["/usr/sbin/nginx","-s","quit"]
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: static-assets
+              mountPath: "/static-assets"
+            - name: panoptes-nginx-config
+              mountPath: "/etc/nginx-sites"
+      volumes:
+        - name: static-assets
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/panoptes-staging-app-static-assets
+            type: DirectoryOrCreate
+        - name: panoptes-nginx-config
+          configMap:
+            name: panoptes-nginx-conf-staging
+        - name: jwt-staging
+          secret:
+            secretName: panoptes-doorkeeper-jwt-staging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: panoptes-staging-azure-canary-shared
+data:
+  RAILS_ENV: staging
+  ZOO_STREAM_KINESIS_STREAM_NAME: zooniverse-staging
+  ZOO_STREAM_SOURCE: panoptes
+  DUMP_CONGESTION_OPTS_INTERVAL: "60"
+  DUMP_CONGESTION_OPTS_MIN_DELAY: "60"
+  CORS_ORIGINS_REGEX: '^https?:\/\/([a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
+  DESIGNATOR_API_HOST: https://designator-staging.zooniverse.org/
+  DESIGNATOR_API_USERNAME: staging
+  EMAIL_EXPORT_S3_BUCKET: zooniverse-exports
+  EVENTS_API_USERNAME: staging_api
+  REDIRECTS_BASE: https://master.pfe-preview.zooniverse.org
+  REDIRECTS_PASSWORD_RESET: /#/reset-password
+  REDIRECTS_UNSUBSCRIBE: /#/unsubscribe
+  MAILER_ADDRESS: email-smtp.us-east-1.amazonaws.com
+  MAILER_DOMAIN: zooniverse.org
+  MEMCACHE_SERVERS: 'panoptes-staging-memcached:11211'
+  NEW_RELIC_APP_NAME: Panoptes Staging
+  NEW_RELIC_LOG_LEVEL: info
+  NEW_RELIC_MONITOR_MODE: 'true'
+  PAGE_SIZE_LIMIT: '100'
+  REDIS_URL: 'redis://panoptes-staging-redis:6379/0'
+  RAILS_MAX_THREADS: '4'
+  SIDEKIQ_CONCURRENCY: '4'
+  STORAGE_ADAPTER: aws
+  STORAGE_BUCKET: zooniverse-static
+  STORAGE_PREFIX: panoptes-uploads.zooniverse.org/staging/
+  AZURE_STORAGE_ACCOUNT: panoptes
+  AZURE_STORAGE_CONTAINER_PUBLIC: public
+  AZURE_STORAGE_CONTAINER_PRIVATE: private
+  TALK_API_HOST: https://talk-staging.zooniverse.org
+  TALK_API_USER: '1'
+  TALK_API_APPLICATION: '1'
+  USER_SUBJECT_LIMIT: '100'
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: panoptes-staging-azure-canary-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "0"
+    nginx.ingress.kubernetes.io/canary-by-cookie: "use-azure-storage"
+spec:
+  tls:
+  - hosts:
+    - panoptes-staging.zooniverse.org
+    secretName: panoptes-staging-tls-secret
+  rules:
+  - host: panoptes-staging.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: panoptes-staging-azure-canary-app
+          servicePort: 80
+        path: /(.*)


### PR DESCRIPTION
The kubernetes/deployment-staging-azure-canary.tmpl contains the instructions for configuring the canary deployment. It includes a deployment template, a ConfigMap with env vars that tell the canary service to use azure storage, and an Ingress. My thought is to initially have the canary-weight be set to 0, and first just test using the canary-by-cookie option. Once we confirm that this works, we can switch over to having a % of requests go to azure. See these articles for more information about canary deployments: 
- [Canary deployment with ingress nginx](https://www.elvinefendi.com/2018/11/25/canary-deployment-with-ingress-nginx.html)
- [Canary release based on Ingress-Nginx](https://kubesphere.io/docs/quick-start/ingress-canary/)
- [Canary annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#canary)

----

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
