### PR TITLE
Cutover production to use Azure Blob Storage

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -100,7 +100,8 @@ data:
   REDIS_URL: 'redis://panoptes-production-redis:6379/0'
   RAILS_MAX_THREADS: '8'
   SIDEKIQ_CONCURRENCY: '8'
-  STORAGE_ADAPTER: aws
+  STORAGE_ADAPTER: azure
+  STORAGE_URL: https://panoptes-uploads.zooniverse.org/
   STORAGE_BUCKET: zooniverse-static
   STORAGE_PREFIX: panoptes-uploads.zooniverse.org/production/
   AZURE_STORAGE_ACCOUNT: panoptesuploads


### PR DESCRIPTION
Updated env vars `STORAGE_ADAPTER` and `STORAGE_URL` - once this is deployed, the panoptes production app will start using the azure adapter.

-----

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
