### PR TITLE
Touch Linked Project on Workflow Update

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -17,6 +17,14 @@ class Api::V1::WorkflowsController < Api::ApiController
     super
   end
 
+  def update
+    super do |workflow|
+      if update_params.key?(:active)
+        ModifyProjectUpdatedAtWorker.perform_async(workflow.project_id)
+      end
+    end
+  end
+
   def update_links
     super do |workflow|
       post_link_actions(workflow)

--- a/app/workers/modify_project_updated_at_worker.rb
+++ b/app/workers/modify_project_updated_at_worker.rb
@@ -1,0 +1,9 @@
+class ModifyProjectUpdatedAtWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :data_low
+
+    def perform(project_id)
+        Project.find(project_id).touch
+    end
+end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -215,7 +215,6 @@ describe Api::V1::WorkflowsController, type: :controller do
           }.to change {
             resource.reload.active
           }.to(true)
-          expect(resource.project).to receive(:touch).once
         end
 
         it "should not update the workflow tasks" do

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -215,6 +215,7 @@ describe Api::V1::WorkflowsController, type: :controller do
           }.to change {
             resource.reload.active
           }.to(true)
+          expect(resource.project).to receive(:touch).once
         end
 
         it "should not update the workflow tasks" do

--- a/spec/workers/modify_project_updated_at_worker_spec.rb
+++ b/spec/workers/modify_project_updated_at_worker_spec.rb
@@ -1,0 +1,17 @@
+  require 'spec_helper'
+
+  describe ModifyProjectUpdatedAtWorker do
+    let(:worker) { described_class.new }
+    let(:project) { create :project }
+
+    describe "project touch timestamp" do
+        before do
+          allow(Project).to receive(:find).and_return(project)
+        end
+    
+        it "should touch the project timestamp on update" do
+          expect(project).to receive(:touch).once
+          worker.perform(project)
+        end
+      end
+  end


### PR DESCRIPTION
Describe your change here.
Closes #3286 

Attempting to close the issue above. Not sure if this is the best way to do so. My first attempt was to touch the linked project on an update (`workflow.project.touch`, or something similar), but I was noticing other tests failing when doing so. Because of that, I went the route of using a worker.

The worker here is **very** basic, but I'm not quite sure what else would be needed if I'm only touching the project resource. Also, I chose `data_low` as the queue option, but there could be a better option.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
