### PR TITLE
increase sidekiq staging cpu resource request

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -271,7 +271,7 @@ spec:
           resources:
             requests:
               memory: "700Mi"
-              cpu: "50m"
+              cpu: "100m"
               ephemeral-storage: "10Gi"
             limits:
               memory: "700Mi"


### PR DESCRIPTION
ensure the HPA scaling metric is calculated correctly as we want to run 1 pod under low cpu conditions

target based horizontal pod autoscalers rely on the resource request for the percentage of use metric, thus previously this was using (avg sum CPU)/50Mi to calc the hpa cpu metric for scaling pods. Thus the HPA kept 2 pods running for this deployment

See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
