### PR TITLE
Modify the production & staging pod disruption budgets (pdb)

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -245,7 +245,7 @@ kind: PodDisruptionBudget
 metadata:
    name: panoptes-production-app-pdb
 spec:
-  minAvailable: 2
+  minAvailable: 50%
   selector:
     matchLabels:
       app: panoptes-production-app
@@ -337,7 +337,7 @@ kind: PodDisruptionBudget
 metadata:
    name: panoptes-production-sidekiq-pdb
 spec:
-  minAvailable: 1
+  minAvailable: 50%
   selector:
     matchLabels:
       app: panoptes-production-sidekiq

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -428,6 +428,16 @@ spec:
       targetPort: 6379
   type: NodePort
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+   name: panoptes-production-redis-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: panoptes-production-redis
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -227,16 +227,6 @@ spec:
   maxReplicas: 2
   targetCPUUtilizationPercentage: 80
 ---
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-   name: panoptes-staging-app-pdb
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: panoptes-staging-app
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
#### switch pdb to percent of available replicas
avoid hard coding the number of PDB replicas, instead use a percent of the available replicas https://kubernetes.io/docs/tasks/run-application/configure-pdb/

This allows more lenient eviction rules for the relevant pods. I came across pods that wouldn't evict due to the PDB settings when doing the cluster / node pool upgrades the other day. Specifically from https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
> If you set maxUnavailable to 0% or 0, or you set minAvailable to 100% or the number of replicas, you are requiring zero voluntary evictions. When you set zero voluntary evictions for a workload object such as ReplicaSet, then you cannot successfully drain a Node running one of those Pods. If you try to drain a Node where an unevictable Pod is running, the drain never completes. This is permitted as per the semantics of PodDisruptionBudget.

#### add pdb to production redis node
ensure we have the panoptes redis pod available at all time. 
Note that using the same value as our replica count will mean this pod can't voluntarily evict which is good as we want this redis node up all the time. That said, this setting will have consequences for node pool upgrades, these can be alleviated by redeploying e.g. `kubectl rollout restart deployment panoptes-production-redis`

#### remove the staging app pdb
Allow the scheduler to keep this node up, we can tolerate some downtime on the staging app and if it's down we can manually investigate / intervene (most likely due to node issues)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
