### PR TITLE
improve API SubjectSetImports docs and fix end point bug

### DIFF
--- a/app/models/subject_set_import/csv_import.rb
+++ b/app/models/subject_set_import/csv_import.rb
@@ -11,7 +11,7 @@ class SubjectSetImport::CsvImport
     csv = CSV.new(@io, headers: true)
 
     csv.each do |row|
-      external_id = row["id"]
+      external_id = row['external_id']
       locations = []
       metadata = {}
 

--- a/app/services/url_downloader.rb
+++ b/app/services/url_downloader.rb
@@ -1,7 +1,7 @@
 class UrlDownloader
   def self.stream(url)
     Tempfile.create('panoptes-downloaded-file') do |file|
-      HTTParty.get(source_url, stream_body: true) do |fragment|
+      HTTParty.get(url, stream_body: true) do |fragment|
         file.write(fragment)
       end
 

--- a/docs/source/includes/_subject_set_imports.md
+++ b/docs/source/includes/_subject_set_imports.md
@@ -8,7 +8,7 @@ This resource is useful when a researcher has a large batch to add. The upload p
 2. She also creates a manifest file (format described below) and uploads the manifest to a web accessible location.
    + The manifest file describes ['subjects'](https://help.zooniverse.org/getting-started/glossary/), which is the Zooniverse term for something that is to be classified.
    + A subject is made up of:
-     + a unique UUID
+     + a unique external ID (used to track the subject from your organization)
      + one or more URLs that host media files e.g. image, video, audio.
      + metadata described as key-value pairs.
 3. In the Zooniverse project builder, the researcher navigates to the subject set to which they would like to have the subjects added.
@@ -59,7 +59,7 @@ Content-Type: application/json
 ## Manifest CSV format
 
 ```csv
-uuid,location:1,location:2,metadata:size,metadata:cuteness
+external_id,location:1,location:2,metadata:size,metadata:cuteness
 1,https://placekitten.com/200/300.jpg,https://placekitten.com/200/100.jpg,small,cute
 2,https://placekitten.com/400/900.jpg,https://placekitten.com/500/100.jpg,large,cute
 ```
@@ -67,7 +67,7 @@ uuid,location:1,location:2,metadata:size,metadata:cuteness
 The manifest.csv file is contains one row per subject. See the example to the right. It is expected to have
 the following columns:
 
-+ `uuid` - Zooniverse uses this to deduplicate/upsert existing subjects, so that
++ `external_id` - Zooniverse uses this to deduplicate/upsert existing subjects, so that
   it's possible to reimport a manifest into a subject set.
 + `location:` - One or more columns that begin with `location:` (including the colon), followed by any
   sequence of characters. The values of cells in this column are URLs pointing

--- a/docs/source/includes/_subject_set_imports.md
+++ b/docs/source/includes/_subject_set_imports.md
@@ -35,7 +35,7 @@ Content-Type: application/json
 
 {
     "subject_set_imports": {
-       "source_url": "https://path.to/some/manifest.json",
+       "source_url": "https://path.to/some/manifest.csv",
        "links": {
            "subject_set": "1"
        }

--- a/spec/models/subject_set_import/csv_import_spec.rb
+++ b/spec/models/subject_set_import/csv_import_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SubjectSetImport::CsvImport do
   let(:csv_data) do
     <<~CSV
-      id,location:1,location:2,metadata:size,metadata:cuteness
+      external_id,location:1,location:2,metadata:size,metadata:cuteness
       1,https://placekitten.com/200/300.jpg,https://placekitten.com/200/100.jpg,small,cute
       2,https://placekitten.com/400/900.jpg,https://placekitten.com/500/100.jpg,large,cute
     CSV

--- a/spec/models/subject_set_import_spec.rb
+++ b/spec/models/subject_set_import_spec.rb
@@ -8,7 +8,7 @@ describe SubjectSetImport, type: :model do
   let(:source_url) { "https://example.org/file.csv" }
   let(:csv_file) do
     StringIO.new <<~CSV
-      id,location:1,location:2,metadata:size,metadata:cuteness
+      external_id,location:1,location:2,metadata:size,metadata:cuteness
       1,https://placekitten.com/200/300.jpg,https://placekitten.com/200/100.jpg,small,cute
       2,https://placekitten.com/400/900.jpg,https://placekitten.com/500/100.jpg,large,cute
     CSV


### PR DESCRIPTION
Update docs and fix the the Vera Rubin observatory (LSST) subject set imports via the API, specifically

- Update the docs to clarify the
    - manifest csv file type
    - external_id to track the external data IDs to Zooniverse subjects
- fix a bug when downloading the remote manifest file by using the correct variable name

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
