### PR TITLE
Revert "Remove the canary weight"

### DIFF
--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -121,6 +121,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "0"
     nginx.ingress.kubernetes.io/canary-by-cookie: "canary-api-testing-opt-in"
 spec:
   tls:


### PR DESCRIPTION
Reverts zooniverse/panoptes#3442

We want the canary deploy to only be reachable via the cookie presence. Removing the weight will modify how the traffic is routed. 

We want the canary to only be reachable while the header is set, if it's missing we don't want traffic to hit the canary inadvertently. 