### PR TITLE
rails5 project preferences spec fix -convert params hash value to string

### DIFF
--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -87,7 +87,10 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
         project_preferences: {
           user_id: upp.user_id,
           project_id: project.id,
-          settings: { workflow_id: 1234, designator: {subject_set_weights: {1 => 100, 2 => 1000}} }
+          settings: {
+            workflow_id: '1234',
+            designator: { subject_set_weights: { 1 => 100, 2 => 1000 } }
+          }
         }
       }
     end


### PR DESCRIPTION
rails 5 leaves the values intact but converts the keys to strings. however rails 4 converts the values and leaves the keys intact.

fix this spec but take note - it shouldn't really matter but may change some jsonb stored values.

Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
