### PR TITLE
switch to Policy scope lookup

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -25,7 +25,7 @@ module Types
     end
 
     def organization(id:)
-      context[:api_user].scope(klass: Organization, action: :show, ids: id)
+      OrganizationPolicy.new(context[:api_user], Organization).scope_for(:show).where(id: id)
     end
 
     def organizations(**filters)


### PR DESCRIPTION
this PR fixes the graphql organisation scope lookup methods - they were never ported to use the new Pundit policy scope system.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
