### PR TITLE
ensure the id params are converted to strings for lookup

### DIFF
--- a/app/controllers/concerns/polymorphic_resource_scope.rb
+++ b/app/controllers/concerns/polymorphic_resource_scope.rb
@@ -138,7 +138,7 @@ module PolymorphicResourceScope
   end
 
   def array_id_params(string_id_params)
-    ids = string_id_params.split(',')
+    ids = string_id_params.to_s.split(',')
     if ids.length < 2
       ids.first
     else


### PR DESCRIPTION
convert the params to a string before splitting them to id lookups. 

Rails 4 controller tests used to parse the params to strings however rails 5 leaves them intact. This PR ensures we are working with string id lookups at all times irrespective of the test setup (request vs controller etc)

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
