### PR TITLE
remove unrecognised cops in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,6 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: true
+
+AllCops:
+  NewCops: enable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,23 +47,3 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: true
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-Style/AccessorGrouping:
-  Enabled: true
-Style/BisectedAttrAccessor:
-  Enabled: true
-Style/RedundantAssignment:
-  Enabled: true
-Style/RedundantFetchBlock:
-  Enabled: true
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-Style/RedundantRegexpEscape:
-  Enabled: true
-Style/SlicingWithRange:
-  Enabled: true


### PR DESCRIPTION
using the Gemfile robocop (0.87.1) I get, removing these fixes it. Noting i also get these errors with the latest version (0.89) https://rubygems.org/gems/rubocop/
```
Error: unrecognized cop Layout/EmptyLinesAroundAttributeAccessor found in .rubocop.yml, unrecognized cop Lint/DeprecatedOpenSSLConstant found in .rubocop.yml, unrecognized cop Lint/MixedRegexpCaptureTypes found in .rubocop.yml, unrecognized cop Style/AccessorGrouping found in .rubocop.yml, unrecognized cop Style/BisectedAttrAccessor found in .rubocop.yml, unrecognized cop Style/RedundantAssignment found in .rubocop.yml, unrecognized cop Style/RedundantFetchBlock found in .rubocop.yml, unrecognized cop Style/RedundantRegexpCharacterClass found in .rubocop.yml, unrecognized cop Style/RedundantRegexpEscape found in .rubocop.yml, unrecognized cop Style/SlicingWithRange found in .rubocop.yml
```
# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
