### PR TITLE
remove sdoc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'ranked-model', '~> 0.4.6'
 gem 'restpack_serializer', git: 'https://github.com/zooniverse/restpack_serializer.git', branch: 'panoptes-api-version', ref: 'cef0969cef'
 gem 'schema_plus_pg_indexes', '~> 0.1'
 gem 'scientist', '~> 1.4.0'
-gem 'sdoc', '~> 1.0.0', group: :doc
 gem 'sidekiq', '~> 5.2.5'
 gem 'sidekiq-congestion', '~> 0.1.0'
 gem 'sidekiq-unique-jobs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,6 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
-    rdoc (6.0.1)
     redis (4.2.1)
     ref (2.0.0)
     regexp_parser (1.7.1)
@@ -413,8 +412,6 @@ GEM
       schema_plus_core (~> 1.0)
       schema_plus_indexes (~> 0.1, >= 0.1.3)
     scientist (1.4.0)
-    sdoc (1.0.0)
-      rdoc (>= 5.0)
     shellany (0.0.1)
     sidekiq (5.2.8)
       connection_pool (~> 2.2, >= 2.2.2)
@@ -534,7 +531,6 @@ DEPENDENCIES
   rubocop-rspec
   schema_plus_pg_indexes (~> 0.1)
   scientist (~> 1.4.0)
-  sdoc (~> 1.0.0)
   sidekiq (~> 5.2.5)
   sidekiq-congestion (~> 0.1.0)
   sidekiq-unique-jobs


### PR DESCRIPTION
Remove the sdoc gem - this has been around since the initial commit, i don't think it's used. 

Supersedes and closes #3526 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
