### PR TITLE
add failed_count to SubjectSetImport serializer

### DIFF
--- a/app/serializers/subject_set_import_serializer.rb
+++ b/app/serializers/subject_set_import_serializer.rb
@@ -3,7 +3,7 @@ class SubjectSetImportSerializer
   include CachedSerializer
   using Refinements::RangeClamping
 
-  attributes :id, :href, :created_at, :updated_at, :source_url, :imported_count, :manifest_count, :progress
+  attributes :id, :href, :created_at, :updated_at, :source_url, :imported_count, :manifest_count, :failed_count, :progress
   can_include :subject_set, :user
 
   can_filter_by :subject_set, :user


### PR DESCRIPTION
Adds the `failed_count` attribute to the SubjectSetImport resource serializer. This allow teams to monitor the number of failed records on import.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
