### PR TITLE
remove old project attributes from apiary

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -902,16 +902,9 @@ It has the following attributes:
 - available_languages
 - title
 - description
-- guide
-- team_members
-- science_case
 - introduction
 - avatar
-- background_image
 - private
-- faq
-- result
-- education_content
 - retired_subjects_count
 - configuration
 - beta
@@ -965,23 +958,8 @@ It has the following attributes:
                     "available_languages": ["en"],
                     "title": "Galaxy Zoo",
                     "description": "A Project ...",
-                    "guide": [{
-                        "image": "http://something.example.com/delorean.jpg",
-                        "explanation": "our ride"
-                    }],
-                    "team_members": [{
-                        "name": "Doc Brown",
-                        "bio": "",
-                        "twitter": "thatsmydelorean",
-                        "insitution": nil
-                    }],
-                    "science_case": "88mph + 1.21 GW = 1955",
                     "introduction": "asdfasdf",
-                    "background_image": "http://test.host/12312asd.jp2",
                     "private": false,
-                    "faq": "This project uses..",
-                    "result": "We found amazing things",
-                    "education_content": "Educator content goes here",
                     "retired_subjects_count": "5000",
                     "configuration": { "option_1": "value" },
                     "beta": "false",


### PR DESCRIPTION
cleanup the apiary docs for projects, remove unused / old attributes that can be confused with the project pages end points

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
