### PR TITLE
use internal service end points in k8s cluster

### DIFF
--- a/app/services/cellect_client.rb
+++ b/app/services/cellect_client.rb
@@ -5,16 +5,8 @@ module CellectClient
   class ResourceNotFound < StandardError; end
   class ServerError < StandardError; end
 
-  def self.default_host
-    if Rails.env.production?
-      'https://cellect.zooniverse.org'
-    else
-      'https://cellect-staging.zooniverse.org'
-    end
-  end
-
   def self.host
-    ENV.fetch('CELLECT_HOST', default_host)
+    @host ||= ENV.fetch('CELLECT_HOST')
   end
 
   def self.add_seen(workflow_id, user_id, subject_id)

--- a/app/services/talk_api_client.rb
+++ b/app/services/talk_api_client.rb
@@ -78,6 +78,8 @@ class TalkApiClient
 
   def request(method, path, *args)
     connection.send(method, path, *args) do |req|
+      # simulate the terminated HTTPS cluster traffic if the we're using HTTP URL
+      req.headers['X-Forwarded-Proto'] = 'https' if connection.scheme == 'http'
       req.headers["Accept"] = "application/vnd.api+json"
       req.headers["Content-Type"] = "application/json"
       req.headers["Authorization"] = "Bearer #{token.token}"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -68,8 +68,9 @@ data:
   RAILS_ENV: staging
   ZOO_STREAM_KINESIS_STREAM_NAME: zooniverse-staging
   ZOO_STREAM_SOURCE: panoptes
+  CELLECT_HOST: http://cellect-staging-app/
   CORS_ORIGINS_REGEX: '^https?:\/\/([a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
-  DESIGNATOR_API_HOST: https://designator-staging.zooniverse.org/
+  DESIGNATOR_API_HOST: http://designator-staging-app/
   DESIGNATOR_API_USERNAME: staging
   DUMP_CONGESTION_OPTS_INTERVAL: "60"
   DUMP_CONGESTION_OPTS_MIN_DELAY: "60"
@@ -98,7 +99,7 @@ data:
   AZURE_STORAGE_ACCOUNT: panoptesuploadsstaging
   AZURE_STORAGE_CONTAINER_PUBLIC: public
   AZURE_STORAGE_CONTAINER_PRIVATE: private
-  TALK_API_HOST: https://talk-staging.zooniverse.org
+  TALK_API_HOST: http://talk-staging-app
   TALK_API_USER: '1'
   TALK_API_APPLICATION: '1'
   USER_SUBJECT_LIMIT: '100'

--- a/spec/services/cellect_client_spec.rb
+++ b/spec/services/cellect_client_spec.rb
@@ -11,17 +11,8 @@ RSpec.describe CellectClient do
   end
 
   describe '::host' do
-    it 'uses the default host' do
-      expect(described_class.host).to eq('https://cellect-staging.zooniverse.org')
-    end
-
-    it 'uses the correct host in prod' do
-      allow(Rails.env).to receive(:production?).and_return(true)
-      expect(described_class.host).to eq('https://cellect.zooniverse.org')
-    end
-
-    it 'uses the ENV var if supplied' do
-      host = 'https://cellect.org'
+    it 'configures the host through ENV var' do
+      host = 'http://cellect.org'
       allow(ENV).to receive(:fetch).and_return(host)
       expect(described_class.host).to eq(host)
     end

--- a/spec/services/talk_api_client_spec.rb
+++ b/spec/services/talk_api_client_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe TalkApiClient do
       it 'should raise an error on failure' do
         expect{subject.request('get', '/error')}.to raise_error(Faraday::ResourceNotFound)
       end
+
+      it 'adds the X-Forwarded-Proto header on http URLs' do
+        subject.request('get', '/') do |req|
+          expect(req.headers['X-Forwarded-Proto']).to eq('https')
+        end
+      end
+
+      it 'does not add the X-Forwarded-Proto header on https URLs' do
+        subject.host = 'https://test.example.com'
+        subject.create_connection([:test, stubs])
+        subject.request('get', '/') do |req|
+          expect(req.headers['X-Forwarded-Proto']).to be_nil
+        end
+      end
     end
 
     describe "#method_missing" do


### PR DESCRIPTION
avoid routing traffic out of the k8s cluster by switching service URLs to their internal k8s service DNS names via HTTP. i.e. pod to pod in the cluster instead of via the ingress combined with TLS termination via HTTPS URL schemes.

see `kubectl get services` for the service DNS discover URLs

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
