### PR TITLE
Use explicit json type graphql

### DIFF
--- a/app/graphql/json_type.rb
+++ b/app/graphql/json_type.rb
@@ -1,9 +1,0 @@
-require 'json'
-
-JsonType = GraphQL::ScalarType.define do
-  name "JsonType"
-  description "Arbitrary JSON object"
-
-  coerce_input ->(value, ctx) { value }
-  coerce_result ->(value, ctx) { value }
-end

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -16,7 +16,7 @@ module Types
       blogs and social media accounts."
 
     field :private, Boolean, null: false
-    field :configuration, JsonType, null: true
+    field :configuration, GraphQL::Types::JSON, null: true
     field :live, Boolean, null: false
     field :migrated, Boolean, null: false
     field :slug, String, null: false


### PR DESCRIPTION
Related to #3653 - app fails to boot due to deprecated type. 

This PR switches away from a custom JSON type to the one provided in the graphql gem - added in rmosolgo/graphql-ruby#2227

Tested locally and with this patch the app now boots

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
