### PR TITLE
add sidekiq pod disruption budget

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -332,6 +332,16 @@ spec:
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+   name: panoptes-production-sidekiq-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: panoptes-production-sidekiq
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
ensure we have at least 1 sidekiq pod running in the k8s cluster

when i was upgrading the nodepool today i managed to evict these pods and they couldn't reschedule due to limits on the available node pool (autoscaler didn't kick in) so sidekiq was down for 30 mins

this PDB should alleviate this issue as when draining nodes, the pods won't evict till rescheduled properly all without service downtime

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
