### PR TITLE
fix ProjectRolesController spec failure

### DIFF
--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -175,14 +175,14 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
     end
 
     context "mailers" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user).id.to_s }
 
       before(:each) do
         default_request scopes: scopes, user_id: authorized_user.id
       end
 
       it "calls the mailer if user added to project" do
-        expect(UserAddedToProjectMailerWorker).to receive(:perform_async).with(user.id.to_i, project.id.to_i, ["collaborator"]).once
+        expect(UserAddedToProjectMailerWorker).to receive(:perform_async).with(user.to_i, project.id.to_i, ["collaborator"]).once
         post :create, create_params
       end
 

--- a/spec/controllers/api/v1/project_roles_controller_spec.rb
+++ b/spec/controllers/api/v1/project_roles_controller_spec.rb
@@ -174,22 +174,23 @@ RSpec.describe Api::V1::ProjectRolesController, type: :controller do
       it_behaves_like "no user"
     end
 
-    context "mailers" do
+    describe 'mailers' do
       let(:user) { create(:user).id.to_s }
 
-      before(:each) do
+      before do
         default_request scopes: scopes, user_id: authorized_user.id
+        allow(UserAddedToProjectMailerWorker).to receive(:perform_async)
       end
 
-      it "calls the mailer if user added to project" do
-        expect(UserAddedToProjectMailerWorker).to receive(:perform_async).with(user.to_i, project.id.to_i, ["collaborator"]).once
+      it 'calls the mailer if user added to project as a collaborator' do
         post :create, create_params
+        expect(UserAddedToProjectMailerWorker).to have_received(:perform_async).with(user.to_i, project.id.to_i, ['collaborator']).once
       end
 
-      it "does not call the mailer not appropriate" do
-        create_params[:project_roles][:roles] = ["tester"]
-        expect(UserAddedToProjectMailerWorker).to_not receive(:perform_async)
+      it 'does not call the mailer if no relevant project role changes' do
+        create_params[:project_roles][:roles] = ['tester']
         post :create, create_params
+        expect(UserAddedToProjectMailerWorker).not_to have_received(:perform_async)
       end
     end
 


### PR DESCRIPTION
fix the failing rails 5 spec for project roles controller

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
