### PR TITLE
passing string to middleware is deprecated

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ require "action_view/railtie"
 require "sprockets/railtie"
 require 'flipper/middleware/memoizer'
 require_relative 'cache_store'
+require_relative '../app/middleware/reject_patch_requests'
+require_relative '../app/middleware/catch_api_json_parse_errors'
 
 Bundler.require(*Rails.groups)
 
@@ -23,9 +25,9 @@ module Panoptes
     config.eager_load_paths += Dir[Rails.root.join('lib', '**/')]
 
     config.action_dispatch.perform_deep_munge = false
-    config.middleware.insert_before ActionDispatch::Cookies, "RejectPatchRequests"
+    config.middleware.insert_before ActionDispatch::Cookies, RejectPatchRequests
     config.action_controller.action_on_unpermitted_parameters = :raise
-    config.middleware.insert_before ActionDispatch::Cookies, "CatchApiJsonParseErrors"
+    config.middleware.insert_before ActionDispatch::Cookies, CatchApiJsonParseErrors
 
     config.active_record.schema_format = :sql
 


### PR DESCRIPTION
addressing

`DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
