### PR TITLE
Update storage accounts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,23 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: true
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+Style/AccessorGrouping:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/SlicingWithRange:
+  Enabled: true

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -103,7 +103,7 @@ data:
   STORAGE_ADAPTER: aws
   STORAGE_BUCKET: zooniverse-static
   STORAGE_PREFIX: panoptes-uploads.zooniverse.org/production/
-  AZURE_STORAGE_ACCOUNT: panoptes
+  AZURE_STORAGE_ACCOUNT: panoptesuploads
   AZURE_STORAGE_CONTAINER_PUBLIC: public
   AZURE_STORAGE_CONTAINER_PRIVATE: private
   TALK_API_HOST: https://talk.zooniverse.org

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -91,7 +91,7 @@ data:
   STORAGE_ADAPTER: aws
   STORAGE_BUCKET: zooniverse-static
   STORAGE_PREFIX: panoptes-uploads.zooniverse.org/staging/
-  AZURE_STORAGE_ACCOUNT: panoptes
+  AZURE_STORAGE_ACCOUNT: panoptesuploadsstaging
   AZURE_STORAGE_CONTAINER_PUBLIC: public
   AZURE_STORAGE_CONTAINER_PRIVATE: private
   TALK_API_HOST: https://talk-staging.zooniverse.org


### PR DESCRIPTION
Update deployment templates to use `panoptesuploads` and `panoptesuploadsstaging` storage accounts.

Also update `rubocop.yml` to remove vs code warning "The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file ..."

------

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
