### PR TITLE
Update project copy end point

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -45,6 +45,7 @@ module Api
       ActiveInteraction::InvalidInteractionError,          with: :unprocessable_entity
     rescue_from Kaminari::ZeroPerPageOperation,            with: :kaminari_zero_page
     rescue_from Api::FeatureDisabled,                      with: :service_unavailable
+    rescue_from Api::MethodNotAllowed,                     with: :method_not_allowed
 
     prepend_before_action :require_login, only: [:create, :update, :destroy]
     prepend_before_action :ban_user, only: [:create, :update, :destroy]

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -94,7 +94,15 @@ class Api::V1::ProjectsController < Api::ApiController
       raise(Api::MethodNotAllowed, error_message)
     end
 
-    ProjectCopyWorker.perform_async(project.id, api_user.id)
+    copied_project = Projects::Copy.with(api_user: api_user).run!(project: project)
+
+
+    # move this response to be a resource crated response ffs
+    # how the fuck are people meant to programatically
+    # interact with this copied resource...
+    # listing all their projects and filtering on the fucking display name...
+    # fuck me.....
+
     head :accepted
   end
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -96,6 +96,11 @@ class Api::V1::ProjectsController < Api::ApiController
 
     copied_project = Projects::Copy.with(api_user: api_user).run!(project: project)
 
+    # TODO: look at creating a new subject set for the VRO use case
+    # perhaps if this end point has an additionaly param payload
+    # "create_subject_set: 'new-subject-setname'"
+    # we can create a new empty subject set here before serializing the response
+
     created_resource_response(copied_project)
   end
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -96,14 +96,7 @@ class Api::V1::ProjectsController < Api::ApiController
 
     copied_project = Projects::Copy.with(api_user: api_user).run!(project: project)
 
-
-    # move this response to be a resource crated response ffs
-    # how the fuck are people meant to programatically
-    # interact with this copied resource...
-    # listing all their projects and filtering on the fucking display name...
-    # fuck me.....
-
-    head :accepted
+    created_resource_response(copied_project)
   end
 
   private

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -91,8 +91,10 @@ class Api::V1::ProjectsController < Api::ApiController
     # check we are copying a template project
     template_project_to_copy = project.configuration.key?('template') && !project.live
     unless template_project_to_copy
-      error_message = "The Project with id #{project.id} does not support copy functionality, check the configuration json has 'template' attribute and the project is not set as 'live'."
-      raise(Api::MethodNotAllowed, error_message)
+      raise(
+        Api::MethodNotAllowed,
+        "Project with id #{project.id} can not be copied, the project must not be 'live' and the configuration json must have the 'template' attribute set"
+      )
     end
 
     operations_params = params.slice(:create_subject_set).merge(project: project)

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -30,4 +30,5 @@ module ApiErrors
       super("Feature has been temporarily disabled")
     end
   end
+  class MethodNotAllowed < PanoptesApiError; end
 end

--- a/app/operations/projects/copy.rb
+++ b/app/operations/projects/copy.rb
@@ -1,0 +1,10 @@
+module Projects
+  class Copy < Operation
+    object :user
+    object :project
+
+    def execute
+      ProjectCopier.new(project.id, user.id).copy
+    end
+  end
+end

--- a/app/operations/projects/copy.rb
+++ b/app/operations/projects/copy.rb
@@ -1,7 +1,10 @@
 module Projects
   class Copy < Operation
-    object :user
     object :project
+    object :user, class: ApiUser, default: -> { api_user }
+
+    validates :user, presence: true
+
 
     def execute
       ProjectCopier.new(project.id, user.id).copy

--- a/app/operations/projects/copy.rb
+++ b/app/operations/projects/copy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Projects
   class Copy < Operation
     object :project

--- a/app/operations/projects/copy.rb
+++ b/app/operations/projects/copy.rb
@@ -4,11 +4,19 @@ module Projects
   class Copy < Operation
     object :project
     object :user, class: ApiUser, default: -> { api_user }
+    string :create_subject_set, default: nil
 
     validates :user, presence: true
 
     def execute
-      ProjectCopier.new(project.id, user.id).copy
+      Project.transaction do
+        copied_project = ProjectCopier.new(project.id, user.id).copy
+
+        # create? a new empty subject set for uploading data with the newly copied a project
+        copied_project.subject_sets.create!(display_name: create_subject_set) if create_subject_set
+
+        copied_project
+      end
     end
   end
 end

--- a/app/operations/projects/copy.rb
+++ b/app/operations/projects/copy.rb
@@ -5,7 +5,6 @@ module Projects
 
     validates :user, presence: true
 
-
     def execute
       ProjectCopier.new(project.id, user.id).copy
     end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -853,7 +853,7 @@ describe Api::V1::ProjectsController, type: :controller do
     it_behaves_like "is deactivatable"
   end
 
-  describe '#copy', :focus do
+  describe '#copy' do
     let(:resource) { create(:private_project, owner: authorized_user, configuration: {template: true} ) }
     let(:req) do
       post :copy, { project_id: resource.id }
@@ -867,14 +867,20 @@ describe Api::V1::ProjectsController, type: :controller do
 
     it 'calls the service operation' do
       operation_double = Projects::Copy.with(api_user: ApiUser.new(nil))
-      allow(operation_double).to receive(:run!)
+      allow(operation_double).to receive(:run!).and_return(resource)
       allow(Projects::Copy).to receive(:with).and_return(operation_double)
       req
       expect(operation_double).to have_received(:run!).with({ project: resource })
     end
 
-    xit 'returns a created resonse ffs' do
-      # flesh this out last
+    it 'return created response code' do
+      req
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'serializes the created resource in the response body' do
+      req
+      expect(created_instance('projects')).not_to be_empty
     end
 
     context 'with an uncopyable project' do

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -921,8 +921,10 @@ describe Api::V1::ProjectsController, type: :controller do
 
       it 'returns a useful error message' do
         req
-        error_message = "The Project with id #{resource.id} does not support copy functionality, check the configuration json has 'template' attribute and the project is not set as 'live'."
-        expect(response.body).to eq(json_error_message(error_message))
+        error_message = json_error_message(
+          "Project with id #{resource.id} can not be copied, the project must not be 'live' and the configuration json must have the 'template' attribute set"
+        )
+        expect(response.body).to eq(error_message)
       end
     end
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -854,10 +854,10 @@ describe Api::V1::ProjectsController, type: :controller do
   end
 
   describe '#copy' do
-    let(:resource) { create(:private_project, owner: authorized_user, configuration: {template: true} ) }
-    let(:req) do
-      post :copy, { project_id: resource.id }
+    let(:resource) do
+      create(:private_project, owner: authorized_user, configuration: { template: true })
     end
+    let(:req) { post :copy, { project_id: resource.id } }
     let(:requesting_user) { authorized_user }
 
     before do

--- a/spec/operations/projects/copy_spec.rb
+++ b/spec/operations/projects/copy_spec.rb
@@ -27,7 +27,7 @@ describe Projects::Copy do
 
   it 'raises an error without project param' do
     expect {
-      operation.run!(operation.run!(params.except(:project)))
+      operation.run!(params.except(:project))
     }.to raise_error(ActiveInteraction::InvalidInteractionError, 'Project is required')
   end
 

--- a/spec/operations/projects/copy_spec.rb
+++ b/spec/operations/projects/copy_spec.rb
@@ -34,7 +34,7 @@ describe Projects::Copy do
   it 'raises an error without api_user param' do
     operation = described_class.with({})
     expect {
-      operation.run!(operation.run!(params))
+      operation.run!(params)
     }.to raise_error(ActiveInteraction::InvalidInteractionError, "User can't be blank")
   end
 

--- a/spec/operations/projects/copy_spec.rb
+++ b/spec/operations/projects/copy_spec.rb
@@ -37,4 +37,21 @@ describe Projects::Copy do
       operation.run!(operation.run!(params))
     }.to raise_error(ActiveInteraction::InvalidInteractionError, "User can't be blank")
   end
+
+  describe 'adding a new empty subject set to the newly copied project' do
+    let(:new_display_name) { 'Tropical F*** Storm' }
+    let(:params) { { project: project_to_copy, create_subject_set: new_display_name } }
+    let(:linked_subject_sets) { copied_project.subject_sets }
+
+    it 'creates one new subject set' do
+      copied_project
+      expect(linked_subject_sets.length).to eq(1)
+    end
+
+    it 'sets the correct display_name for the new subject set' do
+      copied_project
+      new_subject_set = linked_subject_sets.first
+      expect(new_subject_set.display_name).to eq(new_display_name)
+    end
+  end
 end

--- a/spec/operations/projects/copy_spec.rb
+++ b/spec/operations/projects/copy_spec.rb
@@ -5,7 +5,7 @@ describe Projects::Copy do
   let(:api_user) { ApiUser.new(user) }
   let(:operation) { described_class.with(api_user: api_user) }
   let(:project_to_copy) { create(:project, owner: user) }
-  let(:params) { { project: project_to_copy, user: user } }
+  let(:params) { { project: project_to_copy } }
   let(:copied_project) { operation.run!(params) }
 
   it 'sets up the Project copier instance correctly' do
@@ -29,9 +29,10 @@ describe Projects::Copy do
     }.to raise_error(ActiveInteraction::InvalidInteractionError, 'Project is required')
   end
 
-  it 'raises an error without user param' do
+  it 'raises an error without api_user param' do
+    operation = described_class.with({})
     expect {
-      operation.run!(operation.run!(params.except(:user)))
-    }.to raise_error(ActiveInteraction::InvalidInteractionError, 'User is required')
+      operation.run!(operation.run!(params))
+    }.to raise_error(ActiveInteraction::InvalidInteractionError, "User can't be blank")
   end
 end

--- a/spec/operations/projects/copy_spec.rb
+++ b/spec/operations/projects/copy_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Projects::Copy do
+  let(:user) { create :user }
+  let(:api_user) { ApiUser.new(user) }
+  let(:operation) { described_class.with(api_user: api_user) }
+  let(:project_to_copy) { create(:project, owner: user) }
+  let(:params) { { project: project_to_copy, user: user } }
+  let(:copied_project) { operation.run!(params) }
+
+  it 'sets up the Project copier instance correctly' do
+    copier_double = instance_double(ProjectCopier, copy: true)
+    allow(ProjectCopier).to receive(:new).and_return(copier_double)
+    copied_project
+    expect(ProjectCopier).to have_received(:new).with(project_to_copy.id, user.id)
+  end
+
+  it 'calls the project copier copy method' do
+    copier_double = instance_double(ProjectCopier)
+    allow(copier_double).to receive(:copy)
+    allow(ProjectCopier).to receive(:new).and_return(copier_double)
+    copied_project
+    expect(copier_double).to have_received(:copy)
+  end
+
+  it 'raises an error without project param' do
+    expect {
+      operation.run!(operation.run!(params.except(:project)))
+    }.to raise_error(ActiveInteraction::InvalidInteractionError, 'Project is required')
+  end
+
+  it 'raises an error without user param' do
+    expect {
+      operation.run!(operation.run!(params.except(:user)))
+    }.to raise_error(ActiveInteraction::InvalidInteractionError, 'User is required')
+  end
+end

--- a/spec/operations/projects/copy_spec.rb
+++ b/spec/operations/projects/copy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Projects::Copy do


### PR DESCRIPTION
This PR is tied to work on the VRO platform where they will want to quickly spin up projects with existing content in them. As such they need to copy a template project but they need the copied project serialized in the json response so they can programatically interact with the newly copied project without having to search through a list of projects they have access to. 

Thus this PR
- adds an operation to call the ProjectCopier instance
- modifies the copier behaviour to be in-band (not async in a worker)
- serializes the newly copied resource via the HTTP 201 (created) response type
- allows the copier to create a new subject set resource during the copy - used for subsequent data uploads in VRO use case

### TODO
- [x] Add the ability to create a new subject set to the project on the copy operation (avoid a sunsequent API call for the manifest upload preparation step)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
