### PR TITLE
disable sidekiq new relic logging in prod

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -327,6 +327,8 @@ spec:
             value: '2'
           - name: SIDEKIQ_ARGS
             value: '-q dumpworker -q really_high -q high -q data_high -q data_medium -q default -q data_low'
+          - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED
+            value: 'false'
           envFrom:
           - secretRef:
               name: panoptes-common-env-vars
@@ -381,6 +383,9 @@ spec:
                 - /rails_app/scripts/docker/sidekiq_status
             initialDelaySeconds: 20
           args: ["/rails_app/scripts/docker/start-sidekiq.sh"]
+          env:
+          - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED
+            value: 'false'
           envFrom:
           - secretRef:
               name: panoptes-common-env-vars


### PR DESCRIPTION
Linked to #3841 - turn off sidekiq logs being sent to new relic in production

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
