### PR TITLE
increase staging app cpu request

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -120,7 +120,7 @@ spec:
           resources:
             requests:
               memory: "700Mi"
-              cpu: "50m"
+              cpu: "100m"
             limits:
               memory: "700Mi"
               cpu: "1000m"


### PR DESCRIPTION
ensure a better scaling metric for the staging api app hpa, ensure the HPA metric used for scaling up the app has a more robust denominator for the target comparison. 

E.g. 40M/50M = 80% whereas 40/100M = 40% (40M is not very busy)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
