### PR TITLE
Use whole path to image in tag

### DIFF
--- a/.github/workflows/deploy_staging_canary.yml
+++ b/.github/workflows/deploy_staging_canary.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_push_image:
+  deploy_staging_canary:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/deploy_staging_canary.yml
+++ b/.github/workflows/deploy_staging_canary.yml
@@ -32,7 +32,7 @@ jobs:
         context: .
         file: Dockerfile.rails-next
         push: true
-        tags: ${{ github.sha }}-next,latest-next
+        tags: ghcr.io/zooniverse/panoptes:${{ github.sha }}-next
         cache-from: type=gha
         cache-to: type=gha,mode=max
 


### PR DESCRIPTION
The `tag:` option on the `docker/build-push-image` requires the full image path: registry/user/repo:tag.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
