### PR TITLE
rewrite the azure storage paths when cleaning up

### DIFF
--- a/app/workers/medium_removal_worker.rb
+++ b/app/workers/medium_removal_worker.rb
@@ -7,7 +7,7 @@ class MediumRemovalWorker
 
   def perform(medium_src, opts={})
     MediaStorage.delete_file(object_store_path(medium_src), opts)
-  rescue Aws::S3::Errors::AccessDenied, Azure::Core::Http::HTTPError
+  rescue Aws::S3::Errors::AccessDenied
     # do nothing and don't retry this worker
   end
 

--- a/app/workers/medium_removal_worker.rb
+++ b/app/workers/medium_removal_worker.rb
@@ -1,10 +1,30 @@
+# frozen_string_literal: true
+
 class MediumRemovalWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :data_low
 
   def perform(medium_src, opts={})
-    MediaStorage.delete_file(medium_src, opts)
-  rescue Aws::S3::Errors::AccessDenied
+    MediaStorage.delete_file(object_store_path(medium_src), opts)
+  rescue Aws::S3::Errors::AccessDenied, Azure::Core::Http::HTTPError
+    # do nothing and don't retry this worker
+  end
+
+  private
+
+  def object_store_path(path)
+    # only when cleaning up azure objects do the paths need modification
+    return path unless MediaStorage.get_adapter.is_a?(MediaStorage::AzureAdapter)
+
+    # azure paths may need to have the s3 specific storage paths
+    # converted to match the new azure object store location paths
+    # i.e. remove the custom s3 path prefix (hosted_domain/rails_env)
+    # from the resulting object store path vs what we've stored in the db
+    #
+    # note: this path modification is a vestige of our s3 -> azure cloud migration
+    #       specifically the medium.src db values for our exising s3 data that was mapped
+    #       to a different storage account, container path in azure
+    MediaStorage::StoredPath.media_path(path)
   end
 end

--- a/spec/workers/medium_removal_worker_spec.rb
+++ b/spec/workers/medium_removal_worker_spec.rb
@@ -1,15 +1,50 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe MediumRemovalWorker do
-  it 'should delete the given src path' do
-    expect(MediaStorage).to receive(:delete_file)
-    subject.perform('test/path.txt')
+  subject(:worker) { described_class.new }
+
+  let(:medium_src) { 'test/path.txt' }
+
+  it 'deletes the given src path' do
+    allow(MediaStorage).to receive(:delete_file)
+    worker.perform(medium_src)
+    expect(MediaStorage).to have_received(:delete_file).with(medium_src, {})
   end
 
-  it 'should skip any access denied media paths' do
+  it 'ignores any missing s3 (access denied) media paths' do
     allow(MediaStorage)
       .to receive(:delete_file)
-      .and_raise(Aws::S3::Errors::AccessDenied.new(:s3, "fake denied"))
-    expect { subject.perform('test/path.txt') }.not_to raise_error
+      .and_raise(Aws::S3::Errors::AccessDenied.new(:s3, 'fake denied'))
+    expect { worker.perform(medium_src) }.not_to raise_error
+  end
+
+  it 'ignores any missing azure (BlobNotFound (404)) media paths' do
+    require 'azure/core/http/http_error'
+    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 500, body: '', reason_phrase: '')
+    allow(MediaStorage).to receive(:delete_file).and_raise(Azure::Core::Http::HTTPError, response)
+    expect { worker.perform(medium_src) }.not_to raise_error
+  end
+
+  it 'does not modify the storage path for the object store' do
+    allow(MediaStorage).to receive(:delete_file)
+    allow(MediaStorage::StoredPath).to receive(:media_path)
+    worker.perform(medium_src)
+    expect(MediaStorage::StoredPath).not_to have_received(:media_path)
+  end
+
+  context 'when using an azure storage adapter' do
+    before do
+      allow(MediaStorage).to receive(:delete_file)
+      azure_adapter = instance_double('MediaStorage::AzureAdapter', is_a?: true)
+      allow(MediaStorage).to receive(:get_adapter).and_return(azure_adapter)
+    end
+
+    it 'modifies the storage path for the azure blob object store' do
+      allow(MediaStorage::StoredPath).to receive(:media_path)
+      worker.perform(medium_src)
+      expect(MediaStorage::StoredPath).to have_received(:media_path)
+    end
   end
 end

--- a/spec/workers/medium_removal_worker_spec.rb
+++ b/spec/workers/medium_removal_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe MediumRemovalWorker do
     expect { worker.perform(medium_src) }.not_to raise_error
   end
 
-  it 'does not modify the storage path for the object store' do
+  it 'does not modify the storage path for the object store when not using azure adapter' do
     allow(MediaStorage).to receive(:delete_file)
     allow(MediaStorage::StoredPath).to receive(:media_path)
     worker.perform(medium_src)

--- a/spec/workers/medium_removal_worker_spec.rb
+++ b/spec/workers/medium_removal_worker_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe MediumRemovalWorker do
     require 'azure/core/http/http_error'
     response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 500, body: '', reason_phrase: '')
     allow(MediaStorage).to receive(:delete_file).and_raise(Azure::Core::Http::HTTPError, response)
-    expect { worker.perform(medium_src) }.not_to raise_error
+    # allow this worker to fail right now so we can track any azure blob store
+    # path cleanup errors, https://github.com/zooniverse/panoptes/pull/3538/files#r547433486
+    expect { worker.perform(medium_src) }.to raise_error(Azure::Core::Http::HTTPError)
   end
 
   it 'does not modify the storage path for the object store when not using azure adapter' do


### PR DESCRIPTION
fixes the errors reported in https://app.honeybadger.io/projects/40595/faults/72161201

as our older s3 medium objects have different paths as what results in azure, we have to ensure we modify these paths to cleanup in azure correctly. 

Use the same path rewriter code as we do for the `adapter.get_paths` to determine which azure object store path we should attempt to delete.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
