### PR TITLE
avoid reporting kinesis payload error for specific projects

### DIFF
--- a/app/workers/publish_classification_worker.rb
+++ b/app/workers/publish_classification_worker.rb
@@ -23,10 +23,14 @@ class PublishClassificationWorker
   end
 
   def publish_to_kinesis!
-    ZooStream.publish(event: "classification",
-                      data: kinesis_data,
-                      linked: kinesis_linked,
-                      shard_by: [classification.workflow_id, classification.subject_ids].flatten.join("-"))
+    ZooStream.publish(
+      event: "classification",
+      data: kinesis_data,
+      linked: kinesis_linked,
+      shard_by: [classification.workflow_id, classification.subject_ids].flatten.join("-")
+    )
+  rescue Aws::Kinesis::Errors::ValidationException => e
+    handle_kinesis_error(e)
   end
 
   def kinesis_data
@@ -35,5 +39,19 @@ class PublishClassificationWorker
 
   def kinesis_linked
     serialized_classification[:linked]
+  end
+
+  def ignore_project_ids_list
+    ENV.fetch('KINESIS_PAYLOAD_SIZE_ERROR_PROJECT_ID_INGORE_LIST', '').split(',')
+  end
+
+  def handle_kinesis_error(error)
+    # Aws::Kinesis::Errors::ValidationException are broad and contain the specific error data in message
+    # therefore only test for these data payload size errors
+    # all others we raise on to keep visibility to kinesis publishing errors
+    raise error unless error.message.include?("Value at 'data' failed to satisfy constraint: Member must have length less than or equal to")
+
+    # re-raise if this classification's project isn't in the ignore list
+    raise error unless ignore_project_ids_list.include?(classification.project_id.to_s)
   end
 end


### PR DESCRIPTION
This PR introduces a change to avoid reporting kinesis publishing errors for some known projects via an 'ignore' list. 

This change came about as some projects don't use the downstream services (caesar etc) - these we can avoid noisy error reports by not reporting. Note all other kinesis publishing errors will be reported and we report all errors for projects that are not on the 'ignore' list

This will be useful to keep the error signal to noise ratio high for debugging possible issue with very large transcription payloads and our k8s nginx ingress.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
