### PR TITLE
Manifest source url input validation

### DIFF
--- a/app/operations/subject_set_imports/count_manifest_rows.rb
+++ b/app/operations/subject_set_imports/count_manifest_rows.rb
@@ -2,6 +2,7 @@
 
 module SubjectSetImports
   class CountManifestRows < Operation
+    class InvalidUrl < StandardError; end
     class LimitExceeded < StandardError; end
     class ManifestError < StandardError; end
     string :source_url
@@ -13,6 +14,8 @@ module SubjectSetImports
     }
 
     def execute
+      raise(InvalidUrl, 'Source url is malformed') unless valid_url_format?
+
       return manifest_count if user_is_admin || manifest_is_under_limit
 
       # raise if the incoming manifest is over the allowed limit
@@ -23,6 +26,14 @@ module SubjectSetImports
     end
 
     private
+
+    def valid_url_format?
+      uri = URI.parse(source_url)
+      uri.is_a?(URI::HTTP) && !uri.host.nil?
+    rescue URI::InvalidURIError
+      false
+    end
+
 
     def user_is_admin
       api_user.is_admin?

--- a/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
+++ b/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
@@ -24,7 +24,7 @@ describe SubjectSetImports::CountManifestRows do
 
   it 'is invalid with a non url format source_url param' do
     expect {
-      operation.run!({ source_url: 'just a string'} )
+      operation.run!({ source_url: 'just a string' })
     }.to raise_error(SubjectSetImports::CountManifestRows::ManifestError, 'Source url is malformed')
   end
 

--- a/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
+++ b/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
@@ -22,6 +22,12 @@ describe SubjectSetImports::CountManifestRows do
     }.to raise_error(ActiveInteraction::InvalidInteractionError, 'Source url is required')
   end
 
+  it 'is invalid with a non url format source_url param' do
+    expect {
+      operation.run!({ source_url: 'just a string'} )
+    }.to raise_error(SubjectSetImports::CountManifestRows::InvalidUrl, 'Source url is malformed')
+  end
+
   it 'returns the data row count of the manifest' do
     outcome = operation.run!(operation_params)
     expect(outcome).to eq(data_row_count)

--- a/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
+++ b/spec/operations/subject_set_imports/count_manifest_rows_spec.rb
@@ -25,7 +25,7 @@ describe SubjectSetImports::CountManifestRows do
   it 'is invalid with a non url format source_url param' do
     expect {
       operation.run!({ source_url: 'just a string'} )
-    }.to raise_error(SubjectSetImports::CountManifestRows::InvalidUrl, 'Source url is malformed')
+    }.to raise_error(SubjectSetImports::CountManifestRows::ManifestError, 'Source url is malformed')
   end
 
   it 'returns the data row count of the manifest' do


### PR DESCRIPTION
This PR ensures the subject set manifest import `source_url` param is validated as a URL format vs a normal string. Instead of 500 erroring this will now return a useful error message to the client notifying them that the `source_url` param is invalid

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
