### PR TITLE
Subject groups creation bug fixes

### DIFF
--- a/app/operations/subject_groups/create.rb
+++ b/app/operations/subject_groups/create.rb
@@ -8,7 +8,7 @@ module SubjectGroups
     integer :subject_ids_size, default: -> { subject_ids.size }
     integer :group_size
 
-    validates :subject_ids_size, numericality: { greater_than_or_equal_to: ENV.fetch('SUBJECT_GROUP_MIN_SIZE', 2) }
+    validates :subject_ids_size, numericality: { greater_than_or_equal_to: ENV.fetch('SUBJECT_GROUP_MIN_SIZE', 2).to_i }
     validate :group_size, :ensure_subject_ids_size_matches_group_size
 
     def execute

--- a/app/operations/subject_groups/create.rb
+++ b/app/operations/subject_groups/create.rb
@@ -122,7 +122,6 @@ module SubjectGroups
         location_param[:metadata][:originating_subject_id] = media_subject_id
         location_param
       end
-
     end
 
     def update_group_subject_metadata(subject_group)

--- a/app/operations/subject_groups/create.rb
+++ b/app/operations/subject_groups/create.rb
@@ -106,9 +106,14 @@ module SubjectGroups
         # return the mime / url combination for building the media location resources
         { mime_type => media_url }
       end
-      Subject.location_attributes_from_params(external_locations).map do |location_param|
+      # build the subject location params for use in the AR association builder
+      build_external_location_params(external_locations, external_locations_subject_id_lut)
+    end
+
+    def build_external_location_params(media_locations, media_locations_subject_id_lut)
+      Subject.location_attributes_from_params(media_locations).map do |location_param|
         media_url = location_param[:src]
-        media_subject_id = external_locations_subject_id_lut[media_url]
+        media_subject_id = media_locations_subject_id_lut[media_url]
         # store the originating subject resource id to ensure track
         # how the group_subject media location resources are built and to
         # specifically understand the intended subject -> media location ordering
@@ -117,6 +122,7 @@ module SubjectGroups
         location_param[:metadata][:originating_subject_id] = media_subject_id
         location_param
       end
+
     end
 
     def update_group_subject_metadata(subject_group)

--- a/app/operations/subject_groups/selection.rb
+++ b/app/operations/subject_groups/selection.rb
@@ -57,17 +57,18 @@ module SubjectGroups
       [].tap do |subject_groups|
         SubjectGroup.transaction do
           # split the subject ids into equal groups of `grid_size`
-          selected_subject_ids.each_slice(grid_size) do |group_subject_ids|
-            subject_group_key = group_subject_ids.join('-')
+          selected_subject_ids.each_slice(grid_size) do |per_grid_subject_ids|
+            subject_group_key = per_grid_subject_ids.join('-')
 
             # re-use any existing SubjectGroup based on key lookup
             subject_group = SubjectGroup.find_by(key: subject_group_key)
 
             # if we didn't find it, create a new subject group from the selected ids
             subject_group ||= SubjectGroups::Create.run!(
-              subject_ids: selected_subject_ids,
+              subject_ids: per_grid_subject_ids,
               uploader_id: uploader_id,
-              project_id: project_id
+              project_id: project_id,
+              group_size: grid_size
             )
             subject_groups << subject_group
           end

--- a/app/operations/subject_groups/selection.rb
+++ b/app/operations/subject_groups/selection.rb
@@ -12,7 +12,7 @@ module SubjectGroups
     # ensure the num_rows & columns are integers between 1 and 10
     validates :num_rows, numericality: { less_than: 10, greater_than_or_equal_to: 1 }
     validates :num_columns, numericality: { less_than: 10, greater_than_or_equal_to: 1 }
-    validates :grid_size, numericality: { less_than_or_equal_to: ENV.fetch('SUBJECT_GROUP_MAX_GRID_SIZE', 25) }
+    validates :grid_size, numericality: { less_than_or_equal_to: ENV.fetch('SUBJECT_GROUP_MAX_GRID_SIZE', 25).to_i }
 
     def execute
       subject_selector = Subjects::Selector.new(user.user, selector_params)

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -540,6 +540,7 @@ describe Api::V1::SubjectsController, type: :controller do
     before do
       ENV['SUBJECT_GROUP_WORKFLOW_ID_ALLOWLIST'] = workflow.id.to_s
       ENV['SUBJECT_GROUP_UPLOADER_ID'] = workflow.owner.id.to_s
+      ENV['SUBJECT_GROUP_MIN_SIZE'] = '1'
       sms
       flipper_feature
       get :grouped, request_params

--- a/spec/operations/subject_groups/create_spec.rb
+++ b/spec/operations/subject_groups/create_spec.rb
@@ -19,7 +19,7 @@ describe SubjectGroups::Create do
     expect(created_subject_group).to be_valid
   end
 
-  it 'raises with error if it can not find all the subject_ids'  do
+  it 'raises with error if it can not find all the subject_ids' do
     params[:subject_ids] = subject_ids | ['-1']
     params[:group_size] = params[:subject_ids].count
     expect {

--- a/spec/operations/subject_groups/selection_spec.rb
+++ b/spec/operations/subject_groups/selection_spec.rb
@@ -36,6 +36,23 @@ describe SubjectGroups::Selection do
     expect(Subjects::Selector).to have_received(:new).with(user.user, params.merge(page_size: 3))
   end
 
+  it 'calls the subject group create operations correctly' do
+    described_class.run(operation_params)
+    create_operation_params = {
+      subject_ids: [1],
+      uploader_id: workflow.owner.id.to_s,
+      project_id: workflow.project_id.to_s,
+      group_size: 1
+    }
+    # can not test the order of these calls via .ordered expectation
+    # https://github.com/rspec/rspec-mocks/issues/916
+    expect(SubjectGroups::Create).to have_received(:run!).with(create_operation_params)
+    create_operation_params[:subject_ids] = [2]
+    expect(SubjectGroups::Create).to have_received(:run!).with(create_operation_params)
+    create_operation_params[:subject_ids] = [3]
+    expect(SubjectGroups::Create).to have_received(:run!).with(create_operation_params)
+  end
+
   it 'returns three newly created subject_group in the operation result' do
     expect(result.subject_groups).to match_array(created_subject_groups)
   end


### PR DESCRIPTION
Linked to #3549 and #3550  add more checks and validation when creating the special `SubjectGroup.group_subject` Subject resource

Adds validations that the
- group we are creating matches our expected number of subjects
- group is bigger than 1 (else why are we creating a group?)

These will help with issues reported in the above issues where we are incorrectly creating groups

Finally there is a big bug fix in here that ensures we correctly create the `group_subjects` linked image media URLs in the order that they are supplied i.e. the subject ids match the linked images and they aren't mixed. Without this check we may actually show the incorrect image to the user and record the wrong subject ID in the downstream classification - which would corrupt the data and be a very bad thing. 

FWIW - i've added some data tracking metadata on the group subject media locations to record the originating subject resource ids to ensure we can reconstruct the correct ordering / linkage and not corrupt downstream classification data.

### TODO 
- [ ] Ensure each originating subject only has 1 media location as outlined in https://github.com/zooniverse/panoptes/issues/3549#issuecomment-760258970

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
