### PR TITLE
Add http_cache parameter to SubjectGroup selection API

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -58,7 +58,7 @@ class Api::V1::SubjectsController < Api::ApiController
     skip_policy_scope
 
     # setup the selector params from user input, note validation occurs in the operation class
-    selector_param_keys = %i[workflow_id subject_set_id num_rows num_columns]
+    selector_param_keys = %i[workflow_id subject_set_id num_rows num_columns http_cache]
     selector_params = params.permit(*selector_param_keys)
 
     # Sanity check -- use a testing feature flag

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -534,7 +534,7 @@ describe Api::V1::SubjectsController, type: :controller do
     end
     let(:api_resource_links) { [] }
     let(:sms) { create_list(:set_member_subject, 1, subject_set: subject_set) }
-    let(:request_params) { { workflow_id: workflow.id.to_s, num_columns: 1, num_rows: 1 } }
+    let(:request_params) { { workflow_id: workflow.id.to_s, num_columns: 1, num_rows: 1, http_cache: 'true' } }
     let(:flipper_feature) { Panoptes.flipper[:subject_group_selection].enable }
 
     before do


### PR DESCRIPTION
## PR Overview

Closes #3551

- This PR adds "http_cache" to the list of acceptable parameters for the `/subjects/grouped` endpoint.
- The "http_cache=true" parameter is sent by the front end (Panoptes JS library) for pretty much most API calls, so this seems necessary.

### Status

Ready for review, contingent on the assumption that the http_cache wasn't excluded from the list of acceptable parameters on purpose.