### PR TITLE
increase fallback selection subject pool

### DIFF
--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -10,10 +10,6 @@ module Subjects
       selection_strategy.new(available, limit).select
     end
 
-    def any_workflow_data
-      FallbackSelection.new(workflow, limit, opts).any_workflow_data
-    end
-
     private
 
     def selection_strategy

--- a/lib/subjects/selector.rb
+++ b/lib/subjects/selector.rb
@@ -40,7 +40,9 @@ module Subjects
 
       if subject_ids.blank?
         subject_ids = DatabaseReplica.read('fallback_subject_selection_from_replica') do
-          fallback_selector.any_workflow_data
+          fallback_limit = ENV.fetch('FALLBACK_SELECTION_LIMIT', 100)
+          opts = { subject_set_id: subject_set_id }
+          FallbackSelection.new(workflow, fallback_limit, opts).any_workflow_data
         end
         @selection_state = 2
       end
@@ -80,15 +82,11 @@ module Subjects
       ).select
     end
 
-    def fallback_selector_opts
-      { limit: subjects_page_size, subject_set_id: subject_set_id }
-    end
-
     def fallback_selector
       @fallback_selector ||= PostgresqlSelection.new(
         workflow,
         user,
-        fallback_selector_opts
+        { limit: subjects_page_size, subject_set_id: subject_set_id }
       )
     end
 

--- a/spec/lib/subjects/selector_spec.rb
+++ b/spec/lib/subjects/selector_spec.rb
@@ -113,12 +113,12 @@ RSpec.describe Subjects::Selector do
       before do
         allow_any_instance_of(Subjects::PostgresqlSelection)
           .to receive(:select).and_return([])
-        expect_any_instance_of(Subjects::PostgresqlSelection)
+        expect_any_instance_of(Subjects::FallbackSelection)
           .to receive(:any_workflow_data)
           .and_call_original
       end
 
-      it 'should fallback to selecting some data' do
+      it 'returns data from the fallback selector' do
         subjects = subject.get_subject_ids
       end
 
@@ -131,7 +131,7 @@ RSpec.describe Subjects::Selector do
           }
         end
 
-        it 'should fallback to selecting some grouped data' do
+        it 'returns grouped data from the fallback selector' do
           allow_any_instance_of(Workflow).to receive(:grouped).and_return(true)
           subjects = subject.get_subject_ids
         end
@@ -144,7 +144,7 @@ RSpec.describe Subjects::Selector do
         stub_designator_client
       end
 
-      it 'should fallback to using postgres selection' do
+      it 'uses postgres selection' do
         expect_any_instance_of(Subjects::PostgresqlSelection)
           .to receive(:select)
           .and_call_original
@@ -162,15 +162,15 @@ RSpec.describe Subjects::Selector do
         subject.get_subject_ids
       end
 
-      context "when the default postgres selector returns no data" do
+      context 'when the postgres selector returns no data' do
         before do
           allow_any_instance_of(Subjects::PostgresqlSelection)
             .to receive(:select)
             .and_return([])
         end
 
-        it "should fallback to just returning any data" do
-          expect_any_instance_of(Subjects::PostgresqlSelection)
+        it 'uses the fallback selector and returns any data' do
+          expect_any_instance_of(Subjects::FallbackSelection)
             .to receive(:any_workflow_data)
             .and_call_original
           subject.get_subject_ids


### PR DESCRIPTION
select from 100 subjects to increase the variance of available subjects when we return any subject data for a workflow selection.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
