### PR TITLE
correctly preserve the model type string when creating exports

### DIFF
--- a/app/operations/create_classifications_export.rb
+++ b/app/operations/create_classifications_export.rb
@@ -4,7 +4,7 @@ class CreateClassificationsExport < Operation
 
   def execute
     medium = compose(CreateOrUpdateMedium, inputs.merge(type: :classifications_export))
-    ClassificationsDumpWorker.perform_async(object.id, object.class.to_s.downcase, medium.id, api_user.id)
+    ClassificationsDumpWorker.perform_async(object.id, object.model_name.singular, medium.id, api_user.id)
     medium
   end
 end


### PR DESCRIPTION
linked to work in #3719 - ensure we preserve the model name correctly, to derive the object's type string when constantizing

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
