### PR TITLE
[travis-ci skip] increase dumpworker pod RAM & CPU and decrease thread count

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -288,12 +288,12 @@ spec:
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "4000Mi"
+              memory: "6000Mi"
               cpu: "1000m"
               ephemeral-storage: "50Gi"
             limits:
-              memory: "4000Mi"
-              cpu: "1000m"
+              memory: "6000Mi"
+              cpu: "2000m"
               ephemeral-storage: "50Gi"
           livenessProbe:
             exec:
@@ -302,6 +302,10 @@ spec:
             initialDelaySeconds: 20
           args: ["/rails_app/scripts/docker/start-sidekiq.sh"]
           env:
+          - name: RAILS_MAX_THREADS
+            value: '2'
+          - name: SIDEKIQ_CONCURRENCY
+            value: '2'
           - name: SIDEKIQ_ARGS
             value: '-q dumpworker -q really_high -q high -q data_high -q data_medium -q default -q data_low'
           envFrom:


### PR DESCRIPTION
Run only 2 dumpworker threads (2 x concurrent dumps can run) but increase the available RAM & CPU for each dump run.

If we find we need more compute we can scale the replica count to >2 for this dumpworker deployment.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
