### PR TITLE
Improve subject set import error handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,7 @@ Rails/SkipsModelValidations:
   AllowedMethods:
   - update_all
   - update_column
+  - update_columns
   - touch
 
 RSpec/MultipleMemoizedHelpers:

--- a/app/workers/subject_set_import_worker.rb
+++ b/app/workers/subject_set_import_worker.rb
@@ -1,6 +1,9 @@
 class SubjectSetImportWorker
   include Sidekiq::Worker
 
+  # skip retries for this job to avoid re-running imports with errors
+  sidekiq_options retry: 0, queue: :data_medium
+
   def perform(subject_set_import_id)
     subject_set_import = SubjectSetImport.find(subject_set_import_id)
     subject_set_import.import!

--- a/spec/models/subject_set_import/processor_spec.rb
+++ b/spec/models/subject_set_import/processor_spec.rb
@@ -1,20 +1,55 @@
-describe SubjectSetImport::Processor do
-  let(:subject_set) { create :subject_set }
-  let(:user) { create :user }
+# frozen_string_literal: true
 
-  let(:locations) { [{"image/jpeg" => "https://example.org/image.jpg"}] }
-  let(:metadata) { {"a" => 1, "b" => 2} }
+require 'spec_helper'
+
+describe SubjectSetImport::Processor do
+  let(:subject_set) { create(:subject_set) }
+  let(:user) { create(:user) }
+  let(:locations) { [{ 'image/jpeg' => 'https://example.org/image.jpg' }] }
+  let(:metadata) { { 'a' => 1, 'b' => 2 } }
+  let(:processor) { described_class.new(subject_set, user) }
+  let(:run_import) do
+    processor.import(1, { locations: locations, metadata: metadata })
+  end
 
   it 'imports new subjects' do
-    processor = described_class.new(subject_set, user)
-    processor.import(1, {locations: locations, metadata: metadata})
-
+    run_import
     expect(subject_set.subjects.count).to eq(1)
+  end
 
-    expect(subject_set.subjects.first.locations[0].external_link).to be_truthy
-    expect(subject_set.subjects.first.locations[0].content_type).to eq("image/jpeg")
-    expect(subject_set.subjects.first.locations[0].src).to eq(locations[0]["image/jpeg"])
-
+  it 'sets metadata correctly' do
+    run_import
     expect(subject_set.subjects.first.metadata).to eq(metadata)
+  end
+
+  describe 'imported locations' do
+    let(:imported_location) { subject_set.subjects.first.locations[0] }
+
+    before { run_import }
+
+    it 'sets external_link correctly' do
+      expect(imported_location.external_link).to be_truthy
+    end
+
+    it 'sets content_type correctly' do
+      expect(imported_location.content_type).to eq('image/jpeg')
+    end
+
+    it 'sets src correctly' do
+      expect(imported_location.src).to eq(locations[0]['image/jpeg'])
+    end
+  end
+
+  context 'when a record fails to save!' do
+    let(:subject_double) { Subject.new }
+
+    before do
+      allow(subject_double).to receive(:save!).and_raise(ActiveRecord::RecordInvalid, subject_double)
+      allow(processor).to receive(:find_or_initialize_subject).and_return(subject_double)
+    end
+
+    it 'raises a relevant error' do
+      expect { run_import }.to raise_error(SubjectSetImport::Processor::FailedImport)
+    end
   end
 end

--- a/spec/workers/subject_set_import_worker_spec.rb
+++ b/spec/workers/subject_set_import_worker_spec.rb
@@ -3,6 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe SubjectSetImportWorker do
+  # avoid re-running the import on failures
+  it 'does not retry imports' do
+    retry_count = described_class.get_sidekiq_options['retry']
+    expect(retry_count).to eq(0)
+  end
+
   describe '#perform' do
     let(:import_double) do
       instance_double(SubjectSetImport, id: 1, import!: true, subject_set_id: 1)


### PR DESCRIPTION
A follow up to good questions in https://github.com/zooniverse/panoptes/pull/3706#pullrequestreview-780311850

This PR improves the SubjectSetImport behaviour by not failing on individual subject import errors but instead this system will now:
1. log the external UUID in the `failed_uuids` list on the SubjectImport model (accessible by the uploading user)
2. record the number of failed individual subject imports in the `failed_count` on the SubjectImport model
3. stop the import worker running multiple times when there is an error (avoid reprocessing)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
