### PR TITLE
touch updated_at when saving the imported_row_count

### DIFF
--- a/app/models/subject_set_import.rb
+++ b/app/models/subject_set_import.rb
@@ -39,6 +39,7 @@ class SubjectSetImport < ActiveRecord::Base
   private
 
   def save_imported_row_count(imported_row_count)
-    update_column(:imported_count, imported_row_count)
+    self.imported_count = imported_row_count
+    save! # ensure we touch updated_at for busting any serializer cache
   end
 end

--- a/spec/models/subject_set_import_spec.rb
+++ b/spec/models/subject_set_import_spec.rb
@@ -35,7 +35,7 @@ describe SubjectSetImport, type: :model do
   end
 
   # imported_count / manifest_count gives us the progress measure
-  it 'correctly records the progress status during import' do
+  it 'correctly records the progress status during import'do
     allow(subject_set_import).to receive(:save_imported_row_count)
     subject_set_import.import!(2)
     # twice: once when the progress is mod 2 == 0 and once at the end

--- a/spec/models/subject_set_import_spec.rb
+++ b/spec/models/subject_set_import_spec.rb
@@ -35,7 +35,7 @@ describe SubjectSetImport, type: :model do
   end
 
   # imported_count / manifest_count gives us the progress measure
-  it 'correctly records the progress status during import'do
+  it 'correctly records the progress status during import' do
     allow(subject_set_import).to receive(:save_imported_row_count)
     subject_set_import.import!(2)
     # twice: once when the progress is mod 2 == 0 and once at the end


### PR DESCRIPTION
ensure we cache bust the serializer to report the import progress

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
