### PR TITLE
use set display name for naming the export file

### DIFF
--- a/app/models/csv_dumps/finds_medium.rb
+++ b/app/models/csv_dumps/finds_medium.rb
@@ -47,7 +47,7 @@ module CsvDumps
 
     def content_disposition
       case resource
-      when Workflow
+      when Workflow, SubjectSet
         name = resource.display_name.parameterize
       when Project
         name = resource.slug.split("/")[1]

--- a/spec/models/csv_dumps/finds_medium_spec.rb
+++ b/spec/models/csv_dumps/finds_medium_spec.rb
@@ -61,5 +61,18 @@ describe CsvDumps::FindsMedium do
       file_name = "#{name}-#{type}.#{ext}"
       expect(medium.content_disposition).to eq("attachment; filename=\"#{file_name}\"")
     end
+
+    context 'when the resource is a subject-set' do
+      let(:resource) { create :subject_set }
+
+      it 'should update the medium content_disposition' do
+        finder.medium
+        medium.reload
+        type = medium.type.match(/\Aproject_(\w+)_export\z/)[1]
+        ext = MIME::Types[medium.content_type].first.extensions.first
+        file_name = "#{resource.display_name.parameterize}-#{type}.#{ext}"
+        expect(medium.content_disposition).to eq("attachment; filename=\"#{file_name}\"")
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes #3810 

Ensure we set the subject set display name as part of the file export name via the the content-disposition header for per subject set classification exports. 

This PR adds the SubjectSet resource to the lookup types for setting the content disposition and in turn ensures the value is set on the uploaded object store resource to be used when downloading. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
