### PR TITLE
Subject set level classification exports

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
   include FilterByMetadata
   include MediumResponse
 
-  require_authentication %i[create update destroy create_classifications_export], scopes: [:project]
+  require_authentication :create, :update, :destroy, :create_classifications_export, scopes: [:project]
   resource_actions :default
   schema_type :json_schema
   prepend_before_action :require_login, only: %i[create update destroy create_classifications_export]

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::SubjectSetsController < Api::ApiController
   include JsonApiController::PunditPolicy
   include FilterByMetadata
+  include MediumResponse
 
   require_authentication %i[create update destroy create_classifications_export], scopes: [:project]
   resource_actions :default
@@ -81,8 +82,8 @@ class Api::V1::SubjectSetsController < Api::ApiController
   end
 
   def create_classifications_export
-    # medium = CreateClassificationsExport.with( api_user: api_user, object: controlled_resource ).run!(params)
-    # medium_response(medium)
+    medium = CreateClassificationsExport.with(api_user: api_user, object: controlled_resource).run!(params)
+    medium_response(medium)
   end
 
   protected

--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -2,9 +2,10 @@ class Api::V1::SubjectSetsController < Api::ApiController
   include JsonApiController::PunditPolicy
   include FilterByMetadata
 
-  require_authentication :create, :update, :destroy, scopes: [:project]
+  require_authentication %i[create update destroy create_classifications_export], scopes: [:project]
   resource_actions :default
   schema_type :json_schema
+  prepend_before_action :require_login, only: %i[create update destroy create_classifications_export]
 
   IMPORT_COLUMNS = %w(subject_set_id subject_id random).freeze
 
@@ -77,6 +78,11 @@ class Api::V1::SubjectSetsController < Api::ApiController
         end
       end
     end
+  end
+
+  def create_classifications_export
+    # medium = CreateClassificationsExport.with( api_user: api_user, object: controlled_resource ).run!(params)
+    # medium_response(medium)
   end
 
   protected

--- a/app/models/csv_dumps/classification_scope.rb
+++ b/app/models/csv_dumps/classification_scope.rb
@@ -2,12 +2,11 @@
 
 module CsvDumps
   class ClassificationScope < DumpScope
-    attr_reader :cache, :resource_classifications_scope
+    attr_reader :cache
 
-    def initialize(resource, cache, resource_classifications_scope)
+    def initialize(resource, cache)
       super(resource)
       @cache = cache
-      @resource_classifications_scope = resource_classifications_scope
     end
 
     def each
@@ -35,7 +34,8 @@ module CsvDumps
     end
 
     def completed_resource_classifications
-      resource_classifications_scope
+      resource
+        .classifications
         .complete
         .joins(:workflow)
         .where(workflows: { activated_state: 'active' })

--- a/app/models/csv_dumps/classification_scope.rb
+++ b/app/models/csv_dumps/classification_scope.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
 module CsvDumps
   class ClassificationScope < DumpScope
-    attr_reader :cache
+    attr_reader :cache, :resource_classifications_scope
 
-    def initialize(resource, cache)
+    def initialize(resource, cache, resource_classifications_scope)
       super(resource)
       @cache = cache
+      @resource_classifications_scope = resource_classifications_scope
     end
 
     def each
@@ -32,9 +35,10 @@ module CsvDumps
     end
 
     def completed_resource_classifications
-      resource.classifications
+      resource_classifications_scope
         .complete
-        .joins(:workflow).where(workflows: {activated_state: "active"})
+        .joins(:workflow)
+        .where(workflows: { activated_state: 'active' })
         .includes(:user, :workflow)
     end
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -36,7 +36,7 @@ class Medium < ActiveRecord::Base
 
   def linked_resource_details
     # field_guide has a _ in it so manually find it vs prefix_*
-    details = /\A(?<resource>field_guide|[a-z]+)_(?<media_type>\w+)/i.match(type)
+    details = /\A(?<resource>field_guide|subject_set|[a-z]+)_(?<media_type>\w+)/i.match(type)
     [ details[:resource], details[:media_type] ]
   end
 

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -7,6 +7,12 @@ class SubjectSet < ActiveRecord::Base
   has_many :set_member_subjects, dependent: :destroy
   has_many :subjects, through: :set_member_subjects
   has_many :subject_set_imports, dependent: :destroy
+  has_one :classifications_export,
+          -> { where(type: 'subject_set_classifications_export').order(created_at: :desc) },
+          class_name: 'Medium',
+          as: :linked,
+          inverse_of: :linked
+
   validates_presence_of :project
 
   validates_uniqueness_of :display_name, scope: :project_id

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -29,8 +29,6 @@ class SubjectSet < ActiveRecord::Base
   #
   # it will return classifications for all workflows that this set is linked to
   # it will not return classifiations for subjects across projects
-  #
-  # Q?: do we want to isolate even further perhaps to the workflow level
   def classifications
     Classification
       .where(workflow: workflow_ids)

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -23,4 +23,17 @@ class SubjectSet < ActiveRecord::Base
   def belongs_to_project?(other_project_id)
     project_id == other_project_id
   end
+
+  # custom AR scope to find the classifications that belong to this subject set
+  #
+  # it will return classifications for all workflows that this set is linked to
+  # it will not return classifiations for subjects across projects
+  #
+  # Q?: do we want to isolate even further perhaps to the workflow level
+  def classifications
+    Classification
+      .where(workflow: workflow_ids)
+      .joins('INNER JOIN classification_subjects ON classifications.id = classification_subjects.classification_id')
+      .where(classification_subjects: { subject_id: set_member_subjects.select(:subject_id) })
+  end
 end

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -19,6 +19,7 @@ class SubjectSet < ActiveRecord::Base
 
   scope :expert_sets, -> { where(expert_set: true) }
 
+  delegate :communication_emails, to: :project
 
   def belongs_to_project?(other_project_id)
     project_id == other_project_id

--- a/app/operations/create_or_update_medium.rb
+++ b/app/operations/create_or_update_medium.rb
@@ -9,6 +9,9 @@ class CreateOrUpdateMedium < Operation
         integer
       end
     end
+    # default to private exports by default, can be overiden
+    # by operation input composition `inputs.merge(media: { private: true })`
+    boolean :private, default: -> { true }
   end
 
   def execute

--- a/app/policies/subject_set_policy.rb
+++ b/app/policies/subject_set_policy.rb
@@ -6,7 +6,7 @@ class SubjectSetPolicy < ApplicationPolicy
     end
   end
 
-  scope :index, :show, :update, :destroy, :update_links, :destroy_links, with: Scope
+  scope *%i[index show update destroy create_classifications_export update_links destroy_links], with: Scope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/app/policies/subject_set_policy.rb
+++ b/app/policies/subject_set_policy.rb
@@ -6,7 +6,7 @@ class SubjectSetPolicy < ApplicationPolicy
     end
   end
 
-  scope *%i[index show update destroy create_classifications_export update_links destroy_links], with: Scope
+  scope :index, :show, :update, :destroy, :create_classifications_export, :update_links, :destroy_links, with: Scope
 
   def linkable_projects
     policy_for(Project).scope_for(:update)

--- a/app/workers/concerns/dump_mailer.rb
+++ b/app/workers/concerns/dump_mailer.rb
@@ -12,7 +12,7 @@ class DumpMailer
 
     mailer.perform_async(
       resource.id,
-      resource.class.to_s.downcase,
+      resource.model_name.singular,
       lab_export_url,
       emails
     )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,10 @@ Rails.application.routes.draw do
 
       json_api_resources :workflow_versions, links: [:workflow]
 
-      json_api_resources :subject_sets, links: [:subjects]
+      json_api_resources :subject_sets, links: [:subjects] do
+        media_resources classifications_export: { except: %i[create update] }
+        post '/classifications_export', to: 'subject_sets#create_classifications_export', format: false
+      end
 
       json_api_resources :subject_set_imports, links: [:subject_sets, :users], only: [:index, :show, :create]
 

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -409,7 +409,7 @@ describe Api::V1::SubjectSetsController, type: :controller do
     end
   end
 
-  describe '#create_classifications_export', :focus do
+  describe '#create_classifications_export' do
     let(:test_attr) { :type }
     let(:new_resource) { Medium.find(created_instance_id(api_resource_name)) }
     let(:api_resource_name) { 'media' }

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -408,4 +408,30 @@ describe Api::V1::SubjectSetsController, type: :controller do
       end
     end
   end
+
+  describe '#create_classifications_export', :focus do
+    let(:test_attr) { :type }
+    let(:new_resource) { Medium.find(created_instance_id(api_resource_name)) }
+    let(:api_resource_name) { 'media' }
+    let(:api_resource_attributes) do
+      %w[id src created_at content_type media_type href]
+    end
+    let(:api_resource_links) { [] }
+    let(:resource_class) { Medium }
+    let(:content_type) { 'text/csv' }
+    let(:create_params) do
+      {
+        subject_set_id: subject_set.id,
+        media: {
+          content_type: content_type,
+          metadata: { recipients: [owner.id] }
+        }
+      }
+    end
+
+    it_behaves_like 'is creatable', :create_classifications_export do
+      let(:resource_url) { %r{http://test.host/api/subject_sets/#{subject_set.id}/classifications_export} }
+      let(:test_attr_value) { 'subject_set_classifications_export' }
+    end
+  end
 end

--- a/spec/models/csv_dumps/classification_scope_spec.rb
+++ b/spec/models/csv_dumps/classification_scope_spec.rb
@@ -1,19 +1,41 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CsvDumps::ClassificationScope do
   let(:workflow) { create(:workflow) }
-  let(:inactive_workflow) { create(:workflow, activated_state: "inactive") }
+  let(:inactive_workflow) { create(:workflow, activated_state: 'inactive') }
   let(:project) { workflow.project }
   let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
   let(:classifications) do
     create_list(:classification, 2, project: project, workflow: workflow, subjects: [subject])
   end
-  let!(:unincluded_classification) { create(:classification, project: project, workflow: inactive_workflow, subjects: [subject]) }
   let(:cache) { ClassificationDumpCache.new }
+  let(:classification_lookup_scope) { project.classifications }
+  let(:scope) { described_class.new(project, cache, classification_lookup_scope) }
 
-  let(:scope) { described_class.new(project, cache) }
+  before do
+    classifications
+  end
 
-  it "should find all correctly scoped classifications" do
+  it 'correctly finds and yields the scoped classifications' do
     expect { |b| scope.each(&b) }.to yield_successive_args(*classifications)
+  end
+
+  it 'does not include inactive workflow classification data' do
+    inactive_classification = create(:classification, project: project, workflow: inactive_workflow, subjects: [subject])
+    classifications = []
+    scope.each { |c| classifications << c }
+    expect(classifications).not_to include(inactive_classification)
+  end
+
+  context 'with a custom resource classifications scope' do
+    let(:classification_lookup_scope) { Classification.where(id: classifications.first) }
+
+    it 'uses the injected classification scope'do
+      allow(classification_lookup_scope).to receive(:complete).and_call_original
+      scope.each { |c| }
+      expect(classification_lookup_scope).to have_received(:complete).once
+    end
   end
 end

--- a/spec/models/csv_dumps/classification_scope_spec.rb
+++ b/spec/models/csv_dumps/classification_scope_spec.rb
@@ -4,38 +4,30 @@ require 'spec_helper'
 
 describe CsvDumps::ClassificationScope do
   let(:workflow) { create(:workflow) }
-  let(:inactive_workflow) { create(:workflow, activated_state: 'inactive') }
   let(:project) { workflow.project }
   let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
   let(:classifications) do
     create_list(:classification, 2, project: project, workflow: workflow, subjects: [subject])
   end
   let(:cache) { ClassificationDumpCache.new }
-  let(:classification_lookup_scope) { project.classifications }
-  let(:scope) { described_class.new(project, cache, classification_lookup_scope) }
-
-  before do
-    classifications
-  end
+  let(:scope) { described_class.new(project, cache) }
 
   it 'correctly finds and yields the scoped classifications' do
+    classifications
     expect { |b| scope.each(&b) }.to yield_successive_args(*classifications)
   end
 
-  it 'does not include inactive workflow classification data' do
-    inactive_classification = create(:classification, project: project, workflow: inactive_workflow, subjects: [subject])
-    classifications = []
-    scope.each { |c| classifications << c }
-    expect(classifications).not_to include(inactive_classification)
-  end
+  context 'with inactive workflow classifications' do
+    let(:inactive_workflow) { create(:workflow, project: project, activated_state: 'inactive') }
+    let(:inactive_classification) do
+      create(:classification, project: project, workflow: inactive_workflow, subjects: [subject])
+    end
 
-  context 'with a custom resource classifications scope' do
-    let(:classification_lookup_scope) { Classification.where(id: classifications.first) }
-
-    it 'uses the injected classification scope'do
-      allow(classification_lookup_scope).to receive(:complete).and_call_original
-      scope.each { |c| }
-      expect(classification_lookup_scope).to have_received(:complete).once
+    it 'does not include inactive workflow classification data' do
+      inactive_classification
+      classifications = []
+      scope.each { |c| classifications << c }
+      expect(classifications).not_to include(inactive_classification)
     end
   end
 end

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -102,4 +102,24 @@ describe SubjectSet, :type => :model do
       expect(subject_set.classifications_export).to eq(export)
     end
   end
+
+  describe '#classifications' do
+    let(:subject_set) { create(:subject_set_with_subjects, num_subjects: 1) }
+    let(:workflow) { subject_set.workflows.first }
+    let(:project) { subject_set.project }
+    let(:subject) { subject_set.subjects.first }
+    let(:classification) do
+      create(:classification, project: project, workflow: workflow, subjects: [subject])
+    end
+
+    it 'returns the correct active record scope' do
+      expect(subject_set.classifications).to include(classification)
+    end
+
+    it 'does not include classifications for subjects across project workflows' do
+      other_project_workflow = create(:workflow, project: project, activated_state: 'inactive')
+      other_workflow_classification = create(:classification, project: project, workflow: other_project_workflow, subjects: [subject])
+      expect(subject_set.classifications).not_to include(other_workflow_classification)
+    end
+  end
 end

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -116,6 +116,7 @@ describe SubjectSet, :type => :model do
       expect(subject_set.classifications).to include(classification)
     end
 
+    # TODO: double check this sql on this
     it 'does not include classifications for subjects across project workflows' do
       other_project_workflow = create(:workflow, project: project, activated_state: 'inactive')
       other_workflow_classification = create(:classification, project: project, workflow: other_project_workflow, subjects: [subject])

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -116,7 +116,6 @@ describe SubjectSet, :type => :model do
       expect(subject_set.classifications).to include(classification)
     end
 
-    # TODO: double check this sql on this
     it 'does not include classifications for subjects across project workflows' do
       other_project_workflow = create(:workflow, project: project, activated_state: 'inactive')
       other_workflow_classification = create(:classification, project: project, workflow: other_project_workflow, subjects: [subject])

--- a/spec/models/subject_set_spec.rb
+++ b/spec/models/subject_set_spec.rb
@@ -95,4 +95,11 @@ describe SubjectSet, :type => :model do
       expect { subject_set_import.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe '#classification_export' do
+    it 'has the association' do
+      export = subject_set.build_classifications_export(src: 'test', content_type: 'text/csv')
+      expect(subject_set.classifications_export).to eq(export)
+    end
+  end
 end

--- a/spec/policies/subject_set_policy_spec.rb
+++ b/spec/policies/subject_set_policy_spec.rb
@@ -27,6 +27,11 @@ describe SubjectSetPolicy do
       it "includes subject sets from public projects" do
         expect(resolved_scope).to match_array(public_subject_set)
       end
+
+      it 'correctly resolves the create_classifications_export scope' do
+        scope = PunditScopeTester.new(SubjectSet, api_user)
+        expect(scope.create_classifications_export).to be_empty
+      end
     end
 
     context 'for a normal user' do
@@ -34,6 +39,11 @@ describe SubjectSetPolicy do
 
       it "includes subject sets from public projects" do
         expect(resolved_scope).to match_array(public_subject_set)
+      end
+
+      it 'correctly resolves the create_classifications_export scope' do
+        scope = PunditScopeTester.new(SubjectSet, api_user)
+        expect(scope.create_classifications_export).to be_empty
       end
     end
 
@@ -47,6 +57,11 @@ describe SubjectSetPolicy do
       it 'includes subject sets from owned private projects' do
         expect(resolved_scope).to include(private_subject_set)
       end
+
+      it 'correctly resolves the create_classifications_export scope' do
+        scope = PunditScopeTester.new(SubjectSet, api_user)
+        expect(scope.create_classifications_export).to match_array([public_subject_set, private_subject_set])
+      end
     end
 
     context 'for an admin' do
@@ -55,6 +70,11 @@ describe SubjectSetPolicy do
 
       it 'includes everything' do
         expect(resolved_scope).to include(public_subject_set, private_subject_set)
+      end
+
+      it 'correctly resolves the create_classifications_export scope' do
+        scope = PunditScopeTester.new(SubjectSet, api_user)
+        expect(scope.create_classifications_export).to match_array([public_subject_set, private_subject_set])
       end
     end
   end

--- a/spec/support/dump_worker.rb
+++ b/spec/support/dump_worker.rb
@@ -1,5 +1,7 @@
-RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
+RSpec.shared_examples 'dump worker' do |mailer_class, dump_type|
   let(:another_project) { create(:project) }
+  let(:resource) { project }
+  let(:resource_type) { resource.model_name.singular }
 
   context "when the project id doesn't correspond to a project" do
     before(:each) do
@@ -23,22 +25,18 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
     end
   end
 
-  context "when the project exists" do
-    let(:project_file_name) do
-      "#{dump_type}_#{project.owner.login}_#{project.display_name.downcase.gsub(/\s/, "_")}.csv"
-    end
-
-    it "should create a csv file with the correct number of entries" do
+  context 'when the resource exists' do
+    it 'creates a csv file with the correct number of entries' do
       expect_any_instance_of(CSV).to receive(:<<).exactly(num_entries).times
-      worker.perform(project.id, "project")
+      worker.perform(resource.id, resource_type)
     end
 
     it "should queue a worker to send an email" do
-      expect(mailer_class).to receive(:perform_async).with(project.id,
-                                                           "project",
+      expect(mailer_class).to receive(:perform_async).with(resource.id,
+                                                           resource_type,
                                                            anything,
                                                            [project.owner.email])
-      worker.perform(project.id, "project")
+      worker.perform(resource.id, resource_type)
     end
   end
 
@@ -55,15 +53,15 @@ RSpec.shared_examples "dump worker" do |mailer_class, dump_type|
 
     it 'should email the users in the recipients hash' do
       expect(mailer_class).to receive(:perform_async)
-        .with(anything, "project", anything, array_including(receivers.map(&:email)))
-      worker.perform(project.id, "project", medium.id)
+        .with(anything, resource_type, anything, array_including(receivers.map(&:email)))
+      worker.perform(resource.id, resource_type, medium.id)
     end
 
     context "Dump workers are disabled" do
       before { Panoptes.flipper[:dump_worker_exports].disable }
 
       it "raises an exception" do
-        expect { worker.perform(project.id, "project", medium.id) }.to raise_error(ApiErrors::FeatureDisabled)
+        expect { worker.perform(resource.id, resource_type, medium.id) }.to raise_error(ApiErrors::FeatureDisabled)
       end
     end
   end

--- a/spec/support/dump_worker.rb
+++ b/spec/support/dump_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'dump worker' do |mailer_class, dump_type|
   let(:another_project) { create(:project) }
   let(:resource) { project }
@@ -31,12 +33,17 @@ RSpec.shared_examples 'dump worker' do |mailer_class, dump_type|
       worker.perform(resource.id, resource_type)
     end
 
-    it "should queue a worker to send an email" do
-      expect(mailer_class).to receive(:perform_async).with(resource.id,
-                                                           resource_type,
-                                                           anything,
-                                                           [project.owner.email])
+    it 'queues a worker to send an email' do
+      allow(mailer_class).to receive(:perform_async)
       worker.perform(resource.id, resource_type)
+      expect(mailer_class)
+        .to have_received(:perform_async)
+        .with(
+          resource.id,
+          resource_type,
+          anything,
+          [project.owner.email]
+        )
     end
   end
 

--- a/spec/support/pundit_scope_tester.rb
+++ b/spec/support/pundit_scope_tester.rb
@@ -54,7 +54,7 @@ class PunditScopeTester
     Pundit.policy!(@user, @klass).scope_for(:incomplete)
   end
 
-  # Used by projects controller:
+  # Used by projects, workflows, subejct_sets controller:
   def create_classifications_export
     Pundit.policy!(@user, @klass).scope_for(:create_classifications_export)
   end
@@ -74,7 +74,7 @@ class PunditScopeTester
     Pundit.policy!(@user, @klass).scope_for(:create_workflow_contents_export)
   end
 
-  # Used by projects controller:
+  # Used by workflows controller:
   def retire_subjects
     Pundit.policy!(@user, @klass).scope_for(:retire_subjects)
   end

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ClassificationsDumpWorker do
       end
     end
 
-    context 'with a workflow as a resource', :focus do
+    context 'with a workflow as a resource' do
       it_behaves_like 'dump worker', ClassificationDataMailerWorker, 'workflow_classifications_export' do
         let(:resource) { workflow }
         let(:num_entries) { classifications.size + 1 }

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe ClassificationsDumpWorker do
   let(:worker) { described_class.new }
   let(:workflow) { create(:workflow) }
   let(:project) { workflow.project }
-  let(:subject) { create(:subject, project: project, subject_sets: [create(:subject_set, workflows: [workflow])]) }
+  let(:subject_set) { create(:subject_set, project: project, workflows: [workflow]) }
+  let(:subject) { create(:subject, project: project, subject_sets: [subject_set]) }
   let(:classifications) do
     create_list(:classification, 2, project: project, workflow: workflow, subjects: [subject])
   end
@@ -33,6 +34,20 @@ RSpec.describe ClassificationsDumpWorker do
       end
 
       it_behaves_like "dump worker", ClassificationDataMailerWorker, "project_classifications_export" do
+        let(:num_entries) { classifications.size + 1 }
+      end
+    end
+
+    context 'with a workflow as a resource', :focus do
+      it_behaves_like 'dump worker', ClassificationDataMailerWorker, 'workflow_classifications_export' do
+        let(:resource) { workflow }
+        let(:num_entries) { classifications.size + 1 }
+      end
+    end
+
+    context 'with a subject set as a resource' do
+      it_behaves_like 'dump worker', ClassificationDataMailerWorker, 'subject_set_classifications_export' do
+        let(:resource) { subject_set }
         let(:num_entries) { classifications.size + 1 }
       end
     end

--- a/spec/workers/concerns/dump_mailer_spec.rb
+++ b/spec/workers/concerns/dump_mailer_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 describe DumpMailer do
   let(:users) { create_list(:user, 2) }
   let(:owner) { users.sample }
-  let(:resource) do
-    double(id: 1, class: Project, communication_emails: [owner.email])
-  end
+  let(:resource) { Project.new(id: 1, owner: owner) }
   let(:metadata) { {"recipients" => users.map(&:id) } }
   let(:medium) { instance_double("Medium", id: 2, metadata: metadata) }
   let(:dump_mailer) { described_class.new(resource, medium, "classifications") }


### PR DESCRIPTION
Linked to the work in #3714 

This PR introduces the notion of classification exports at the subject set level. The subject set will now have it's own `classifications_export` resource link. This is created using the existing `CreateClassificationsExport` operation and the `ClassificationsDumpWorker` code.

### TODO
- [x] ensure our export worker can accept the subject set resource
- [x] test the flow of data from the worker to the export creation
- [x] how do we handle rate limiting these exports? Use the existing infra?
- [x] end to end testing of this feature from the API

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
