### PR TITLE
Enforce 10k limit SubjectSetImport manifest uploads

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -17,7 +17,8 @@ module Api
       Subjects::Selector::MissingSubjectSet,
       Subjects::Selector::MissingSubjects,                 with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
-    rescue_from Api::LiveProjectChanges,                   with: :forbidden
+    rescue_from Api::LiveProjectChanges,
+                Api::ImportManifestLimitExceeded,          with: :forbidden
     rescue_from Api::NotLoggedIn,
       Api::UnauthorizedTokenError,
       Operation::Unauthenticated,                          with: :not_authenticated

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -18,7 +18,7 @@ module Api
       Subjects::Selector::MissingSubjects,                 with: :not_found
     rescue_from ActiveRecord::RecordInvalid,               with: :invalid_record
     rescue_from Api::LiveProjectChanges,
-                Api::ImportManifestLimitExceeded,          with: :forbidden
+      SubjectSetImports::CountManifestRows::LimitExceeded, with: :forbidden
     rescue_from Api::NotLoggedIn,
       Api::UnauthorizedTokenError,
       Operation::Unauthenticated,                          with: :not_authenticated

--- a/app/controllers/api/v1/subject_set_imports_controller.rb
+++ b/app/controllers/api/v1/subject_set_imports_controller.rb
@@ -8,12 +8,10 @@ class Api::V1::SubjectSetImportsController < Api::ApiController
   schema_type :json_schema
 
   def create
-    # get a data row count of the incoming manifest
-    manifest_count = count_manifest_rows
-
+    operation = SubjectSetImports::CountManifestRows.with(api_user: api_user)
     # add the count of data rows to store on the SubjectSetImport resource
     # as this count is used for progress reporting while the import runs
-    create_params['manifest_count'] = manifest_count
+    create_params['manifest_count'] = operation.run!(source_url: create_params[:source_url])
 
     super do |subject_set_import|
       SubjectSetImportWorker.perform_async(subject_set_import.id)
@@ -24,29 +22,5 @@ class Api::V1::SubjectSetImportsController < Api::ApiController
     super do |body_params, link_params|
       body_params[:user_id] = api_user.id
     end
-  end
-
-  private
-
-  # TODO: extract this to an operation that returns the manifest count
-  # and avoid the controller test setup cruft
-  # should have done this the first time :(
-  def count_manifest_rows
-    manifest_count = UrlDownloader.stream(create_params[:source_url]) do |io|
-      csv_import = SubjectSetImport::CsvImport.new(io)
-      csv_import.count
-    end
-
-    manifest_row_count_limit = ENV.fetch('SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT', 10000)
-    manifest_is_over_limit = manifest_count > manifest_row_count_limit
-    user_is_not_admin = !api_user.is_admin?
-
-    if user_is_not_admin && manifest_is_over_limit
-      # raise if the incoming manifest is not over the allowed limit
-      error_message = "Manifest row count (#{manifest_count}) exceeds the limit (#{manifest_row_count_limit}) and can not be imported"
-      raise(Api::ImportManifestLimitExceeded, error_message)
-    end
-
-    manifest_count
   end
 end

--- a/app/controllers/api/v1/subject_set_imports_controller.rb
+++ b/app/controllers/api/v1/subject_set_imports_controller.rb
@@ -8,6 +8,13 @@ class Api::V1::SubjectSetImportsController < Api::ApiController
   schema_type :json_schema
 
   def create
+    # get a data row count of the incoming manifest
+    manifest_count = count_manifest_rows
+
+    # add the count of data rows to store on the SubjectSetImport resource
+    # as this count is used for progress reporting while the import runs
+    create_params['manifest_count'] = manifest_count
+
     super do |subject_set_import|
       SubjectSetImportWorker.perform_async(subject_set_import.id)
     end
@@ -17,5 +24,26 @@ class Api::V1::SubjectSetImportsController < Api::ApiController
     super do |body_params, link_params|
       body_params[:user_id] = api_user.id
     end
+  end
+
+  private
+
+  def count_manifest_rows
+    manifest_count = UrlDownloader.stream(create_params[:source_url]) do |io|
+      csv_import = SubjectSetImport::CsvImport.new(io)
+      csv_import.count
+    end
+
+    manifest_row_count_limit = ENV.fetch('SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT', 10000)
+    manifest_is_over_limit = manifest_count > manifest_row_count_limit
+    user_is_not_admin = !api_user.is_admin?
+
+    if user_is_not_admin && manifest_is_over_limit
+      # raise if the incoming manifest is not over the allowed limit
+      error_message = "Manifest row count (#{manifest_count}) exceeds the limit (#{manifest_row_count_limit}) and can not be imported"
+      raise(Api::ImportManifestLimitExceeded, error_message)
+    end
+
+    manifest_count
   end
 end

--- a/app/controllers/api/v1/subject_set_imports_controller.rb
+++ b/app/controllers/api/v1/subject_set_imports_controller.rb
@@ -28,6 +28,9 @@ class Api::V1::SubjectSetImportsController < Api::ApiController
 
   private
 
+  # TODO: extract this to an operation that returns the manifest count
+  # and avoid the controller test setup cruft
+  # should have done this the first time :(
   def count_manifest_rows
     manifest_count = UrlDownloader.stream(create_params[:source_url]) do |io|
       csv_import = SubjectSetImport::CsvImport.new(io)

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -30,4 +30,5 @@ module ApiErrors
       super("Feature has been temporarily disabled")
     end
   end
+  class ImportManifestLimitExceeded < PanoptesApiError; end
 end

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -30,5 +30,4 @@ module ApiErrors
       super("Feature has been temporarily disabled")
     end
   end
-  class ImportManifestLimitExceeded < PanoptesApiError; end
 end

--- a/app/models/subject_set_import.rb
+++ b/app/models/subject_set_import.rb
@@ -10,9 +10,6 @@ class SubjectSetImport < ActiveRecord::Base
     UrlDownloader.stream(source_url) do |io|
       csv_import = SubjectSetImport::CsvImport.new(io)
 
-      # store the number of data lines in our manifest for progress reporting
-      update_column(:manifest_count, csv_import.count)
-
       imported_row_count = 0
 
       csv_import.each do |external_id, attributes|

--- a/app/models/subject_set_import/csv_import.rb
+++ b/app/models/subject_set_import/csv_import.rb
@@ -57,12 +57,4 @@ class SubjectSetImport::CsvImport
     extension = File.extname(url).sub(/\A\./, '')
     Mime::Type.lookup_by_extension(extension).to_s
   end
-
-  def count_records
-    return @count if @count
-
-    @count = csv.count
-    # ensure after counting we rewind the file for all future reads
-    csv.rewind
-  end
 end

--- a/app/models/subject_set_import/csv_import.rb
+++ b/app/models/subject_set_import/csv_import.rb
@@ -1,15 +1,22 @@
 require 'csv'
 
 class SubjectSetImport::CsvImport
-  attr_reader :csv, :count
+  attr_reader :csv
 
   delegate :headers, to: :csv
 
   def initialize(io)
     @csv = CSV.new(io, headers: true)
+  end
+
+  def count
+    return @count if @count
+
     @count = csv.count
     # ensure after counting we rewind the file for all future reads
     csv.rewind
+
+    @count
   end
 
   def each
@@ -49,5 +56,13 @@ class SubjectSetImport::CsvImport
   def mime_type_from_file_extension(url)
     extension = File.extname(url).sub(/\A\./, '')
     Mime::Type.lookup_by_extension(extension).to_s
+  end
+
+  def count_records
+    return @count if @count
+
+    @count = csv.count
+    # ensure after counting we rewind the file for all future reads
+    csv.rewind
   end
 end

--- a/app/operations/subject_set_imports/count_manifest_rows.rb
+++ b/app/operations/subject_set_imports/count_manifest_rows.rb
@@ -2,7 +2,7 @@
 
 module SubjectSetImports
   class CountManifestRows < Operation
-    class ImportManifestLimitExceeded < Error; end
+    class LimitExceeded < Error; end
     string :source_url
     integer :manifest_count, default: -> {
       UrlDownloader.stream(source_url) do |io|
@@ -15,7 +15,7 @@ module SubjectSetImports
       return manifest_count if user_is_admin || manifest_is_under_limit
 
       # raise if the incoming manifest is over the allowed limit
-      raise(ImportManifestLimitExceeded, limit_error_message)
+      raise(LimitExceeded, limit_error_message)
     end
 
     private

--- a/app/operations/subject_set_imports/count_manifest_rows.rb
+++ b/app/operations/subject_set_imports/count_manifest_rows.rb
@@ -15,7 +15,10 @@ module SubjectSetImports
       return manifest_count if user_is_admin || manifest_is_under_limit
 
       # raise if the incoming manifest is over the allowed limit
-      raise(LimitExceeded, limit_error_message)
+      raise(
+        LimitExceeded,
+        "Manifest row count (#{manifest_count}) exceeds the limit (#{manifest_row_count_limit}) and can not be imported"
+      )
     end
 
     private
@@ -30,10 +33,6 @@ module SubjectSetImports
 
     def manifest_is_under_limit
       manifest_count <= manifest_row_count_limit
-    end
-
-    def limit_error_message
-      "Manifest row count (#{manifest_count}) exceeds the limit (#{manifest_row_count_limit}) and can not be imported"
     end
   end
 end

--- a/app/operations/subject_set_imports/count_manifest_rows.rb
+++ b/app/operations/subject_set_imports/count_manifest_rows.rb
@@ -2,7 +2,7 @@
 
 module SubjectSetImports
   class CountManifestRows < Operation
-    class LimitExceeded < Error; end
+    class LimitExceeded < ApiErrors::PanoptesApiError; end
     string :source_url
     integer :manifest_count, default: -> {
       UrlDownloader.stream(source_url) do |io|

--- a/app/operations/subject_set_imports/count_manifest_rows.rb
+++ b/app/operations/subject_set_imports/count_manifest_rows.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module SubjectSetImports
+  class CountManifestRows < Operation
+    class ImportManifestLimitExceeded < Error; end
+    string :source_url
+    integer :manifest_count, default: -> {
+      UrlDownloader.stream(source_url) do |io|
+        csv_import = SubjectSetImport::CsvImport.new(io)
+        csv_import.count
+      end
+    }
+
+    def execute
+      return manifest_count if user_is_admin || manifest_is_under_limit
+
+      # raise if the incoming manifest is over the allowed limit
+      raise(ImportManifestLimitExceeded, limit_error_message)
+    end
+
+    private
+
+    def manifest_row_count_limit
+      ENV.fetch('SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT', 10000)
+    end
+
+    def user_is_admin
+      api_user.is_admin?
+    end
+
+    def manifest_is_under_limit
+      manifest_count <= manifest_row_count_limit
+    end
+
+    def limit_error_message
+      "Manifest row count (#{manifest_count}) exceeds the limit (#{manifest_row_count_limit}) and can not be imported"
+    end
+  end
+end

--- a/spec/controllers/api/v1/subject_set_imports_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_set_imports_controller_spec.rb
@@ -38,7 +38,8 @@ describe Api::V1::SubjectSetImportsController, type: :controller do
   describe '#create' do
     let(:test_attr) { :source_url }
     let(:source_url) { 'https://example.org/file.csv' }
-    let(:test_attr_value)  { source_url }
+    let(:test_attr_value) { source_url }
+    let(:data_row_count) { 2 }
     let(:create_params) do
       {
         subject_set_imports: {
@@ -49,31 +50,40 @@ describe Api::V1::SubjectSetImportsController, type: :controller do
         }
       }
     end
+    let(:operation_double) do
+      SubjectSetImports::CountManifestRows.with(api_user: ApiUser.new(nil), source_url: source_url)
+    end
 
     before do
-      allow(UrlDownloader).to receive(:stream).and_yield(true)
-      csv_import_double = instance_double(SubjectSetImport::CsvImport, count: 2)
-      allow(SubjectSetImport::CsvImport).to receive(:new).and_return(csv_import_double)
+      allow(SubjectSetImports::CountManifestRows).to receive(:with).and_return(operation_double)
     end
 
-    it_behaves_like 'is creatable'
+    context 'when the manifest is under the limit' do
+      before do
+        allow(operation_double).to receive(:run!).and_return(data_row_count)
+        default_request scopes: scopes, user_id: authorized_user.id
+      end
 
-    it 'enqueues a worker' do
-      default_request scopes: scopes, user_id: authorized_user.id
-      expect { post :create, create_params }
-        .to change(SubjectSetImportWorker.jobs, :size).by(1)
-    end
+      it_behaves_like 'is creatable'
 
-    it 'sets the manifest_count attribute' do
-      default_request scopes: scopes, user_id: authorized_user.id
-      post :create, create_params
-      import = SubjectSetImport.find(created_instance_id('subject_set_imports'))
-      expect(import.manifest_count).to eq(2)
+      it 'enqueues a worker' do
+        expect { post :create, create_params }
+          .to change(SubjectSetImportWorker.jobs, :size).by(1)
+      end
+
+      it 'sets the manifest_count attribute' do
+        post :create, create_params
+        import = SubjectSetImport.find(created_instance_id('subject_set_imports'))
+        expect(import.manifest_count).to eq(data_row_count)
+      end
     end
 
     context 'when the manifest is over the limit' do
+      let(:error_message) { 'Manifest row count (2) exceeds the limit (1) and can not be imported' }
+      let(:operation_error) { SubjectSetImports::CountManifestRows::LimitExceeded.new(error_message) }
+
       before do
-        allow(ENV).to receive(:fetch).with('SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT', 10000).and_return(1)
+        allow(operation_double).to receive(:run!).and_raise(operation_error)
         default_request scopes: scopes, user_id: authorized_user.id
       end
 
@@ -84,14 +94,8 @@ describe Api::V1::SubjectSetImportsController, type: :controller do
 
       it 'returns a useful error message when the manifest is over the limit' do
         post :create, create_params
-        error_message = json_error_message('Manifest row count (2) exceeds the limit (1) and can not be imported')
-        expect(response.body).to eq(error_message)
-      end
-
-      it 'skips validation for admin uploads' do
-        project.owner.update_column(:admin, true)
-        post :create, create_params.merge(admin: true)
-        expect(response).to have_http_status(:created)
+        returned_error_message = json_error_message(error_message)
+        expect(response.body).to eq(returned_error_message)
       end
     end
   end

--- a/spec/controllers/api/v1/subject_set_imports_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_set_imports_controller_spec.rb
@@ -87,7 +87,7 @@ describe Api::V1::SubjectSetImportsController, type: :controller do
         default_request scopes: scopes, user_id: authorized_user.id
       end
 
-      it 'returns a fobidden status code when the manifest is over the limit' do
+      it 'returns a forbidden status code when the manifest is over the limit' do
         post :create, create_params
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/models/subject_set_import/csv_import_spec.rb
+++ b/spec/models/subject_set_import/csv_import_spec.rb
@@ -58,6 +58,7 @@ describe SubjectSetImport::CsvImport do
 
   describe '#count' do
     it 'returns the correct number of data rows not including headers' do
+      csv_import.count
       expect(csv_import.count).to eq(2)
     end
 

--- a/spec/models/subject_set_import_spec.rb
+++ b/spec/models/subject_set_import_spec.rb
@@ -29,11 +29,6 @@ describe SubjectSetImport, type: :model do
     expect(subject_set.subjects.count).to eq(2)
   end
 
-  it 'stores the count of the expected total subjects' do
-    subject_set_import.import!
-    expect(subject_set_import.reload.manifest_count).to eq(2)
-  end
-
   it 'stores the count of imported subjects' do
     subject_set_import.import!
     expect(subject_set_import.imported_count).to eq(2)

--- a/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
+++ b/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SubjectSetImports::CountManifestRows do
+  let(:source_url) { 'https://example.org/file.csv' }
+  let(:user) { build_stubbed(:user) }
+  let(:api_user) { ApiUser.new(user) }
+  let(:data_row_count) { 2 }
+  let(:operation_params) { { source_url: source_url } }
+  let(:operation) { described_class.with(api_user: api_user) }
+
+  before do
+    allow(UrlDownloader).to receive(:stream).and_yield(true)
+    csv_import_double = instance_double(SubjectSetImport::CsvImport, count: data_row_count)
+    allow(SubjectSetImport::CsvImport).to receive(:new).and_return(csv_import_double)
+  end
+
+  it 'is invalid without the source_url param' do
+    expect {
+      operation.run!(operation_params.except(:source_url))
+    }.to raise_error(ActiveInteraction::InvalidInteractionError, 'Source url is required')
+  end
+
+  it 'returns the data row count of the manifest' do
+    outcome = operation.run!(operation_params)
+    expect(outcome).to eq(data_row_count)
+  end
+
+  context 'when the manifest is over the limit' do
+    before do
+      allow(ENV).to receive(:fetch).with('SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT', 10000).and_return(1)
+    end
+
+    it 'raises an error code when the manifest is over the limit' do
+      expect {
+        operation.run!(operation_params)
+      }.to raise_error(Operation::Error, 'Manifest row count (2) exceeds the limit (1) and can not be imported')
+    end
+
+    it 'skips validation for admin uploads' do
+      allow(api_user).to receive(:is_admin?).and_return(true)
+      expect {
+        operation.run!(operation_params)
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
+++ b/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
@@ -35,10 +35,7 @@ describe SubjectSetImports::CountManifestRows do
     it 'raises an error code when the manifest is over the limit' do
       expect {
         operation.run!(operation_params)
-      }.to raise_error(
-        SubjectSetImports::CountManifestRows::LimitExceeded,
-        'Manifest row count (2) exceeds the limit (1) and can not be imported'
-      )
+      }.to raise_error(SubjectSetImports::CountManifestRows::LimitExceeded, 'Manifest row count (2) exceeds the limit (1) and can not be imported')
     end
 
     it 'skips validation for admin uploads' do

--- a/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
+++ b/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
@@ -35,7 +35,10 @@ describe SubjectSetImports::CountManifestRows do
     it 'raises an error code when the manifest is over the limit' do
       expect {
         operation.run!(operation_params)
-      }.to raise_error(Operation::Error, 'Manifest row count (2) exceeds the limit (1) and can not be imported')
+      }.to raise_error(
+        SubjectSetImports::CountManifestRows::LimitExceeded,
+        'Manifest row count (2) exceeds the limit (1) and can not be imported'
+      )
     end
 
     it 'skips validation for admin uploads' do


### PR DESCRIPTION
This PR ensures we don't allow folks to create SubjectSetImport manifests over a row count limit and thus limit the number of subject records a user imports to a project at any given time (note: all subjects created by this import process are externally hosted).

It does this by counting the incoming manifest data rows before creating a SubjectSetImport resource, thus avoiding the poor UX of erroring while processing and orphaning an resource in an error state (there are no updates on that resource). 

Sadly this means we download the manifest twice**, once on validation check before we create / save the subject set import resource and once when processing. I think that's ok as they shouldn't be very large and the second download is robust via the worker retry mechanisms. 

** We can't pass a tmp download file to the worker system as it runs in a different ruby vm, we could save this file as a resource attachment but I think it's simpler in code / resources to pay the download cost again.

### TODO

- [x] Extract the manifest counter and limit validations to an operation class and cleanup the controller specs (should have done this first)


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
