### PR TITLE
extract azure path from s3 url for private media

### DIFF
--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -2,7 +2,7 @@
 
 module MediaStorage
   class AzureAdapter < AbstractAdapter
-    attr_reader :url, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
+    attr_reader :domain_prefix, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
 
     DEFAULT_EXPIRES_IN = 3 # time in minutes, see get_expiry_time(expires_in)
 
@@ -10,7 +10,7 @@ module MediaStorage
       @storage_account_name = opts[:azure_storage_account]
       @public_container = opts[:azure_storage_container_public]
       @private_container = opts[:azure_storage_container_private]
-      @url = opts[:url]
+      @domain_prefix = opts[:domain_prefix]
       @get_expiration = opts.dig(:expiration, :get) || DEFAULT_EXPIRES_IN
       @put_expiration = opts.dig(:expiration, :put) || DEFAULT_EXPIRES_IN
 
@@ -42,7 +42,7 @@ module MediaStorage
           expiry: get_expiry_time(opts[:get_expires] || get_expiration)
         ).to_s
       else
-        StoredPath.media_url(url, path)
+        StoredPath.media_url(domain_prefix, path)
       end
     end
 

--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -33,8 +33,9 @@ module MediaStorage
 
     def get_path(path, opts={})
       if opts[:private]
+        azure_path = StoredPath.media_path(path)
         signer.signed_uri(
-          client.generate_uri("#{private_container}/#{path}"),
+          client.generate_uri("#{private_container}/#{azure_path}"),
           false,
           service: 'b', # blob
           permissions: 'r', # read

--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -2,7 +2,7 @@
 
 module MediaStorage
   class AzureAdapter < AbstractAdapter
-    attr_reader :domain_prefix, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
+    attr_reader :url_prefix, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
 
     DEFAULT_EXPIRES_IN = 3 # time in minutes, see get_expiry_time(expires_in)
 
@@ -10,7 +10,7 @@ module MediaStorage
       @storage_account_name = opts[:azure_storage_account]
       @public_container = opts[:azure_storage_container_public]
       @private_container = opts[:azure_storage_container_private]
-      @domain_prefix = opts[:domain_prefix]
+      @url_prefix = opts[:url_prefix]
       @get_expiration = opts.dig(:expiration, :get) || DEFAULT_EXPIRES_IN
       @put_expiration = opts.dig(:expiration, :put) || DEFAULT_EXPIRES_IN
 
@@ -42,7 +42,7 @@ module MediaStorage
           expiry: get_expiry_time(opts[:get_expires] || get_expiration)
         ).to_s
       else
-        StoredPath.media_url(domain_prefix, path)
+        StoredPath.media_url(url_prefix, path)
       end
     end
 

--- a/app/services/media_storage/stored_path.rb
+++ b/app/services/media_storage/stored_path.rb
@@ -21,10 +21,11 @@ module MediaStorage
       end
 
       def media_url(domain_prefix, stored_path)
-        azure_path = rewrite_stored_path(stored_path)
-        File.join(domain_prefix, azure_path)
-      rescue PublicSuffix::DomainNotAllowed
-        azure_path = stored_path
+        begin
+          azure_path = rewrite_stored_path(stored_path)
+        rescue PublicSuffix::DomainNotAllowed
+          azure_path = stored_path
+        end
         File.join(domain_prefix, azure_path)
       end
 

--- a/app/services/media_storage/stored_path.rb
+++ b/app/services/media_storage/stored_path.rb
@@ -1,21 +1,26 @@
 # frozen_string_literal: true
 
 module MediaStorage
+  # StoredPath: module used by AzureAdapter for constructing the
+  # stored path/url of the media resource in azure
+  #
+  # Old S3 paths will include the panoptes-uploads domain prefix
+  # and the environment in their path, for example:
+  # panoptes-uploads.zooniverse.org/staging/subject_location/49f02f969a5.jpeg
+  # These URLs need to be rewritten such that domain prefix and env get removed
+  # Azure native paths do not need to be rewritten
   module StoredPath
-    # Construct the media access URL
-    # and ensure we remove the old aws s3 domain prefix in the stored paths
-    # but leave intact any non old s3 URL, i.e. new azure ones
+    # Construct path and join to the passed in URL
     def self.media_url(url, stored_path)
       uri = URI("https://#{stored_path}")
       # if the parse succeeds, we know we have a valid domain prefix,
-      # i.e. it is an old s3 stored path - hence, we need to rewrite the url
+      # i.e. it is an old s3 stored path and we need to rewrite it
       PublicSuffix.parse(uri.host)
 
       uri_path = path_without_env_prefix(uri.path)
       File.join(url, uri_path)
     rescue PublicSuffix::DomainNotAllowed
-      # failure here indicates we do not have
-      # a valid domain prefix in the stored path
+      # if parse fails, we do not have a valid domain prefix in the stored path
       # e.g. /user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg
       # so we do not need to rewrite the URL
       File.join(url, stored_path)
@@ -23,19 +28,15 @@ module MediaStorage
 
     def self.media_path(stored_path)
       uri = URI("https://#{stored_path}")
-      # if the parse succeeds, we know we have a valid domain prefix,
-      # i.e. it is an old s3 stored path - hence, we need to extract just the azure path
       PublicSuffix.parse(uri.host)
+      # S3 path
       path_without_env_prefix(uri.path)
     rescue PublicSuffix::DomainNotAllowed
-      # failure here indicates we do not have a valid domain prefix and dont need to rewrite
-      # return path as is
+      # azure path
       stored_path
     end
 
-    private
-
-    def path_without_env_prefix(uri_path)
+    private_class_method def self.path_without_env_prefix(uri_path)
       # remove env prefix if present
       env_prefix = '/' + Rails.env
       uri_path.sub(env_prefix, '') if uri_path.start_with? env_prefix

--- a/app/services/media_storage/stored_path.rb
+++ b/app/services/media_storage/stored_path.rb
@@ -22,11 +22,10 @@ module MediaStorage
 
       def media_url(domain_prefix, stored_path)
         azure_path = rewrite_stored_path(stored_path)
+        File.join(domain_prefix, azure_path)
       rescue PublicSuffix::DomainNotAllowed
         azure_path = stored_path
-      ensure
-        # a valid stored path without a TLD prefix, combine with the supplied domain prefix
-        return File.join(domain_prefix, azure_path)
+        File.join(domain_prefix, azure_path)
       end
 
       private

--- a/app/services/media_storage/stored_path.rb
+++ b/app/services/media_storage/stored_path.rb
@@ -10,12 +10,8 @@ module MediaStorage
       # if the parse succeeds, we know we have a valid domain prefix,
       # i.e. it is an old s3 stored path - hence, we need to rewrite the url
       PublicSuffix.parse(uri.host)
-      uri_path = uri.path
 
-      env_prefix = '/' + Rails.env
-      # remove env prefix if present
-      uri_path = uri_path.sub(env_prefix, '') if uri_path.start_with? env_prefix
-
+      uri_path = path_without_env_prefix(uri.path)
       File.join(url, uri_path)
     rescue PublicSuffix::DomainNotAllowed
       # failure here indicates we do not have
@@ -23,6 +19,26 @@ module MediaStorage
       # e.g. /user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg
       # so we do not need to rewrite the URL
       File.join(url, stored_path)
+    end
+
+    def self.media_path(stored_path)
+      uri = URI("https://#{stored_path}")
+      # if the parse succeeds, we know we have a valid domain prefix,
+      # i.e. it is an old s3 stored path - hence, we need to extract just the azure path
+      PublicSuffix.parse(uri.host)
+      path_without_env_prefix(uri.path)
+    rescue PublicSuffix::DomainNotAllowed
+      # failure here indicates we do not have a valid domain prefix and dont need to rewrite
+      # return path as is
+      stored_path
+    end
+
+    private
+
+    def path_without_env_prefix(uri_path)
+      # remove env prefix if present
+      env_prefix = '/' + Rails.env
+      uri_path.sub(env_prefix, '') if uri_path.start_with? env_prefix
     end
   end
 end

--- a/config/initializers/storage.rb
+++ b/config/initializers/storage.rb
@@ -6,7 +6,7 @@ module Panoptes
       @configuration ||=
         {
           adapter: ENV.fetch('STORAGE_ADAPTER', 'test'),
-          url: ENV['STORAGE_URL'],
+          domain_prefix: ENV['STORAGE_URL'],
           # s3 adapter specific
           prefix: ENV['STORAGE_PREFIX'],
           bucket: ENV['STORAGE_BUCKET'],

--- a/config/initializers/storage.rb
+++ b/config/initializers/storage.rb
@@ -6,7 +6,7 @@ module Panoptes
       @configuration ||=
         {
           adapter: ENV.fetch('STORAGE_ADAPTER', 'test'),
-          domain_prefix: ENV['STORAGE_URL'],
+          url_prefix: ENV['STORAGE_URL'],
           # s3 adapter specific
           prefix: ENV['STORAGE_PREFIX'],
           bucket: ENV['STORAGE_BUCKET'],

--- a/spec/services/media_storage/azure_adapter_spec.rb
+++ b/spec/services/media_storage/azure_adapter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MediaStorage::AzureAdapter do
   let(:private_container) { 'secret-magic-container' }
   let(:opts) do
     {
-      domain_prefix: 'https://test-uploads.zooniverse.org/container_name',
+      url_prefix: 'https://test-uploads.zooniverse.org/container_name',
       azure_storage_account: storage_account_name,
       azure_storage_access_key: 'fake',
       azure_storage_container_public: public_container,
@@ -117,7 +117,7 @@ RSpec.describe MediaStorage::AzureAdapter do
         allow(MediaStorage::StoredPath).to receive(:media_url)
         src = 'subject_locations/name.jpg'
         adapter.get_path(src)
-        expect(MediaStorage::StoredPath).to have_received(:media_url).with(opts[:domain_prefix], src)
+        expect(MediaStorage::StoredPath).to have_received(:media_url).with(opts[:url_prefix], src)
       end
 
       it 'returns the path as a https link' do

--- a/spec/services/media_storage/azure_adapter_spec.rb
+++ b/spec/services/media_storage/azure_adapter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MediaStorage::AzureAdapter do
   let(:private_container) { 'secret-magic-container' }
   let(:opts) do
     {
-      url: 'https://test-uploads.zooniverse.org/container_name',
+      domain_prefix: 'https://test-uploads.zooniverse.org/container_name',
       azure_storage_account: storage_account_name,
       azure_storage_access_key: 'fake',
       azure_storage_container_public: public_container,
@@ -117,7 +117,7 @@ RSpec.describe MediaStorage::AzureAdapter do
         allow(MediaStorage::StoredPath).to receive(:media_url)
         src = 'subject_locations/name.jpg'
         adapter.get_path(src)
-        expect(MediaStorage::StoredPath).to have_received(:media_url).with(opts[:url], src)
+        expect(MediaStorage::StoredPath).to have_received(:media_url).with(opts[:domain_prefix], src)
       end
 
       it 'returns the path as a https link' do

--- a/spec/services/media_storage/stored_path_spec.rb
+++ b/spec/services/media_storage/stored_path_spec.rb
@@ -3,8 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe MediaStorage::StoredPath do
+  let(:url) { 'https://media.storage.domain/path' }
+
+  before do
+    allow(Rails)
+      .to receive(:env)
+      .and_return('production')
+  end
+
   describe '.media_url' do
-    let(:url) { 'https://media.storage.domain/path' }
     let(:result) do
       described_class.media_url(url, stored_path)
     end
@@ -15,12 +22,6 @@ RSpec.describe MediaStorage::StoredPath do
       end
       let(:expected_url) do
         "#{url}/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg"
-      end
-
-      before do
-        allow(Rails)
-          .to receive(:env)
-          .and_return('production')
       end
 
       it 'returns a url without the old path prefix' do
@@ -41,13 +42,45 @@ RSpec.describe MediaStorage::StoredPath do
     end
 
     context 'with an azure native stored path (no old aws prefixes)' do
-      let(:stored_path) { 'production/subject_location/f2eb4dbc-1353-4598-b1f6-3bf9e9a14169.jpeg' }
+      let(:stored_path) { 'subject_location/f2eb4dbc-1353-4598-b1f6-3bf9e9a14169.jpeg' }
       let(:expected_url) do
-        "#{url}/production/subject_location/f2eb4dbc-1353-4598-b1f6-3bf9e9a14169.jpeg"
+        "#{url}/subject_location/f2eb4dbc-1353-4598-b1f6-3bf9e9a14169.jpeg"
       end
 
       it 'returns the expected url' do
         expect(result).to eq(expected_url)
+      end
+    end
+  end
+
+  describe '.media_path' do
+    let(:result) do
+      described_class.media_path(stored_path)
+    end
+
+    context 'with a migrated aws stored path' do
+      let(:stored_path) do
+        'panoptes-uploads.zooniverse.org/production/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
+      end
+      let(:expected_result) do
+        '/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
+      end
+
+      it 'returns a path without the old domain prefix and env prefix' do
+        expect(result).not_to include('panoptes-uploads.zooniverse.org/production')
+      end
+
+      it 'returns the expected path' do
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with with an azure native stored path (no old aws prefixes)' do
+      let(:stored_path) { 'subject_location/f2eb4dbc-1353-4598-b1f6-3bf9e9a14169.jpeg' }
+      let(:expected_result) { 'subject_location/f2eb4dbc-1353-4598-b1f6-3bf9e9a14169.jpeg' }
+
+      it 'returns the expected path' do
+        expect(result).to eq(expected_result)
       end
     end
   end

--- a/spec/services/media_storage/stored_path_spec.rb
+++ b/spec/services/media_storage/stored_path_spec.rb
@@ -5,12 +5,6 @@ require 'spec_helper'
 RSpec.describe MediaStorage::StoredPath do
   let(:url) { 'https://media.storage.domain/path' }
 
-  before do
-    allow(Rails)
-      .to receive(:env)
-      .and_return('production')
-  end
-
   describe '.media_url' do
     let(:result) do
       described_class.media_url(url, stored_path)
@@ -18,7 +12,7 @@ RSpec.describe MediaStorage::StoredPath do
 
     context 'with a migrated aws stored path' do
       let(:stored_path) do
-        'panoptes-uploads.zooniverse.org/production/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
+        'panoptes-uploads.zooniverse.org/test/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
       end
       let(:expected_url) do
         "#{url}/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg"
@@ -33,7 +27,7 @@ RSpec.describe MediaStorage::StoredPath do
       end
 
       it 'returns the url without the env prefix' do
-        expect(result).not_to include('/production')
+        expect(result).not_to include('/test')
       end
 
       it 'returns the expected url' do
@@ -60,14 +54,14 @@ RSpec.describe MediaStorage::StoredPath do
 
     context 'with a migrated aws stored path' do
       let(:stored_path) do
-        'panoptes-uploads.zooniverse.org/production/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
+        'panoptes-uploads.zooniverse.org/test/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
       end
       let(:expected_result) do
         '/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
       end
 
       it 'returns a path without the old domain prefix and env prefix' do
-        expect(result).not_to include('panoptes-uploads.zooniverse.org/production')
+        expect(result).not_to include('panoptes-uploads.zooniverse.org/test')
       end
 
       it 'returns the expected path' do


### PR DESCRIPTION
Add method for getting just the media path to the StoredPath module. For use by the azure adapter. This will fix requests for private media items stored in azure.

-----

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
