### PR TITLE
Fix double slash issue in export URLs

### DIFF
--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -34,7 +34,7 @@ module MediaStorage
     def get_path(path, opts={})
       if opts[:private]
         azure_path = StoredPath.media_path(path)
-        azure_container_path = File.join(private_container, azure_path);
+        azure_container_path = File.join(private_container, azure_path)
         signer.signed_uri(
           client.generate_uri(azure_container_path),
           false,

--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -35,7 +35,7 @@ module MediaStorage
       if opts[:private]
         azure_path = StoredPath.media_path(path)
         signer.signed_uri(
-          client.generate_uri("#{private_container}/#{azure_path}"),
+          client.generate_uri(File.join(private_container, azure_path)),
           false,
           service: 'b', # blob
           permissions: 'r', # read

--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -34,8 +34,9 @@ module MediaStorage
     def get_path(path, opts={})
       if opts[:private]
         azure_path = StoredPath.media_path(path)
+        azure_container_path = File.join(private_container, azure_path);
         signer.signed_uri(
-          client.generate_uri(File.join(private_container, azure_path)),
+          client.generate_uri(azure_container_path),
           false,
           service: 'b', # blob
           permissions: 'r', # read

--- a/app/services/media_storage/stored_path.rb
+++ b/app/services/media_storage/stored_path.rb
@@ -11,7 +11,7 @@ module MediaStorage
   # Azure native paths do not need to be rewritten
   module StoredPath
     class << self
-      ENV_REMOVAL_REGEX = /\A(?:\/?#{Rails.env}\/?)?(.+)\z/
+      ENV_REMOVAL_REGEX = /\A(?:\/?#{Rails.env}\/?)?(.+)\z/.freeze
 
       def media_path(stored_path)
         rewrite_stored_path(stored_path)

--- a/app/services/media_storage/stored_path.rb
+++ b/app/services/media_storage/stored_path.rb
@@ -11,7 +11,7 @@ module MediaStorage
   # Azure native paths do not need to be rewritten
   module StoredPath
     class << self
-      ENV_PATH_PREFIX = '/' + Rails.env
+      ENV_REMOVAL_REGEX = /\A(?:\/?#{Rails.env}\/?)?(.+)\z/
 
       def media_path(stored_path)
         rewrite_stored_path(stored_path)
@@ -41,11 +41,7 @@ module MediaStorage
         PublicSuffix.parse(uri.host)
 
         # remove Rails env prefix if present (remnant path prefix from s3 land)
-        if uri.path.start_with?(ENV_PATH_PREFIX)
-          uri.path.sub(ENV_PATH_PREFIX, '')
-        else
-          uri.path
-        end
+        uri.path.match(ENV_REMOVAL_REGEX)[1]
       end
     end
   end

--- a/spec/services/media_storage/stored_path_spec.rb
+++ b/spec/services/media_storage/stored_path_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe MediaStorage::StoredPath do
         'panoptes-uploads.zooniverse.org/test/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
       end
       let(:expected_result) do
-        '/user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
+        'user_avatar/1e5fc9b5-86f1-4df3-986f-549f02f969a5.jpeg'
       end
 
       it 'returns a path without the old domain prefix and env prefix' do


### PR DESCRIPTION
We were previously using string concatenation to join the container name to the path:
https://github.com/zooniverse/panoptes/blob/4e1add082c779f3f7bc227cae83c37de1a537506/app/services/media_storage/azure_adapter.rb#L38

In the case of old S3 URLs, this resulted in a path with a double slash, e.g. `https://panoptesuploadsstaging.blob.core.windows.net/private//project_workflows_export/b8821786-f1a4-495e-9fc5-119c01680d5e.csv?sp=r&sv=2017-11-09&se=2020-11-06T19%3A09%3A54Z&sr=b&sig=IZE60%2B2swS2NCWi%2F065lFDr3T2hYaQb9NkoJDbVjrO4%3D`. Use File.join instead of string concatenation to avoid this issue.

Also updated `StoredPath` to use regex matching to remove the `/` at the beginning of the path if present, so that `#media_path` returned path with consistent format no matter whether we passed in an S3 path or an azure native path.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
