### PR TITLE
Optimise pod limits & requests and hpa scaling

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -351,11 +351,11 @@ spec:
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "4000Mi"
+              memory: "500Mi"
               cpu: "1000m"
               ephemeral-storage: "50Gi"
             limits:
-              memory: "4000Mi"
+              memory: "2000Mi"
               cpu: "2000m"
               ephemeral-storage: "50Gi"
           livenessProbe:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -288,7 +288,7 @@ spec:
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "6000Mi"
+              memory: "2000Mi"
               cpu: "1000m"
               ephemeral-storage: "50Gi"
             limits:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -136,7 +136,7 @@ spec:
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "1500Mi"
+              memory: "1000Mi"
               cpu: "500m"
             limits:
               memory: "1500Mi"
@@ -180,7 +180,7 @@ spec:
           image: zooniverse/nginx:1.19.0
           resources:
             requests:
-              memory: "100Mi"
+              memory: "50Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -290,11 +290,9 @@ spec:
             requests:
               memory: "2000Mi"
               cpu: "1000m"
-              ephemeral-storage: "50Gi"
             limits:
               memory: "6000Mi"
               cpu: "2000m"
-              ephemeral-storage: "50Gi"
           livenessProbe:
             exec:
               command:
@@ -353,11 +351,9 @@ spec:
             requests:
               memory: "500Mi"
               cpu: "1000m"
-              ephemeral-storage: "50Gi"
             limits:
               memory: "2000Mi"
               cpu: "2000m"
-              ephemeral-storage: "50Gi"
           livenessProbe:
             exec:
               command:
@@ -396,8 +392,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: panoptes-production-sidekiq
-  minReplicas: 1
-  maxReplicas: 6
+  minReplicas: 2
+  maxReplicas: 8
   targetCPUUtilizationPercentage: 95
 ---
 apiVersion: policy/v1beta1

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -398,7 +398,7 @@ spec:
     name: panoptes-production-sidekiq
   minReplicas: 1
   maxReplicas: 6
-  targetCPUUtilizationPercentage: 80
+  targetCPUUtilizationPercentage: 95
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -240,7 +240,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: panoptes-production-app
-  minReplicas: 2
+  minReplicas: 3
   maxReplicas: 16
   targetCPUUtilizationPercentage: 80
 ---

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -265,7 +265,7 @@ spec:
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "700Mi"
+              memory: "500Mi"
               cpu: "100m"
               ephemeral-storage: "10Gi"
             limits:
@@ -324,7 +324,7 @@ spec:
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "700Mi"
+              memory: "500Mi"
               cpu: "100m"
               ephemeral-storage: "10Gi"
             limits:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -124,7 +124,7 @@ spec:
           resources:
             requests:
               memory: "500Mi"
-              cpu: "100m"
+              cpu: "500m"
             limits:
               memory: "700Mi"
               cpu: "1000m"
@@ -229,7 +229,7 @@ spec:
     name: panoptes-staging-app
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 80
+  targetCPUUtilizationPercentage: 95
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -267,11 +267,9 @@ spec:
             requests:
               memory: "500Mi"
               cpu: "100m"
-              ephemeral-storage: "10Gi"
             limits:
               memory: "700Mi"
               cpu: "500m"
-              ephemeral-storage: "10Gi"
           livenessProbe:
             exec:
               command:
@@ -326,11 +324,9 @@ spec:
             requests:
               memory: "500Mi"
               cpu: "100m"
-              ephemeral-storage: "10Gi"
             limits:
               memory: "700Mi"
               cpu: "500m"
-              ephemeral-storage: "10Gi"
           livenessProbe:
             exec:
               command:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -123,7 +123,7 @@ spec:
           image: zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "700Mi"
+              memory: "500Mi"
               cpu: "100m"
             limits:
               memory: "700Mi"
@@ -167,11 +167,11 @@ spec:
           image: zooniverse/nginx:1.19.0
           resources:
             requests:
-              memory: "100Mi"
+              memory: "25Mi"
               cpu: "10m"
             limits:
-              memory: "100Mi"
-              cpu: "500m"
+              memory: "50Mi"
+              cpu: "200m"
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Update the K8s pod CPU and RAM limits and modify how the HPA works to have a more stable service and less scaling events. linked to https://github.com/zooniverse/talk-api/pull/264

All values for new requests and limits are based on value inspection from the following cmd to inspect the history of the deployment pods `kubectl top pod --containers | grep panoptes`

Specifically this PR introduces these changes:
- modify the API RAM and CPU requests and limits
- modify the sidekiq pods to request less RAM and decrease their limits now the exports run on their own deployment
- modify the dumpworkers ram requests to allow less pressure on node scheduling 
- increase the replica counts for API and sidekiq pods for spare capacity to soak up spiky load and decrease scaling events
- removed the ephemeral-storage constraints**

All these changes should provide less scheduling pressure and allow us to run more pods on the same number of K8s nodes (we can modify the node count if there are seperate IOPS issues). The changes to the number of replicas should also help avoid the HPA frequently scaling the deployments and thus reduce the pod registration events in the nginx ingress controller (these cause nginx reloads and can impact traffic flow through the ingresses).

**The tmp storage on those k8s nodes is 150GB so lots of room now so no need to limit (allow the app to error and notify us vs silently fail via k8s pod killing)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
