### PR TITLE
add per subject_set selection to the designator client

### DIFF
--- a/app/services/designator_client.rb
+++ b/app/services/designator_client.rb
@@ -51,9 +51,9 @@ class DesignatorClient
     end
   end
 
-  def get_subjects(workflow_id, user_id, _group_id, limit)
+  def get_subjects(workflow_id, user_id, subject_set_id, limit)
     url = "/api/workflows/#{workflow_id}"
-    params = { user_id: user_id, limit: limit }
+    params = { user_id: user_id, subject_set_id: subject_set_id, limit: limit }.compact
     request(:get, [ url, params ])
   end
 

--- a/spec/services/designator_client_spec.rb
+++ b/spec/services/designator_client_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe DesignatorClient do
         expect(subject_ids).to eq([1,2,3,4])
       end
 
+      it 'respects the sujbject_set (group) id' do
+        stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.get('/api/workflows/338?limit=5&subject_set_id=10', headers) do |_env|
+            [200, { 'Content-Type' => 'application/json' }, [1, 2].to_json]
+          end
+        end
+
+        subject_ids = described_class.new([:test, stubs]).get_subjects(338, nil, 10, 5)
+        expect(subject_ids).to eq([1, 2])
+      end
+
       it_behaves_like "handles server errors" do
         let(:method) { :get_subjects }
         let(:params) { [ 338, 1, nil, 5 ] }


### PR DESCRIPTION
closes #3630 

Preserve the subject_set_id in the selector client calls to ensure we only select subjects from the specified group

linked to the designator API change in https://github.com/zooniverse/designator/pull/74

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
