### PR TITLE
Handle non public subject import manifests

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -43,6 +43,7 @@ module Api
       RestPack::Serializer::InvalidInclude,
       ActiveRecord::RecordNotUnique,
       Operation::Error,
+      SubjectSetImports::CountManifestRows::ManifestError,
       ActiveInteraction::InvalidInteractionError,          with: :unprocessable_entity
     rescue_from Kaminari::ZeroPerPageOperation,            with: :kaminari_zero_page
     rescue_from Api::FeatureDisabled,                      with: :service_unavailable

--- a/app/operations/subject_set_imports/count_manifest_rows.rb
+++ b/app/operations/subject_set_imports/count_manifest_rows.rb
@@ -2,17 +2,17 @@
 
 module SubjectSetImports
   class CountManifestRows < Operation
-    class LimitExceeded < ApiErrors::PanoptesApiError; end
+    class LimitExceeded < StandardError; end
+    class ManifestError < StandardError; end
     string :source_url
     integer :manifest_count, default: -> {
-      UrlDownloader.stream(source_url) do |io|
-        csv_import = SubjectSetImport::CsvImport.new(io)
-        csv_import.count
-      end
+      count_manifest_data_rows
     }
     integer :manifest_row_count_limit, default: -> {
       ENV.fetch('SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT', 10000).to_i
     }
+
+    attr_reader :manifest
 
     def execute
       return manifest_count if user_is_admin || manifest_is_under_limit
@@ -32,6 +32,15 @@ module SubjectSetImports
 
     def manifest_is_under_limit
       manifest_count <= manifest_row_count_limit
+    end
+
+    def count_manifest_data_rows
+      UrlDownloader.stream(source_url) do |io|
+        csv_import = SubjectSetImport::CsvImport.new(manifest)
+        csv_import.count
+      end
+    rescue UrlDownloader::Failed => e
+      raise ManifestError, "Failed to download manifest: #{source_url}"
     end
   end
 end

--- a/app/operations/subject_set_imports/count_manifest_rows.rb
+++ b/app/operations/subject_set_imports/count_manifest_rows.rb
@@ -12,8 +12,6 @@ module SubjectSetImports
       ENV.fetch('SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT', 10000).to_i
     }
 
-    attr_reader :manifest
-
     def execute
       return manifest_count if user_is_admin || manifest_is_under_limit
 
@@ -36,10 +34,10 @@ module SubjectSetImports
 
     def count_manifest_data_rows
       UrlDownloader.stream(source_url) do |io|
-        csv_import = SubjectSetImport::CsvImport.new(manifest)
+        csv_import = SubjectSetImport::CsvImport.new(io)
         csv_import.count
       end
-    rescue UrlDownloader::Failed => e
+    rescue UrlDownloader::Failed
       raise ManifestError, "Failed to download manifest: #{source_url}"
     end
   end

--- a/app/services/url_downloader.rb
+++ b/app/services/url_downloader.rb
@@ -1,9 +1,18 @@
 class UrlDownloader
+  class Failed < StandardError; end
   def self.stream(url)
     Tempfile.create('panoptes-downloaded-file') do |file|
       HTTParty.get(url, stream_body: true) do |fragment|
+        # follow redirects and keep processing
+        next if [301, 302].include?(fragment.code)
+
+        # any other failure modes we raise, e.g. 404
+        raise Failed, "#{fragment.code} - Failed to download URL: #{url}" unless fragment.code == 200
+
+        # 200 on fetch so we can copy the remote content to the file
         file.write(fragment)
       end
+
       # rewind the file post writing for new reads
       file.rewind
 

--- a/spec/controllers/api/v1/subject_set_imports_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_set_imports_controller_spec.rb
@@ -58,6 +58,21 @@ describe Api::V1::SubjectSetImportsController, type: :controller do
       allow(SubjectSetImports::CountManifestRows).to receive(:with).and_return(operation_double)
     end
 
+    context 'when the manifest is not downloadable' do
+      let(:error_message) { "Failed to download manifest: #{source_url}" }
+
+      before do
+        allow(operation_double).to receive(:run!).and_raise(SubjectSetImports::CountManifestRows::ManifestError, error_message)
+        default_request scopes: scopes, user_id: authorized_user.id
+      end
+
+      it 'returns a useful error message' do
+        post :create, create_params
+        returned_error_message = json_error_message(error_message)
+        expect(response.body).to eq(returned_error_message)
+      end
+    end
+
     context 'when the manifest is under the limit' do
       before do
         allow(operation_double).to receive(:run!).and_return(data_row_count)

--- a/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
+++ b/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
@@ -45,4 +45,26 @@ describe SubjectSetImports::CountManifestRows do
       }.not_to raise_error
     end
   end
+
+  context 'when the manifest is not publically available' do
+    let(:error_message) { '404 - Failed to download URL: $URL' }
+    let(:operation_error_message) { "Failed to download manifest: #{source_url}" }
+
+    before do
+      allow(UrlDownloader).to receive(:stream).and_raise(UrlDownloader::Failed, error_message)
+    end
+
+    it 'raises a relevant error' do
+      expect {
+        operation.run!(operation_params)
+      }.to raise_error(SubjectSetImports::CountManifestRows::ManifestError, operation_error_message)
+    end
+
+    it 'raises an error on admin uploads' do
+      allow(api_user).to receive(:is_admin?).and_return(true)
+      expect {
+        operation.run!(operation_params)
+      }.to raise_error(SubjectSetImports::CountManifestRows::ManifestError, operation_error_message)
+    end
+  end
 end


### PR DESCRIPTION
Add error handling when a manifest source URL can not be downloaded

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
