### PR TITLE
Nginx panoptes shared conf files

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -54,19 +54,19 @@ data:
     server {
       server_name www.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      include /etc/nginx/panoptes-nginx-common.conf;
+      include /etc/nginx/shared/panoptes-nginx-common.conf;
     }
 
     server {
       server_name panoptes.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      include /etc/nginx/panoptes-nginx-common.conf;
+      include /etc/nginx/shared/panoptes-nginx-common.conf;
     }
 
     server {
       server_name signin.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      include /etc/nginx/panoptes-nginx-common.conf;
+      include /etc/nginx/shared/panoptes-nginx-common.conf;
     }
 kind: ConfigMap
 metadata:
@@ -207,7 +207,7 @@ spec:
             - name: panoptes-nginx-config
               mountPath: "/etc/nginx-sites"
             - name: panoptes-nginx-common
-              mountPath: "/etc/nginx"
+              mountPath: "/etc/nginx/shared"
       volumes:
         - name: static-assets
           hostPath:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -54,7 +54,7 @@ data:
     server {
       server_name panoptes-staging.zooniverse.org;
       include /etc/nginx/ssl.default.conf;
-      include /etc/nginx/panoptes-nginx-common.conf;
+      include /etc/nginx/shared/panoptes-nginx-common.conf;
     }
 kind: ConfigMap
 metadata:
@@ -194,7 +194,7 @@ spec:
             - name: panoptes-nginx-config
               mountPath: "/etc/nginx-sites"
             - name: panoptes-nginx-common
-              mountPath: "/etc/nginx"
+              mountPath: "/etc/nginx/shared"
       volumes:
         - name: static-assets
           hostPath:


### PR DESCRIPTION
Fixes bug Introduced in https://github.com/zooniverse/panoptes/pull/3439#discussion_r464427625

Avoid clobbering `/etc/nginx`, instead mount the shared config files via a sub directory in `/etc/nginx/shared`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
