### PR TITLE
Fix gold standard classification UI loading for legacy projects

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -36,11 +36,12 @@ class Api::V1::ClassificationsController < Api::ApiController
   end
 
   def gold_standard
+    # load the api_user out of the replica read only block
+    skip_policy_scope
+    gold_standard_policy = Pundit.policy!(api_user, GoldStandardAnnotation)
     DatabaseReplica.read('classification_serializer_data_from_replica') do
-      skip_policy_scope
-      resources = Pundit.policy!(api_user, GoldStandardAnnotation).scope_for(:index)
+      resources = gold_standard_policy.scope_for(:index)
       resources = resources.where(workflow_id: params[:workflow_id]) if params[:workflow_id]
-
       resources = resources.where(id: resource_ids) if resource_ids.present?
 
       gold_standard_page = GoldStandardAnnotationSerializer.page(


### PR DESCRIPTION
Some projects like https://www.zooniverse.org/projects/povich/milky-way-project/classify still use the old GS classification data model for wiring up the UI.

loading the user requires write access to the db, allow these to still work by loading the user outside the the read replica block

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
