### PR TITLE
allow the canary to route traffic via the header setting

### DIFF
--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -134,7 +134,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "0"
     nginx.ingress.kubernetes.io/canary-by-header: "Canary-Testing-Opt-In"
 spec:
   tls:


### PR DESCRIPTION
Remove the canary weight 0 setting as it was stopping traffic from being routed to the canary, https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#canary

Note: I've manually applied this change to the ingress to ensure traffic routes correctly. 

I also manually removed the old duplicated staging azure-canary-ingress setup `kubectl delete ingress panoptes-staging-azure-canary-ingress` as it was conflicting with the new `panoptes-staging-canary-ingress` configs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
