### PR TITLE
add www.zooniverse.org nginx server block

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -54,19 +54,19 @@ data:
     server {
       server_name www.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      include /etc/nginx-sites/panoptes-nginx-common.conf;
+      include /etc/nginx/panoptes-nginx-common.conf;
     }
 
     server {
       server_name panoptes.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      include /etc/nginx-sites/panoptes-nginx-common.conf;
+      include /etc/nginx/panoptes-nginx-common.conf;
     }
 
     server {
       server_name signin.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      include /etc/nginx-sites/panoptes-nginx-common.conf;
+      include /etc/nginx/panoptes-nginx-common.conf;
     }
 kind: ConfigMap
 metadata:
@@ -207,7 +207,7 @@ spec:
             - name: panoptes-nginx-config
               mountPath: "/etc/nginx-sites"
             - name: panoptes-nginx-common.conf
-              mountPath: "/etc/nginx-sites"
+              mountPath: "/etc/nginx"
       volumes:
         - name: static-assets
           hostPath:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -1,96 +1,72 @@
 apiVersion: v1
 data:
   nginx.conf: |+
+    gzip_types *;
+
+    proxy_buffer_size 8k;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+
+    location = /commit_id.txt {
+      root /static-assets/;
+      expires off;
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, HEAD';
+      add_header 'Access-Control-Allow-Credentials' 'true';
+    }
+
+    location ~ ^/api-assets/ {
+      root /static-assets/;
+      gzip_static on; # to serve pre-gzipped version
+      expires max;
+      add_header Cache-Control public;
+    }
+
+    location = /favicon.ico {
+      root /static-assets/;
+      expires max;
+      add_header Cache-Control public;
+    }
+
+    location = /robots.txt {
+      root /static-assets/;
+      expires max;
+      add_header Cache-Control public;
+    }
+
+    location / {
+      # avoid attacker setting the host value for links in rails_app
+      # https://github.com/rails/rails/issues/29893
+      proxy_set_header X-Forwarded-Host $server_name;
+      proxy_pass http://docker-panoptes;
+    }
+kind: ConfigMap
+metadata:
+  name: panoptes-nginx-common-conf-production
+---
+apiVersion: v1
+data:
+  nginx.conf: |+
     upstream docker-panoptes {
       server localhost:81;
+    }
+    
+    server {
+      server_name www.zooniverse.org;
+      include /etc/nginx/ssl.default.conf;
+      include /etc/nginx-sites/panoptes-nginx-common.conf;
     }
 
     server {
       server_name panoptes.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      gzip_types *;
-
-      proxy_buffer_size 8k;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-
-      location = /commit_id.txt {
-        root /static-assets/;
-        expires off;
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, HEAD';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-      }
-
-      location ~ ^/api-assets/ {
-        root /static-assets/;
-        gzip_static on; # to serve pre-gzipped version
-        expires max;
-        add_header Cache-Control public;
-      }
-
-      location = /favicon.ico {
-        root /static-assets/;
-        expires max;
-        add_header Cache-Control public;
-      }
-
-      location = /robots.txt {
-        root /static-assets/;
-        expires max;
-        add_header Cache-Control public;
-      }
-
-      location / {
-        # avoid attacker setting the host value for links in rails_app
-        # https://github.com/rails/rails/issues/29893
-        proxy_set_header X-Forwarded-Host $server_name;
-        proxy_pass http://docker-panoptes;
-      }
+      include /etc/nginx-sites/panoptes-nginx-common.conf;
     }
 
     server {
       server_name signin.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      gzip_types *;
-
-      proxy_buffer_size 8k;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-
-      location = /commit_id.txt {
-        root /static-assets/;
-        expires off;
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, HEAD';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-      }
-
-      location ~ ^/api-assets/ {
-        root /static-assets/;
-        gzip_static on; # to serve pre-gzipped version
-        expires max;
-        add_header Cache-Control public;
-      }
-
-      location = /favicon.ico {
-        root /static-assets/;
-        expires max;
-        add_header Cache-Control public;
-      }
-
-      location = /robots.txt {
-        root /static-assets/;
-        expires max;
-        add_header Cache-Control public;
-      }
-
-      location / {
-        # avoid attacker setting the host value for links in rails_app
-        # https://github.com/rails/rails/issues/29893
-        proxy_set_header X-Forwarded-Host $server_name;
-        proxy_pass http://docker-panoptes;
-      }
+      include /etc/nginx-sites/panoptes-nginx-common.conf;
     }
 kind: ConfigMap
 metadata:
@@ -230,6 +206,8 @@ spec:
               mountPath: "/static-assets"
             - name: panoptes-nginx-config
               mountPath: "/etc/nginx-sites"
+            - name: panoptes-nginx-common.conf
+              mountPath: "/etc/nginx-sites"
       volumes:
         - name: static-assets
           hostPath:
@@ -239,6 +217,9 @@ spec:
         - name: panoptes-nginx-config
           configMap:
             name: panoptes-nginx-conf-production
+        - name: panoptes-nginx-common.conf
+          configMap:
+            name: panoptes-nginx-common-conf-production
         - name: jwt-production
           secret:
             secretName: panoptes-doorkeeper-jwt-production

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  nginx.conf: |+
+  panoptes-nginx-common.conf: |+
     gzip_types *;
 
     proxy_buffer_size 8k;
@@ -50,7 +50,7 @@ data:
     upstream docker-panoptes {
       server localhost:81;
     }
-    
+
     server {
       server_name www.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
@@ -206,7 +206,7 @@ spec:
               mountPath: "/static-assets"
             - name: panoptes-nginx-config
               mountPath: "/etc/nginx-sites"
-            - name: panoptes-nginx-common.conf
+            - name: panoptes-nginx-common
               mountPath: "/etc/nginx"
       volumes:
         - name: static-assets
@@ -217,7 +217,7 @@ spec:
         - name: panoptes-nginx-config
           configMap:
             name: panoptes-nginx-conf-production
-        - name: panoptes-nginx-common.conf
+        - name: panoptes-nginx-common
           configMap:
             name: panoptes-nginx-common-conf-production
         - name: jwt-production

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -1,14 +1,7 @@
 apiVersion: v1
 data:
-  nginx.conf: |+
-    upstream docker-panoptes {
-      server localhost:81;
-    }
-
-    server {
-      server_name panoptes-staging.zooniverse.org;
-      include /etc/nginx/ssl.default.conf;
-      gzip_types *;
+  panoptes-nginx-common.conf: |+
+    gzip_types *;
 
       proxy_buffer_size 8k;
       proxy_set_header Host $http_host;
@@ -47,6 +40,21 @@ data:
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_pass http://docker-panoptes;
       }
+kind: ConfigMap
+metadata:
+  name: panoptes-nginx-common-conf-staging
+---
+apiVersion: v1
+data:
+  nginx.conf: |+
+    upstream docker-panoptes {
+      server localhost:81;
+    }
+
+    server {
+      server_name panoptes-staging.zooniverse.org;
+      include /etc/nginx/ssl.default.conf;
+      include /etc/nginx/panoptes-nginx-common.conf;
     }
 kind: ConfigMap
 metadata:
@@ -185,6 +193,8 @@ spec:
               mountPath: "/static-assets"
             - name: panoptes-nginx-config
               mountPath: "/etc/nginx-sites"
+            - name: panoptes-nginx-common
+              mountPath: "/etc/nginx"
       volumes:
         - name: static-assets
           hostPath:
@@ -194,6 +204,9 @@ spec:
         - name: panoptes-nginx-config
           configMap:
             name: panoptes-nginx-conf-staging
+        - name: panoptes-nginx-common
+          configMap:
+            name: panoptes-nginx-common-conf-staging
         - name: jwt-staging
           secret:
             secretName: panoptes-doorkeeper-jwt-staging


### PR DESCRIPTION
allow serving requests proxied from the www.zooniverse.org domain without incorrect host name redirection. 
Extract the common nginx config blocks to it's own config map and reuse these across different server name blocks.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
