### PR TITLE
Update rails next dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM ruby:2.5-slim-stretch
 
 WORKDIR /rails_app
 
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,id=panoptes-apt-cache,target=/var/cache/apt --mount=type=cache,id=panoptes-apt-lib,target=/var/lib/apt \
-    apt-get update && apt-get -y upgrade && \
+RUN apt-get update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y \
         build-essential \
         # git is required for installing gems from git repos
@@ -14,7 +12,9 @@ RUN --mount=type=cache,id=panoptes-apt-cache,target=/var/cache/apt --mount=type=
         libjemalloc1 \
         libpq-dev \
         nodejs \
-        tmpreaper
+        tmpreaper \
+        && \
+        apt-get clean
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 
@@ -28,7 +28,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-RUN --mount=type=cache,id=panoptes-gems,target=/usr/local/bundle/cache bundle install --without development test
+RUN bundle install --without development test
 
 ADD ./ /rails_app
 

--- a/Dockerfile.rails-next
+++ b/Dockerfile.rails-next
@@ -12,18 +12,23 @@ RUN apt-get update && apt-get -y upgrade && \
     && \
     apt-get clean
 
-ADD ./Gemfile /rails_app/
-ADD ./Gemfile.lock /rails_app/
+# set a default RAILS_ENV for the build scripts
+# this is required for the `rake assets:precompile` script
+# to write assets to target dir set in `config.assets.prefix`
+ARG RAILS_ENV=production
+ENV RAILS_ENV=$RAILS_ENV
+
+ADD ./Gemfile.next /rails_app/
+ADD ./Gemfile.next.lock /rails_app/
+
+ENV BUNDLE_GEMFILE=Gemfile.next
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1` && \
     bundle install
 
-ADD ./Gemfile.next /rails_app/
-ADD ./Gemfile.next.lock /rails_app/
-RUN next bundle install
-
 ADD ./ /rails_app
 
 RUN (cd /rails_app && mkdir -p tmp/pids && rm -f tmp/pids/*.pid)
+RUN (cd /rails_app && SECRET_KEY_BASE=1a bundle exec rake assets:precompile)
 
 CMD ["/rails_app/scripts/docker/start.sh"]

--- a/Dockerfile.rails-next
+++ b/Dockerfile.rails-next
@@ -21,6 +21,7 @@ ENV RAILS_ENV=$RAILS_ENV
 ADD ./Gemfile.next /rails_app/
 ADD ./Gemfile.next.lock /rails_app/
 
+# ensure we use the rails-next gemfile setup to ensure we boot the upgraded libaries
 ENV BUNDLE_GEMFILE=Gemfile.next
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1` && \

--- a/docker-compose-rails-next.yml
+++ b/docker-compose-rails-next.yml
@@ -17,6 +17,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.rails-next
+      args:
+        RAILS_ENV: development
     volumes:
       - ./:/rails_app
       - gem_cache:/usr/local/bundle


### PR DESCRIPTION
Linked to the work in #3884 

This PR ensures the rails-next dockerfile has only the next rails version libraries and is ready for a non dev env boot (i.e. has assets compiled etc). Also I've cleaned up the current rails version dockerfile to remove old jenkins specific docker build caching setup as we no longer use it (this should be done for all repos that have these artifacts). 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
