### PR TITLE
add rails5 memcached configs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,9 +47,15 @@ module Panoptes
     config.middleware.use Flipper::Middleware::Memoizer
 
     if Panoptes::Cache.enabled?
-      # use ENV MEMCACHE_SERVERS var to configure the servers
-      # https://github.com/petergoldstein/dalli#usage-with-rails-3x-and-4x
-      config.cache_store = :dalli_store, nil, Panoptes::Cache.options
+      if (_rails4 = Gem::Version.new(Rails.version) < Gem::Version.new('5.0'))
+        # use ENV MEMCACHE_SERVERS var to configure the servers
+        # https://github.com/petergoldstein/dalli#usage-with-rails-3x-and-4x
+        config.cache_store = :dalli_store, nil, Panoptes::Cache.options
+      else
+        # Rails 5 configuration of memcache and dalli
+        # https://github.com/petergoldstein/dalli/wiki/Using-Dalli-with-Rails#cache-store
+        config.cache_store = :mem_cache_store, Panoptes::Cache.servers, Panoptes::Cache.options
+      end
     end
   end
 end

--- a/config/cache_store.rb
+++ b/config/cache_store.rb
@@ -1,5 +1,9 @@
 module Panoptes
   module Cache
+    def self.servers
+      ENV.fetch('MEMCACHE_SERVERS', '')
+    end
+
     def self.enabled?
       ENV.key?('MEMCACHE_SERVERS')
     end


### PR DESCRIPTION
This PR adds the new rails5 / dalli gem configurations for setting up rails memcached caching systems while still allowing the rails 4 version of the app to configure the old version of the rails caching system and dalli client.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
