### PR TITLE
fix subject group media location URLs for Survos API

### DIFF
--- a/app/operations/subject_groups/create.rb
+++ b/app/operations/subject_groups/create.rb
@@ -118,7 +118,7 @@ module SubjectGroups
       external_locations = subject_locations.map do |loc|
         extension = File.extname(loc.src).downcase[1..-1]
         mime_type = Mime::Type.lookup_by_extension(extension).to_s
-        media_url = "https://#{loc.src}"
+        media_url = loc.get_url
         # track the subject URL and the originating subject id
         external_locations_subject_id_lut[media_url] = loc.linked_id
         # return the mime / url combination for building the media location resources

--- a/spec/operations/subject_groups/create_spec.rb
+++ b/spec/operations/subject_groups/create_spec.rb
@@ -78,7 +78,7 @@ describe SubjectGroups::Create do
       expect { created_subject_group }.to change(Subject, :count).by(1)
     end
 
-    it 'uses creates external media locations' do
+    it 'creates external media locations' do
       group_subject = created_subject_group.group_subject
       external_locations = group_subject.locations.map(&:external_link)
       expect(external_locations).to match_array(Array.new(subjects.size, true))
@@ -96,6 +96,15 @@ describe SubjectGroups::Create do
       original_locations = subjects.map(&:locations).flatten.map { |loc| "https://#{loc.src}" }
       expect(external_locations).to match_array(original_locations)
     end
+
+    it 'correctly orders the locations based on the original selected subject ids', :focus do
+      locations_in_order = subjects.map(&:locations).flatten
+      expected_locations = locations_in_order.map { |loc| "https://#{loc.src}" }
+      result_locations = created_subject_group.group_subject.ordered_locations.map(&:src)
+      expect(result_locations).to match_array(expected_locations)
+    end
+
+    it 'tracks the original subject data provenance in the linked locations' do
       locations_in_order = subjects.map(&:locations).flatten
       expected_locations = locations_in_order.map do |loc|
         ["https://#{loc.src}", loc.linked_id]
@@ -109,9 +118,6 @@ describe SubjectGroups::Create do
         [loc.src, loc.metadata['originating_subject_id']]
       end
       expect(result_locations).to match_array(expected_locations)
-      # alternatively we could use the ordered locations
-      # but this is really important so i'd like to track / test the data provenance
-      # media resource metadata, e.g. result_locations = created_subject_group.group_subject.ordered_locations.map(&:src)
     end
 
     describe 'tracking the subject group info in the group_subject metadata' do

--- a/spec/operations/subject_groups/create_spec.rb
+++ b/spec/operations/subject_groups/create_spec.rb
@@ -84,7 +84,18 @@ describe SubjectGroups::Create do
       expect(external_locations).to match_array(Array.new(subjects.size, true))
     end
 
-    it 'creates the locations based on the subject data order' do
+    it 'uses the MediaStorage service to construct the external media locations' do
+      allow(MediaStorage).to receive(:get_path)
+      created_subject_group.group_subject
+      expect(MediaStorage).to have_received(:get_path).twice
+    end
+
+    it 'creates correct media locations' do
+      group_subject = created_subject_group.group_subject
+      external_locations = group_subject.locations.map(&:src)
+      original_locations = subjects.map(&:locations).flatten.map { |loc| "https://#{loc.src}" }
+      expect(external_locations).to match_array(original_locations)
+    end
       locations_in_order = subjects.map(&:locations).flatten
       expected_locations = locations_in_order.map do |loc|
         ["https://#{loc.src}", loc.linked_id]

--- a/spec/operations/subject_groups/create_spec.rb
+++ b/spec/operations/subject_groups/create_spec.rb
@@ -97,7 +97,7 @@ describe SubjectGroups::Create do
       expect(external_locations).to match_array(original_locations)
     end
 
-    it 'correctly orders the locations based on the original selected subject ids', :focus do
+    it 'correctly orders the locations based on the original selected subject ids' do
       locations_in_order = subjects.map(&:locations).flatten
       expected_locations = locations_in_order.map { |loc| "https://#{loc.src}" }
       result_locations = created_subject_group.group_subject.ordered_locations.map(&:src)


### PR DESCRIPTION
Ensure we use the medium.get_url method (and thus the media storage service object) to construct the media location URLs for the SubjectGroup. Without using this change the URLs will be missing the domain prefix and won't be valid. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
