### PR TITLE
add db env var for ruby 2.6 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,7 @@ matrix:
         - DATABASE_URL=postgresql://localhost/travis_ci_test?user=postgres
         - SPECS="spec/lib spec/workers spec/serializers spec/services spec/requests spec/middleware spec/mailers spec/policies"
     - rvm: 2.6
+      env:
+        - DATABASE_URL=postgresql://localhost/travis_ci_test?user=postgres
 
 script: "bundle exec rspec $SPECS"


### PR DESCRIPTION
ensure the next ruby version (2.6) specs can run against a known test db in travis 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
