### PR TITLE
Allow subject sets to be deleted if they are built by a subject set import

### DIFF
--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -6,7 +6,7 @@ class SubjectSet < ActiveRecord::Base
 
   has_many :set_member_subjects, dependent: :destroy
   has_many :subjects, through: :set_member_subjects
-  has_many :subject_set_imports
+  has_many :subject_set_imports, dependent: :destroy
   validates_presence_of :project
 
   validates_uniqueness_of :display_name, scope: :project_id

--- a/db/migrate/20210226173243_add_on_delete_constraint_to_subject_sets_import.rb
+++ b/db/migrate/20210226173243_add_on_delete_constraint_to_subject_sets_import.rb
@@ -1,0 +1,6 @@
+class AddOnDeleteConstraintToSubjectSetsImport < ActiveRecord::Migration
+  def change
+    remove_foreign_key :subject_set_imports, :subject_sets
+    add_foreign_key :subject_set_imports, :subject_sets, on_update: :cascade, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20210226173243_add_on_delete_constraint_to_subject_sets_import.rb
+++ b/db/migrate/20210226173243_add_on_delete_constraint_to_subject_sets_import.rb
@@ -1,6 +1,17 @@
+# frozen_string_literal: true
+
 class AddOnDeleteConstraintToSubjectSetsImport < ActiveRecord::Migration
   def change
-    remove_foreign_key :subject_set_imports, :subject_sets
-    add_foreign_key :subject_set_imports, :subject_sets, on_update: :cascade, on_delete: :cascade, validate: false
+    reversible do |dir|
+      dir.up do
+        remove_foreign_key :subject_set_imports, :subject_sets
+        add_foreign_key :subject_set_imports, :subject_sets, on_update: :cascade, on_delete: :cascade, validate: false
+      end
+
+      dir.down do
+        remove_foreign_key :subject_set_imports, :subject_sets
+        add_foreign_key :subject_set_imports, :subject_sets
+      end
+    end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4022,7 +4022,7 @@ ALTER TABLE ONLY public.tutorials
 --
 
 ALTER TABLE ONLY public.subject_set_imports
-    ADD CONSTRAINT fk_rails_8661e689b0 FOREIGN KEY (subject_set_id) REFERENCES public.subject_sets(id);
+    ADD CONSTRAINT fk_rails_8661e689b0 FOREIGN KEY (subject_set_id) REFERENCES public.subject_sets(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -4802,4 +4802,6 @@ INSERT INTO schema_migrations (version) VALUES ('20200717155424');
 INSERT INTO schema_migrations (version) VALUES ('20200720125246');
 
 INSERT INTO schema_migrations (version) VALUES ('20201113151433');
+
+INSERT INTO schema_migrations (version) VALUES ('20210226173243');
 

--- a/spec/models/subject_set_import_spec.rb
+++ b/spec/models/subject_set_import_spec.rb
@@ -13,12 +13,22 @@ describe SubjectSetImport, type: :model do
       2,https://placekitten.com/400/900.jpg,https://placekitten.com/500/100.jpg,large,cute
     CSV
   end
+  let(:subject_set_import) do
+    described_class.new(source_url: source_url, subject_set: subject_set, user: user)
+  end
 
-  it 'imports subjects' do
+  before do
     allow(UrlDownloader).to receive(:stream).with(source_url).and_yield(csv_file)
-    subject_set_import = SubjectSetImport.new(source_url: source_url, subject_set: subject_set, user: user)
     subject_set_import.import!
+  end
 
+  it 'imports subjects to the set' do
     expect(subject_set.subjects.count).to eq(2)
+  end
+
+  it 'removes the subject_set_import if the set is deleted', :focus do
+    # uses FK on delete cascade constraint
+    subject_set_import.save
+    expect { subject_set.delete }.not_to raise_error
   end
 end

--- a/spec/models/subject_set_import_spec.rb
+++ b/spec/models/subject_set_import_spec.rb
@@ -25,10 +25,4 @@ describe SubjectSetImport, type: :model do
   it 'imports subjects to the set' do
     expect(subject_set.subjects.count).to eq(2)
   end
-
-  it 'removes the subject_set_import if the set is deleted', :focus do
-    # uses FK on delete cascade constraint
-    subject_set_import.save
-    expect { subject_set.delete }.not_to raise_error
-  end
 end

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -92,7 +92,7 @@ describe SubjectSet, :type => :model do
     it 'removes all subject_set_imports on destroy' do
       subject_set_import
       subject_set.destroy
-      expect{ subject_set_import.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { subject_set_import.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -83,4 +83,16 @@ describe SubjectSet, :type => :model do
       expect(subject_set.belongs_to_project?(subject_set.project_id)).to eq(true)
     end
   end
+
+  describe '#subject_set_imports' do
+    let(:subject_set_import) do
+      create(:subject_set_import, subject_set: subject_set)
+    end
+
+    it 'removes all subject_set_imports on destroy' do
+      subject_set_import
+      subject_set.destroy
+      expect{ subject_set_import.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
LSST folks are testing the subject set import functionality and after a successful import they can't remove the subject set.

Accordinly, this PR modifies the
-  `subject_set` to delete any linked `subject_set_imports` on destroy
-  `subject_set_import` FK constraints to `subject_set` table to `cascade delete` to ensure if a subject set is deleted the `subject_set_import` record is as well

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
