### PR TITLE
reset the counters and lifecycle state attributes

### DIFF
--- a/lib/workflow_copier.rb
+++ b/lib/workflow_copier.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
 class WorkflowCopier
+  EXCLUDE_ATTRIBUTES = %i[
+    classifications_count
+    completeness
+    published_version_id
+    real_set_member_subjects_count
+    retired_set_member_subjects_count
+    finished_at
+  ].freeze
+
   def self.copy_by_id(workflow_id, target_project_id)
     source_workflow = Workflow.find(workflow_id)
     copy(source_workflow, target_project_id)
   end
 
   def self.copy(source_workflow, target_project_id)
-    copied_workflow = source_workflow.deep_clone(except: %i[published_version_id])
+    copied_workflow = source_workflow.deep_clone(except: EXCLUDE_ATTRIBUTES)
     copied_workflow.project_id = target_project_id
     copied_workflow.active = false
     copied_workflow.display_name = "#{copied_workflow.display_name} (copy: #{Time.now.utc})"

--- a/spec/lib/workflow_copier_spec.rb
+++ b/spec/lib/workflow_copier_spec.rb
@@ -4,9 +4,7 @@ require 'spec_helper'
 
 describe WorkflowCopier do
   let(:workflow) do
-    create(:workflow, classifications_count: 100, retired_set_member_subjects_count: 10, real_set_member_subjects_count: 10, finished_at: Time.now.utc, completeness: 100.0) do |wf|
-      wf.publish!
-    end
+    create(:workflow, classifications_count: 100, retired_set_member_subjects_count: 10, real_set_member_subjects_count: 10, finished_at: Time.now.utc, completeness: 100.0, &:publish!)
   end
   let(:target_project) { create(:project) }
   let(:copier) { target_project.user }

--- a/spec/lib/workflow_copier_spec.rb
+++ b/spec/lib/workflow_copier_spec.rb
@@ -3,7 +3,11 @@
 require 'spec_helper'
 
 describe WorkflowCopier do
-  let(:workflow) { create(:workflow) }
+  let(:workflow) do
+    create(:workflow, classifications_count: 100, retired_set_member_subjects_count: 10, real_set_member_subjects_count: 10, finished_at: Time.now.utc, completeness: 100.0) do |wf|
+      wf.publish!
+    end
+  end
   let(:target_project) { create(:project) }
   let(:copier) { target_project.user }
   let(:copied_workflow) { described_class.copy(workflow, target_project.id) }


### PR DESCRIPTION
follow up to #3626 ensure we reset the workflow lifecycle state attribtues like counters and finished_at etc.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
