### PR TITLE
decrease min pod replica count for sidekiq prod

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -328,7 +328,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: panoptes-production-sidekiq
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80
 ---

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -120,7 +120,7 @@ spec:
           resources:
             requests:
               memory: "700Mi"
-              cpu: "50m"
+              cpu: "100m"
             limits:
               memory: "700Mi"
               cpu: "1000m"


### PR DESCRIPTION
save on CPU and memory in the k8s cluster. Allow sidekiq prod to scale down to 1 pod when it's not busy and allow the HPA to scale the pod replicas up when needed

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
