### PR TITLE
Azure adapter: remove env prefix from stored path

### DIFF
--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -3,6 +3,7 @@
 module MediaStorage
   class AzureAdapter < AbstractAdapter
     attr_reader :url, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
+
     DEFAULT_EXPIRES_IN = 3 # time in minutes, see get_expiry_time(expires_in)
 
     def initialize(opts={})
@@ -25,7 +26,7 @@ module MediaStorage
 
     def stored_path(content_type, medium_type, *path_prefix)
       extension = get_extension(content_type)
-      path += "#{medium_type}/"
+      path = "#{medium_type}/"
       path += "#{path_prefix.join('/')}/" unless path_prefix.empty?
       path + "#{SecureRandom.uuid}.#{extension}"
     end

--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -2,7 +2,7 @@
 
 module MediaStorage
   class AzureAdapter < AbstractAdapter
-    attr_reader :url, :prefix, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
+    attr_reader :url, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
     DEFAULT_EXPIRES_IN = 3 # time in minutes, see get_expiry_time(expires_in)
 
     def initialize(opts={})
@@ -10,7 +10,6 @@ module MediaStorage
       @public_container = opts[:azure_storage_container_public]
       @private_container = opts[:azure_storage_container_private]
       @url = opts[:url]
-      @prefix = opts[:prefix] || Rails.env
       @get_expiration = opts.dig(:expiration, :get) || DEFAULT_EXPIRES_IN
       @put_expiration = opts.dig(:expiration, :put) || DEFAULT_EXPIRES_IN
 
@@ -26,8 +25,6 @@ module MediaStorage
 
     def stored_path(content_type, medium_type, *path_prefix)
       extension = get_extension(content_type)
-      path = prefix.to_s
-      path += '/' unless path[-1] == '/'
       path += "#{medium_type}/"
       path += "#{path_prefix.join('/')}/" unless path_prefix.empty?
       path + "#{SecureRandom.uuid}.#{extension}"

--- a/config/initializers/storage.rb
+++ b/config/initializers/storage.rb
@@ -6,9 +6,9 @@ module Panoptes
       @configuration ||=
         {
           adapter: ENV.fetch('STORAGE_ADAPTER', 'test'),
-          prefix: ENV['STORAGE_PREFIX'],
           url: ENV['STORAGE_URL'],
           # s3 adapter specific
+          prefix: ENV['STORAGE_PREFIX'],
           bucket: ENV['STORAGE_BUCKET'],
           # azure adapter specific
           azure_storage_account: ENV.fetch('AZURE_STORAGE_ACCOUNT', 'panoptes'),

--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -45,8 +45,6 @@ spec:
             value: azure
           - name:  STORAGE_URL
             value: 'https://panoptesuploadsstaging.blob.core.windows.net/public'
-          - name: STORAGE_PREFIX
-            value: 'staging/'
           envFrom:
           - secretRef:
               name: panoptes-common-env-vars

--- a/spec/services/media_storage/azure_adapter_spec.rb
+++ b/spec/services/media_storage/azure_adapter_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe MediaStorage::AzureAdapter do
   let(:private_container) { 'secret-magic-container' }
   let(:opts) do
     {
-      prefix: 'test',
       url: 'https://test-uploads.zooniverse.org/container_name',
       azure_storage_account: storage_account_name,
       azure_storage_access_key: 'fake',
@@ -35,11 +34,6 @@ RSpec.describe MediaStorage::AzureAdapter do
       expect(adapter.put_expiration).to eq(default)
     end
 
-    it 'defaults to current rails environment for the prefix when no prefix is given' do
-      adapter = described_class.new(opts.except(:prefix))
-      expect(adapter.prefix).to eq('test')
-    end
-
     it 'creates the blob storage client using passed in options' do
       adapter
       expect(Azure::Storage::Blob::BlobService)
@@ -64,7 +58,7 @@ RSpec.describe MediaStorage::AzureAdapter do
     end
 
     it { is_expected.to be_a(String) }
-    it { is_expected.to match(/test\/subject_location/) }
+    it { is_expected.to match(/subject_location/) }
     it { is_expected.to match(/\.jpeg/) }
     it { is_expected.to match(uuid_v4_regex) }
 


### PR DESCRIPTION
Azure Adapter: 
Construct `stored_path` without env prefix.

`media.src` attributes (in the database) will now look something like this:
`subject_location/7c669787-2677-40ce-90bc-5d3ef185863d.jpeg`
`project_avatar/1adcb95b-06bf-4f84-ab83-530c1df7c086.jpeg`

In leu of using the env prefix, we will have two CDN domains, one for prod and one for staging:
staging: `panoptes-uploads-staging.zooniverse.org`
production: `panoptes-uploads.zooniverse.org`
We will store the respective domain URLs in the `STORAGE_URL` env var. We'll also include the container name in the `STORAGE_URL` env var, so it'll look like `panoptes-uploads-staging.zooniverse.org/public`, etc.

The azure adapter `get_url` method will call the `StoredPath` class, which will use the correct domain to construct the URL at which the public media item can be accessed. The final URL returned to the client will look something like this:
`panoptes-uploads-staging.zooniverse.org/public/subject_location/7c669787-2677-40ce-90bc-5d3ef185863d.jpeg`

-----

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
