### PR TITLE
add k8s env vars for large kinesis payloads errors

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -95,6 +95,7 @@ data:
   REDIRECTS_BASE: https://www.zooniverse.org
   REDIRECTS_PASSWORD_RESET: /reset-password
   REDIRECTS_UNSUBSCRIBE: /unsubscribe
+  KINESIS_PAYLOAD_SIZE_ERROR_PROJECT_ID_INGORE_LIST: '17097'
   MAILER_ADDRESS: email-smtp.us-east-1.amazonaws.com
   MAILER_DOMAIN: zooniverse.org
   MEMCACHE_SERVERS: 'panoptes-production-memcached:11211'

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -85,6 +85,7 @@ data:
   REDIRECTS_BASE: https://master.pfe-preview.zooniverse.org
   REDIRECTS_PASSWORD_RESET: /#/reset-password
   REDIRECTS_UNSUBSCRIBE: /#/unsubscribe
+  KINESIS_PAYLOAD_SIZE_ERROR_PROJECT_ID_INGORE_LIST: '1873'
   MAILER_ADDRESS: email-smtp.us-east-1.amazonaws.com
   MAILER_DOMAIN: zooniverse.org
   MEMCACHE_SERVERS: 'panoptes-staging-memcached:11211'


### PR DESCRIPTION
ignore known projects with large kinesis payloads to keep this error signal high

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
