### PR TITLE
add subject_set id attribute sorting

### DIFF
--- a/app/serializers/subject_set_serializer.rb
+++ b/app/serializers/subject_set_serializer.rb
@@ -7,7 +7,7 @@ class SubjectSetSerializer
              :created_at, :updated_at, :href, :completeness
 
   can_include :project, :workflows
-  can_sort_by :display_name
+  can_sort_by :display_name, :id
   can_filter_by :display_name
 
   preload :workflows


### PR DESCRIPTION
ID is auto incrementing so is a proxy for the created_at attribute but has an index, https://github.com/RestPack/restpack_serializer#sorting

Linked to https://github.com/zooniverse/Panoptes-Front-End/pull/6042

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
