### PR TITLE
Improve pod probes staging service

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -151,6 +151,8 @@ spec:
               httpHeaders:
                  - name: X-Forwarded-Proto
                    value: https
+            # allow a longer response time than 1s
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /
@@ -159,6 +161,8 @@ spec:
                  - name: X-Forwarded-Proto
                    value: https
             initialDelaySeconds: 20
+            # allow a longer response time than 1s
+            timeoutSeconds: 10
           env:
           - name: PG_STATEMENT_TIMEOUT
             value: '65000'

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -34,6 +34,11 @@ data:
         add_header Cache-Control public;
       }
 
+      location /healthz {
+        add_header Content-Type text/plain;
+        return 200;
+      }
+
       location / {
         # avoid attacker setting the host value for links in rails_app
         # https://github.com/rails/rails/issues/29893
@@ -175,7 +180,7 @@ spec:
               cpu: "200m"
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 80
               httpHeaders:
                  - name: X-Forwarded-Proto
@@ -183,7 +188,7 @@ spec:
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 80
               httpHeaders:
                  - name: X-Forwarded-Proto

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -134,6 +134,16 @@ spec:
             limits:
               memory: "700Mi"
               cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            # wait 6 * 10 seconds(default periodSeconds) for the container to start
+            # after this succeeds once the liveness probe takes over
+            failureThreshold: 6
           livenessProbe:
             httpGet:
               path: /

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -160,6 +160,7 @@ spec:
               httpHeaders:
                  - name: X-Forwarded-Proto
                    value: https
+            # start checking for readiness after 20s (to serve traffic)
             initialDelaySeconds: 20
             # allow a longer response time than 1s
             timeoutSeconds: 10

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -193,7 +193,7 @@ spec:
               httpHeaders:
                  - name: X-Forwarded-Proto
                    value: https
-            initialDelaySeconds: 20
+            initialDelaySeconds: 5
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
This PR attempt to improve the k8s pod probes and isolate the rails and nginx pod probes. In theory this probe setup should provide better pod failure detection without forcing unnecessary pod restarts and thus service traffic loss at the ingress, we can iterate on these settings to improve any pod lifecycle behaviour changes.

This is a test for the staging service setup, once we've used this setup in staging we can revisit on production.

This PR specifically adds / improves the probes by:
1. increasing the response time from 1s to 10s to avoid pods failing probes / being restarted when busy
2. adds a `startupProbe` (allow max 60s boot time) for the rails app to avoid running the liveness probes on boot - https://v1-19.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
3. isolates the nginx pod probes from the upstream rails app by adding in a `healthz` endpoint to nginx conf - test the nginx pod readiness not the rails app and thus don't restart nginx pods if not needed.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
