### PR TITLE
ensure we use strings param keys

### DIFF
--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -46,7 +46,7 @@ describe TokensController, type: :controller do
       end
 
       context "when supplying valid user credentials" do
-        let(:valid_creds) { params.merge!(login: owner.login, password: owner.password) }
+        let(:valid_creds) { params.merge!('login' => owner.login, 'password' => owner.password) }
         let(:req) { post :create, valid_creds }
 
         it_behaves_like "a valid login"

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -27,7 +27,7 @@ describe TokensController, type: :controller do
 
       context "when supplying invalid user credentials" do
         it "it should respond with 401" do
-          post :create, params.merge!(login: "fake_login_name", password: "sekret")
+          post :create, params.merge!('login' => 'fake_login_name', 'password' => 'sekret')
           expect(response.status).to eq(401)
         end
       end


### PR DESCRIPTION
change controller request specs to use string keys as symbol keys aren't parsed correctly

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
