### PR TITLE
update storage url to zooniverse custom domain

### DIFF
--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -44,7 +44,7 @@ spec:
           - name: STORAGE_ADAPTER
             value: azure
           - name:  STORAGE_URL
-            value: 'https://panoptesuploadsstaging.blob.core.windows.net/public'
+            value: 'https://panoptes-uploads-staging.zooniverse.org/'
           envFrom:
           - secretRef:
               name: panoptes-common-env-vars


### PR DESCRIPTION
Update `STORAGE_URL` env var to our custom domain https://panoptes-uploads-staging.zooniverse.org. DNS and Front Door have been set up and tested for this domain, it correctly redirects to https://panoptesuploadsstaging.blob.core.windows.net/public. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
