### PR TITLE
convert ActionDispatch::Response::Header to hash for rspec

### DIFF
--- a/spec/requests/v1/api_cors_headers_spec.rb
+++ b/spec/requests/v1/api_cors_headers_spec.rb
@@ -1,26 +1,28 @@
 require 'spec_helper'
 
 shared_examples 'cors headers' do
-  it 'should have Access-Control-Allow-Origin header' do
-    expect(response.headers).to include('Access-Control-Allow-Origin' => '*')
+  let(:hashed_response_headers) { response.headers.to_h }
+
+  it 'has the Access-Control-Allow-Origin header' do
+    expect(hashed_response_headers).to include('Access-Control-Allow-Origin' => '*')
   end
 
-  it 'should have Access-Control-Expose-Headers header' do
-    expect(response.headers).to include('Access-Control-Expose-Headers')
+  it 'has the Access-Control-Expose-Headers header' do
+    expect(hashed_response_headers).to include('Access-Control-Expose-Headers')
   end
 
-  it 'should expose the correct headers' do
+  it 'exposes the correct headers' do
     expect(
       response.headers['Access-Control-Expose-Headers']
     ).to eq('ETag, X-CSRF-Param, X-CSRF-Token')
   end
 
-  it 'should have Access-Control-Allow-Methods header' do
-    expect(response.headers).to include('Access-Control-Allow-Methods' => "DELETE, GET, POST, OPTIONS, PUT, HEAD")
+  it 'has the Access-Control-Allow-Methods header' do
+    expect(hashed_response_headers).to include('Access-Control-Allow-Methods' => 'DELETE, GET, POST, OPTIONS, PUT, HEAD')
   end
 
-  it 'should have the correct Access-Control-Max-Age header' do
-    expect(response.headers).to include('Access-Control-Max-Age' => "300")
+  it 'has the correct Access-Control-Max-Age header' do
+    expect(hashed_response_headers).to include('Access-Control-Max-Age' => '300')
   end
 end
 


### PR DESCRIPTION
Convert to hash for use in rspec `include?` matching https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/include-matcher#hash-usage

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
