### PR TITLE
convert ActionController::Parameters to hash for operation schema

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -20,9 +20,9 @@ class Api::V1::OrganizationsController < Api::ApiController
 
   def create
     @created_resources = Organization.transaction(requires_new: true) do
-      Array.wrap(create_params).map do |organization_params|
+      Array.wrap(create_params.to_h).map do |organization_params|
         operation = Organizations::Create.with(api_user: api_user)
-        operation.run!(schema_create_params: organization_params)
+        operation.run!(schema_create_params: organization_params.to_h)
       end
     end
 
@@ -31,7 +31,7 @@ class Api::V1::OrganizationsController < Api::ApiController
 
   def update
     @updated_resources = Organization.transaction(requires_new: true) do
-      Array.wrap(resource_ids).zip(Array.wrap(update_params)).map do |organization_id, organization_params|
+      Array.wrap(resource_ids).zip(Array.wrap(update_params.to_h)).map do |organization_id, organization_params|
         update_operation = Organizations::Update.with(api_user: api_user, id: organization_id)
         update_operation.run!(schema_update_params: organization_params)
       end


### PR DESCRIPTION
This PR updates Organization create and update controllers to convert the rails 5 `ActionController::Parameters` to hashes for use in the relevant create and update organization operations (these expect hashes not a ActionController params object).

Note in for rails 4 versions calling `.to_h` on a hash is a no-op that returns self, https://ruby-doc.org/core-2.5.9/Hash.html so this should be an inexpensive change to make, either it passes the hash through (rails 4) or converts to hash before the operation runs (rails 5).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
