### PR TITLE
explicitly handle error when subject set is empty

### DIFF
--- a/spec/workers/subject_set_completeness_worker_spec.rb
+++ b/spec/workers/subject_set_completeness_worker_spec.rb
@@ -85,5 +85,15 @@ RSpec.describe SubjectSetCompletenessWorker do
         }.to(0.0)
       end
     end
+
+    context 'with no subjects in the subect set' do
+      let(:subject_set) { create(:subject_set) }
+
+      it 'raises a custom EmptySubjectSet error' do
+        expect {
+          worker.perform(subject_set.id, workflow.id)
+        }.to raise_error(SubjectSetCompletenessWorker::EmptySubjectSet, "No subjets in subject set: #{subject_set.id}")
+      end
+    end
   end
 end


### PR DESCRIPTION
linked to #3450

avoid trying to set NaN values in the DB (0.0 / 0.0), instead raise a custom error which we may ingore longer term via HB via something like 
```
Honeybadger.configure do |config|
  config.exceptions.ignore << SubjectSetCompletenessWorker::EmptySubjectSet
end
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
