### PR TITLE
track when a user has seen a subject

### DIFF
--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -5,12 +5,20 @@ class UserSeenSubject < ActiveRecord::Base
   validates_presence_of :user, :workflow
 
   def self.add_seen_subjects_for_user(user: nil, workflow: nil, subject_ids: nil)
-    uss = where(user: user, workflow: workflow)
-    if uss.exists?
-      uss.update_all(["subject_ids = uniq(subject_ids + array[?])", subject_ids])
-    else
-      uss.create!(subject_ids: subject_ids)
+    newly_created = false
+    uss = where(user: user, workflow: workflow).first_or_create! do |uss_to_create|
+      newly_created = true
+      uss_to_create.user = user
+      uss_to_create.workflow = workflow
+      uss_to_create.subject_ids = subject_ids
     end
+
+    return uss if newly_created
+
+    # existing records we need to uniquely update the subject_ids using an atomic update via update_all
+    where(user: user, workflow: workflow).update_all(['subject_ids = uniq(subject_ids + array[?])', subject_ids])
+    # touch the updated_at timestamp on the record to track when the subject_ids were last modified
+    uss.touch
   end
 
   def self.count_user_activity(user_id, workflow_ids=[])

--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -6,16 +6,11 @@ class UserSeenSubject < ActiveRecord::Base
 
   def self.add_seen_subjects_for_user(user: nil, workflow: nil, subject_ids: nil)
     newly_created = false
-    uss = where(user: user, workflow: workflow).first_or_create! do |uss_to_create|
-      newly_created = true
-      uss_to_create.user = user
-      uss_to_create.workflow = workflow
-      uss_to_create.subject_ids = subject_ids
-    end
-
+    # find or create the USS record and track if it's newly created
+    uss = where(user: user, workflow: workflow).first_or_create!(user: user, workflow: workflow, subject_ids: subject_ids) { |_| newly_created = true }
     return uss if newly_created
 
-    # existing records we need to uniquely update the subject_ids using an atomic update via update_all
+    # uniquely update the subject_ids on existing records using atomic update (update_all)
     where(user: user, workflow: workflow).update_all(['subject_ids = uniq(subject_ids + array[?])', subject_ids])
     # touch the updated_at timestamp on the record to track when the subject_ids were last modified
     uss.touch

--- a/spec/models/user_seen_subject_spec.rb
+++ b/spec/models/user_seen_subject_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe UserSeenSubject, :type => :model do
           user_seen_subject.reload
           expect(user_seen_subject.subject_ids).to include(subject.id)
         end
+
+        it 'touches the updated_at timestamp' do
+          expect { described_class.add_seen_subjects_for_user(params) }.to change { user_seen_subject.reload.updated_at }
+        end
       end
     end
   end


### PR DESCRIPTION
This PR modifies the behaviour of how we track the subject ids a user has seen in the UserSeenSubject record. Specifically we now touch an existing uss record when we update the tracked subject_ids, this allows us to use the USS model as a proxy for when they've last seen a subject on a workflow.

Also this will switch to an explicit `first_or_create!` method to ensure we are still creating the record when we can't find it in the db.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
