### PR TITLE
Fix subjects controller spec rails5

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -104,7 +104,7 @@ class Api::V1::SubjectsController < Api::ApiController
 
     # setup the selector params from user input, note validation occurs in the operation class
     selector_param_keys = %i[workflow_id subject_set_id num_rows num_columns http_cache admin]
-    selector_params = params.permit(*selector_param_keys)
+    selector_params = params.permit(*selector_param_keys).to_h
 
     group_selection_result = SubjectGroups::Selection.run!(
       num_rows: selector_params.delete(:num_rows),

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -104,13 +104,13 @@ class Api::V1::SubjectsController < Api::ApiController
 
     # setup the selector params from user input, note validation occurs in the operation class
     selector_param_keys = %i[workflow_id subject_set_id num_rows num_columns http_cache admin]
-    selector_params = params.permit(*selector_param_keys).to_h
+    selector_params = params.permit(*selector_param_keys)
 
     group_selection_result = SubjectGroups::Selection.run!(
       num_rows: selector_params.delete(:num_rows),
       num_columns: selector_params.delete(:num_columns),
       uploader_id: ENV.fetch('SUBJECT_GROUP_UPLOADER_ID'),
-      params: selector_params,
+      params: selector_params.to_h,
       user: api_user
     )
     # get the list of the groups 'placeholder' group_subject ids

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -40,7 +40,7 @@ class Subject < ActiveRecord::Base
       location_params = case loc
                         when String
                           { content_type: standardize_mimetype(loc) }
-                        when Hash
+                        when Hash, ActionController::Parameters
                           {
                             content_type: standardize_mimetype(loc.keys.first),
                             external_link: true,


### PR DESCRIPTION
This PR fixes the subjects controller spec for the rails 5 upgrade. 

Similar issues as faced in #3868 we need to convert the `ActionController::Parameters` to a hash for us in the operation class and we also needed to allow the `ActionController::Parameters` for the subject locations params building method `location_attributes_from_params`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
