### PR TITLE
increase sidekiq RAM limits

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -372,10 +372,10 @@ spec:
           image: ghcr.io/zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "500Mi"
+              memory: "1000Mi"
               cpu: "500m"
             limits:
-              memory: "2000Mi"
+              memory: "4000Mi"
               cpu: "2000m"
           livenessProbe:
             exec:


### PR DESCRIPTION
avoid OOM killer errors by increasing the RAM limits
```
Containers:
  panoptes-production-sidekiq:
    ....
    Args:
      /rails_app/scripts/docker/start-sidekiq.sh
    State:          Running
      Started:      Mon, 13 Jun 2022 18:40:47 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Thu, 09 Jun 2022 09:08:12 +0100
      Finished:     Mon, 13 Jun 2022 18:40:46 +0100
    Ready:          True
    Restart Count:  1
    Limits:
      cpu:     2
      memory:  2000Mi
```


Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
