### PR TITLE
Import manifest import progress reporting

### DIFF
--- a/app/controllers/api/v1/subject_set_imports_controller.rb
+++ b/app/controllers/api/v1/subject_set_imports_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::SubjectSetImportsController < Api::ApiController
     create_params['manifest_count'] = operation.run!(source_url: create_params[:source_url])
 
     super do |subject_set_import|
-      SubjectSetImportWorker.perform_async(subject_set_import.id)
+      SubjectSetImportWorker.perform_async(subject_set_import.id, create_params['manifest_count'])
     end
   end
 

--- a/app/workers/subject_set_import_worker.rb
+++ b/app/workers/subject_set_import_worker.rb
@@ -4,9 +4,9 @@ class SubjectSetImportWorker
   # skip retries for this job to avoid re-running imports with errors
   sidekiq_options retry: 0, queue: :data_medium
 
-  def perform(subject_set_import_id)
+  def perform(subject_set_import_id, manifest_row_count)
     subject_set_import = SubjectSetImport.find(subject_set_import_id)
-    subject_set_import.import!
+    subject_set_import.import!(manifest_row_count)
     SubjectSetSubjectCounterWorker.new.perform(subject_set_import.subject_set_id)
   end
 end

--- a/spec/models/subject_set_import_spec.rb
+++ b/spec/models/subject_set_import_spec.rb
@@ -18,19 +18,19 @@ describe SubjectSetImport, type: :model do
   let(:subject_set_import) do
     described_class.create(source_url: source_url, subject_set: subject_set, user: user)
   end
-  let(:num_lines) { 3 }
+  let(:manifest_row_count) { 2 }
 
   before do
     allow(UrlDownloader).to receive(:stream).with(source_url).and_yield(csv_file)
   end
 
   it 'imports subjects to the set' do
-    subject_set_import.import!
+    subject_set_import.import!(manifest_row_count)
     expect(subject_set.subjects.count).to eq(2)
   end
 
   it 'stores the count of imported subjects' do
-    subject_set_import.import!
+    subject_set_import.import!(manifest_row_count)
     expect(subject_set_import.imported_count).to eq(2)
   end
 
@@ -38,7 +38,7 @@ describe SubjectSetImport, type: :model do
   it 'correctly records the progress status during import' do
     allow(subject_set_import).to receive(:save_imported_row_count)
     allow(SubjectSetImport::ProgressUpdateCadence).to receive(:calculate).and_return(2)
-    subject_set_import.import!(2)
+    subject_set_import.import!(manifest_row_count)
     # twice: once when the progress is mod 2 == 0 and once at the end
     expect(subject_set_import).to have_received(:save_imported_row_count).twice
   end
@@ -51,16 +51,16 @@ describe SubjectSetImport, type: :model do
     end
 
     it 'continues processing' do
-      expect { subject_set_import.import! }.not_to raise_error
+      expect { subject_set_import.import!(manifest_row_count) }.not_to raise_error
     end
 
     it 'stores the failed count' do
-      subject_set_import.import!
+      subject_set_import.import!(manifest_row_count)
       expect(subject_set_import.failed_count).to eq(2)
     end
 
     it 'stores the failed UUIDs' do
-      subject_set_import.import!
+      subject_set_import.import!(manifest_row_count)
       expect(subject_set_import.failed_uuids).to match_array(%w[1 2])
     end
   end

--- a/spec/workers/subject_set_import_worker_spec.rb
+++ b/spec/workers/subject_set_import_worker_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SubjectSetImportWorker do
     let(:count_worker_double) do
       instance_double(SubjectSetSubjectCounterWorker, perform: true)
     end
+    let(:manifest_row_count) { 2 }
 
     before do
       allow(SubjectSetImport).to receive(:find).and_return(import_double)
@@ -23,12 +24,12 @@ RSpec.describe SubjectSetImportWorker do
     end
 
     it 'runs the subjet set import code' do
-      described_class.new.perform(import_double.id)
-      expect(import_double).to have_received(:import!)
+      described_class.new.perform(import_double.id, manifest_row_count)
+      expect(import_double).to have_received(:import!).with(manifest_row_count)
     end
 
     it 'calls the subject set counter worker inline' do
-      described_class.new.perform(import_double.id)
+      described_class.new.perform(import_double.id, manifest_row_count)
       expect(count_worker_double).to have_received(:perform).with(import_double.subject_set_id)
     end
   end


### PR DESCRIPTION
This PR introduces dynamic progress reporting when importing a manifest based on the manifest size. It balances the we balance useful progress reporting cadence against the cost of db updates.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
