### PR TITLE
add removal note on AR lib extension post landing rails 5.0

### DIFF
--- a/lib/gem_ext/rails/query_methods.rb
+++ b/lib/gem_ext/rails/query_methods.rb
@@ -1,9 +1,9 @@
 # Backported .or query methods from Rails 5.0
 # https://github.com/rails/rails/pull/16052/files
-
-if Gem::Version.new(Rails.version) < Gem::Version.new("5.0")
+#
+# Remove this library extension once the upgrade to Rails 5.0 is done
+if Gem::Version.new(Rails.version) < Gem::Version.new('5.0')
   ActiveRecord::QueryMethods.module_eval do
-
     # Returns a new relation, which is the logical union of this relation and the one passed as an
     # argument.
     #


### PR DESCRIPTION
this PR adds a comment to let folks know this AR library extension code (added AR scope `.or` methods in rails 4.2) can go once we've landed on rails 5.0+

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
