### PR TITLE
Subject selection endpoint for known subjects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Rails/SkipsModelValidations:
   - update_all
   - touch
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 Style/NumericLiterals:
   Enabled: false
 Style/RegexpLiteral:
@@ -50,3 +53,4 @@ Style/HashTransformValues:
 
 AllCops:
   NewCops: enable
+  TargetRailsVersion: 4.2

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -60,14 +60,37 @@ class Api::V1::SubjectsController < Api::ApiController
     # setup the selector params from user input, note validation occurs in the operation class
     selector_param_keys = %i[workflow_id ids http_cache]
     selector_params = params.permit(*selector_param_keys)
+    worfklow_id = selector_params.delete(:workflow_id)
 
-    _selected_subjects = Subjects::SelectionByIds.run!(
-      subject_ids: selector_params.delete(:ids),
-      workflow_id: selector_params.delete(:workflow_id),
-      params: selector_params,
-      user: api_user
+    selected_subject_ids = Subjects::SelectionByIds.run!(
+      ids: selector_params.delete(:ids),
+      workflow_id: worfklow_id
     )
 
+    selected_subject_scope =
+      if selected_subject_ids.empty?
+        Subject.none
+      else
+        Subject.active.where(id: selected_subject_ids).order("idx(array[#{selected_subject_ids.join(',')}], id)")
+      end
+
+    # create a special 'fake' selector for the serializer
+    subject_selector = OpenStruct.new(
+      user: api_user.user,
+      workflow: Workflow.find_without_json_attrs(worfklow_id),
+      selection_state: :normal # this end point will always be normal or raise
+    )
+
+    selection_context = Subjects::SelectorContext.new(
+      subject_selector,
+      selected_subject_ids
+    ).format
+
+    render json_api: SubjectSelectorSerializer.page(
+      selector_params,
+      selected_subject_scope,
+      selection_context
+    )
   end
 
   # special selection end point create SubjectGroups

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::SubjectsController < Api::ApiController
       if selected_subject_ids.empty?
         Subject.none
       else
-        Subject.active.where(id: selected_subject_ids).order("idx(array[#{selected_subject_ids.join(',')}], id)")
+        Subject.active.where(id: selected_subject_ids).order("idx(array[#{selected_subject_ids.join(',')}], id)") # guardrails-disable-line
       end
 
     # create a special 'fake' selector for the serializer

--- a/app/operations/subjects/selection_by_ids.rb
+++ b/app/operations/subjects/selection_by_ids.rb
@@ -10,7 +10,7 @@ module Subjects
       message: 'must be a comma seperated list of digits (max 10)'
     }
     # lazily loaded and split the formated ids string up
-    array :subject_ids, default: -> { ids.split(',') }
+    array :subject_ids, default: -> { ids&.split(',') }
 
     def execute
       validate_workflow_subject_linkage

--- a/app/operations/subjects/selection_by_ids.rb
+++ b/app/operations/subjects/selection_by_ids.rb
@@ -15,7 +15,7 @@ module Subjects
     def execute
       validate_workflow_subject_linkage
 
-      Subject.active.where(id: subject_ids).order("idx(array[#{subject_ids.join(',')}], id)")
+      subject_ids
     end
 
     private

--- a/app/operations/subjects/selection_by_ids.rb
+++ b/app/operations/subjects/selection_by_ids.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Subjects
+  class SelectionByIds < Operation
+    integer :workflow_id
+    string :ids
+    # ensure ids param conforms to the non zero digit comma delimited format, e.g. 1,2,3 (max of 10)
+    validates :ids, format: {
+      with: /\A(\d+)(?:,\d+){0,9}\z/,
+      message: 'must be a comma seperated list of digits (max 10)'
+    }
+    # lazily loaded and split the formated ids string up
+    array :subject_ids, default: -> { ids.split(',') }
+
+    def execute
+      validate_workflow_subject_linkage
+
+      Subject.active.where(id: subject_ids).order("idx(array[#{subject_ids.join(',')}], id)")
+    end
+
+    private
+
+    def validate_workflow_subject_linkage
+      # query how many times a subject links to subject_sets for the workflow
+      subject_workflow_links_count = SetMemberSubject.by_subject_workflow(subject_ids, workflow_id).group(:subject_id).count
+      # now count the unique number of subject_ids groups keys
+      # as these keys represent the linkage between a workflow and a subject
+      workflow_subject_link_counts = subject_workflow_links_count.keys.count
+      return if workflow_subject_link_counts == subject_ids.size
+
+      raise Error, 'Supplied subject ids do not belong to the workflow'
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
         collection do
           get :queued # Subject selection end point
           get :grouped # SubjectGroup selection end point
+          get :selection # Subject selection by subject ids end point
         end
       end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -630,15 +630,22 @@ describe Api::V1::SubjectsController, type: :controller do
     before do
       subject_ids
       flipper_feature
+      allow(SubjectSelectorSerializer).to receive(:page).and_call_original
       get :selection, request_params
     end
 
-    it 'returns 200', :focus do
+    it 'returns 200' do
+      get :selection, request_params
       expect(response.status).to eq(200)
     end
 
     it 'returns a page with only 1 resource' do
+      get :selection, request_params
       expect(json_response[api_resource_name].length).to eq(1)
+    end
+
+    it 'uses the SubjectSelectorSerializer class' do
+      expect(SubjectSelectorSerializer).to have_received(:page)
     end
 
     it_behaves_like 'an api response'

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -635,12 +635,10 @@ describe Api::V1::SubjectsController, type: :controller do
     end
 
     it 'returns 200' do
-      get :selection, request_params
       expect(response.status).to eq(200)
     end
 
     it 'returns a page with only 1 resource' do
-      get :selection, request_params
       expect(json_response[api_resource_name].length).to eq(1)
     end
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -617,7 +617,7 @@ describe Api::V1::SubjectsController, type: :controller do
     end
   end
 
-  describe '#selection', :focus do
+  describe '#selection' do
     let(:workflow) { create(:workflow_with_subject_sets) }
     let(:api_resource_links) { [] }
     let(:sms) { create_list(:set_member_subject, 1, subject_set: subject_set) }
@@ -633,7 +633,7 @@ describe Api::V1::SubjectsController, type: :controller do
       get :selection, request_params
     end
 
-    it 'returns 200' do
+    it 'returns 200', :focus do
       expect(response.status).to eq(200)
     end
 
@@ -651,7 +651,7 @@ describe Api::V1::SubjectsController, type: :controller do
       end
 
       it 'has a useful error message' do
-        expect(response.body).to include('Subject ids required')
+        expect(response.body).to include('Ids is required')
       end
     end
 

--- a/spec/operations/subjects/selection_by_ids_spec.rb
+++ b/spec/operations/subjects/selection_by_ids_spec.rb
@@ -28,25 +28,13 @@ describe Subjects::SelectionByIds do
     let(:workflow) { create(:workflow_with_subject_sets) }
     let(:subject_set) { workflow.subject_sets.first }
     let(:sms) { create_list(:set_member_subject, 2, subject_set: subject_set) }
-    let(:subject_ids) { sms.map(&:subject_id) }
+    let(:subject_ids) { sms.map(&:subject_id).map(&:to_s) }
     let(:operation_params) do
       { workflow_id: workflow.id, ids: subject_ids.join(',') }
     end
-    let(:selected_subject_ids) { result.map(&:id) }
 
-    it 'returns the active subjects scope in order' do
-      expect(selected_subject_ids).to eq(subject_ids)
-    end
-
-    it 'returns only active subjects' do
-      sms.first.subject.inactive!
-      expect(selected_subject_ids).to eq([sms.last.subject_id])
-    end
-
-    it 'returns an empty array if no active subjects' do
-      sms.map { |sms| sms.subject.inactive! }
-      selected_subject_ids = result.map(&:id)
-      expect(selected_subject_ids).to match_array([])
+    it 'returns the subjects scope in order' do
+      expect(result).to eq(subject_ids)
     end
 
     context 'when subject ids do not belong to the workflow' do

--- a/spec/operations/subjects/selection_by_ids_spec.rb
+++ b/spec/operations/subjects/selection_by_ids_spec.rb
@@ -24,6 +24,11 @@ describe Subjects::SelectionByIds do
     expect(outcome.errors.full_messages).to include('Ids must be a comma seperated list of digits (max 10)')
   end
 
+  it 'validates ids param does is present' do
+    outcome = described_class.run(operation_params.except(:ids))
+    expect(outcome.errors.full_messages).to include('Ids is required')
+  end
+
   context 'with subjects that belong to the workflow' do
     let(:workflow) { create(:workflow_with_subject_sets) }
     let(:subject_set) { workflow.subject_sets.first }

--- a/spec/operations/subjects/selection_by_ids_spec.rb
+++ b/spec/operations/subjects/selection_by_ids_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Subjects::SelectionByIds do
+  let(:user) { ApiUser.new(nil) }
+  let(:operation_params) do
+    { workflow_id: 1, ids: '1,2,3' }
+  end
+  let(:result) { described_class.run(operation_params).result }
+
+  it 'validates ids param' do
+    outcome = described_class.run(operation_params.merge(ids: 'invalid'))
+    expect(outcome.errors.full_messages).to include('Ids must be a comma seperated list of digits (max 10)')
+  end
+
+  it 'validates ids param contains digits' do
+    outcome = described_class.run(operation_params.merge(ids: '1,b'))
+    expect(outcome.errors.full_messages).to include('Ids must be a comma seperated list of digits (max 10)')
+  end
+
+  it 'validates ids param does not exceed 10 ids' do
+    outcome = described_class.run(operation_params.merge(ids: '1,2,3,4,5,6,7,8,9,10,11'))
+    expect(outcome.errors.full_messages).to include('Ids must be a comma seperated list of digits (max 10)')
+  end
+
+  context 'with subjects that belong to the workflow' do
+    let(:workflow) { create(:workflow_with_subject_sets) }
+    let(:subject_set) { workflow.subject_sets.first }
+    let(:sms) { create_list(:set_member_subject, 2, subject_set: subject_set) }
+    let(:subject_ids) { sms.map(&:subject_id) }
+    let(:operation_params) do
+      { workflow_id: workflow.id, ids: subject_ids.join(',') }
+    end
+    let(:selected_subject_ids) { result.map(&:id) }
+
+    it 'returns the active subjects scope in order' do
+      expect(selected_subject_ids).to eq(subject_ids)
+    end
+
+    it 'returns only active subjects' do
+      sms.first.subject.inactive!
+      expect(selected_subject_ids).to eq([sms.last.subject_id])
+    end
+
+    it 'returns an empty array if no active subjects' do
+      sms.map { |sms| sms.subject.inactive! }
+      selected_subject_ids = result.map(&:id)
+      expect(selected_subject_ids).to match_array([])
+    end
+
+    context 'when subject ids do not belong to the workflow' do
+      let(:another_workflow) { create(:workflow, project: workflow.project) }
+      let(:operation_params) do
+        { workflow_id: another_workflow.id, ids: subject_ids.join(',') }
+      end
+
+      it 'raises with error' do
+        expect {
+          described_class.run!(operation_params)
+        }.to raise_error(Operation::Error, 'Supplied subject ids do not belong to the workflow')
+      end
+    end
+
+    context 'when subject ids are in multiple sets for the workflow' do
+      let(:another_set) { create(:subject_set, workflows: [workflow], project: workflow.project) }
+      let(:subject_in_mulitple_sets) { sms.first.subject }
+
+      it 'does not raise with error' do
+        create(:set_member_subject, subject_set: another_set, subject: subject_in_mulitple_sets)
+        expect {
+          described_class.run!(operation_params)
+        }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Engaging Crowds project has a use case where the user selects a subject id from a UI component** and needs to convert this subject id into the subject selection response format for use in the classifier component. 

This PR adds a new endpoint to retrieve the subject selection response object for known subject ids e.g. 
`GET /api/subjects/selection?ids=1,2,3&workflow_id=1`

As this feature doesn't need to run the selection code (or call designator) we use an `Operation` class to ensure the list of subject ids param is valid and all the subjects belong the the supplied workflow. Once the operation has validated the list of ids the controller loads the active subjects from the database and then serializers these subjects using the `SubjectSelectionSerialzlier` as per the normal selection end point responses on  queued`. 

The above ensures the UI classifier component has a consistent data interface to configure the classifier UI i.e. wire up the favourites button retired & seen banners etc.

** this UI component is a table of subjects that are active for a subject set, see https://github.com/zooniverse/front-end-monorepo/pull/1875

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
