### PR TITLE
only count subjects that are in the subject set

### DIFF
--- a/app/counters/subject_set_workflow_counter.rb
+++ b/app/counters/subject_set_workflow_counter.rb
@@ -11,12 +11,8 @@ class SubjectSetWorkflowCounter
   # count the number of subjects in this subject set
   # that have been retired for this workflow
   def retired_subjects
-    scope =
-      SubjectWorkflowStatus
-      .where(workflow: workflow_id)
-      .joins(workflow: :subject_sets)
-      .where(subject_sets: { id: subject_set_id })
-      .retired
+    sms_subject_ids_scope = SetMemberSubject.where(subject_set_id: subject_set_id).select(:subject_id)
+    scope = SubjectWorkflowStatus.where(workflow: workflow_id).where(subject_id: sms_subject_ids_scope).retired
 
     scope.count
   end

--- a/spec/counters/subject_set_workflow_counter_spec.rb
+++ b/spec/counters/subject_set_workflow_counter_spec.rb
@@ -12,13 +12,28 @@ describe SubjectSetWorkflowCounter do
       expect(counter.retired_subjects).to eq(0)
     end
 
-    context 'with retired_subjects' do
+    context 'with retired, unretired and unrelated subjects' do
       let(:subject_to_retire) { subject_set.subjects.first }
+      let(:subject_not_retired) { subject_set.subjects.last }
+      let(:another_subject_set) { create(:subject_set_with_subjects, num_workflows: 1, workflows: [workflow], num_subjects: 1) }
+      let(:another_subject_set_subject) { another_subject_set.subjects.first }
 
       before do
+        # retired subject in the set
         SubjectWorkflowStatus.create(
           workflow_id: workflow.id,
           subject_id: subject_to_retire.id,
+          retired_at: Time.now.utc
+        )
+        # unretired subject in the set
+        SubjectWorkflowStatus.create(
+          workflow_id: workflow.id,
+          subject_id: subject_not_retired.id
+        )
+        # retired subject in another unrelated set
+        SubjectWorkflowStatus.create(
+          workflow_id: workflow.id,
+          subject_id: another_subject_set_subject.id,
           retired_at: Time.now.utc
         )
       end


### PR DESCRIPTION
ensure we only count retired subjects in the subject set, not all subjects that are linked to a workflow

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
