### PR TITLE
Pg selection spec rails5

### DIFF
--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -23,13 +23,46 @@ module Subjects
     def available
       query = Subjects::SetMemberSubjectSelector.new(workflow, user).set_member_subjects
       subject_set_ids = if workflow.grouped
-                            # respect the user if they want to select from a training set
-                            opts[:subject_set_id]
-                          else
-                            # default mode: do not select from training sets
-                            workflow.non_training_subject_sets.pluck(:id)
-                          end
-      query.where(subject_set_id: subject_set_ids)
+                          # respect the user if they want to select from a training set
+                          Array.wrap(opts[:subject_set_id])
+                        else
+                          # default mode: do not select from training sets
+                          workflow.non_training_subject_sets.pluck(:id)
+                        end
+      # Handle a bug when the rails 5.0 AR scope bind params merge in rails 5.0 (works find in 4.2)
+      #
+      # failed fix 1 - ensure the subject_set_id param clause is before the id clause
+      #
+      # SetMemberSubject.where(subject_set_id: subject_set_ids, id: query).select(:id)
+      #
+      # as that fixes the incorrect subject_set_id bind param - fails to bind limit correctly later on :(
+      #
+      # failed fix 2 - leave as is but wrap subject set ids in array
+      #
+      # query.where(subject_set_id: subject_set_ids)
+      #
+      # duplicate query clauses which make no sense and can be cleaned up
+      # but it still fails on the limit bind param fails later on :(
+      #
+      # failed fix 3 - tried to merge the AR queries manually
+      #
+      # query.merge(SetMemberSubject.where(subject_set_id: subject_set_ids))
+      #
+      # fixes the duplicate query clause but still fails on the limit bind param later on :(
+      #
+      # failed fix 4 - use an explicit sub query
+      #
+      # SetMemberSubject.where(subject_set_id: subject_set_ids, id: SetMemberSubject.select('id').from(query)).select(:id)
+      #
+      # fixes the subject set id bind param but still fails on the limit bind param later on :(
+
+      # Working solution
+      #
+      # run two queries
+      # one with with a pluck on the query select to pull the avaialble SMS IDs
+      # and then apply the subject set id filter to create a new simple scope
+      # that we pass onto to the selector strategy class which then applies the limit bind params etc
+      SetMemberSubject.where(id: query.pluck(:id), subject_set_id: subject_set_ids).select(:id)
     end
 
     def limit

--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -29,40 +29,44 @@ module Subjects
                           # default mode: do not select from training sets
                           workflow.non_training_subject_sets.pluck(:id)
                         end
-      # Handle a bug when the rails 5.0 AR scope bind params merge in rails 5.0 (works find in 4.2)
-      #
-      # failed fix 1 - ensure the subject_set_id param clause is before the id clause
-      #
-      # SetMemberSubject.where(subject_set_id: subject_set_ids, id: query).select(:id)
-      #
-      # as that fixes the incorrect subject_set_id bind param - fails to bind limit correctly later on :(
-      #
-      # failed fix 2 - leave as is but wrap subject set ids in array
-      #
-      # query.where(subject_set_id: subject_set_ids)
-      #
-      # duplicate query clauses which make no sense and can be cleaned up
-      # but it still fails on the limit bind param fails later on :(
-      #
-      # failed fix 3 - tried to merge the AR queries manually
-      #
-      # query.merge(SetMemberSubject.where(subject_set_id: subject_set_ids))
-      #
-      # fixes the duplicate query clause but still fails on the limit bind param later on :(
-      #
-      # failed fix 4 - use an explicit sub query
-      #
-      # SetMemberSubject.where(subject_set_id: subject_set_ids, id: SetMemberSubject.select('id').from(query)).select(:id)
-      #
-      # fixes the subject set id bind param but still fails on the limit bind param later on :(
+      if Gem::Version.new(Rails.version) > Gem::Version.new('5.0')
+        # Handle a bug when the rails 5.0 AR scope bind params merge in rails 5.0 (works find in 4.2)
+        #
+        # failed fix 1 - ensure the subject_set_id param clause is before the id clause
+        #
+        # SetMemberSubject.where(subject_set_id: subject_set_ids, id: query).select(:id)
+        #
+        # as that fixes the incorrect subject_set_id bind param - fails to bind limit correctly later on :(
+        #
+        # failed fix 2 - leave as is but wrap subject set ids in array
+        #
+        # query.where(subject_set_id: subject_set_ids)
+        #
+        # duplicate query clauses which make no sense and can be cleaned up
+        # but it still fails on the limit bind param fails later on :(
+        #
+        # failed fix 3 - tried to merge the AR queries manually
+        #
+        # query.merge(SetMemberSubject.where(subject_set_id: subject_set_ids))
+        #
+        # fixes the duplicate query clause but still fails on the limit bind param later on :(
+        #
+        # failed fix 4 - use an explicit sub query
+        #
+        # SetMemberSubject.where(subject_set_id: subject_set_ids, id: SetMemberSubject.select('id').from(query)).select(:id)
+        #
+        # fixes the subject set id bind param but still fails on the limit bind param later on :(
 
-      # Working solution
-      #
-      # run two queries
-      # one with with a pluck on the query select to pull the avaialble SMS IDs
-      # and then apply the subject set id filter to create a new simple scope
-      # that we pass onto to the selector strategy class which then applies the limit bind params etc
-      SetMemberSubject.where(id: query.pluck(:id), subject_set_id: subject_set_ids).select(:id)
+        # Working solution
+        #
+        # run two queries
+        # one with with a pluck on the query select to pull the avaialble SMS IDs
+        # and then apply the subject set id filter to create a new simple scope
+        # that we pass onto to the selector strategy class which then applies the limit bind params etc
+        SetMemberSubject.where(id: query.pluck(:id), subject_set_id: subject_set_ids).select(:id)
+      else
+        query.merge(SetMemberSubject.where(subject_set_id: subject_set_ids))
+      end
     end
 
     def limit


### PR DESCRIPTION
This PR fixes the postgresql available SetMemberSubject Active Record query where the bind params are incorrectly assigned. I tried a few solutions and left notes as comments in the code. 

We've got a rails 4 / 5 conditional branch here to keep the single DB round trip for rails 4 but allow the rails 5 version to use the 2 db round trips but maintain correctness. 

Longer term rails 5.1 may fix this and we can switch back to the single db round trip code that works in rails 4.2

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
