### PR TITLE
Add completeness to subject set workflows

### DIFF
--- a/app/workers/subject_set_completeness_worker.rb
+++ b/app/workers/subject_set_completeness_worker.rb
@@ -30,13 +30,6 @@ class SubjectSetCompletenessWorker
       subject_set_completeness = calculate_subject_set_completeness
     end
 
-    # check if we've got a completeness record for this workflow
-    if (existing_set_completeness = subject_set.completeness[workflow.id.to_s])
-      no_completeness_change = existing_set_completeness.to_d == subject_set_completeness.to_d
-      # return if the completeness state has not changed
-      return if no_completeness_change
-    end
-
     # store these per workflow completeness metric in a json object keyed by the workflow id
     # use the atomic DB json operator to avoid clobbering data in the jsonb attribute by other updates
     # https://www.postgresql.org/docs/11/functions-json.html

--- a/app/workers/subject_set_completeness_worker.rb
+++ b/app/workers/subject_set_completeness_worker.rb
@@ -30,8 +30,12 @@ class SubjectSetCompletenessWorker
       subject_set_completeness = calculate_subject_set_completeness
     end
 
-# ONLY RUN THE FOLLOWING STATE TRANSITIONS IF WE ARE MOVING COMPLETENESS STATES
-
+    # check if we've got a completeness record for this workflow
+    if (existing_set_completeness = subject_set.completeness[workflow.id.to_s])
+      no_completeness_change = existing_set_completeness.to_d == subject_set_completeness.to_d
+      # return if the completeness state has not changed
+      return if no_completeness_change
+    end
 
     # store these per workflow completeness metric in a json object keyed by the workflow id
     # use the atomic DB json operator to avoid clobbering data in the jsonb attribute by other updates

--- a/db/migrate/20211124175756_add_completeness_to_subject_set_workflows.rb
+++ b/db/migrate/20211124175756_add_completeness_to_subject_set_workflows.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCompletenessToSubjectSetWorkflows < ActiveRecord::Migration
   def change
     add_column :subject_sets_workflows, :completeness, :decimal, default: 0.0

--- a/db/migrate/20211124175756_add_completeness_to_subject_set_workflows.rb
+++ b/db/migrate/20211124175756_add_completeness_to_subject_set_workflows.rb
@@ -1,0 +1,5 @@
+class AddCompletenessToSubjectSetWorkflows < ActiveRecord::Migration
+  def change
+    add_column :subject_sets_workflows, :completeness, :decimal, default: 0.0
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 11.11 (Debian 11.11-1.pgdg90+1)
--- Dumped by pg_dump version 11.12
+-- Dumped by pg_dump version 11.14
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1312,7 +1312,8 @@ ALTER SEQUENCE public.subject_sets_id_seq OWNED BY public.subject_sets.id;
 CREATE TABLE public.subject_sets_workflows (
     id integer NOT NULL,
     workflow_id integer,
-    subject_set_id integer
+    subject_set_id integer,
+    completeness numeric DEFAULT 0.0
 );
 
 
@@ -4813,4 +4814,6 @@ INSERT INTO schema_migrations (version) VALUES ('20210602210437');
 INSERT INTO schema_migrations (version) VALUES ('20210729152047');
 
 INSERT INTO schema_migrations (version) VALUES ('20211007125705');
+
+INSERT INTO schema_migrations (version) VALUES ('20211124175756');
 

--- a/spec/workers/subject_set_completeness_worker_spec.rb
+++ b/spec/workers/subject_set_completeness_worker_spec.rb
@@ -126,22 +126,5 @@ RSpec.describe SubjectSetCompletenessWorker do
         expect(SubjectSetCompletedMailerWorker).to have_received(:perform_async).with(subject_set.id)
       end
     end
-
-    context 'when the subject set was already complete' do
-      let(:counter_double) { instance_double(SubjectSetWorkflowCounter, retired_subjects: 2) }
-
-      before do
-        allow(SubjectSetWorkflowCounter).to receive(:new).and_return(counter_double)
-        subject_set.update_column(:completeness, { workflow.id.to_s => '1.0' })
-      end
-
-      it 'does not run the SubjectSetCompletedMailerWorker' do
-        allow(SubjectSet).to receive(:find).with(subject_set.id).and_return(subject_set)
-        allow(subject_set.project).to receive(:notify_on_subject_set_completion?).and_return(true)
-        allow(SubjectSetCompletedMailerWorker).to receive(:perform_async)
-        worker.perform(subject_set.id, workflow.id)
-        expect(SubjectSetCompletedMailerWorker).not_to have_received(:perform_async)
-      end
-    end
   end
 end

--- a/spec/workers/subject_set_completeness_worker_spec.rb
+++ b/spec/workers/subject_set_completeness_worker_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SubjectSetCompletenessWorker do
     create(:subject_set_with_subjects, num_workflows: 1, num_subjects: 2, completeness: { fake_wf_id => 0.8 })
   end
   let(:workflow) { subject_set.workflows.first }
+  let(:subject_sets_workflow) { subject_set.subject_sets_workflows.where(workflow_id: workflow.id).first }
 
   describe '#perform' do
     it 'ignores an unknown subject set' do
@@ -43,6 +44,14 @@ RSpec.describe SubjectSetCompletenessWorker do
         }.to change {
           subject_set.reload.completeness[workflow.id.to_s]
         }.from(nil).to(0.5)
+      end
+
+      it 'stores 0.5 in the linked subject_set_workflows record' do
+        expect {
+          worker.perform(subject_set.id, workflow.id)
+        }.to change {
+          subject_sets_workflow.reload.completeness
+        }.from(0.0).to(0.5)
       end
 
       it 'does not clobber existing per workflow completeness data' do

--- a/spec/workers/subject_set_completeness_worker_spec.rb
+++ b/spec/workers/subject_set_completeness_worker_spec.rb
@@ -126,5 +126,22 @@ RSpec.describe SubjectSetCompletenessWorker do
         expect(SubjectSetCompletedMailerWorker).to have_received(:perform_async).with(subject_set.id)
       end
     end
+
+    context 'when the subject set was already complete' do
+      let(:counter_double) { instance_double(SubjectSetWorkflowCounter, retired_subjects: 2) }
+
+      before do
+        allow(SubjectSetWorkflowCounter).to receive(:new).and_return(counter_double)
+        subject_set.update_column(:completeness, { workflow.id.to_s => '1.0' })
+      end
+
+      it 'does not run the SubjectSetCompletedMailerWorker' do
+        allow(SubjectSet).to receive(:find).with(subject_set.id).and_return(subject_set)
+        allow(subject_set.project).to receive(:notify_on_subject_set_completion?).and_return(true)
+        allow(SubjectSetCompletedMailerWorker).to receive(:perform_async)
+        worker.perform(subject_set.id, workflow.id)
+        expect(SubjectSetCompletedMailerWorker).not_to have_received(:perform_async)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a completeness attribute to the `SubjectSetsWorkflow` resource (the join table between SubjectSets and Workflows) to track completeness outside of the subject set JSON attributes.

The join model is useful for looking up / searching the completeness state of a known subject set - workflow relation vs trying to look through the JSON data model in subject set. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
