### PR TITLE
Email notification for subject set manifest import success / failure

### DIFF
--- a/app/mailers/subject_set_import_completed_mailer.rb
+++ b/app/mailers/subject_set_import_completed_mailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SubjectSetImportCompletedMailer < ApplicationMailer
+  layout false
+
+  def notify_project_team(project, subject_set_import)
+    subject_set = subject_set_import.subject_set
+    lab_url_prefix = "#{Panoptes.frontend_url}/lab/#{project.id}"
+    @subject_set_lab_url = "#{lab_url_prefix}/subject-sets/#{subject_set.id}"
+    @subject_set_name = subject_set.display_name
+    @email_to = project.communication_emails
+    @no_errors = subject_set_import.failed_count.zero?
+
+    import_status = @no_errors ? 'success' : 'completed with errors'
+
+    subject = "Your Zooniverse project - subject set import #{import_status}"
+
+    mail(to: @email_to, subject: subject)
+  end
+end

--- a/app/views/subject_set_import_completed_mailer/notify_project_team.text.erb
+++ b/app/views/subject_set_import_completed_mailer/notify_project_team.text.erb
@@ -1,0 +1,19 @@
+Hi Project Team,
+
+<% if @no_errors %>
+Your Zooniverse project's subject set <%= @subject_set_name %> has completed successfully.
+<% else %>
+There were some errors when importing your manifest to the the subject set <%= @subject_set_name %>.
+<% end %>
+
+Please visit <%= @subject_set_lab_url %> to view the imported subjects from your manifest.
+
+Regards,
+Zooniverse Team
+
+This is an automated email, please do not respond.
+
+To manage your Zooniverse email subscription preferences visit https://zooniverse.org/settings
+
+To unsubscribe to all Zooniverse messages please visit https://zooniverse.org/unsubscribe
+Please be aware that the above link will unsubscribe you from ALL Zooniverse emails.

--- a/app/workers/subject_set_import_completed_mailer_worker.rb
+++ b/app/workers/subject_set_import_completed_mailer_worker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SubjectSetImportCompletedMailerWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_high
+
+  def perform(subject_set_import_id)
+    subject_set_import = SubjectSetImport.find(subject_set_import_id)
+    project = subject_set_import.subject_set.project
+
+    SubjectSetImportCompletedMailer.notify_project_team(project, subject_set_import).deliver
+  end
+end

--- a/app/workers/subject_set_import_worker.rb
+++ b/app/workers/subject_set_import_worker.rb
@@ -8,5 +8,7 @@ class SubjectSetImportWorker
     subject_set_import = SubjectSetImport.find(subject_set_import_id)
     subject_set_import.import!(manifest_row_count)
     SubjectSetSubjectCounterWorker.new.perform(subject_set_import.subject_set_id)
+    # notify the project team about the import success / failure
+    SubjectSetImportCompletedMailerWorker.perform_async(subject_set_import.id)
   end
 end

--- a/spec/mailers/subject_set_import_completed_mailer_spec.rb
+++ b/spec/mailers/subject_set_import_completed_mailer_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SubjectSetImportCompletedMailer, type: :mailer do
+  let(:subject_set) { create(:subject_set, num_workflows: 0) }
+  let(:subject_set_import) { create(:subject_set_import, subject_set: subject_set) }
+  let(:project) { subject_set.project }
+
+  describe '#notify_project_team' do
+    let(:mail) { described_class.notify_project_team(project, subject_set_import) }
+
+    it 'mails the users' do
+      expect(mail.to).to match_array(project.communication_emails)
+    end
+
+    it 'includes the subject' do
+      expect(mail.subject).to include('Your Zooniverse project - subject set import success')
+    end
+
+    it 'includes the subject set name' do
+      expect(mail.body.encoded).to include("subject set #{subject_set.display_name}")
+    end
+
+    it 'includes the subject sets lab link' do
+      expect(mail.body.encoded).to include("#{Panoptes.frontend_url}/lab/#{project.id}/subject-sets/#{subject_set.id}")
+    end
+
+    it 'comes from no-reply@zooniverse.org' do
+      expect(mail.from).to include('no-reply@zooniverse.org')
+    end
+
+    it 'has the success statement' do
+      expect(mail.body.encoded).to include('has completed successfully.')
+    end
+
+    context 'with a failed subject set import' do
+      let(:subject_set_import) { create(:subject_set_import, subject_set: subject_set, failed_count: 1) }
+
+      it 'includes the failed subject suffix' do
+        expect(mail.subject).to include('Your Zooniverse project - subject set import completed with errors')
+      end
+
+      it 'reports the failures statement' do
+        expect(mail.body.encoded).to include('There were some errors when importing your manifest to the the subject set')
+      end
+    end
+  end
+end

--- a/spec/workers/subject_set_import_completed_mailer_worker_spec.rb
+++ b/spec/workers/subject_set_import_completed_mailer_worker_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SubjectSetImportCompletedMailerWorker do
+  let(:subject_set_import) { create(:subject_set_import) }
+
+  it 'delivers the mail' do
+    expect { described_class.new.perform(subject_set_import.id) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  context 'with an unknown subject_set_id' do
+    it 'raises an error so we know about it' do
+      expect { described_class.new.perform(nil) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/workers/subject_set_import_worker_spec.rb
+++ b/spec/workers/subject_set_import_worker_spec.rb
@@ -21,11 +21,17 @@ RSpec.describe SubjectSetImportWorker do
     before do
       allow(SubjectSetImport).to receive(:find).and_return(import_double)
       allow(SubjectSetSubjectCounterWorker).to receive(:new).and_return(count_worker_double)
+      allow(SubjectSetImportCompletedMailerWorker).to receive(:perform_async)
     end
 
     it 'runs the subjet set import code' do
       described_class.new.perform(import_double.id, manifest_row_count)
       expect(import_double).to have_received(:import!).with(manifest_row_count)
+    end
+
+    it 'calls the subject set import mailer worker' do
+      described_class.new.perform(import_double.id, manifest_row_count)
+      expect(SubjectSetImportCompletedMailerWorker).to have_received(:perform_async).with(import_double.subject_set_id)
     end
 
     it 'calls the subject set counter worker inline' do


### PR DESCRIPTION
The Vera Rubin team wants to have an email run letting the project team know when the subject set import (manifest) has been processed. 

This PR introduces a `SubjectSetImportCompleted` mailer with the success / failure status of the subject set import resource. This email is sent after the manifest has imported and is run via an async worker.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
