### PR TITLE
Admin attribute run completion events

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -107,9 +107,8 @@ class Api::V1::ProjectsController < Api::ApiController
   end
 
   def admin_allowed_params
-    [ :beta_approved, :launch_approved, :redirect,
-      :launched_row_order_position, :beta_row_order_position,
-      :experimental_tools, :featured ]
+    %i[ beta_approved launch_approved redirect launched_row_order_position
+        beta_row_order_position experimental_tools featured run_subject_set_completion_events ]
   end
 
   def build_resource_for_create(create_params)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -169,12 +169,4 @@ class Project < ActiveRecord::Base
   def communication_emails
     users_with_project_roles(%w(owner communications)).pluck(:email)
   end
-
-  def run_subject_set_completion_events?
-    # short term use ENV vars to 'allowlist' projects into this functionality - so we control it
-    # longer term perhaps switch to opt in behaviours via project configuration setting?
-    # or should this be an admin only flag for our control??
-    allow_list_project_ids = ENV.fetch('SUBJECT_SET_COMPLETION_EVENT_PROJECT_IDS', '').split(',').map(&:to_i)
-    allow_list_project_ids.include?(id)
-  end
 end

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -38,6 +38,6 @@ class SubjectSet < ActiveRecord::Base
 
   # delegate method to project but with a more succinct name
   def run_completion_events?
-    project.run_subject_set_completion_events?
+    project.run_subject_set_completion_events
   end
 end

--- a/app/schemas/project_create_schema.rb
+++ b/app/schemas/project_create_schema.rb
@@ -109,6 +109,10 @@ class ProjectCreateSchema < JsonSchema
       end
     end
 
+    property 'run_subject_set_completion_events' do
+      type 'boolean'
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/app/schemas/project_update_schema.rb
+++ b/app/schemas/project_update_schema.rb
@@ -121,6 +121,10 @@ class ProjectUpdateSchema < JsonSchema
       type "string"
     end
 
+    property 'run_subject_set_completion_events' do
+      type 'boolean'
+    end
+
     property "links" do
       type "object"
       additional_properties false

--- a/db/migrate/20211201164326_add_project_run_subject_set_completion_events.rb
+++ b/db/migrate/20211201164326_add_project_run_subject_set_completion_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddProjectRunSubjectSetCompletionEvents < ActiveRecord::Migration
   def change
     add_column :projects, :run_subject_set_completion_events, :boolean, default: false

--- a/db/migrate/20211201164326_add_project_run_subject_set_completion_events.rb
+++ b/db/migrate/20211201164326_add_project_run_subject_set_completion_events.rb
@@ -1,0 +1,5 @@
+class AddProjectRunSubjectSetCompletionEvents < ActiveRecord::Migration
+  def change
+    add_column :projects, :run_subject_set_completion_events, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1060,7 +1060,8 @@ CREATE TABLE public.projects (
     url_labels jsonb,
     workflow_description text,
     researcher_quote text,
-    authentication_invitation text
+    authentication_invitation text,
+    run_subject_set_completion_events boolean DEFAULT false
 );
 
 
@@ -4816,4 +4817,6 @@ INSERT INTO schema_migrations (version) VALUES ('20210729152047');
 INSERT INTO schema_migrations (version) VALUES ('20211007125705');
 
 INSERT INTO schema_migrations (version) VALUES ('20211124175756');
+
+INSERT INTO schema_migrations (version) VALUES ('20211201164326');
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -404,6 +404,10 @@ describe Api::V1::ProjectsController, type: :controller do
       it_behaves_like "admin only option", :experimental_tools, ["survey"]
     end
 
+    describe 'run_subject_set_completion_events attribute' do
+      it_behaves_like 'admin only option', :run_subject_set_completion_events, true
+    end
+
     describe "create talk admin" do
       it 'should queue a talk admin create worker' do
         expect(TalkAdminCreateWorker)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -535,7 +535,7 @@ describe Project, type: :model do
     let(:project) { build(:project) }
     let(:primary_language) { project.primary_language }
 
-    it 'includes the primary langage by default' do
+    it 'includes the primary langage by default', :focus do
       expect(project.available_languages).to match_array([primary_language])
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -551,17 +551,4 @@ describe Project, type: :model do
       expect(project.available_languages).to match_array(expected_languages)
     end
   end
-
-  describe 'run_subject_set_completion_events?' do
-    it 'returns false if the project is not configured to notify' do
-      expect(project.run_subject_set_completion_events?).to eq(false)
-    end
-
-    it 'returns true if the project is configured to notify' do
-      project.id = 1
-      ENV['SUBJECT_SET_COMPLETION_EVENT_PROJECT_IDS'] = project.id.to_s
-      expect(project.run_subject_set_completion_events?).to eq(true)
-      ENV.delete('SUBJECT_SET_COMPLETION_EVENT_PROJECT_IDS')
-    end
-  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -535,7 +535,7 @@ describe Project, type: :model do
     let(:project) { build(:project) }
     let(:primary_language) { project.primary_language }
 
-    it 'includes the primary langage by default', :focus do
+    it 'includes the primary langage by default' do
       expect(project.available_languages).to match_array([primary_language])
     end
 


### PR DESCRIPTION
Follow up PR to the good review points raised in https://github.com/zooniverse/panoptes/pull/3714/files#r760323485

This PR adds a `run_subject_set_completion_events` attribute to project model that defaults to false but can be set via the API by Zoo admins. 

This avoids the need for dev team involvement to activate the "set completion events feature" added in #3714 thus saving the team members time and increasing the turnaround time for project teams 🎉 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
