### PR TITLE
fix translations when project copying

### DIFF
--- a/lib/project_copier.rb
+++ b/lib/project_copier.rb
@@ -16,15 +16,27 @@ class ProjectCopier
 
     copied_project = project.deep_clone include: INCLUDE_ASSOCIATIONS, except: EXCLUDE_ATTRIBUTES
     copied_project.owner = user
-    copied_project.configuration.delete(:template)
 
     if user == project.owner
       copied_project.display_name += " (copy)"
     end
 
     copied_project.assign_attributes(launch_approved: false, live: false)
-    copied_project.configuration[:source_project_id] = project.id
-    copied_project.save!
+    # reset the project's configuration but record the source project id
+    copied_project.configuration = { source_project_id: project.id }
+    # reset the copied translations to not have any old string versions
+    copied_project.translations.each { |tr| tr.string_versions = {} }
+
+    Project.transaction(requires_new: true) do
+      # save the project and create the project versions for use in translation strings
+      copied_project.save!
+      # update all the translation strings versions to match the latest project_version resource
+      copied_project.translations.each do |translation|
+        translated_strings = TranslationStrings.new(copied_project).extract
+        translation.update_strings_and_versions(translated_strings, copied_project.latest_version_id)
+        translation.save!
+      end
+    end
     copied_project
   end
 end


### PR DESCRIPTION
Closes #3055 and #3126

Ensure we correctly setup the translations when copying a project. To do this we need to reset the string versions to `{}` before the copied project can be saved. After we have saved the project resource we will have a project_version resource, we then use that to update the translation `string_versions` resource to list out what strings belong to what project version.

The `string_versions` are used in the translations app to show what is out of date with the primary language resource. 




# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
