### PR TITLE
allow admin param for grouped and per subject end points

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -58,7 +58,7 @@ class Api::V1::SubjectsController < Api::ApiController
     skip_policy_scope
 
     # setup the selector params from user input, note validation occurs in the operation class
-    selector_param_keys = %i[workflow_id ids http_cache]
+    selector_param_keys = %i[workflow_id ids http_cache admin]
     selector_params = params.permit(*selector_param_keys)
     worfklow_id = selector_params.delete(:workflow_id)
 
@@ -101,7 +101,7 @@ class Api::V1::SubjectsController < Api::ApiController
     skip_policy_scope
 
     # setup the selector params from user input, note validation occurs in the operation class
-    selector_param_keys = %i[workflow_id subject_set_id num_rows num_columns http_cache]
+    selector_param_keys = %i[workflow_id subject_set_id num_rows num_columns http_cache admin]
     selector_params = params.permit(*selector_param_keys)
 
     # Sanity check -- use a testing feature flag

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -592,6 +592,16 @@ describe Api::V1::SubjectsController, type: :controller do
       end
     end
 
+    context 'with admin param' do
+      let(:request_params) do
+        { workflow_id: workflow.id.to_s, num_columns: 1, num_rows: 1, admin: true }
+      end
+
+      it 'responds with 200' do
+        expect(response.status).to eq(200)
+      end
+    end
+
     context 'with a workflow that is not allow listed for this end point' do
       let(:request_params) { { workflow_id: (workflow.id - 1).to_s, num_columns: 1, num_rows: 1 } }
 

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -593,7 +593,7 @@ describe Api::V1::SubjectsController, type: :controller do
 
     context 'with admin param' do
       let(:request_params) do
-        { workflow_id: workflow.id.to_s, num_columns: 1, num_rows: 1, admin: true }
+        { workflow_id: workflow.id.to_s, num_columns: 2, num_rows: 1, admin: true }
       end
 
       it 'responds with 200' do


### PR DESCRIPTION
Allow the 'admin' query param to avoid 422 errors as sometimes zoo team folks are in admin mode and the API returns 422s on these end points. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
