### PR TITLE
Add Canary header to ingress config

### DIFF
--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -140,9 +140,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "0"
-    nginx.ingress.kubernetes.io/canary-by-cookie: "canary_api_testing_opt_in"
-    nginx.ingress.kubernetes.io/canary-by-header: "Canary"
-    nginx.ingress.kubernetes.io/canary-by-header-value: "always"
+    nginx.ingress.kubernetes.io/canary-by-header: "Canary-Testing-Opt-In"
 spec:
   tls:
   - hosts:

--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -141,6 +141,8 @@ metadata:
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "0"
     nginx.ingress.kubernetes.io/canary-by-cookie: "canary_api_testing_opt_in"
+    nginx.ingress.kubernetes.io/canary-by-header: "Canary"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "always"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
> Canary rules are evaluated in order of precedence. Precedence is as follows: `canary-by-header -> canary-by-cookie -> canary-weight`

This will allow for the use of canary.pfe-preview.zooniverse.org to test the Azure media adapter via header. The cookie isn't being forwarded through PFE, so that staged brach uses a monkeypatched version of the client that always adds the `Canary: always` header to API requests.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
