### PR TITLE
control ratio of real and training subjects in fallback selection

### DIFF
--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -2,30 +2,58 @@ module Subjects
   class FallbackSelection
     attr_reader :workflow, :limit, :options
 
+    def self.num_training_subjects_limit
+      ENV.fetch('FALLBACK_NUM_TRAINING_SUBJECTS_LIMIT', 10)
+    end
+
     def initialize(workflow, limit, options = {})
       @workflow, @limit, @options = workflow, limit, options
     end
 
     def any_workflow_data
-      any_workflow_data_scope
-        .limit(limit)
-        .pluck("set_member_subjects.subject_id")
-        .shuffle
+      if workflow.grouped
+        fallback_grouped_selection.shuffle
+      else
+        fallback_selection.shuffle
+      end
     end
 
     private
 
-    def any_workflow_data_scope
-      scope = workflow.set_member_subjects
-      if workflow.grouped
-        if subject_set_id = options[:subject_set_id]
-          scope = scope.where(subject_set_id: subject_set_id)
-        else
-          msg = "subject_set_id parameter missing for grouped workflow"
-          raise Subjects::Selector::MissingParameter.new(msg)
-        end
+    def fallback_grouped_selection
+      unless (subject_set_id = options[:subject_set_id])
+        raise Subjects::Selector::MissingParameter, 'subject_set_id parameter missing for grouped workflow'
       end
-      scope
+
+      workflow
+        .set_member_subjects
+        .where(subject_set_id: subject_set_id)
+        .limit(limit)
+        .pluck('set_member_subjects.subject_id')
+    end
+
+    def fallback_selection
+      (non_training_subject_ids | training_subject_ids)
+    end
+
+    def non_training_subject_ids
+      SetMemberSubject
+        .where(subject_set_id: workflow.non_training_subject_set_ids)
+        .limit(limit)
+        .pluck('set_member_subjects.subject_id')
+    end
+
+    def training_subject_ids
+      return [] if workflow.training_set_ids.empty?
+
+      # by default a ~10:1 ratio of real subjects to training
+      # modify this ration by num_training_subjects_limit class method
+      training_limit = (limit.to_f / self.class.num_training_subjects_limit).round
+
+      SetMemberSubject
+        .where(subject_set_id: workflow.training_set_ids)
+        .limit(training_limit)
+        .pluck('set_member_subjects.subject_id')
     end
   end
 end

--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -33,13 +33,21 @@ module Subjects
     end
 
     def fallback_selection
-      (non_training_subject_ids | training_subject_ids)
+      selected_training_subject_ids = training_subject_ids
+      if selected_training_subject_ids.empty?
+        non_training_subject_ids
+      else
+        # respect the request limit and return the correct mix of
+        # training and non-training subject ids
+        selected_non_training_subject_ids = non_training_subject_ids.take(non_training_limit)
+        selected_non_training_subject_ids | selected_training_subject_ids
+      end
     end
 
     def non_training_subject_ids
       SetMemberSubject
         .where(subject_set_id: workflow.non_training_subject_set_ids)
-        .limit(non_training_limit)
+        .limit(limit)
         .pluck('set_member_subjects.subject_id')
     end
 

--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -2,8 +2,8 @@ module Subjects
   class FallbackSelection
     attr_reader :workflow, :limit, :options
 
-    def self.num_training_subjects_limit
-      ENV.fetch('FALLBACK_NUM_TRAINING_SUBJECTS_LIMIT', 10)
+    def self.num_training_subjects_denominator
+      ENV.fetch('FALLBACK_NUM_TRAINING_SUBJECTS_DENOMINATOR', 10)
     end
 
     def initialize(workflow, limit, options = {})
@@ -48,7 +48,7 @@ module Subjects
 
       # by default a ~10:1 ratio of real subjects to training
       # modify this ration by num_training_subjects_limit class method
-      training_limit = (limit.to_f / self.class.num_training_subjects_limit).round
+      training_limit = (limit.to_f / self.class.num_training_subjects_denominator).round
 
       SetMemberSubject
         .where(subject_set_id: workflow.training_set_ids)

--- a/lib/subjects/fallback_selection.rb
+++ b/lib/subjects/fallback_selection.rb
@@ -39,21 +39,28 @@ module Subjects
     def non_training_subject_ids
       SetMemberSubject
         .where(subject_set_id: workflow.non_training_subject_set_ids)
-        .limit(limit)
+        .limit(non_training_limit)
         .pluck('set_member_subjects.subject_id')
     end
 
     def training_subject_ids
       return [] if workflow.training_set_ids.empty?
 
-      # by default a ~10:1 ratio of real subjects to training
-      # modify this ration by num_training_subjects_limit class method
-      training_limit = (limit.to_f / self.class.num_training_subjects_denominator).round
-
       SetMemberSubject
         .where(subject_set_id: workflow.training_set_ids)
         .limit(training_limit)
         .pluck('set_member_subjects.subject_id')
+    end
+
+    # by default a ~10:1 ratio of real subjects to training
+    # modify this ration by num_training_subjects_limit class method
+    def training_limit
+      @training_limit ||= (limit.to_f / self.class.num_training_subjects_denominator).round
+    end
+
+    # respect the original request limit
+    def non_training_limit
+      limit - training_limit
     end
   end
 end

--- a/spec/lib/subjects/fallback_selection_spec.rb
+++ b/spec/lib/subjects/fallback_selection_spec.rb
@@ -23,7 +23,8 @@ describe Subjects::FallbackSelection do
 
   describe "#any_workflow_data" do
     let(:subject_set_id) { nil }
-    let(:opts) { { limit: 5, subject_set_id: subject_set_id } }
+    let(:request_limit) { 5 }
+    let(:opts) { { limit: request_limit, subject_set_id: subject_set_id } }
     let(:expected_ids) do
       workflow.set_member_subjects.pluck("set_member_subjects.subject_id")
     end
@@ -46,6 +47,10 @@ describe Subjects::FallbackSelection do
       it 'includes some training subject ids from the workflow' do
         selected_training_subject_ids = training_subject_ids & subject_ids
         expect(selected_training_subject_ids).not_to be_empty
+      end
+
+      it 'returns the correct number of subjects' do
+        expect(subject_ids.count).to eq(request_limit)
       end
     end
 

--- a/spec/lib/subjects/fallback_selection_spec.rb
+++ b/spec/lib/subjects/fallback_selection_spec.rb
@@ -34,6 +34,10 @@ describe Subjects::FallbackSelection do
       expect(expected_ids).to include(*subject_ids)
     end
 
+    it 'returns the correct number of subjects' do
+      expect(subject_ids.count).to eq(request_limit)
+    end
+
     context 'with training sets on the workflow' do
       let(:training_set_id) { [workflow.subject_set_ids.sample] }
       let(:training_subject_ids) do


### PR DESCRIPTION
by default provide at least 1 training subject for every 10 real subjects in fallback selection

avoid showing the user mostly training subjects

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
