### PR TITLE
double the number of sidekiq replicas

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -393,7 +393,7 @@ spec:
     kind: Deployment
     name: panoptes-production-sidekiq
   minReplicas: 2
-  maxReplicas: 8
+  maxReplicas: 16
   targetCPUUtilizationPercentage: 95
 ---
 apiVersion: policy/v1beta1


### PR DESCRIPTION
i'm seeing the hpa max out with current traffic volumes (high number of incoming classification)
```
$kubectl describe hpa panoptes-production-sidekiq
...
Reference:                                             Deployment/panoptes-production-sidekiq
Metrics:                                               ( current / target )
  resource cpu on pods  (as a percentage of request):  202% (1011m) / 95%
Min replicas:                                          2
Max replicas:                                          8
Deployment pods:                                       8 current / 8 desired`
```
this PR doubles the current HPA limit to 16 sidekiq pod replicas

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
