### PR TITLE
fix metadata reserved keys transform

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -201,6 +201,8 @@ class Api::V1::SubjectsController < Api::ApiController
   end
 
   def downcase_reserved_metadata_keys(params)
+    return unless params.key?(:metadata)
+
     params[:metadata].transform_keys! do |key|
       if RESERVED_METADATA_KEYS.include?(key.downcase)
         key.downcase

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -723,6 +723,14 @@ describe Api::V1::SubjectsController, type: :controller do
         default_request user_id: authorized_user.id, scopes: scopes
       end
 
+      it 'updates without errors without metadata params' do
+        no_metadata_update_params = {
+          id: resource.id,
+          subjects: { locations: locations }
+        }
+        expect { put :update, no_metadata_update_params }.not_to raise_error
+      end
+
       describe "using external urls" do
         let(:external_locs) do
           [


### PR DESCRIPTION
fixes  #3832

fixes a bug introduced in #3815 - this PR will now skip the metadata reserved key transform when metadata params are not present in the update action.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
