### PR TITLE
ignore cleaning up missing blobs in azure

### DIFF
--- a/spec/workers/medium_removal_worker_spec.rb
+++ b/spec/workers/medium_removal_worker_spec.rb
@@ -22,10 +22,15 @@ RSpec.describe MediumRemovalWorker do
 
   it 'ignores any missing azure (BlobNotFound (404)) media paths' do
     require 'azure/core/http/http_error'
-    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 500, body: '', reason_phrase: '')
+    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', body: '', status_code: 404,  body: '', reason_phrase: '')
     allow(MediaStorage).to receive(:delete_file).and_raise(Azure::Core::Http::HTTPError, response)
-    # allow this worker to fail right now so we can track any azure blob store
-    # path cleanup errors, https://github.com/zooniverse/panoptes/pull/3538/files#r547433486
+    expect { worker.perform(medium_src) }.not_to raise_error(Azure::Core::Http::HTTPError)
+  end
+
+  it 'raises any unknown azure responses' do
+    require 'azure/core/http/http_error'
+    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 500,  body: '', reason_phrase: '')
+    allow(MediaStorage).to receive(:delete_file).and_raise(Azure::Core::Http::HTTPError, response)
     expect { worker.perform(medium_src) }.to raise_error(Azure::Core::Http::HTTPError)
   end
 

--- a/spec/workers/medium_removal_worker_spec.rb
+++ b/spec/workers/medium_removal_worker_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe MediumRemovalWorker do
 
   it 'ignores any missing azure (BlobNotFound (404)) media paths' do
     require 'azure/core/http/http_error'
-    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', body: '', status_code: 404,  body: '', reason_phrase: '')
+    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 404, body: '', reason_phrase: '')
     allow(MediaStorage).to receive(:delete_file).and_raise(Azure::Core::Http::HTTPError, response)
     expect { worker.perform(medium_src) }.not_to raise_error(Azure::Core::Http::HTTPError)
   end
 
   it 'raises any unknown azure responses' do
     require 'azure/core/http/http_error'
-    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 500,  body: '', reason_phrase: '')
+    response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 500, body: '', reason_phrase: '')
     allow(MediaStorage).to receive(:delete_file).and_raise(Azure::Core::Http::HTTPError, response)
     expect { worker.perform(medium_src) }.to raise_error(Azure::Core::Http::HTTPError)
   end


### PR DESCRIPTION
move on from any 404 errors (missing and probably not uploaded) but ensure we surface any unknown error codes (not 404)

related to https://github.com/zooniverse/panoptes/pull/3538#discussion_r547433486

I've monitored these errors in error tracking and sidekiq and we can safely ignore these now. There are all from failed uploads post our cloud migration, i.e. 404.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
