### PR TITLE
update the subject set subject counts post import

### DIFF
--- a/app/workers/subject_set_import_worker.rb
+++ b/app/workers/subject_set_import_worker.rb
@@ -4,5 +4,6 @@ class SubjectSetImportWorker
   def perform(subject_set_import_id)
     subject_set_import = SubjectSetImport.find(subject_set_import_id)
     subject_set_import.import!
+    SubjectSetSubjectCounterWorker.new.perform(subject_set_import.subject_set_id)
   end
 end

--- a/spec/workers/subject_set_import_worker_spec.rb
+++ b/spec/workers/subject_set_import_worker_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SubjectSetImportWorker do
+  describe '#perform' do
+    let(:import_double) do
+      instance_double(SubjectSetImport, id: 1, import!: true, subject_set_id: 1)
+    end
+    let(:count_worker_double) do
+      instance_double(SubjectSetSubjectCounterWorker, perform: true)
+    end
+
+    before do
+      allow(SubjectSetImport).to receive(:find).and_return(import_double)
+      allow(SubjectSetSubjectCounterWorker).to receive(:new).and_return(count_worker_double)
+    end
+
+    it 'runs the subjet set import code' do
+      described_class.new.perform(import_double.id)
+      expect(import_double).to have_received(:import!)
+    end
+
+    it 'calls the subject set counter worker inline' do
+      described_class.new.perform(import_double.id)
+      expect(count_worker_double).to have_received(:perform).with(import_double.subject_set_id)
+    end
+  end
+end


### PR DESCRIPTION
sync the subject set's subject counts after running the subject set importer

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
