### PR TITLE
remove rails logging in CI

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -52,3 +52,4 @@ jobs:
         run: bundle exec rspec ${{ matrix.spec-commands }}
         env:
            RAILS_ENV: test
+           DISABLE_TEST_LOGGING: 1

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,12 @@ Rails.application.configure do
   config.to_prepare do
     Doorkeeper::ApplicationsController.helper Doorkeeper::Helpers::Controller
   end
+
+  if ENV['DISABLE_TEST_LOGGING']
+    # rubocop:disable Rails/Output
+    puts 'Logs are being suppressed to speed up the test suite. ' \
+         'Remove DISABLE_TEST_LOGGING env var to add logging back.'
+    # rubocop:enable Rails/Output
+    config.log_level = :warn
+  end
 end


### PR DESCRIPTION
avoid rails file logging in test CI runs - should help speed up the CI test suite

https://test-prof.evilmartians.io/#/recipes/logging

#### Results

Slight speed up observed in test runs from ~10-30s depending on which spec group runs, see actions for details.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
