### PR TITLE
ensure hidden subject metadata on the group subject

### DIFF
--- a/app/operations/subject_groups/create.rb
+++ b/app/operations/subject_groups/create.rb
@@ -68,13 +68,6 @@ module SubjectGroups
 
     def build_subject_group_member(subject_group, subject, index)
       SubjectGroupMember.new(
-        # TODO: look at adding some of the selection context in here
-        # workflow finished? (useful probs not as retirement is offline for this project)
-        # selecter state is probably useful
-        # the passed in subject ids in their order?
-        # selection timing will be tracked by the record timestamps...
-        # what else?
-        # context: {hash_of_useful_selector_context_info}
         project: project,
         subject: subject,
         subject_group: subject_group,
@@ -101,11 +94,9 @@ module SubjectGroups
     def update_group_subject_metadata(subject_group)
       group_subject = subject_group.group_subject
       group_subject_metadata = group_subject.metadata
-      group_subject_metadata['subject_group'] = {
-        # TODO: should this be hidden metadata?
-        subject_group_id: subject_group.id,
-        group_subject_ids: subject_group.key
-      }
+      # ensure these metadata fields are hidden
+      group_subject_metadata['#subject_group_id'] = subject_group.id
+      group_subject_metadata['#group_subject_ids'] = subject_group.key
       group_subject.update_column(:metadata, group_subject_metadata) #rubocop:disable Rails/SkipsModelValidations
     end
   end

--- a/spec/operations/subject_groups/create_spec.rb
+++ b/spec/operations/subject_groups/create_spec.rb
@@ -53,10 +53,16 @@ describe SubjectGroups::Create do
       expect(result_locations).to match(expected_locations)
     end
 
-    it 'tracks the subject_group id & subject_key in the group_subject metadata' do
-      group_subject = created_subject_group.group_subject
-      subject_group_metadata = { subject_group_id: created_subject_group.id, group_subject_ids: created_subject_group.key }
-      expect(group_subject.metadata['subject_group']).to match(subject_group_metadata)
+    describe 'tracking the subject group info in the group_subject metadata' do
+      let(:group_subject) { created_subject_group.group_subject }
+
+      it 'records the subject_group id in hidden metadata attribute' do
+        expect(group_subject.metadata['#subject_group_id']).to match(created_subject_group.id)
+      end
+
+      it 'records the group subject ids in hidden metadata attribute' do
+        expect(group_subject.metadata['#group_subject_ids']).to match(created_subject_group.key)
+      end
     end
   end
 end


### PR DESCRIPTION
don't nest an object as this may not be handled by PFE correctly as it assumes non nested objects. Ensure these metadata values are hidden in the PFE / FEM interface as they are meant for internal use only (avoid confusing volunteers)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
