### PR TITLE
cleanup left over tmp files every 6h

### DIFF
--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -3,7 +3,11 @@
 cd /rails_app
 
 # cleanup the dump worker temp files
-tmpreaper 7d /tmp/
+# that have not changed (had data added to them) in the last 6 hours
+# use the mtime (default is atime)
+# reason: handle the case where the exporter died mid export
+#         e.g the disk filled up OR OOM error on container process
+tmpreaper 6h --mtime /tmp/
 
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid


### PR DESCRIPTION
closes #3516 

Use a more aggressive exporter artifacts cleanup in /tmp. avoid these exports filling up our tmp disks and causing more errors

Linked to https://app.honeybadger.io/projects/40595/faults/70494224

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
