### PR TITLE
add production canary deploy template

### DIFF
--- a/kubernetes/deployment-production-azure-canary.tmpl
+++ b/kubernetes/deployment-production-azure-canary.tmpl
@@ -22,7 +22,7 @@ spec:
               cpu: "50m"
             limits:
               memory: "700Mi"
-              cpu: "1000m"
+              cpu: "500m"
           livenessProbe:
             httpGet:
               path: /

--- a/kubernetes/deployment-production-azure-canary.tmpl
+++ b/kubernetes/deployment-production-azure-canary.tmpl
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: panoptes-production-azure-canary-app
+  name: panoptes-production-canary-app
   labels:
-    app: panoptes-production-azure-canary-app
+    app: panoptes-production-canary-app
 spec:
   selector:
     matchLabels:
-      app: panoptes-production-azure-canary-app
+      app: panoptes-production-canary-app
   template:
     metadata:
       labels:
-        app: panoptes-production-azure-canary-app
+        app: panoptes-production-canary-app
     spec:
       containers:
-        - name: panoptes-production-azure-canary-app
+        - name: panoptes-production-canary-app
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
@@ -123,7 +123,7 @@ metadata:
   name: panoptes-production-canary
 spec:
   selector:
-    app: panoptes-production-azure-canary-app
+    app: panoptes-production-canary-app
   ports:
     - protocol: TCP
       port: 80

--- a/kubernetes/deployment-production-azure-canary.tmpl
+++ b/kubernetes/deployment-production-azure-canary.tmpl
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: panoptes-production-azure-canary-app
+  labels:
+    app: panoptes-production-azure-canary-app
+spec:
+  selector:
+    matchLabels:
+      app: panoptes-production-azure-canary-app
+  template:
+    metadata:
+      labels:
+        app: panoptes-production-azure-canary-app
+    spec:
+      containers:
+        - name: panoptes-production-azure-canary-app
+          image: zooniverse/panoptes:__IMAGE_TAG__
+          resources:
+            requests:
+              memory: "700Mi"
+              cpu: "50m"
+            limits:
+              memory: "700Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
+          env:
+          - name: PG_STATEMENT_TIMEOUT
+            value: '65000'
+          - name: STORAGE_ADAPTER
+            value: azure
+          - name:  STORAGE_URL
+            value: 'https://panoptes-uploads.zooniverse.org/'
+          envFrom:
+          - secretRef:
+              name: panoptes-common-env-vars
+          - secretRef:
+              name: panoptes-production-env-vars
+          - configMapRef:
+              name: panoptes-production-shared
+          volumeMounts:
+            - name: static-assets
+              mountPath: "/static-assets"
+            - name: jwt-production
+              mountPath: "/rails_app/config/keys"
+              readOnly: true
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
+        - name: panoptes-production-nginx
+          image: zooniverse/nginx:1.19.0
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 20
+          lifecycle:
+            preStop:
+              exec:
+                # SIGTERM triggers a quick exit; gracefully terminate instead
+                command: ["/usr/sbin/nginx","-s","quit"]
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: static-assets
+              mountPath: "/static-assets"
+            - name: panoptes-nginx-config
+              mountPath: "/etc/nginx-sites"
+            - name: panoptes-nginx-common
+              mountPath: "/etc/nginx/shared"
+      volumes:
+        - name: static-assets
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/panoptes-production-app-static-assets
+            type: DirectoryOrCreate
+        - name: panoptes-nginx-config
+          configMap:
+            name: panoptes-nginx-conf-production
+        - name: panoptes-nginx-common
+          configMap:
+            name: panoptes-nginx-common-conf-production
+        - name: jwt-production
+          secret:
+            secretName: panoptes-doorkeeper-jwt-production
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: panoptes-production-canary
+spec:
+  selector:
+    app: panoptes-production-azure-canary-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: panoptes-production-azure-canary-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "0"
+    nginx.ingress.kubernetes.io/canary-by-header: "Canary-Testing-Opt-In"
+spec:
+  tls:
+  - hosts:
+    - panoptes.zooniverse.org
+    secretName: panoptes-production-tls-secret
+  rules:
+  - host: panoptes.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: panoptes-production-canary
+          servicePort: 80
+        path: /(.*)


### PR DESCRIPTION
Like in the staging canary template, the k8s template for the production canary deployment includes definitions for the deployment, the service and the ingress.

I'm thinking that giving it the same resource allocation (memory/CPU) as the staging canary should suffice, since the canary deploy will only be touched by our team. Let me know if you disagree.

Once this PR is deployed, a CDN record and Front Door for the canary production URL needs to be created (akin to https://canary.pfe-preview.zooniverse.org/). URL will be https://canary.zooniverse.org.

-----

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
