### PR TITLE
tweak sidekiq worker cpu request values

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -289,7 +289,7 @@ spec:
           resources:
             requests:
               memory: "2000Mi"
-              cpu: "1000m"
+              cpu: "250m"
             limits:
               memory: "6000Mi"
               cpu: "2000m"
@@ -350,7 +350,7 @@ spec:
           resources:
             requests:
               memory: "500Mi"
-              cpu: "1000m"
+              cpu: "500m"
             limits:
               memory: "2000Mi"
               cpu: "2000m"


### PR DESCRIPTION
setting these too high means the pod can't schedule on our nodes, e.g.
"Warning  FailedScheduling  2m22s  default-scheduler   0/6 nodes are available: 1 node(s) had taint {servicelife: longlife}, that the pod didn't tolerate, 5 Insufficient cpu."

prod sidekiq dumpworker can be set low as it doesn't have an autoscaler that uses these request values

prod sidekiq uses the request values to trigger scaling events, set this lower to allow scheduling but know that this will cause pods to come up and down with load - note these aren't service pods so shouldn't have any impact with the nginx ingress.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
