### PR TITLE
Unretire subject by subject ids

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -54,7 +54,6 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def unretire_subjects
-    puts "mdy114 params #{params}"
     operation.run!(params)
     render nothing: true, status: 204
   end

--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -54,6 +54,7 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def unretire_subjects
+    puts "mdy114 params #{params}"
     operation.run!(params)
     render nothing: true, status: 204
   end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -8,16 +8,32 @@ module Workflows
     integer :subject_id, default: nil
     array :subject_ids, default: [] do
       integer
-    end
+    end;
+    integer :subject_set_id, default: nil
+    array :subject_set_ids, default: [] do 
+      integer
+    end;
 
     def execute
       return if cached_subject_ids.empty?
-
+      puts "MDY114 CACHED SUBJECT IDS BEFORE #{cached_subject_ids}"
       UnretireSubjectWorker.perform_async(workflow_id, cached_subject_ids)
     end
 
     def cached_subject_ids
       @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+      if !subject_set_subject_ids.empty?
+        puts 'MDY114 HITS CHECK'
+        @cached_subject_ids.push(*subject_set_subject_ids)
+      end
+      return @cached_subject_ids
+    end
+
+    def subject_set_subject_ids
+      puts 'MDY114 SUBJECT SET IDS'
+
+      set_ids ||= Array.wrap(@subject_set_ids) | Array.wrap(@subject_set_id)
+      SetMemberSubject.where(subject_set_id: set_ids).pluck(:subject_id)
     end
   end
 end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -21,9 +21,9 @@ module Workflows
     end
 
     def cached_subject_ids
-      @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
-      @cached_subject_ids.push(*subject_set_subject_ids) unless subject_set_subject_ids.empty?
-      @cached_subject_ids
+      cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
+      cached_subject_ids.push(*subject_set_subject_ids) unless subject_set_subject_ids.empty?
+      @cached_subject_ids = cached_subject_ids
     end
 
     def subject_set_subject_ids

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -21,13 +21,15 @@ module Workflows
     end
 
     def cached_subject_ids
-      cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
-      cached_subject_ids.push(*subject_set_subject_ids) unless subject_set_subject_ids.empty?
-      @cached_subject_ids = cached_subject_ids
+      @cached_subject_ids ||= subject_ids | subject_set_subject_ids
+    end
+
+    def subject_ids
+      Array.wrap(@subject_ids) | Array.wrap(@subject_id)
     end
 
     def subject_set_subject_ids
-      set_ids ||= Array.wrap(@subject_set_ids) | Array.wrap(@subject_set_id)
+      set_ids = Array.wrap(@subject_set_ids) | Array.wrap(@subject_set_id)
       SetMemberSubject.where(subject_set_id: set_ids).pluck(:subject_id)
     end
   end

--- a/app/operations/workflows/unretire_subjects.rb
+++ b/app/operations/workflows/unretire_subjects.rb
@@ -8,30 +8,25 @@ module Workflows
     integer :subject_id, default: nil
     array :subject_ids, default: [] do
       integer
-    end;
+    end
     integer :subject_set_id, default: nil
-    array :subject_set_ids, default: [] do 
+    array :subject_set_ids, default: [] do
       integer
-    end;
+    end
 
     def execute
       return if cached_subject_ids.empty?
-      puts "MDY114 CACHED SUBJECT IDS BEFORE #{cached_subject_ids}"
+
       UnretireSubjectWorker.perform_async(workflow_id, cached_subject_ids)
     end
 
     def cached_subject_ids
       @cached_subject_ids ||= Array.wrap(@subject_ids) | Array.wrap(@subject_id)
-      if !subject_set_subject_ids.empty?
-        puts 'MDY114 HITS CHECK'
-        @cached_subject_ids.push(*subject_set_subject_ids)
-      end
-      return @cached_subject_ids
+      @cached_subject_ids.push(*subject_set_subject_ids) unless subject_set_subject_ids.empty?
+      @cached_subject_ids
     end
 
     def subject_set_subject_ids
-      puts 'MDY114 SUBJECT SET IDS'
-
       set_ids ||= Array.wrap(@subject_set_ids) | Array.wrap(@subject_set_id)
       SetMemberSubject.where(subject_set_id: set_ids).pluck(:subject_id)
     end

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -45,7 +45,7 @@ describe Workflows::UnretireSubjects do
       .with(workflow.id, [subject1.id, subject2.id])
   end
 
-  it 'calls unretirement worker with subject ids of subject set ids given' do
+  it 'calls unretirement worker with subject_ids of subject_set_ids given' do
     run_params = params.except(:subject_id)
     operation.run!(run_params.merge(subject_set_ids: [subject_set.id]))
     expect(UnretireSubjectWorker)

--- a/spec/operations/workflows/unretire_subjects_spec.rb
+++ b/spec/operations/workflows/unretire_subjects_spec.rb
@@ -37,6 +37,22 @@ describe Workflows::UnretireSubjects do
       .with(workflow.id, [subject1.id, subject2.id])
   end
 
+  it 'calls unretirement worker with subject ids of the subject set id given' do
+    run_params = params.except(:subject_id)
+    operation.run!(run_params.merge(subject_set_id: subject_set.id))
+    expect(UnretireSubjectWorker)
+      .to have_received(:perform_async)
+      .with(workflow.id, [subject1.id, subject2.id])
+  end
+
+  it 'calls unretirement worker with subject ids of subject set ids given' do
+    run_params = params.except(:subject_id)
+    operation.run!(run_params.merge(subject_set_ids: [subject_set.id]))
+    expect(UnretireSubjectWorker)
+      .to have_received(:perform_async)
+      .with(workflow.id, [subject1.id, subject2.id])
+  end
+
   it 'is invalid with a missing workflow_id param' do
     result = operation.run(params.except(:workflow_id))
     expect(result).not_to be_valid


### PR DESCRIPTION
**Changes**
- update unretire subjects by subject set id (updating corresponding operation to grab subject ids from subject set id and then send it over to the worker.)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
