### PR TITLE
Remove the canary weight

### DIFF
--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -121,7 +121,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "0"
     nginx.ingress.kubernetes.io/canary-by-cookie: "canary-api-testing-opt-in"
 spec:
   tls:


### PR DESCRIPTION
The cookie annotation should take precedence over the weight, but just in case this is confusing things, let's remove it.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
