### PR TITLE
Add Panoptes (production) ingress for www-panoptes.zooniverse.org

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -534,4 +534,40 @@ spec:
           serviceName: panoptes-production-app
           servicePort: 80
         path: /(.*)
-
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: www-panoptes-production-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Host www.zooniverse.org;
+spec:
+  tls:
+  - hosts:
+    - www-panoptes.zooniverse.org
+    secretName: www-panoptes-production-tls
+  rules:
+  - host: www-panoptes.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: panoptes-production-app
+          servicePort: 80
+        path: /
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: www-panoptes-production-tls
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: www-panoptes-production-tls
+  dnsNames:
+    - www-panoptes.zooniverse.org

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -544,8 +544,7 @@ metadata:
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header Host www.zooniverse.org;
+    nginx.ingress.kubernetes.io/upstream-vhost: "www.zooniverse.org"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
## PR Overview

This PR adds a new Kubernetes ingress for `www-panoptes.zooniverse.org`

- This PR is part of a solution for https://github.com/zooniverse/operations/issues/459#issuecomment-726289233
- The `www-panoptes.zooniverse.org` ingress is unique in that it adds a proxy-header to login requests from oAuth apps
- A new Certificate resource is added to the deployment template, _https://_ www-panoptes.zooniverse.org

### Dev Notes

- `rewrite-target` logic isn't used in the new ingress block
- The Certificate resource doesn't need `use-azuredns-solver: "true"` unlike in other current configurations
  - Rules for adding custom NGINX upstream vhost: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-nginx-upstream-vhost
  - Correct syntax for `proxy_set_header Host`: https://github.com/kubernetes/ingress-nginx/issues/5240

### Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.

### Status

Ready for review; monitoring the tests to ensure nothing breaks, at minimum.