### PR TITLE
ensure training_set_ids respect the linked set ids

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -161,8 +161,10 @@ class Workflow < ActiveRecord::Base
   end
 
   def training_set_ids
-    config_training_set_ids = Array.wrap(configuration.dig("training_set_ids"))
-    config_training_set_ids.reject { |id| id.to_i.zero? }
+    config_training_set_ids = Array.wrap(configuration.dig('training_set_ids'))
+    config_training_set_ids = config_training_set_ids.map(&:to_i)
+    config_training_set_ids = config_training_set_ids.reject(&:zero?)
+    config_training_set_ids & subject_set_ids
   end
 
   def selector_page_size(default_page_size=10)

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -428,18 +428,27 @@ describe Workflow, type: :model do
     end
   end
 
-  describe "#training_subject_sets" do
-    let(:training_ids) { ["1"] }
+  describe '#training_set_ids' do
+    let(:training_ids) { ['1'] }
+    let(:expected_training_ids) { training_ids.map(&:to_i) }
 
-    it "should return the data in the config object" do
-
-      workflow.configuration["training_set_ids"] = training_ids
-      expect(workflow.training_set_ids).to match_array(training_ids)
+    before do
+      allow(workflow).to receive(:subject_set_ids).and_return(expected_training_ids)
     end
 
-    it "should sanitize the return values to known integer values" do
-      workflow.configuration["training_set_ids"] = training_ids | ["test"]
-      expect(workflow.training_set_ids).to match_array(training_ids)
+    it 'returns the data in the config object' do
+      workflow.configuration['training_set_ids'] = training_ids
+      expect(workflow.training_set_ids).to match_array(expected_training_ids)
+    end
+
+    it 'sanitizes the return values to known integer values' do
+      workflow.configuration['training_set_ids'] = training_ids | ['test']
+      expect(workflow.training_set_ids).to match_array(expected_training_ids)
+    end
+
+    it 'returns the intersection with the currently linked subject_set_ids' do
+      workflow.configuration['training_set_ids'] = training_ids | [-1]
+      expect(workflow.training_set_ids).to match_array(expected_training_ids)
     end
   end
 


### PR DESCRIPTION
related to #3486 - @mwalmsley found that he could enable fallback selection for subject sets that were no longer actively linked to the workflow.

This PR fixes the found bug by ensuring the `workflow.training_set_ids` method returns the intersection of workflow config `training_set_ids` and the currently linked `subject_set_ids`. This ensures the configuration directive doesn't allow selection of non linked sets.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
