### PR TITLE
Use explicit certificate resource on ingresses

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -504,7 +504,7 @@ metadata:
   name: panoptes-production-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
@@ -544,7 +544,7 @@ metadata:
   name: www-panoptes-production-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
     nginx.ingress.kubernetes.io/upstream-vhost: "www.zooniverse.org"

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -552,7 +552,7 @@ spec:
   tls:
   - hosts:
     - www-panoptes.zooniverse.org
-    secretName: www-panoptes-production-tls
+    secretName: panoptes-production-tls-secret
   rules:
   - host: www-panoptes.zooniverse.org
     http:
@@ -565,11 +565,14 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: www-panoptes-production-tls
+  name: panoptes-production-tls-secret
 spec:
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
-  secretName: www-panoptes-production-tls
+  secretName: panoptes-production-tls-secret
   dnsNames:
+    - panoptes.azure.zooniverse.org
+    - panoptes.zooniverse.org
+    - signin.zooniverse.org
     - www-panoptes.zooniverse.org

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -460,7 +460,7 @@ metadata:
   name: panoptes-staging-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -477,3 +477,15 @@ spec:
           serviceName: panoptes-staging-app
           servicePort: 80
         path: /(.*)
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: panoptes-staging-tls-secret
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: panoptes-staging-tls-secret
+  dnsNames:
+    - panoptes-staging.zooniverse.org


### PR DESCRIPTION
Let's encrypt cert expiry notifications led me to not find any cert resources for the panoptes ingresses. Luckily these are still valid and stored in the relevant secrets e.g. https://github.com/zooniverse/panoptes/blob/9f0d0e872be06409d67fdbcf8b6444584d95c9fc/kubernetes/deployment-production.tmpl#L517

Previously this worked due to the use of ingress annotations https://github.com/zooniverse/panoptes/blob/9f0d0e872be06409d67fdbcf8b6444584d95c9fc/kubernetes/deployment-production.tmpl#L507 
and the cert-manager shim would respect the annotations and configure a certificate in the defined secret, https://cert-manager.io/docs/usage/ingress/#how-it-works

However post the cert-manager upgrade these annotations are out of date so the cert manager doesn't recognise these anymore, see https://github.com/zooniverse/operations/pull/502 for details on the cert-manager annotation changes.

So this PR updates the ingress annotations (even though it doesn't use them) and will now explicitly configure certificates for each ingress. Explicit certs allow us to easily find them from the k8s yaml declarations and the `kubectl get certificate` cmd. 

Finally this PR combines the custom `www panoptes` ingress certificate to the main ingress as created in #3523. Post deployment i'll manually cleanup the `www-panoptes-production-tls` certificate and secret resources in k8s.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
