### PR TITLE
handle any case of #priority subject metadata

### DIFF
--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -29,12 +29,13 @@ class SubjectMetadataWorker
 
   def run_ar5_update
     update_sms_priority_sql =
-      <<-SQL
+      <<-SQL.squish
         UPDATE set_member_subjects
-        SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
+        SET    priority = CAST(value AS NUMERIC)
         FROM   subjects
+        cross join jsonb_each_text(metadata)
         WHERE  subjects.id = set_member_subjects.subject_id
-        AND    subjects.metadata ? '#priority'
+        AND    lower(key) = '#priority'
         AND    set_member_subjects.id IN $1
       SQL
     ActiveRecord::Base.connection.exec_update(
@@ -46,12 +47,13 @@ class SubjectMetadataWorker
 
   def run_ar4_update
     update_sms_priority_sql =
-      <<-SQL
+      <<-SQL.squish
         UPDATE set_member_subjects
-        SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
+        SET    priority = CAST(value AS NUMERIC)
         FROM   subjects
+        cross join jsonb_each_text(metadata)
         WHERE  subjects.id = set_member_subjects.subject_id
-        AND    subjects.metadata ? '#priority'
+        AND    lower(key) = '#priority'
         AND    set_member_subjects.id IN (:sms_ids)
       SQL
     # handle incorrect bind params for non preparted statements

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe SubjectMetadataWorker do
   let(:project) { create :project_with_workflow, owner: user }
   let(:workflow) { project.workflows.first }
   let(:subject_one) do
-    create(:subject, project: project, uploader: project.owner, metadata: {'#priority'=>1/3.0})
+    create(:subject, project: project, uploader: project.owner, metadata: { '#priority' => 1 / 3.0 })
   end
   let(:subject_two) do
-    create(:subject, project: project, uploader: project.owner, metadata: {'#PrioRITy'=>'2'})
+    create(:subject, project: project, uploader: project.owner, metadata: { '#PrioRITy' => '2' })
   end
   let(:subject_set) do
     create(

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SubjectMetadataWorker do
     create(:subject, project: project, uploader: project.owner, metadata: {'#priority'=>1/3.0})
   end
   let(:subject_two) do
-    create(:subject, project: project, uploader: project.owner, metadata: {'#priority'=>'2'})
+    create(:subject, project: project, uploader: project.owner, metadata: {'#PrioRITy'=>'2'})
   end
   let(:subject_set) do
     create(
@@ -39,6 +39,7 @@ RSpec.describe SubjectMetadataWorker do
 
     # TODO: Rails 5 combine the tests to one
     # to test behaviour not AR calling interface
+
     it 'calls the correct RAILS 5 AR methods' do
       stub_const("ActiveRecord::VERSION::MAJOR", 5)
       expect(ActiveRecord::Base.connection)


### PR DESCRIPTION
allow project owners leeway to get the #priority metadata case wrong and still have the same behaviour of correctly specifying the subject selection ordering

This PR changes the case sensitive metadata key lookup to an insensitive one. It relies on the the `jsonb_each_text` function to extract the keys and values from all subject metadata and then we can do a lower case comparison on the `#priority` metadata key. 
https://www.postgresql.org/docs/11/functions-json.html

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
