### PR TITLE
test the relation link on the reloaded resource

### DIFF
--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -444,7 +444,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
       it_behaves_like "supports update_links" do
         it 'links the tutorial to the workflow' do
-          expect(resource.tutorials.pluck(:id).map(&:to_s)).to eq(test_relation_ids)
+          expect(updated_resource.tutorials.pluck(:id).map(&:to_s)).to eq(test_relation_ids)
         end
 
       end


### PR DESCRIPTION
This PR fixes the failing workflows to tutorials controller linkage spec - ensure we test the relation links on the reloaded resource at the controller spec, not the original one with the empty relation.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
