### PR TITLE
Allow subjects to be unretired

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -54,8 +54,8 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def unretire_subjects
-    put 'mdy114 params'
-    put params
+    puts 'mdy114 params'
+    puts params
     render nothing: true, status: 204
   end
 

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   include SyncResourceTranslationStrings
   include MediumResponse
 
-  require_authentication :update, :create, :destroy, :retire_subjects, :create_classifications_export, scopes: [:project]
+  require_authentication :update, :create, :destroy, :retire_subjects, :create_classifications_export, :unretire_subjects, scopes: [:project]
 
   resource_actions :index, :show, :create, :update, :deactivate
   schema_type :json_schema

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -54,8 +54,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def unretire_subjects
-    puts 'mdy114 params'
-    puts params
+    operation.run!(params)
     render nothing: true, status: 204
   end
 

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -53,6 +53,12 @@ class Api::V1::WorkflowsController < Api::ApiController
     render nothing: true, status: 204
   end
 
+  def unretire_subjects
+    put 'mdy114 params'
+    put params
+    render nothing: true, status: 204
+  end
+
   def create_classifications_export
     medium = CreateClassificationsExport.with( api_user: api_user, object: controlled_resource ).run!(params)
     medium_response(medium)

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -1,5 +1,24 @@
 module Workflows
     class UnretireSubjects < Operation
-        
+        validates :workflow_id, presence: true
+
+        integer :workflow_id
+        integer :subject_id, default: nil
+        array :subject_ids, default: [] do
+            integer
+        end
+
+        def execute
+            return if subject_ids.empty?
+            puts "MDY114 WORKFLOW ID #{workflow_id}"
+            SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil, retirement_reason: nil)
+            RefreshWorkflowStatusWorker.perform_async(workflow_id)
+            NotifySubjectSelectorOfChangeWorker.perform_async(workflow_id)
+        end
+
+        def subject_ids 
+            @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+        end
+
     end
 end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Workflows
   class UnretireSubjects < Operation
     validates :workflow_id, presence: true
@@ -10,11 +12,12 @@ module Workflows
 
     def execute
       return if subject_ids.empty?
+
       UnretireSubjectWorker.perform_async(workflow_id, subject_ids)
     end
 
-    def subject_ids 
-      @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+    def subject_ids
+      @subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
     end
   end
 end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -11,9 +11,7 @@ module Workflows
         def execute
             return if subject_ids.empty?
 
-            SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil, retirement_reason: nil)
-            RefreshWorkflowStatusWorker.perform_async(workflow_id)
-            NotifySubjectSelectorOfChangeWorker.perform_async(workflow_id)
+            UnretireSubjectWorker.perform_async(workflow_id, subject_ids)
         end
 
         def subject_ids 

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -11,13 +11,13 @@ module Workflows
     end
 
     def execute
-      return if subject_ids.empty?
+      return if cached_subject_ids.empty?
 
-      UnretireSubjectWorker.perform_async(workflow_id, subject_ids)
+      UnretireSubjectWorker.perform_async(workflow_id, cached_subject_ids)
     end
 
-    def subject_ids
-      @subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+    def cached_subject_ids
+      @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
     end
   end
 end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -1,0 +1,5 @@
+module Workflows
+    class UnretireSubjects < Operation
+        
+    end
+end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -1,21 +1,20 @@
 module Workflows
-    class UnretireSubjects < Operation
-        validates :workflow_id, presence: true
+  class UnretireSubjects < Operation
+    validates :workflow_id, presence: true
 
-        integer :workflow_id
-        integer :subject_id, default: nil
-        array :subject_ids, default: [] do
-            integer
-        end
-
-        def execute
-            return if subject_ids.empty?
-
-            UnretireSubjectWorker.perform_async(workflow_id, subject_ids)
-        end
-
-        def subject_ids 
-            @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
-        end
+    integer :workflow_id
+    integer :subject_id, default: nil
+    array :subject_ids, default: [] do
+      integer
     end
+
+    def execute
+      return if subject_ids.empty?
+      UnretireSubjectWorker.perform_async(workflow_id, subject_ids)
+    end
+
+    def subject_ids 
+      @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+    end
+  end
 end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -2,7 +2,7 @@
 
 module Workflows
   class UnretireSubjects < Operation
-    validates :workflow_id, presence: true
+    validates :workflow_id, presence: true, numericality: { greater_than: 0, only_integer: true }
 
     integer :workflow_id
     integer :subject_id, default: nil

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -17,6 +17,5 @@ module Workflows
         def subject_ids 
             @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
         end
-
     end
 end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -10,7 +10,7 @@ module Workflows
 
         def execute
             return if subject_ids.empty?
-            puts "MDY114 WORKFLOW ID #{workflow_id}"
+
             SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil, retirement_reason: nil)
             RefreshWorkflowStatusWorker.perform_async(workflow_id)
             NotifySubjectSelectorOfChangeWorker.perform_async(workflow_id)

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -21,7 +21,7 @@ class ProjectPolicy < ApplicationPolicy
         :create_subjects_export,
         :create_workflows_export,
         :create_workflow_contents_export,
-        :retire_subjects, with: WriteScope
+        :retire_subjects, :unretire_subjects, with: WriteScope
   scope :translate, with: TranslateScope
 
   def linkable_subject_sets

--- a/app/policies/workflow_policy.rb
+++ b/app/policies/workflow_policy.rb
@@ -7,7 +7,7 @@ class WorkflowPolicy < ApplicationPolicy
   end
 
   scope :index, :show, :update, :destroy, :update_links, :destroy_links,
-        :translate, :versions, :version, :retire_subjects, :create_classifications_export,
+        :translate, :versions, :version, :retire_subjects, :create_classifications_export, :unretire_subjects,
         with: Scope
 
   def linkable_subject_sets

--- a/app/workers/unretire_subject_worker.rb
+++ b/app/workers/unretire_subject_worker.rb
@@ -2,23 +2,15 @@
 
 class UnretireSubjectWorker
   include Sidekiq::Worker
-  attr_reader :workflow_id
 
   sidekiq_options queue: :high
 
   def perform(workflow_id, subject_ids)
-    @workflow_id = workflow_id
-    return unless workflow_exists?
+    return unless  Workflow.exists?(id: workflow_id)
 
     SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil,
                                                                                                                          retirement_reason: nil)
     RefreshWorkflowStatusWorker.perform_async(workflow_id)
     NotifySubjectSelectorOfChangeWorker.perform_async(workflow_id)
-  end
-
-  private
-
-  def workflow_exists?
-    Workflow.exists?(id: workflow_id)
   end
 end

--- a/app/workers/unretire_subject_worker.rb
+++ b/app/workers/unretire_subject_worker.rb
@@ -1,0 +1,21 @@
+class UnretireSubjectWorker
+    include Sidekiq::Worker
+    attr_reader :workflow_id
+
+    sidekiq_options queue: :high
+    
+    def perform(workflow_id, subject_ids)
+        @workflow_id = workflow_id
+        
+        if workflow_exists?
+            SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil, retirement_reason: nil)
+            RefreshWorkflowStatusWorker.perform_async(workflow_id)
+            NotifySubjectSelectorOfChangeWorker.perform_async(workflow_id)
+        end
+    end
+
+    def workflow_exists?
+        Workflow.where(id: workflow_id).exists?
+    end
+
+end

--- a/app/workers/unretire_subject_worker.rb
+++ b/app/workers/unretire_subject_worker.rb
@@ -1,22 +1,22 @@
 class UnretireSubjectWorker
-    include Sidekiq::Worker
-    attr_reader :workflow_id
+  include Sidekiq::Worker
+  attr_reader :workflow_id
 
-    sidekiq_options queue: :high
-    
-    def perform(workflow_id, subject_ids)
-        @workflow_id = workflow_id
+  sidekiq_options queue: :high
 
-        if workflow_exists?
-            SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil, retirement_reason: nil)
-            RefreshWorkflowStatusWorker.perform_async(workflow_id)
-            NotifySubjectSelectorOfChangeWorker.perform_async(workflow_id)
-        end
+  def perform(workflow_id, subject_ids)
+    @workflow_id = workflow_id
+
+    if workflow_exists?
+      SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil, retirement_reason: nil)
+      RefreshWorkflowStatusWorker.perform_async(workflow_id)
+      NotifySubjectSelectorOfChangeWorker.perform_async(workflow_id)
     end
+  end
 
-    private
+  private
 
-    def workflow_exists?
-        Workflow.where(id: workflow_id).exists?
-    end
+  def workflow_exists?
+    Workflow.where(id: workflow_id).exists?
+  end
 end

--- a/app/workers/unretire_subject_worker.rb
+++ b/app/workers/unretire_subject_worker.rb
@@ -6,7 +6,7 @@ class UnretireSubjectWorker
     
     def perform(workflow_id, subject_ids)
         @workflow_id = workflow_id
-        
+
         if workflow_exists?
             SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil, retirement_reason: nil)
             RefreshWorkflowStatusWorker.perform_async(workflow_id)
@@ -17,5 +17,4 @@ class UnretireSubjectWorker
     def workflow_exists?
         Workflow.where(id: workflow_id).exists?
     end
-
 end

--- a/app/workers/unretire_subject_worker.rb
+++ b/app/workers/unretire_subject_worker.rb
@@ -6,7 +6,7 @@ class UnretireSubjectWorker
   sidekiq_options queue: :high
 
   def perform(workflow_id, subject_ids)
-    return unless  Workflow.exists?(id: workflow_id)
+    return unless Workflow.exists?(id: workflow_id)
 
     SubjectWorkflowStatus.where.not(retired_at: nil).where(workflow_id: workflow_id, subject_id: subject_ids).update_all(retired_at: nil,
                                                                                                                          retirement_reason: nil)

--- a/app/workers/unretire_subject_worker.rb
+++ b/app/workers/unretire_subject_worker.rb
@@ -14,6 +14,8 @@ class UnretireSubjectWorker
         end
     end
 
+    private
+
     def workflow_exists?
         Workflow.where(id: workflow_id).exists?
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,7 +118,7 @@ Rails.application.routes.draw do
         media_resources :attached_images, classifications_export: { except: [:create] }
 
         post "/retired_subjects", to: "workflows#retire_subjects"
-        post "/unretire_subjects", to: "workflows#unretire_subjects"
+        post '/unretire_subjects', to: 'workflows#unretire_subjects'
         post "/classifications_export", to: "workflows#create_classifications_export", format: false
         post '/publish', to: 'workflows#publish'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
         media_resources :attached_images, classifications_export: { except: [:create] }
 
         post "/retired_subjects", to: "workflows#retire_subjects"
+        post "/unretire_subjects", to: "workflows#unretire_subjects"
         post "/classifications_export", to: "workflows#create_classifications_export", format: false
         post '/publish', to: 'workflows#publish'
       end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -740,9 +740,9 @@ describe Api::V1::WorkflowsController, type: :controller do
     end
 
     let(:subject_set_project) { project }
-    let(:subject_set) { create(:subject_set, project: project, workflows: [project.workflows.first]) }
+    let(:subject_set) { create(:subject_set_with_subjects, num_subjects: 1, project: project, workflows: [project.workflows.first]) }
     let(:subject_set_id) { subject_set.id }
-    let(:subject1) { create(:subject, subject_sets: [subject_set]) }
+    let(:subject1) { subject_set.subjects.first }
 
     it 'returns a 204 status' do
       post :unretire_subjects, workflow_id: workflow.id, subject_id: subject1.id

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -742,17 +742,17 @@ describe Api::V1::WorkflowsController, type: :controller do
     let(:subject_set_project) { project }
     let(:subject_set) { create(:subject_set, project: project, workflows: [project.workflows.first]) }
     let(:subject_set_id) { subject_set.id }
-    let(:subject) { create(:subject, subject_sets: [subject_set]) }
+    let(:subject1) { create(:subject, subject_sets: [subject_set]) }
 
-    it 'returns a 204 status' do 
-      post :unretire_subjects, workflow_id: workflow.id, subject_id: subject.id
+    it 'returns a 204 status' do
+      post :unretire_subjects, workflow_id: workflow.id, subject_id: subject1.id
       expect(response.status).to eq(204)
     end
 
-    it 'queues an unretire subject worker' do 
-      allow(UnretireSubjectWorker).to receive(:perform_async).with(workflow.id, [subject.id])
-      post :unretire_subjects, workflow_id: workflow.id, subject_id: subject.id
-      expect(UnretireSubjectWorker).to have_received(:perform_async).with(workflow.id, [subject.id])
+    it 'queues an unretire subject worker' do
+      allow(UnretireSubjectWorker).to receive(:perform_async).with(workflow.id, [subject1.id])
+      post :unretire_subjects, workflow_id: workflow.id, subject_id: subject1.id
+      expect(UnretireSubjectWorker).to have_received(:perform_async).with(workflow.id, [subject1.id])
     end
   end
 

--- a/spec/operations/workflows/retire_subjects_spec.rb
+++ b/spec/operations/workflows/retire_subjects_spec.rb
@@ -38,7 +38,7 @@ describe Workflows::RetireSubjects do
       .with(workflow.id, [subject1.id], "nothing_here")
     operation.run!(params.merge(retirement_reason: "blank"))
   end
- 
+
   it 'is invalid with a missing workflow_id param' do
     result = operation.run(params.except(:workflow_id))
     expect(result).not_to be_valid

--- a/spec/operations/workflows/retire_subjects_spec.rb
+++ b/spec/operations/workflows/retire_subjects_spec.rb
@@ -38,7 +38,7 @@ describe Workflows::RetireSubjects do
       .with(workflow.id, [subject1.id], "nothing_here")
     operation.run!(params.merge(retirement_reason: "blank"))
   end
-
+ 
   it 'is invalid with a missing workflow_id param' do
     result = operation.run(params.except(:workflow_id))
     expect(result).not_to be_valid

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -5,9 +5,11 @@ require 'spec_helper'
 describe Workflows::UnretireSubjects do
   let(:api_user) { ApiUser.new(build_stubbed(:user)) }
   let(:workflow) { create(:workflow) }
-  let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
-  let(:subject1) { create(:subject, subject_sets: [subject_set]) }
-  let(:subject2) { create(:subject, subject_sets: [subject_set]) }
+  let(:subject_set) do
+    create(:subject_set_with_subjects, num_subjects: 2, project: workflow.project, workflows: [workflow])
+  end
+  let(:subject1) { subject_set.subjects.first }
+  let(:subject2) { subject_set.subjects.last }
   let(:params) do
     {
       workflow_id: workflow.id,

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -5,8 +5,17 @@ describe Workflows::UnretireSubjects do
     let (:workflow) { create(:workflow) }
     let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
     let(:subject_set_id) { subject_set.id }
+    let(:subject1) { create(:subject, subject_sets: [subject_set] ) }
+    let(:subject_workflow_count) { create() }
+    let(:params) do
+        {
+          workflow_id: workflow.id,
+          subject_id: subject1.id,
+        }
+      end
 
     it "should unretire given subjects with subject ids for the workflow", :focus => true do 
-        
+        result = operation.run(params)
+        SubjectWorkflowStatus
     end
 end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -34,7 +34,7 @@ describe Workflows::UnretireSubjects do
     operation.run!(run_params.merge(subject_ids: [subject1.id, subject2.id]))
     expect(UnretireSubjectWorker)
       .to have_received(:perform_async)
-      .with(workflow.id, subject_ids)
+      .with(workflow.id, [subject1.id, subject2.id])
   end
 
   it 'is invalid with a missing workflow_id param' do

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -12,10 +12,14 @@ describe Workflows::UnretireSubjects do
           workflow_id: workflow.id,
           subject_id: subject1.id,
         }
-      end
+    end
+    let(:operation) { described_class.with(api_user: api_user) }
 
-    it "should unretire given subjects with subject ids for the workflow", :focus => true do 
-        result = operation.run(params)
-        SubjectWorkflowStatus
+
+    it "should call unretirement worker with subject_id", :focus => true do 
+        expect(UnretireSubjectWorker)
+            .to receive(:perform_async)
+            .with(workflow.id, [ subject1.id ])
+        operation.run!(params)
     end
 end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -1,24 +1,26 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe Workflows::UnretireSubjects do 
+describe Workflows::UnretireSubjects do
   let(:api_user) { ApiUser.new(build_stubbed(:user)) }
-  let (:workflow) { create(:workflow) }
+  let(:workflow) { create(:workflow) }
   let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
   let(:subject_set_id) { subject_set.id }
-  let(:subject1) { create(:subject, subject_sets: [subject_set] ) }
-  let(:subject_workflow_count) { create() }
+  let(:subject1) { create(:subject, subject_sets: [subject_set]) }
+  let(:subject_workflow_count) { create }
   let(:params) do
-  {
-    workflow_id: workflow.id,
-    subject_id: subject1.id,
-  }
+    {
+      workflow_id: workflow.id,
+      subject_id: subject1.id
+    }
   end
   let(:operation) { described_class.with(api_user: api_user) }
 
-  it "should call unretirement worker with subject_id" do 
+  it 'calls the unretirement worker with subject_id' do
     expect(UnretireSubjectWorker)
-    .to receive(:perform_async)
-    .with(workflow.id, [ subject1.id ])
+      .to receive(:perform_async)
+      .with(workflow.id, [subject1.id])
     operation.run!(params)
   end
 end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -6,6 +6,7 @@ describe Workflows::UnretireSubjects do
     let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
     let(:subject_set_id) { subject_set.id }
 
-    it "should unretire given subjects with subhect ids for the workflow" do 
+    it "should unretire given subjects with subject ids for the workflow", :focus => true do 
+        
     end
 end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -1,25 +1,24 @@
 require 'spec_helper'
 
 describe Workflows::UnretireSubjects do 
-    let(:api_user) { ApiUser.new(build_stubbed(:user)) }
-    let (:workflow) { create(:workflow) }
-    let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
-    let(:subject_set_id) { subject_set.id }
-    let(:subject1) { create(:subject, subject_sets: [subject_set] ) }
-    let(:subject_workflow_count) { create() }
-    let(:params) do
-        {
-          workflow_id: workflow.id,
-          subject_id: subject1.id,
-        }
-    end
-    let(:operation) { described_class.with(api_user: api_user) }
+  let(:api_user) { ApiUser.new(build_stubbed(:user)) }
+  let (:workflow) { create(:workflow) }
+  let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
+  let(:subject_set_id) { subject_set.id }
+  let(:subject1) { create(:subject, subject_sets: [subject_set] ) }
+  let(:subject_workflow_count) { create() }
+  let(:params) do
+  {
+    workflow_id: workflow.id,
+    subject_id: subject1.id,
+  }
+  end
+  let(:operation) { described_class.with(api_user: api_user) }
 
-
-    it "should call unretirement worker with subject_id", :focus => true do 
-        expect(UnretireSubjectWorker)
-            .to receive(:perform_async)
-            .with(workflow.id, [ subject1.id ])
-        operation.run!(params)
-    end
+  it "should call unretirement worker with subject_id" do 
+    expect(UnretireSubjectWorker)
+    .to receive(:perform_async)
+    .with(workflow.id, [ subject1.id ])
+    operation.run!(params)
+  end
 end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -8,6 +8,7 @@ describe Workflows::UnretireSubjects do
   let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
   let(:subject_set_id) { subject_set.id }
   let(:subject1) { create(:subject, subject_sets: [subject_set]) }
+  let(:subject2) { create(:subject, subject_sets: [subject_set]) }
   let(:subject_workflow_count) { create }
   let(:params) do
     {
@@ -16,7 +17,8 @@ describe Workflows::UnretireSubjects do
     }
   end
   let(:operation) { described_class.with(api_user: api_user) }
-  before do 
+
+  before do
     allow(UnretireSubjectWorker).to receive(:perform_async).and_return(true)
   end
 
@@ -28,10 +30,8 @@ describe Workflows::UnretireSubjects do
   end
 
   it 'calls unretirement worker with subject_ids' do
-    subject2 = create(:subject, subject_sets: [subject_set])
-    subject_ids = [subject1.id, subject2.id]
     run_params = params.except(:subject_id)
-    operation.run!(run_params.merge(subject_ids: subject_ids))
+    operation.run!(run_params.merge(subject_ids: [subject1.id, subject2.id]))
     expect(UnretireSubjectWorker)
       .to have_received(:perform_async)
       .with(workflow.id, subject_ids)

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -17,21 +17,25 @@ describe Workflows::UnretireSubjects do
   end
   let(:operation) { described_class.with(api_user: api_user) }
 
-  it 'calls the unretirement worker with subject_id' do
-    expect(UnretireSubjectWorker)
-      .to receive(:perform_async)
-      .with(workflow.id, [subject1.id])
-    operation.run!(params)
+  before do 
+    allow(UnretireSubjectWorker).to receive(:perform_async).and_return(true)
   end
 
-  it 'calls unretirement worker with ubject_ids' do
+  it 'calls the unretirement worker with subject_id' do
+    operation.run!(params)
+    expect(UnretireSubjectWorker)
+      .to have_received(:perform_async)
+      .with(workflow.id, [subject1.id])
+  end
+
+  it 'calls unretirement worker with subject_ids' do
     subject2 = create(:subject, subject_sets: [subject_set])
     subject_ids = [subject1.id, subject2.id]
-    expect(UnretireSubjectWorker)
-      .to receive(:perform_async)
-      .with(workflow.id, subject_ids)
     run_params = params.except(:subject_id)
     operation.run!(run_params.merge(subject_ids: subject_ids))
+    expect(UnretireSubjectWorker)
+      .to have_received(:perform_async)
+      .with(workflow.id, subject_ids)
   end
 
   it 'is invalid with a missing workflow_id param' do

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Workflows::UnretireSubjects do 
+    let(:api_user) { ApiUser.new(build_stubbed(:user)) }
+    let (:workflow) { create(:workflow) }
+    let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
+    let(:subject_set_id) { subject_set.id }
+
+    it "should unretire given subjects with subhect ids for the workflow" do 
+    end
+end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -16,7 +16,6 @@ describe Workflows::UnretireSubjects do
     }
   end
   let(:operation) { described_class.with(api_user: api_user) }
-
   before do 
     allow(UnretireSubjectWorker).to receive(:perform_async).and_return(true)
   end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -6,10 +6,8 @@ describe Workflows::UnretireSubjects do
   let(:api_user) { ApiUser.new(build_stubbed(:user)) }
   let(:workflow) { create(:workflow) }
   let(:subject_set) { create(:subject_set, project: workflow.project, workflows: [workflow]) }
-  let(:subject_set_id) { subject_set.id }
   let(:subject1) { create(:subject, subject_sets: [subject_set]) }
   let(:subject2) { create(:subject, subject_sets: [subject_set]) }
-  let(:subject_workflow_count) { create }
   let(:params) do
     {
       workflow_id: workflow.id,

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -23,4 +23,19 @@ describe Workflows::UnretireSubjects do
       .with(workflow.id, [subject1.id])
     operation.run!(params)
   end
+
+  it 'calls unretirement worker with ubject_ids' do
+    subject2 = create(:subject, subject_sets: [subject_set])
+    subject_ids = [subject1.id, subject2.id]
+    expect(UnretireSubjectWorker)
+      .to receive(:perform_async)
+      .with(workflow.id, subject_ids)
+    run_params = params.except(:subject_id)
+    operation.run!(run_params.merge(subject_ids: subject_ids))
+  end
+
+  it 'is invalid with a missing workflow_id param' do
+    result = operation.run(params.except(:workflow_id))
+    expect(result).not_to be_valid
+  end
 end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -36,6 +36,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to be_empty }
       its(:create_workflow_contents_export) { is_expected.to be_empty }
       its(:retire_subjects) { is_expected.to be_empty }
+      its(:unretire_subjects) { is_expected.to be_empty }
       its(:translate) { is_expected.to be_empty }
     end
 
@@ -55,6 +56,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to be_empty }
       its(:create_workflow_contents_export) { is_expected.to be_empty }
       its(:retire_subjects) { is_expected.to be_empty }
+      its(:unretire_subjects) { is_expected.to be_empty }
       its(:translate) { is_expected.to be_empty }
     end
 
@@ -79,6 +81,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to be_empty }
       its(:create_workflow_contents_export) { is_expected.to be_empty }
       its(:retire_subjects) { is_expected.to be_empty }
+      its(:unretire_subjects) { is_expected.to be_empty }
       its(:translate) { is_expected.to be_empty }
     end
 
@@ -103,6 +106,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to be_empty }
       its(:create_workflow_contents_export) { is_expected.to be_empty }
       its(:retire_subjects) { is_expected.to be_empty }
+      its(:unretire_subjects) { is_expected.to be_empty }
       its(:translate) { is_expected.to match_array([public_project, private_project]) }
     end
 
@@ -127,6 +131,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to be_empty }
       its(:create_workflow_contents_export) { is_expected.to be_empty }
       its(:retire_subjects) { is_expected.to be_empty }
+      its(:unretire_subjects) { is_expected.to be_empty }
       its(:translate) { is_expected.to be_empty }
     end
 
@@ -151,6 +156,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to be_empty }
       its(:create_workflow_contents_export) { is_expected.to be_empty }
       its(:retire_subjects) { is_expected.to be_empty }
+      its(:unretire_subjects) { is_expected.to be_empty }
       its(:translate) { is_expected.to be_empty }
     end
 
@@ -175,6 +181,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to match_array([public_project, private_project]) }
       its(:create_workflow_contents_export) { is_expected.to match_array([public_project, private_project]) }
       its(:retire_subjects) { is_expected.to match_array([public_project, private_project]) }
+      its(:unretire_subjects) { is_expected.to match_array([public_project, private_project]) }
       its(:translate) { is_expected.to match_array([public_project, private_project]) }
     end
 
@@ -194,6 +201,7 @@ describe ProjectPolicy do
       its(:create_workflows_export) { is_expected.to match_array([public_project, private_project]) }
       its(:create_workflow_contents_export) { is_expected.to match_array([public_project, private_project]) }
       its(:retire_subjects) { is_expected.to match_array([public_project, private_project]) }
+      its(:unretire_subjects) { is_expected.to match_array([public_project, private_project]) }
       its(:translate) { is_expected.to match_array([public_project, private_project]) }
     end
   end

--- a/spec/support/pundit_scope_tester.rb
+++ b/spec/support/pundit_scope_tester.rb
@@ -79,7 +79,7 @@ class PunditScopeTester
     Pundit.policy!(@user, @klass).scope_for(:retire_subjects)
   end
 
-  #Used by workflows controller:
+  # Used by workflows controller:
   def unretire_subjects
     Pundit.policy!(@user, @klass).scope_for(:unretire_subjects)
   end

--- a/spec/support/pundit_scope_tester.rb
+++ b/spec/support/pundit_scope_tester.rb
@@ -78,4 +78,9 @@ class PunditScopeTester
   def retire_subjects
     Pundit.policy!(@user, @klass).scope_for(:retire_subjects)
   end
+
+  #Used by workflows controller:
+  def unretire_subjects
+    Pundit.policy!(@user, @klass).scope_for(:unretire_subjects)
+  end
 end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -5,23 +5,35 @@ require 'spec_helper'
 RSpec.describe UnretireSubjectWorker do
   let(:worker) { described_class.new }
   let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
-  let(:subject) { workflow.subjects.first }
+  let(:subject1) { workflow.subjects.first }
   let(:sms) { subject.set_member_subject.first }
   let(:set) { sms.subject_set }
-  let(:status) { create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: 1.day.ago, retirement_reason: 'other') }
+  let(:status) { create(:subject_workflow_status, subject: subject1, workflow: workflow, retired_at: 1.day.ago, retirement_reason: 'other') }
 
   describe '#perform' do
     context 'when subjects are unretireable' do
       it 'sets retired_at to nil' do
-        expect { worker.perform(workflow.id, [subject.id]) }.to change {
+        expect { worker.perform(workflow.id, [subject1.id]) }.to change {
           status.reload.retired_at
         }.to(nil)
       end
 
       it 'sets retirement_reason to nil' do
-        expect { worker.perform(workflow.id, [subject.id]) }.to change {
+        expect { worker.perform(workflow.id, [subject1.id]) }.to change {
           status.reload.retirement_reason
         }.to(nil)
+      end
+
+      it 'calls RefreshWorkflowStatusWorker with workflow id' do
+        allow(RefreshWorkflowStatusWorker).to receive(:perform_async).and_return(true)
+        worker.perform(workflow.id, [subject1.id])
+        expect(RefreshWorkflowStatusWorker).to have_received(:perform_async).with(workflow.id)
+      end
+
+      it 'calls NotifySubjectSelectorOfChangeWorker with workflow id' do
+        allow(NotifySubjectSelectorOfChangeWorker).to receive(:perform_async).and_return(true)
+        worker.perform(workflow.id, [subject1.id])
+        expect(NotifySubjectSelectorOfChangeWorker).to have_received(:perform_async).with(workflow.id)
       end
     end
   end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -1,27 +1,26 @@
 require 'spec_helper'
 
 RSpec.describe UnretireSubjectWorker do
-    let(:worker) { described_class.new }
-    let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
-    let(:subject) { workflow.subjects.first }
-    let(:sms) { subject.set_member_subject.first }
-    let(:set) { sms.subject_set }
-    let(:status) { create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: 1.days.ago, retirement_reason: 'other') }
+  let(:worker) { described_class.new }
+  let(:workflow) { create(:workflow_with_subjects, num_sPets: 1) }
+  let(:subject) { workflow.subjects.first }
+  let(:sms) { subject.set_member_subject.first }
+  let(:set) { sms.subject_set }
+  let(:status) { create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: 1.days.ago, retirement_reason: 'other') }
 
-    describe "#perform" do 
-        context "is unretireable" do 
-            it "should set retired_at to nil", :focus => true do 
-                expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
-                    status.reload.retired_at
-            }.to(nil)
-            end
+  describe "#perform" do
+    context "is unretireable" do
+      it "should set retired_at to nil" do
+        expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
+          status.reload.retired_at
+      }.to(nil)
+      end
 
-            it "should set retirement_reason to nil", :focus => true do 
-                expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
-                    status.reload.retirement_reason
-            }.to(nil)
-            end
-
-        end
+      it "should set retirement_reason to nil" do
+        expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
+          status.reload.retirement_reason
+      }.to(nil)
+      end
     end
+  end
 end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe UnretireSubjectWorker do
@@ -6,18 +8,18 @@ RSpec.describe UnretireSubjectWorker do
   let(:subject) { workflow.subjects.first }
   let(:sms) { subject.set_member_subject.first }
   let(:set) { sms.subject_set }
-  let(:status) { create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: 1.days.ago, retirement_reason: 'other') }
+  let(:status) { create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: 1.day.ago, retirement_reason: 'other') }
 
-  describe "#perform" do
-    context "is unretireable" do
-      it "should set retired_at to nil" do
-        expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
+  describe '#perform' do
+    context 'when subjects are unretireable' do
+      it 'sets retired_at to nil' do
+        expect { worker.perform(workflow.id, [subject.id]) }.to change {
           status.reload.retired_at
         }.to(nil)
       end
 
-      it "should set retirement_reason to nil" do
-        expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
+      it 'sets retirement_reason to nil' do
+        expect { worker.perform(workflow.id, [subject.id]) }.to change {
           status.reload.retirement_reason
         }.to(nil)
       end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe UnretireSubjectWorker do
+    let(:worker) { described_class.new }
+    let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
+    let(:subject) { workflow.subjects.first }
+    let(:sms) { subject.set_member_subject.first }
+    let(:set) { sms.subject_set }
+    let(:status) { create(:subject_workflow_status, subject: subject, workflow: workflow, retired_at: 1.days.ago, retirement_reason: 'other') }
+
+    describe "#perform" do 
+        context "is unretireable" do 
+            it "should set retired_at to nil", :focus => true do 
+                expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
+                    status.reload.retired_at
+            }.to(nil)
+            end
+        end
+    end
+end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe UnretireSubjectWorker do
   let(:worker) { described_class.new }
-  let(:workflow) { create(:workflow_with_subjects, num_sPets: 1) }
+  let(:workflow) { create(:workflow_with_subjects, num_sets: 1) }
   let(:subject) { workflow.subjects.first }
   let(:sms) { subject.set_member_subject.first }
   let(:set) { sms.subject_set }
@@ -13,13 +13,13 @@ RSpec.describe UnretireSubjectWorker do
       it "should set retired_at to nil" do
         expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
           status.reload.retired_at
-      }.to(nil)
+        }.to(nil)
       end
 
       it "should set retirement_reason to nil" do
         expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
           status.reload.retirement_reason
-      }.to(nil)
+        }.to(nil)
       end
     end
   end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe UnretireSubjectWorker do
                     status.reload.retired_at
             }.to(nil)
             end
+
+            it "should set retirement_reason to nil", :focus => true do 
+                expect{ worker.perform(workflow.id, [ subject.id ] ) }.to change {
+                    status.reload.retirement_reason
+            }.to(nil)
+            end
+
         end
     end
 end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -42,12 +42,13 @@ RSpec.describe UnretireSubjectWorker do
 
     it 'handles unknown workflow' do
       expect { worker.perform(-1, [subject1.id]) }.not_to raise_error
-    end 
+    end
 
     it 'handles unknown subject id' do
       expect { worker.perform(workflow.id, [-1]) }.not_to raise_error
-    end    
-    context 'when unknown workflow' do 
+    end
+
+    context 'when unknown workflow' do
       it 'does not run RefreshWorkflowStatusWorker' do
         worker.perform(-1, [subject1.id])
         expect(RefreshWorkflowStatusWorker).not_to have_received(:perform_async).with(workflow.id)

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -36,5 +36,25 @@ RSpec.describe UnretireSubjectWorker do
         expect(NotifySubjectSelectorOfChangeWorker).to have_received(:perform_async).with(workflow.id)
       end
     end
+
+    it 'handles unknown workflow' do
+      expect { worker.perform(-1, [subject1.id]) }.not_to raise_error
+    end 
+
+    it 'handles unknown subject id' do
+      expect { worker.perform(workflow.id, [-1]) }.not_to raise_error
+    end
+    
+    context 'when unknown workflow' do 
+      it 'does not run RefreshWorkflowStatusWorker' do
+        expect(RefreshWorkflowStatusWorker).not_to receive(:perform_async)
+        worker.perform(-1, [subject1.id])
+      end
+
+      it 'does not run NotifySubjectSelectorOfChangeWorker' do
+        expect(NotifySubjectSelectorOfChangeWorker).not_to receive(:perform_async)
+        worker.perform(-1, [subject1.id])
+      end
+    end
   end
 end

--- a/spec/workers/unretire_subject_worker_spec.rb
+++ b/spec/workers/unretire_subject_worker_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UnretireSubjectWorker do
       allow(NotifySubjectSelectorOfChangeWorker).to receive(:perform_async)
     end
 
-    context 'when subjects are unretireable' do
+    context 'when subjects are already retired' do
       it 'sets retired_at to nil' do
         expect { worker.perform(workflow.id, [subject1.id]) }.to change {
           status.reload.retired_at


### PR DESCRIPTION
I believe this is in a good spot. Let me know if I missed cases.  Mainly followed `retire_subjects` path as a guide. 

**Changes**
- creating a new route to unretire subjects by workflow_id.. route is `/api/workflows/YOUR_WF_ID/unretire_subjects` 
-  updated corresponding controller for route action 
- creating operator that calls an UnretirementSubjectWorker
- created UnretirementSubjectWorker that sets the `retired_at` and `retirement_reason` to nil 

**TODO**

- [x] Still getting my feet wet with rspec, but I want to add more tests

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
