### PR TITLE
move worker specs to faster run group

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       matrix:
         spec-commands:
-          - 'spec/controllers/api/v1/[a-m]*.rb spec/serializers spec/workers'
-          - 'spec/controllers/api/v1/[n-s]*.rb spec/operations spec/counters'
+          - 'spec/controllers/api/v1/[a-m]*.rb spec/counters spec/operations spec/serializers spec/workers'
+          - 'spec/controllers/api/v1/[n-s]*.rb'
           - 'spec/controllers/api/v1/[t-z]*.rb spec/controllers/**.rb spec/lib spec/requests'
           - 'spec/controllers/api/*.rb spec/mailers spec/middleware spec/models spec/policies spec/routes spec/services'
     steps:


### PR DESCRIPTION
PR relates to the GH Actions CI runs and balancing the run times of these to avoid 1 long running spec group

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
