### PR TITLE
No morgue workers

### DIFF
--- a/app/workers/notify_subject_selector_of_change_worker.rb
+++ b/app/workers/notify_subject_selector_of_change_worker.rb
@@ -1,7 +1,7 @@
 class NotifySubjectSelectorOfChangeWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: 3, queue: :data_high
+  sidekiq_options retry: 3, dead: false, queue: :data_high
 
   def perform(workflow_id)
     workflow = Workflow.find_without_json_attrs(workflow_id)

--- a/app/workers/notify_subject_selector_of_retirement_worker.rb
+++ b/app/workers/notify_subject_selector_of_retirement_worker.rb
@@ -1,7 +1,7 @@
 class NotifySubjectSelectorOfRetirementWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: 3, queue: :data_high
+  sidekiq_options retry: 3, dead: false, queue: :data_high
 
   def perform(subject_id, workflow_id)
     workflow = Workflow.find_without_json_attrs(workflow_id)

--- a/app/workers/notify_subject_selector_of_seen_worker.rb
+++ b/app/workers/notify_subject_selector_of_seen_worker.rb
@@ -1,7 +1,7 @@
 class NotifySubjectSelectorOfSeenWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: 3, queue: :data_high
+  sidekiq_options retry: 3, dead: false, queue: :data_high
 
   def perform(workflow_id, user_id, subject_id)
     return if user_id.nil?

--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -2,6 +2,8 @@ class SubjectMetadataWorker
   include Sidekiq::Worker
   attr_reader :sms_ids
 
+  sidekiq_options retry: 10, dead: false
+
   def perform(sms_ids)
     return if Panoptes.flipper[:skip_subject_metadata_worker].enabled?
 


### PR DESCRIPTION
Avoid transient jobs piling up in the morgue. 

Selector notifications can dissapear as this data is in flux. 
Metadata update workers may sometimes be fired for data that is deleted, not commited etc. These can just fail without going to the [sidekiq morgue](https://github.com/mperham/sidekiq/wiki/Error-Handling#dead-set) after 10 retries to ensure they have time for transactions commit visibility. 

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
