### PR TITLE
Add NASA comms field backfill rake task

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -26,7 +26,7 @@ namespace :user do
 
   desc "Backfill NASA email communication field in batches"
   task backfill_nasa_email_communications_field: :environment do
-    User.where(select(:id).find_in_batches do |users|
+    User.select(:id).find_in_batches do |users|
       null_nasa_email_user_scope = User.where(
         id: users.map(&:id),
         nasa_email_communication: nil

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -24,7 +24,7 @@ namespace :user do
     end
   end
 
-desc "Backfill NASA email communication field in batches"
+  desc "Backfill NASA email communication field in batches"
   task backfill_nasa_email_communications_field: :environment do
     User.where(select(:id).find_in_batches do |users|
       null_nasa_email_user_scope = User.where(

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -3,7 +3,7 @@
 
 namespace :user do
 
-  desc "Touch user updated at"
+  desc 'Touch user updated at'
   task touch_user_record: :environment do
     User.select('id').find_in_batches do |users|
       ids = users.map(&:id)
@@ -11,7 +11,7 @@ namespace :user do
     end
   end
 
-  desc "Backfill UX testing emails comms field in batches"
+  desc 'Backfill UX testing emails comms field in batches'
   task backfill_ux_testing_email_field: :environment do
     User.select(:id).find_in_batches do |users|
       null_ux_testing_user_scope = User.where(
@@ -24,7 +24,7 @@ namespace :user do
     end
   end
 
-  desc "Backfill NASA email communication field in batches"
+  desc 'Backfill NASA email communication field in batches'
   task backfill_nasa_email_communications_field: :environment do
     User.select(:id).find_in_batches do |users|
       null_nasa_email_user_scope = User.where(
@@ -37,7 +37,7 @@ namespace :user do
     end
   end
 
-  desc "Backfill intervention_notifications field in batches (restartable)"
+  desc 'Backfill intervention_notifications field in batches (restartable)'
   task backfill_intervention_notifications_field: :environment do
     User.select(:id).find_in_batches do |users|
       non_backfilled_users = User.where(
@@ -66,7 +66,7 @@ namespace :user do
       User.find_by!("lower(login) = '#{login.downcase}'")
     end
 
-    desc "update user subject limits"
+    desc 'update user subject limits'
     task :update_subject_limits, [:user_login, :new_subject_limit] => [:environment] do |t, args|
       begin
         login, new_subject_limit = update_user_limit_params(args)
@@ -81,7 +81,7 @@ namespace :user do
       end
     end
 
-    desc "show user subject limits"
+    desc 'show user subject limits'
     task :show_subject_limits, [:user_login ] => [:environment] do |t, args|
       begin
         if login = args[:user_login].try(:downcase)

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -24,6 +24,19 @@ namespace :user do
     end
   end
 
+desc "Backfill NASA email communication field in batches"
+  task backfill_nasa_email_communications_field: :environment do
+    User.where(select(:id).find_in_batches do |users|
+      null_nasa_email_user_scope = User.where(
+        id: users.map(&:id),
+        nasa_email_communication: nil
+      )
+      null_nasa_email_user_scope.update_all(
+        nasa_email_communication: false
+      )
+    end
+  end
+
   desc "Backfill intervention_notifications field in batches (restartable)"
   task backfill_intervention_notifications_field: :environment do
     User.select(:id).find_in_batches do |users|


### PR DESCRIPTION
> will there be a follow up PR to backfill the default and switch the default column value over? without it this might end up with inconsitent data `null, false, true`

_Originally posted by @camallen in https://github.com/zooniverse/panoptes/pull/3421/files_

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
