### PR TITLE
use the medium get_path url for avatars

### DIFF
--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -15,11 +15,9 @@ class OrganizationSerializer
           :avatar, :background, :attached_images
 
   def avatar_src
-    if avatar = @model.avatar
-      avatar.external_link ? avatar.external_link : avatar.src
-    else
-      ""
-    end
+    return '' unless (avatar = @model.avatar)
+
+    avatar.external_link || avatar.get_url
   end
 
   def self.links

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -128,10 +128,8 @@ class ProjectSerializer
   end
 
   def avatar_src
-    if avatar = @model.avatar
-      avatar.external_link ? avatar.external_link : avatar.src
-    else
-      ""
-    end
+    return '' unless (avatar = @model.avatar)
+
+    avatar.external_link || avatar.get_url
   end
 end

--- a/spec/serializers/organization_serializer_spec.rb
+++ b/spec/serializers/organization_serializer_spec.rb
@@ -61,7 +61,9 @@ describe OrganizationSerializer do
   end
 
   describe "#avatar_src" do
-    let(:avatar) { double("avatar", external_link: external_url, src: src) }
+    let(:avatar) do
+      instance_double('avatar', external_link: external_url, get_url: src)
+    end
     let(:src) { nil }
     let(:external_url) { nil }
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -106,7 +106,9 @@ describe ProjectSerializer do
   end
 
   describe "#avatar_src" do
-    let(:avatar) { double("avatar", external_link: external_url, src: src) }
+    let(:avatar) do
+      instance_double('avatar', external_link: external_url, get_url: src)
+    end
     let(:src) { nil }
     let(:external_url) { nil }
 


### PR DESCRIPTION
ensure the special card routes have the updated avatar src urls (rewritten) via azure storage adapter.

Since we've modified how the panoptes-upload URLs work we need to avoid serializing the linked avatar URL path directly from the `model.src` attribute. Instead use custom Media storage adapter (Azure in this case) for rewriting the staging `src` attributes to `panoptes-uploads-staging` domain and stripping the `/production` paths on the `panoptes-uploads` domain.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
