### PR TITLE
Only allow POST requests to omniauth

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,1 @@
+OmniAuth.config.allowed_request_methods = [:post]


### PR DESCRIPTION
Only allow POST requests to omniauth to guard against CSRF vulnerability in omniauth gem - as recommended in omniauth's [mitigation instructions](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).

I'm thinking we should also take the next step of removing the gem and all associated code (if it's not being used), unless people think it's not worth our time to do so. Thoughts?

-----

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
