### PR TITLE
switch instructions to use the BUNDLE_GEMFILE env var for env dual boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,25 @@ https://www.youtube.com/watch?v=6aCfc0DkSFo
 
 #### Install the gems via next
 
+`BUNDLE_GEMFILE=Gemfile.next bundle install`
+
+or
+
 `next bundle install`
 
 ### check for incompatible gems for target rails verion
 
+`BUNDLE_GEMFILE=Gemfile.next bundle exec bundle_report compatibility --rails-version=5.0.7`
+
+or
+
 `next bundle exec bundle_report compatibility --rails-version=5.0.7`
 
 ### check for outdated gems
+
+`BUNDLE_GEMFILE=Gemfile.next bundle exec bundle_report outdated`
+
+or
 
 `next bundle exec bundle_report outdated`
 
@@ -116,18 +128,42 @@ https://www.youtube.com/watch?v=6aCfc0DkSFo
 It's recommeded to enable spring for testing env
 `unset DISABLE_SPRING`
 run all specs for rails 5 gemfile
+`BUNDLE_GEMFILE=Gemfile.next bundle exec rspec`
+
+or
+
 `next bundle exec rspec`
 
 or fail fast
+`BUNDLE_GEMFILE=Gemfile.next bundle exec rspec --fail-fast`
+
+or
+
 `next bundle exec rspec --fail-fast`
 
 or with gaurd (recommended to enable spring)
+`BUNDLE_GEMFILE=Gemfile.next bundle exec guard --no-interactions`
+
+or
+
 `next bundle exec guard --no-interactions`
 
 #### Boot the rails app
 
-`next rails s`
+#### Via Rails server
+
+`BUNDLE_GEMFILE=Gemfile.next rails s`
+
 or
+
+`next rails s`
+
+#### Via Puma
+
+`BUNDLE_GEMFILE=Gemfile.next bundle exec puma -C config/puma.rb`
+
+or
+
 `next bundle exec puma -C config/puma.rb`
 
 ## Contributing


### PR DESCRIPTION
This PR adds instructions for running the switching to rails 5 install of the app vs using the next bin cmd. For some reason outside of docker the next shell script doesn't work, thus we can avoid it an override the gemfile env var to determine the version of next gems. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
