### PR TITLE
Enumerator.new without block is deprecated use Object.to_enum instead

### DIFF
--- a/app/models/subject_set_import/csv_import.rb
+++ b/app/models/subject_set_import/csv_import.rb
@@ -20,7 +20,7 @@ class SubjectSetImport::CsvImport
   end
 
   def each
-    return self.to_enum unless block_given?
+    return to_enum unless block_given?
 
     csv.each do |row|
       external_id = row['external_id']

--- a/app/models/subject_set_import/csv_import.rb
+++ b/app/models/subject_set_import/csv_import.rb
@@ -20,7 +20,7 @@ class SubjectSetImport::CsvImport
   end
 
   def each
-    return Enumerator.new(self) unless block_given?
+    return self.to_enum unless block_given?
 
     csv.each do |row|
       external_id = row['external_id']


### PR DESCRIPTION
Updating methods due to deprecation warning: 
` /rails_app/app/models/subject_set_import/csv_import.rb:23: warning: Enumerator.new without a block is deprecated; use Object#to_enum`
- [ ] 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
