### PR TITLE
remove specific error class on not raise_error

### DIFF
--- a/spec/workers/medium_removal_worker_spec.rb
+++ b/spec/workers/medium_removal_worker_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe MediumRemovalWorker do
     require 'azure/core/http/http_error'
     response = instance_double('Azure::Core::Http::HTTPResponse', uri: 'fake-uri', status_code: 404, body: '', reason_phrase: '')
     allow(MediaStorage).to receive(:delete_file).and_raise(Azure::Core::Http::HTTPError, response)
-    expect { worker.perform(medium_src) }.not_to raise_error(Azure::Core::Http::HTTPError)
+    expect { worker.perform(medium_src) }.not_to raise_error
   end
 
   it 'raises any unknown azure responses' do


### PR DESCRIPTION
cleanup a spec that tests not `raise_error` as this could fail due to other raises and best practice is to not specify a specific error when testing no raised errors.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
