### PR TITLE
scale the canary deployments to zero

### DIFF
--- a/kubernetes/deployment-production-azure-canary.tmpl
+++ b/kubernetes/deployment-production-azure-canary.tmpl
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: panoptes-production-canary-app
 spec:
+  replicas: 0
   selector:
     matchLabels:
       app: panoptes-production-canary-app

--- a/kubernetes/deployment-staging-azure-canary.tmpl
+++ b/kubernetes/deployment-staging-azure-canary.tmpl
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: panoptes-staging-azure-canary-app
 spec:
+  replicas: 0
   selector:
     matchLabels:
       app: panoptes-staging-azure-canary-app


### PR DESCRIPTION
add a replica directive to scale the prod & staging canary deployments to 0

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
