### PR TITLE
Handle unknown subjects in the retirement worker

### DIFF
--- a/app/workers/retire_subject_worker.rb
+++ b/app/workers/retire_subject_worker.rb
@@ -10,6 +10,9 @@ class RetireSubjectWorker
       Array.wrap(subject_ids).each do |subject_id|
         count = subject_workflow_status(subject_id)
         RetirementWorker.perform_async(count.id, true, reason)
+      rescue ActiveRecord::RecordInvalid
+        # need to rescue the error when folks pass in a subject id that doesn't exist
+        # but we still keep processing the whole list of subjects we have
       end
     end
   end

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -12,8 +12,14 @@ RSpec.describe RetireSubjectWorker do
   let(:subject_ids) { [sms.subject_id, sms2.subject_id] }
 
   describe "#perform" do
-    it 'should handle an unknow workflow' do
+    it 'ignores an unknown workflow' do
       expect { worker.perform(-1, subject.id) }.not_to raise_error
+    end
+
+    it 'ignores an unknown subject' do
+      allow(RetirementWorker).to receive(:perform_async)
+      worker.perform(workflow.id, [-1, subject.id])
+      expect(RetirementWorker).to have_received(:perform_async).once
     end
 
     it 'should call the retirement worker with the subject workflow status resource' do

--- a/spec/workers/retire_subject_worker_spec.rb
+++ b/spec/workers/retire_subject_worker_spec.rb
@@ -47,21 +47,5 @@ RSpec.describe RetireSubjectWorker do
       expect(RetirementWorker).not_to receive(:perform_async)
       worker.perform(-1, subject.id)
     end
-
-    describe "creating the sws resource" do
-      it 'should raise if there is a problem with the workflow' do
-        allow(worker).to receive(:workflow_exists?).and_return(true)
-        expect {
-          worker.perform(-1, subject.id)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it 'should raise if there is a problem with the subject' do
-        allow(worker).to receive(:workflow_exists?).and_return(true)
-        expect {
-          worker.perform(workflow.id, -1)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR changes the retirement worker to ignore any unknown subject ids passed in. Previously this would raise and error and stop processing the list of subjects we had for retirement. Thus 1 incorrect subject_id could break the retirement list processing at any point. 

I found this issue due to a failed (dead) job in sidekiq and some data debugging found 1 unknown subject id in the list. 

linked HB error https://app.honeybadger.io/projects/40595/faults/38047692

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
