### PR TITLE
link rails logger to logstash logger

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -107,4 +107,6 @@ Rails.application.configure do
   config.logstasher.logger = Logger.new(STDOUT)
   # turn off rails logs
   config.logstasher.suppress_app_log = true
+  # link rails logger to logstasher logger
+  config.logger = config.logstasher.logger
 end


### PR DESCRIPTION
new relic logs via the Rails `config.logger` but we've got logstasher setup on it's own. This PR ties these together to capture application logs via the default logger

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
