### PR TITLE
ensure primary language resources are created for template project association resources

### DIFF
--- a/app/workers/project_copy_worker.rb
+++ b/app/workers/project_copy_worker.rb
@@ -4,7 +4,7 @@ class ProjectCopyWorker
   sidekiq_options queue: :data_high, lock: :until_executed
 
   def perform(project_id, user_id)
-    ProjectCopier.copy(project_id, user_id)
+    ProjectCopier.new(project_id, user_id).copy
   rescue ActiveRecord::RecordNotFound
   end
 end

--- a/lib/project_copier.rb
+++ b/lib/project_copier.rb
@@ -1,32 +1,74 @@
 class ProjectCopier
-  EXCLUDE_ATTRIBUTES = [:classifications_count, :launched_row_order, :beta_row_order].freeze
-  INCLUDE_ASSOCIATIONS = [:tutorials,
-                          :field_guides,
-                          :pages,
-                          :tags,
-                          :tagged_resources,
-                          :avatar,
-                          :background,
-                          {active_workflows: [:tutorials, :attached_images]}].freeze
+  attr_reader :project_to_copy, :user
 
-  def self.copy(project_id, user_id)
-    project = Project.find(project_id)
-    user = User.find(user_id)
+  EXCLUDE_ATTRIBUTES = %i[classifications_count launched_row_order beta_row_order].freeze
+  INCLUDE_ASSOCIATIONS = [
+    :tutorials,
+    :field_guides,
+    :pages,
+    :tags,
+    :tagged_resources,
+    :avatar,
+    :background,
+    { active_workflows: %i[tutorials attached_images] }
+  ].freeze
 
-    copied_project = project.deep_clone include: INCLUDE_ASSOCIATIONS, except: EXCLUDE_ATTRIBUTES
+  def initialize(project_id, user_id)
+    @project_to_copy = Project.find(project_id)
+    @user = User.find(user_id)
+  end
+
+  def copy
+    copied_project = copy_project
+
+
+    # Note for the newly copied project relations
+    # the below syncs the primary language translation strings
+    # but it doesn't copy the associated resource's translations
+    # long term we may want to ensure these are copied as well
+    #
+    # active_workflows and their tutorials
+    # copied_project.active_workflows.each do |workflow|
+    #   TranslationSyncWorker.new.perform(workflow.class.name, workflow.id, workflow.translatable_language)
+    #   wf.tutorials.each do |tutorial|
+    #     TranslationSyncWorker.new.perform(tutorial.class.name, tutorial.id, tutorial.translatable_language)
+    #   end
+    # end
+    # # project field_guides
+    # copied_project.field_guides.each do |field_guide|
+    #   TranslationSyncWorker.new.perform(field_guide.class.name, field_guide.id, field_guide.translatable_language)
+    # end
+    # # project pages
+    # copied_project.pages.each do |pages|
+    #   TranslationSyncWorker.new.perform(pages.class.name, pages.id, pages.translatable_language)
+    # end
+
+    copied_project
+  end
+
+  private
+
+  def copy_project
+    copied_project = project_to_copy.deep_clone include: INCLUDE_ASSOCIATIONS, except: EXCLUDE_ATTRIBUTES
     copied_project.owner = user
 
-    if user == project.owner
-      copied_project.display_name += " (copy)"
-    end
+    copied_project.display_name += ' (copy)' if user == project_to_copy.owner
 
     copied_project.assign_attributes(launch_approved: false, live: false)
     # reset the project's configuration but record the source project id
-    copied_project.configuration = { source_project_id: project.id }
+    copied_project.configuration = { source_project_id: project_to_copy.id }
 
+    # sync the project translations
+    sync_project_translations!(copied_project)
+
+    # return the newly copied project
+    copied_project
+  end
+
+  def sync_project_translations!(copied_project)
     # copy the translation resources from the source project
     # note they currently have the wrong version id as it relates to the source project
-    copied_translations = project.translations.map(&:dup)
+    copied_translations = project_to_copy.translations.map(&:dup)
 
     Project.transaction(requires_new: true) do
       # save the project and create the project versions for use in translation strings
@@ -42,6 +84,5 @@ class ProjectCopier
       # persist the translations association
       copied_project.translations = copied_translations
     end
-    copied_project
   end
 end

--- a/lib/project_copier.rb
+++ b/lib/project_copier.rb
@@ -19,6 +19,10 @@ class ProjectCopier
   end
 
   def copy
+    # shoudl this all be wrapped in a transaction to ensure we
+    # rollback an sub resource creations,
+    # e.g. inband primary lang strings for the associated resources....
+  # Project.transaction(requires_new: true) do ??
     copied_project = copy_project
 
     # sync the project translations
@@ -91,6 +95,7 @@ class ProjectCopier
   end
 
   def sync_association_translations_via_worker(association_resource)
+    # Should this be in band or async?
     TranslationSyncWorker.perform_async(
       association_resource.class.name,
       association_resource.id,

--- a/spec/lib/project_copier_spec.rb
+++ b/spec/lib/project_copier_spec.rb
@@ -92,5 +92,13 @@ describe ProjectCopier do
         expect(translation_string_version_ids).to match([copied_project.latest_version_id])
       end
     end
+
+    # add tests for the testing the syncing of the pimary language translation strings
+    # for when the project has
+    # - active workflows
+    # - active workflows
+    #   - tutorials
+    # - field_guides
+    # - pages
   end
 end

--- a/spec/lib/project_copier_spec.rb
+++ b/spec/lib/project_copier_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe ProjectCopier do
-  describe '#copy' do
+  describe '#copy', :focus do
     let(:project) { create(:full_project) }
     let(:copyist) { create(:user) }
-    let(:copied_project) { described_class.copy(project.id, copyist.id) }
+    let(:copied_project) { described_class.new(project.id, copyist.id).copy }
 
     it 'returns a valid project' do
-      expect(described_class.copy(project.id, copyist.id)).to be_valid
+      expect(described_class.new(project.id, copyist.id).copy).to be_valid
     end
 
     it 'sets the owner to the api_user' do
@@ -15,7 +15,7 @@ describe ProjectCopier do
     end
 
     it 'renames a project when the owner is copying their own project' do
-      new_copy = described_class.copy(project.id, project.owner.id)
+      new_copy = described_class.new(project.id, project.owner.id).copy
       expect(new_copy.display_name).to include('(copy)')
     end
 

--- a/spec/lib/project_copier_spec.rb
+++ b/spec/lib/project_copier_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ProjectCopier do
-  describe '#copy', :focus do
+  describe '#copy' do
     let(:project) { create(:full_project) }
     let(:copyist) { create(:user) }
     let(:copied_project) { described_class.new(project.id, copyist.id).copy }
@@ -23,8 +23,11 @@ describe ProjectCopier do
       expect(copied_project.display_name).to eq(project.display_name)
     end
 
-    it 'has updated attributes' do
+    it 'resets the live attribute' do
       expect(copied_project.live).to be false
+    end
+
+    it 'resets the launch_approved attribute' do
       expect(copied_project.launch_approved).to be false
     end
 
@@ -36,9 +39,31 @@ describe ProjectCopier do
       expect(copied_project.configuration['source_project_id']).to be(project.id)
     end
 
-    it 'has valid copied workflows' do
-      expect(copied_project.workflows.first).to be_valid
-      expect(copied_project.workflows.first.display_name).to eq(project.workflows.first.display_name)
+    context 'when a project has active_worklfows' do
+      it 'creates a valid workflow copy' do
+        expect(copied_project.active_workflows.first).to be_valid
+      end
+
+      it 'copies the workflow display_name' do
+        expect(copied_project.active_workflows.first.display_name).to eq(project.active_workflows.first.display_name)
+      end
+
+      it 'creates a primary language translation resource for the workflow' do
+        active_workflow = copied_project.active_workflows.first
+        expect(active_workflow.translations.first.language).to eq(project.primary_language)
+      end
+    end
+
+    context "when a project's active_workflow has a tutorial" do
+      before do
+        create(:tutorial, project: project, workflows: [project.active_workflows.first])
+      end
+
+      it 'creates a primary language translation resource for the tutorial' do
+        active_workflow = copied_project.active_workflows.first
+        tutorial = active_workflow.tutorials.first
+        expect(tutorial.translations.first.language).to eq(project.primary_language)
+      end
     end
 
     context 'when a project has tags' do
@@ -53,12 +78,24 @@ describe ProjectCopier do
         create(:field_guide, project: project)
         expect(copied_project.field_guides.first).to be_valid
       end
+
+      it 'creates a primary language translation resource for the field_guide' do
+        create(:field_guide, project: project)
+        field_guide = copied_project.field_guides.first
+        expect(field_guide.translations.first.language).to eq(project.primary_language)
+      end
     end
 
     context 'when a project has a project page' do
       it 'is a valid record' do
         create(:project_page, project: project)
         expect(copied_project.pages.first).to be_valid
+      end
+
+      it 'creates a primary language translation resource for the page' do
+        create(:project_page, project: project)
+        page = copied_project.pages.first
+        expect(page.translations.first.language).to eq(project.primary_language)
       end
     end
 
@@ -92,13 +129,5 @@ describe ProjectCopier do
         expect(translation_string_version_ids).to match([copied_project.latest_version_id])
       end
     end
-
-    # add tests for the testing the syncing of the pimary language translation strings
-    # for when the project has
-    # - active workflows
-    # - active workflows
-    #   - tutorials
-    # - field_guides
-    # - pages
   end
 end

--- a/spec/workers/project_copy_worker_spec.rb
+++ b/spec/workers/project_copy_worker_spec.rb
@@ -4,22 +4,33 @@ describe ProjectCopyWorker do
   let(:worker) { described_class.new }
   let(:project) { create(:project) }
   let(:user) { create(:user) }
+  let(:project_copier_double) { instance_double(ProjectCopier) }
 
   it { is_expected.to be_a Sidekiq::Worker }
 
-  describe "#perform" do
-    it "tells the project copier to copy the project" do
-      expect(ProjectCopier)
-        .to receive(:copy)
-        .with(project.id, user.id)
-      worker.perform(project.id, user.id)
+  describe '#perform' do
+    before do
+      allow(project_copier_double).to receive(:copy)
+      allow(ProjectCopier).to receive(:new).and_return(project_copier_double)
     end
 
-    it "should ignore unknown users and projects" do
+    it 'uses the project copier correctly' do
+      worker.perform(project.id, user.id)
+      expect(ProjectCopier).to have_received(:new).with(project.id, user.id)
+    end
+
+    it 'uses the project copier to copy the project' do
+      worker.perform(project.id, user.id)
+      expect(project_copier_double).to have_received(:copy)
+    end
+
+    it 'ignores unknown users' do
       expect{
         worker.perform(-1, user.id)
       }.not_to raise_error
+    end
 
+    it 'ignores unknown projects' do
       expect{
         worker.perform(project.id, -1)
       }.not_to raise_error


### PR DESCRIPTION
Ensure we don't break the translations.zooniverse.org app's expected data model when copying a template project's associated resources, e.g. `project.active_workflows`, `project.pages`, project.field_guides`

In the normal `CRUD` API landscape all translated resources will have these primary language translations setup correctly and the translations app relies on them being present. Thus we need to set these up when copying these template project and their translated association resources. 

Thus this PR syncs the default translation (primary language) strings from the copied association resource to the translation. It does not however copy any existing translations on these translated associations (`active_workflows`, etc). Long term this is probably desired but out of scope for this data model fix PR**.

** FWIW this template project copy feature isn't in active use via the API right now but may be as project team and collaborators find the feature useful. We can revisit this if and when they need the full template project translations resources copied as well.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
