### PR TITLE
export media src rewrite

### DIFF
--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -301,7 +301,6 @@ namespace :migrate do
         project_workflow_contents_export
         project_workflows_export
         workflow_classifications_export
-        Workflow_classifications_export
       ]
 
       puts 'starting export media src rewrite'

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -305,15 +305,14 @@ namespace :migrate do
       ]
 
       puts 'starting export media src rewrite'
-      Medium.where(type: export_media_types).find_each.with_index do |medium, index|
+      Medium.where(private: true, type: export_media_types).find_each.with_index do |medium, index|
         matches = OLD_PATH_REGEX.match(medium.src)
         # array index 1 will be nil if src does not start with panoptes-uploads.../production/
         if matches[1]
-          puts matches[2]
           # array index 2 is the second capture group (anything after panoptes-uploads.../production/)
           medium.update_column(:src, matches[2])
         end
-        puts "progress: #{index} records processed" if index % 1000.zero?
+        puts "progress: #{index} records processed" if (index % 1000).zero?
       end
       puts 'finished export media src rewrite'
     end


### PR DESCRIPTION
Closes #3539 

Rewrite `src` attribute of export media records in order to resolve https://github.com/zooniverse/panoptes/issues/3539
Reasoning behind this choice explained [here](https://github.com/zooniverse/panoptes/issues/3539#issuecomment-754123093).

The new task will remove `panoptes-uploads.zooniverse.org/{env}/` from the src path. I have tested the rake task locally with manually generated media records, we will also be able to test on staging to confirm that the paths get updated as expected. Since we'll be able to test on staging, separating out the cases for each export type for testing is likely unnecessary, but feel free to comment if you think otherwise.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
