### PR TITLE
add staging rake task job template

### DIFF
--- a/kubernetes/job-rake-task-staging.tmpl
+++ b/kubernetes/job-rake-task-staging.tmpl
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: __JOB_NAME__
+spec:
+  template:
+    spec:
+      containers:
+      - name: panoptes-rake-task-staging
+        image: zooniverse/panoptes:__IMAGE_TAG__
+        command: ["bundle",  "exec", "rake", __RAKE_TASK_NAME__]
+        envFrom:
+        - secretRef:
+            name: panoptes-common-env-vars
+        - secretRef:
+            name: panoptes-staging-env-vars
+        - configMapRef:
+            name: panoptes-staging-shared
+      restartPolicy: Never
+  backoffLimit: 1


### PR DESCRIPTION
Add a k8s job template for running rake tasks, staging only right now.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
