### PR TITLE
add internal prod service routes

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -80,8 +80,9 @@ data:
   RAILS_ENV: production
   ZOO_STREAM_KINESIS_STREAM_NAME: zooniverse-production
   ZOO_STREAM_SOURCE: panoptes
+  CELLECT_HOST: http://cellect-production-app/
   CORS_ORIGINS_REGEX: '^https?:\/\/((www|staging)\.antislaverymanuscripts\.org|(www|relaunch|field-book)\.notesfromnature\.org|www\.scribesofthecairogeniza\.org|([a-z0-9-]+\.)?zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
-  DESIGNATOR_API_HOST: https://designator.zooniverse.org/
+  DESIGNATOR_API_HOST: http://designator-production-app/
   DESIGNATOR_API_USERNAME: production
   DUMP_WORKER_SIDEKIQ_QUEUE: dumpworker
   EMAIL_EXPORT_S3_BUCKET: zooniverse-exports
@@ -110,7 +111,7 @@ data:
   AZURE_STORAGE_ACCOUNT: panoptesuploads
   AZURE_STORAGE_CONTAINER_PUBLIC: public
   AZURE_STORAGE_CONTAINER_PRIVATE: private
-  TALK_API_HOST: https://talk.zooniverse.org
+  TALK_API_HOST: http://talk-production-app
   TALK_API_USER: '1'
   TALK_API_APPLICATION: '1'
   UPLOADED_SUBJECTS_COUNT_CACHE_EXPIRY: '604800'


### PR DESCRIPTION
Use the internal cluster service DNS via HTTP instead of using the external internet URLs (traffic leaves the cluster) with HTTPS.

Linked to #3642 - after testing this works correctly on staging we can use the same technique on production. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
