### PR TITLE
build on the existing docs for LSST use case

### DIFF
--- a/docs/source/includes/_subject_set_imports.md
+++ b/docs/source/includes/_subject_set_imports.md
@@ -1,33 +1,36 @@
 # SubjectSetImports
 
-```json
-{
-    "source_url": "https://path.to/some/manifest.json",
-    "links": {
-        "subject_set": "1"
-    }
-}
-```
+## Feature Description
 
 This resource is useful when a researcher has a large batch to add. The upload process goes as follows:
 
-1. A researcher uploads image files into an S3 bucket, or other publicly
-   accessible location. She also creates a manifest file (format described
-   below). The manifest file describes "subjects", which is the Zooniverse term
-   for something that is to be classified. A subject is made up of a unique
-   UUID, one or more URLs that host media files, and metadata described as
-   key-value pairs.
-3. In the Zooniverse project builder, the researcher navigates to the subject
-   set to which they would like to have the subjects added. The researcher then
-   clicks "Import manifest", and enters the URL to the manifest (as given to
-   them by step 2)
+1. A researcher uploads image files into a web accessible location (e.g. s3 bucket, azure blob store, etc).
+2. She also creates a manifest file (format described below) and uploads the manifest to a web accessible location.
+   + The manifest file describes ['subjects'](https://help.zooniverse.org/getting-started/glossary/), which is the Zooniverse term for something that is to be classified.
+      + A subject is made up of:
+          + a unique UUID
+          + one or more URLs that host media files e.g. image, video, audio.
+          + metadata described as key-value pairs.
+3. In the Zooniverse project builder, the researcher navigates to the subject set to which they would like to have the subjects added.
+4. The researcher then clicks "Import manifest" and enters the URL to the manifest (from by step 2 above).
+5. This calls the Zooniverse API which enqueues a background job on the Zooniverse servers.
+    + In the background, the Zooniverse's systems process the downloaded manifest file, creating subjects in the specified subject set.
 
-This calls a Zooniverse API which enqueues a background job on the Zooniverse servers. In the background, the Zooniverse's job workers download the manifest file, and process it, creating subjects in the specified subject set.
-Additional features beyond the MVP:
-When the science platform opens a new browser tab/window to send the researcher to the project builder, it can pass along the manifest URL for the small sample of <100 subjects as URL query parameters. The Zooniverse project builder will then make the Import button more prominent and prefill the URL.
+### Additional features beyond the MVP
+
+When the science platform opens a new browser tab/window to send the researcher to the project builder, it can pass along the manifest URL for the small sample of <100 subjects as URL query parameters.
+
+The Zooniverse project builder will then make the Import button more prominent and prefill the URL.
+
 After approval, when the researcher needs to get a full set of data into their Zooniverse project, at the end the supertask can call the Zooniverse API to trigger the import rather than requesting the researcher to go back to the project builder and click a button.
 
-## Creating a new import
+***
+
+## Zooniverse API Feature Description
+
+***
+
+### Creating a new subject set import
 
 ```http
 POST /api/subject_set_imports HTTP/1.1
@@ -46,7 +49,9 @@ Content-Type: application/json
 
 Returns a SubjectSetImport resource with an ID. This resource can be polled in order to get the status of the import.
 
-## Retrieve a single import
+***
+
+### Retrieve a single import
 
 ```http
 GET /api/subject_set_imports/1 HTTP/1.1
@@ -56,6 +61,8 @@ Content-Type: application/json
 
 + Parameters
   + id (required, integer) ... integer id of the resource to retrieve
+
+***
 
 ## Manifest CSV format
 


### PR DESCRIPTION
update the LSST subject set import docs, deployed at https://zooniverse.github.io/panoptes/#subjectsetimports

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
