### PR TITLE
Azure adapter: method to get required headers

### DIFF
--- a/app/services/media_storage/abstract_adapter.rb
+++ b/app/services/media_storage/abstract_adapter.rb
@@ -12,11 +12,18 @@ module MediaStorage
       raise NotImplementedError
     end
 
+    # Returns URL/path to be used to make a GET request to the storage service
     def get_path(path, opts={})
       raise NotImplementedError
     end
 
+    # Returns URL/path to be used to make a PUT request to the storage service
     def put_path(path, opts={})
+      raise NotImplementedError
+    end
+
+    # Returns required headers for making a put request to the storage service
+    def headers_for_direct_upload
       raise NotImplementedError
     end
 

--- a/app/services/media_storage/aws_adapter.rb
+++ b/app/services/media_storage/aws_adapter.rb
@@ -45,6 +45,11 @@ module MediaStorage
       ).to_s
     end
 
+    # Returns empty hash since AWS does not require any special headers for uploads
+    def headers_for_direct_upload
+      {}
+    end
+
     def put_file(path, file_path, opts={})
       upload_options = {
         content_type: opts[:content_type],

--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -24,6 +24,7 @@ module MediaStorage
       )
     end
 
+    # Returns the path at which the medium lives in Blob Storage
     def stored_path(content_type, medium_type, *path_prefix)
       extension = get_extension(content_type)
       path = prefix.to_s
@@ -33,6 +34,7 @@ module MediaStorage
       path + "#{SecureRandom.uuid}.#{extension}"
     end
 
+    # Returns URL/path to be used to make a GET request to the Blob Service
     def get_path(path, opts={})
       if opts[:private]
         signer.signed_uri(
@@ -47,6 +49,7 @@ module MediaStorage
       end
     end
 
+    # Returns URL/path to be used to make a PUT request to the Blob Service
     def put_path(path, opts={})
       container = opts[:private] ? private_container : public_container
 
@@ -58,6 +61,11 @@ module MediaStorage
         expiry: get_expiry_time(opts[:put_expires] || put_expiration),
         content_type: opts[:content_type]
       ).to_s
+    end
+
+    # Returns required headers for making a put request to the Blob Service
+    def headers_for_direct_upload
+      { "x-ms-blob-type" => "BlockBlob" }
     end
 
     def put_file(path, file_path, opts={})

--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -65,7 +65,7 @@ module MediaStorage
 
     # Returns required headers for making a put request to the Blob Service
     def headers_for_direct_upload
-      { "x-ms-blob-type" => "BlockBlob" }
+      { 'x-ms-blob-type' => 'BlockBlob' }
     end
 
     def put_file(path, file_path, opts={})

--- a/spec/services/media_storage/azure_adapter_spec.rb
+++ b/spec/services/media_storage/azure_adapter_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe MediaStorage::AzureAdapter do
 
   describe '#headers_for_direct_upload' do
     it 'returns the blob-type header' do
-      expect(adapter.headers_for_direct_upload).to eq({ "x-ms-blob-type" => "BlockBlob" })
+      expect(adapter.headers_for_direct_upload).to eq({ 'x-ms-blob-type' => 'BlockBlob' })
     end
   end
 

--- a/spec/services/media_storage/azure_adapter_spec.rb
+++ b/spec/services/media_storage/azure_adapter_spec.rb
@@ -201,6 +201,12 @@ RSpec.describe MediaStorage::AzureAdapter do
     end
   end
 
+  describe '#headers_for_direct_upload' do
+    it 'returns the blob-type header' do
+      expect(adapter.headers_for_direct_upload).to eq({ "x-ms-blob-type" => "BlockBlob" })
+    end
+  end
+
   describe '#put_file' do
     let(:file) { instance_double('File') }
     let(:method_call_options) { { content_type: 'text/plain' } }


### PR DESCRIPTION
The blob service will return a 400 error notifying you of a missing header if you do not include the `x-ms-blob-type` header when making a PUT request to the blob path. Here, I add a method that PFE will need to call in order to see what headers will need to be added to the request. We will also need to make changes to PFE in order for this to work.

I have named the method after [Rails Active Storage](https://github.com/rails/rails/blob/357e15290ab06af8b4f32dd480b48a8c6e31e9e7/activestorage/lib/active_storage/service/azure_storage_service.rb#L104), but I was also thinking of naming it `headers_for_put_path` to better line up with our `put_path` method name (the method will need to be used in conjunction with the `put_path` method). Any preferences?

Also curious if other have thoughts on different ways to fix the current missing header issue.

-----

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
