### PR TITLE
read user subject upload counts from db replica

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -347,7 +347,9 @@ class User < ActiveRecord::Base
 
   def uploaded_subjects_count
     count = Rails.cache.fetch(subjects_count_cache_key, expires_in: subject_count_cache_expiry) do
-      Subject.where(upload_user_id: id).count
+      DatabaseReplica.read('read_user_uploaded_subjects_counts_from_replica') do
+        Subject.where(upload_user_id: id).count
+      end
     end
     count.to_i
   end


### PR DESCRIPTION
this PR pushes to the replica DB the expensive count queries for how many subjects a user has uploaded to the system. These queries are only run when the cache is missing or invalid but these are serialized on the user resource and also used when determining if a user is over their upload quota. 

#### TODO 
- [x] Add the flipper feature flag `read_user_uploaded_subjects_counts_from_replica` to read the counts from the replica DB

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
