### PR TITLE
split default and www-panoptes ingress certificates

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -552,7 +552,7 @@ spec:
   tls:
   - hosts:
     - www-panoptes.zooniverse.org
-    secretName: panoptes-production-tls-secret
+    secretName: www-panoptes-production-tls
   rules:
   - host: www-panoptes.zooniverse.org
     http:
@@ -561,6 +561,18 @@ spec:
           serviceName: panoptes-production-app
           servicePort: 80
         path: /
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: www-panoptes-production-tls
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: www-panoptes-production-tls
+  dnsNames:
+    - www-panoptes.zooniverse.org
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -575,4 +587,3 @@ spec:
     - panoptes.azure.zooniverse.org
     - panoptes.zooniverse.org
     - signin.zooniverse.org
-    - www-panoptes.zooniverse.org


### PR DESCRIPTION
ensure the www-panoptes ingress has a valid certificate. Putting all the dns domain on one cert clobbers if they aren't used on the same ingress, i.e. we lose www-panoptes.zooniverse.org on the cert.

I think this is related to the shim and the ingress `cert-manager.io` annotation but i'm not sure.

TBH It's explicit this way and most likely easier to track the certs and ingress domains as well.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
