### PR TITLE
Add retry mechanism when a medium uploads files to an object store

### DIFF
--- a/app/models/csv_dumps/direct_to_s3.rb
+++ b/app/models/csv_dumps/direct_to_s3.rb
@@ -30,6 +30,19 @@ module CsvDumps
       )
     end
 
+    def put_file_with_retry(gzip_file_path, opts={}, num_retries=5)
+      attempts ||= 1
+      put_file(gzip_file_path, opts)
+    rescue UnencryptedBucket => e # do not retry this error
+      raise e
+    rescue => e # rubocop:disable Style/RescueStandardError
+      retry if (attempts += 1) <= num_retries
+
+      # ensure we raise unexpected errors once we've exhausted
+      # the number of retries to continute to surface these errors
+      raise e
+    end
+
     def storage_adapter(adapter='aws')
       return @storage_adapter if @storage_adapter
 

--- a/app/models/csv_dumps/dump_processor.rb
+++ b/app/models/csv_dumps/dump_processor.rb
@@ -50,7 +50,7 @@ module CsvDumps
     end
 
     def write_to_object_store(gzip_file_path)
-      medium.put_file(gzip_file_path, compressed: true)
+      medium.put_file_with_retry(gzip_file_path, compressed: true)
     end
   end
 end

--- a/app/models/csv_dumps/dump_processor.rb
+++ b/app/models/csv_dumps/dump_processor.rb
@@ -34,7 +34,7 @@ module CsvDumps
 
     def upload_dump
       gzip_file_path = csv_dump.gzip!
-      write_to_s3(gzip_file_path)
+      write_to_object_store(gzip_file_path)
       set_ready_state
     end
 
@@ -49,7 +49,7 @@ module CsvDumps
       medium.save!
     end
 
-    def write_to_s3(gzip_file_path)
+    def write_to_object_store(gzip_file_path)
       medium.put_file(gzip_file_path, compressed: true)
     end
   end

--- a/spec/models/csv_dumps/dump_processor_spec.rb
+++ b/spec/models/csv_dumps/dump_processor_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe CsvDumps::DumpProcessor do
   let(:formatter) { double("Formatter", headers: false).tap { |f| allow(f).to receive(:to_rows) { |model| [model] } } }
   let(:scope) { [] }
-  let(:medium) { double("Medium", put_file: true, metadata: {}, save!: true) }
+  let(:medium) { instance_double('Medium', put_file_with_retry: true, metadata: {}, save!: true) }
   let(:csv_dump) { double(CsvDump, cleanup!: true, gzip!: true) }
   let(:processor) { described_class.new(formatter, scope, medium, csv_dump) }
 
@@ -29,14 +29,15 @@ RSpec.describe CsvDumps::DumpProcessor do
     processor.execute
   end
 
-  it "push the file to s3" do
+  it "push the file to an object store" do
     path = double
     allow(csv_dump).to receive(:gzip!).and_return(path)
-    expect(medium).to receive(:put_file).with(path, compressed: true).once
+    allow(medium).to receive(:put_file_with_retry)
     processor.execute
+    expect(medium).to have_received(:put_file_with_retry).with(path, compressed: true).once
   end
 
-  it "should clean up the file after sending to s3" do
+  it "should clean up the file after sending to object store" do
     expect(csv_dump).to receive(:cleanup!).once
     processor.execute
   end

--- a/spec/models/csv_dumps/dump_processor_spec.rb
+++ b/spec/models/csv_dumps/dump_processor_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CsvDumps::DumpProcessor do
     processor.execute
   end
 
-  it "push the file to an object store" do
+  it 'push the file to an object store' do
     path = double
     allow(csv_dump).to receive(:gzip!).and_return(path)
     allow(medium).to receive(:put_file_with_retry)
@@ -37,7 +37,7 @@ RSpec.describe CsvDumps::DumpProcessor do
     expect(medium).to have_received(:put_file_with_retry).with(path, compressed: true).once
   end
 
-  it "should clean up the file after sending to object store" do
+  it 'cleans up the file after sending to object store' do
     expect(csv_dump).to receive(:cleanup!).once
     processor.execute
   end

--- a/spec/support/dump_worker.rb
+++ b/spec/support/dump_worker.rb
@@ -11,9 +11,10 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
       worker.perform(another_project.id, "project")
     end
 
-    it "should not push a file to s3" do
-      expect(worker).to_not receive(:write_to_s3)
-      worker.perform(another_project.id, "project")
+    it 'does not write the file to a remote object store' do
+      allow(worker).to receive(:write_to_object_store)
+      worker.perform(another_project.id, 'project')
+      expect(worker).not_to have_received(:write_to_object_store)
     end
 
     it "should not queue a worker to send an email" do


### PR DESCRIPTION
This PR adds a retry mechanism around `put_file` on the Medium resource when uploading to the remote object store. 

When exporting data, the exports are created on the file system and the files have been compressed but when uploading to the object store (s3, azure blob, etc) the `put_file` call fails (e.g. `Faraday::ConnectionFailed: Connection reset by peer`) and the export never finishes and the UX shows broken export requests. 

The problem is outlined in this error https://app.honeybadger.io/projects/40595/faults/78910693

This error is transient thus we can't really predict the failure mode, thus using the retry mechanism seems a reasonable approach to attempt to avoid this error. Longer term having the our network or object store provider not error on upload seems a more reasonable solution. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
