### PR TITLE
Subject set import use bulk Active Record Import and batching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,7 @@ Rails/SkipsModelValidations:
   AllowedMethods:
   - update_all
   - update_column
+  - update_columns
   - touch
 
 RSpec/MultipleMemoizedHelpers:

--- a/app/models/subject_set_import.rb
+++ b/app/models/subject_set_import.rb
@@ -4,44 +4,59 @@ class SubjectSetImport < ActiveRecord::Base
   belongs_to :subject_set
   belongs_to :user
 
-  def import!(update_progress_every_rows=500)
+  # TODO: move this behaviour to an operation class - out of the model
+  def import!(batch_size=500)
     processor = SubjectSetImport::Processor.new(subject_set, user)
 
     UrlDownloader.stream(source_url) do |io|
+
       csv_import = SubjectSetImport::CsvImport.new(io)
 
       # store the number of data lines in our manifest for progress reporting
       update_column(:manifest_count, csv_import.count)
 
-      imported_row_count = 0
-
-      csv_import.each do |external_id, attributes|
-        begin
-          processor.import(external_id, attributes)
-        rescue SubjectSetImport::Processor::FailedImport
-          update_columns(
-            # increment the failed_count field
-            failed_count: failed_count + 1,
-            # log the failed external unique identifier
-            failed_uuids: failed_uuids | [external_id]
-          )
+      # import the data in batch_size
+      import_batch = csv_import.to_a
+      import_batch.in_groups_of(batch_size, false) do |batch|
+        subjects_to_import = []
+        batch.each do |external_id, attributes|
+          subjects_to_import << processor.import(external_id, attributes)
         end
+        # build import the subject and associated media resource records
+        import_results = Subject.import(subjects_to_import, recursive: true)
+        # update the import success and failure values
+        save_imported_row_count(import_results.ids.size)
+        save_failed_import_rows(import_results.failed_instances)
 
-        imported_row_count += 1
-
-        # update the imported_count as we progress through the import
-        # so we can use this as a progress metric on API resource polling
-        save_imported_row_count(imported_row_count) if (imported_row_count % update_progress_every_rows).zero?
+        # link the imported subjects to the correct subject_set
+        set_member_subjects_to_import = import_results.ids.map do |subject_id|
+          SetMemberSubject.new(subject_set_id: subject_set.id, subject_id: subject_id, random: rand)
+        end
+        # and build import the batch
+        SetMemberSubject.import(set_member_subjects_to_import, validate: false)
       end
-
-      # finish reporting the number of imported records
-      save_imported_row_count(imported_row_count)
     end
   end
 
   private
 
   def save_imported_row_count(imported_row_count)
-    update_column(:imported_count, imported_row_count)
+    return if imported_row_count.zero?
+
+    self.class.where(id: id).update_all("imported_count = imported_count + #{imported_row_count}")
+  end
+
+  def save_failed_import_rows(failed_instances)
+    failed_import_row_uuids = failed_instances.map(&:external_id)
+    failed_import_row_count = failed_import_row_uuids.size
+    return if failed_import_row_count.zero?
+
+    update_statements = [
+      # increment the failed_count field by num of failures
+      "failed_count = failed_count + #{failed_import_row_count}",
+      # record the failed external unique identifiers
+      'failed_uuids = failed_uuids || array[?]::varchar[]'
+    ].join(',')
+    self.class.where(id: id).update_all([update_statements, failed_import_row_uuids])
   end
 end

--- a/app/models/subject_set_import/csv_import.rb
+++ b/app/models/subject_set_import/csv_import.rb
@@ -36,6 +36,15 @@ class SubjectSetImport::CsvImport
     end
   end
 
+  # TODO: spec this out
+  def to_a
+    [].tap do |import_batch|
+      each do |external_id, attributes|
+        import_batch << [external_id, attributes]
+      end
+    end
+  end
+
   private
 
   def extract_header(header)

--- a/app/workers/subject_set_import_worker.rb
+++ b/app/workers/subject_set_import_worker.rb
@@ -1,6 +1,9 @@
 class SubjectSetImportWorker
   include Sidekiq::Worker
 
+  # skip retries for this job to avoid re-running imports with errors
+  sidekiq_options retry: 0, queue: :data_medium
+
   def perform(subject_set_import_id)
     subject_set_import = SubjectSetImport.find(subject_set_import_id)
     subject_set_import.import!

--- a/spec/models/subject_set_import/processor_spec.rb
+++ b/spec/models/subject_set_import/processor_spec.rb
@@ -1,20 +1,55 @@
-describe SubjectSetImport::Processor do
-  let(:subject_set) { create :subject_set }
-  let(:user) { create :user }
+# frozen_string_literal: true
 
-  let(:locations) { [{"image/jpeg" => "https://example.org/image.jpg"}] }
-  let(:metadata) { {"a" => 1, "b" => 2} }
+require 'spec_helper'
+
+describe SubjectSetImport::Processor do
+  let(:subject_set) { create(:subject_set) }
+  let(:user) { create(:user) }
+  let(:locations) { [{ 'image/jpeg' => 'https://example.org/image.jpg' }] }
+  let(:metadata) { { 'a' => 1, 'b' => 2 } }
+  let(:processor) { described_class.new(subject_set, user) }
+  let(:run_import) do
+    processor.import(1, { locations: locations, metadata: metadata })
+  end
 
   it 'imports new subjects' do
-    processor = described_class.new(subject_set, user)
-    processor.import(1, {locations: locations, metadata: metadata})
-
+    run_import
     expect(subject_set.subjects.count).to eq(1)
+  end
 
-    expect(subject_set.subjects.first.locations[0].external_link).to be_truthy
-    expect(subject_set.subjects.first.locations[0].content_type).to eq("image/jpeg")
-    expect(subject_set.subjects.first.locations[0].src).to eq(locations[0]["image/jpeg"])
-
+  it 'sets metadata correctly' do
+    run_import
     expect(subject_set.subjects.first.metadata).to eq(metadata)
+  end
+
+  describe 'imported locations' do
+    let(:imported_location) { subject_set.subjects.first.locations[0] }
+
+    before { run_import }
+
+    it 'sets external_link correctly' do
+      expect(imported_location.external_link).to be_truthy
+    end
+
+    it 'sets content_type correctly' do
+      expect(imported_location.content_type).to eq('image/jpeg')
+    end
+
+    it 'sets src correctly' do
+      expect(imported_location.src).to eq(locations[0]['image/jpeg'])
+    end
+  end
+
+  context 'when a record fails to save!' do
+    let(:subject_double) { Subject.new }
+
+    before do
+      allow(subject_double).to receive(:save!).and_raise(ActiveRecord::RecordInvalid, subject_double)
+      allow(processor).to receive(:find_or_initialize_subject).and_return(subject_double)
+    end
+
+    it 'raises a relevant error' do
+      expect { run_import }.to raise_error(SubjectSetImport::Processor::FailedImport)
+    end
   end
 end

--- a/spec/workers/subject_set_import_worker_spec.rb
+++ b/spec/workers/subject_set_import_worker_spec.rb
@@ -3,6 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe SubjectSetImportWorker do
+  # avoid re-running the import on failures
+  it 'does not retry imports' do
+    retry_count = described_class.get_sidekiq_options['retry']
+    expect(retry_count).to eq(0)
+  end
+
   describe '#perform' do
     let(:import_double) do
       instance_double(SubjectSetImport, id: 1, import!: true, subject_set_id: 1)


### PR DESCRIPTION
This PR switches the subject set import processing paradigm from individual row to Subject records imports N x 3 db inserts** for each row in the manifest to using https://github.com/zdennis/activerecord-import/ to optimize the db insert calls and import the manifest in batches. This change results in 3 DB insert calls per batch (1 x list of subject, 1 x list of media resources, 1 x list of links to the subject set)

** N x 3 == 1 subject inserts 1 media and 1 subject set record for each subject

this PR builds on top of #3710 and will need a rebase once that's in. 

### TODO
- [ ] Lots - this is a mvp PR to determine if it's worth pursuing this avenue

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
