### PR TITLE
before_filter replaced with before_action

### DIFF
--- a/app/controllers/api/v1/classifications_controller.rb
+++ b/app/controllers/api/v1/classifications_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::ClassificationsController < Api::ApiController
   class MissingParameter < StandardError; end
 
 
-  skip_before_filter :require_login, only: :create
+  skip_before_action :require_login, only: :create
   require_authentication :show, :index, :destroy, :update, :incomplete, :project,
     scopes: [:classification]
 

--- a/app/controllers/api/v1/field_guides_controller.rb
+++ b/app/controllers/api/v1/field_guides_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::FieldGuidesController < Api::ApiController
 
   schema_type :json_schema
 
-  before_filter :set_language_if_missing, only: [:index]
+  before_action :set_language_if_missing, only: [:index]
 
   private
 

--- a/app/controllers/api/v1/memberships_controller.rb
+++ b/app/controllers/api/v1/memberships_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::MembershipsController < Api::ApiController
   include JsonApiController::PunditPolicy
 
-  before_filter :require_login
+  before_action :require_login
   require_authentication :all, scopes: [:group]
   resource_actions :index, :show, :create, :update, :deactivate
   schema_type :strong_params

--- a/app/controllers/api/v1/tutorials_controller.rb
+++ b/app/controllers/api/v1/tutorials_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::TutorialsController < Api::ApiController
 
   schema_type :json_schema
 
-  before_filter :set_language_if_missing, only: [:index]
+  before_action :set_language_if_missing, only: [:index]
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :null_session
 
-  before_filter :configure_devise_permitted_parameters, if: :devise_controller?
+  before_action :configure_devise_permitted_parameters, if: :devise_controller?
 
   def unknown_route
     exception = ActionController::RoutingError.new("Not Found")

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationsController < Doorkeeper::ApplicationsController
-  skip_before_filter :authenticate_admin!
-  before_filter :authenticate_user!
+  skip_before_action :authenticate_admin!
+  before_action :authenticate_user!
   before_action :add_public_scope, only: [:create, :update]
 
   respond_to :html

--- a/app/controllers/concerns/pages.rb
+++ b/app/controllers/concerns/pages.rb
@@ -11,7 +11,7 @@ module Pages
     allowed_params :create, :url_key, :title, :content, :language
     allowed_params :update, :url_key, :title, :content, :language
 
-    before_filter :set_language_if_missing, only: [:index]
+    before_action :set_language_if_missing, only: [:index]
 
     # Methods defined here in order to avoid being overridden by resource modules
     define_method(:link_header) do |resource|

--- a/app/controllers/concerns/preferences_controller.rb
+++ b/app/controllers/concerns/preferences_controller.rb
@@ -2,7 +2,7 @@ module PreferencesController
   extend ActiveSupport::Concern
 
   included do
-    prepend_before_filter :require_login
+    prepend_before_action :require_login
 
     resource_actions :index, :show, :create, :update
 

--- a/app/controllers/concerns/roles_controller.rb
+++ b/app/controllers/concerns/roles_controller.rb
@@ -5,10 +5,10 @@ module RolesController
     resource_actions :default
     schema_type :strong_params
 
-    before_filter :format_filter_params, only: :index
-    before_filter :filter_by_user_id, only: :index
+    before_action :format_filter_params, only: :index
+    before_action :filter_by_user_id, only: :index
 
-    skip_before_filter :check_destroy_class_matches_controller, only: :destroy
+    skip_before_action :check_destroy_class_matches_controller, only: :destroy
 
     include BuildOverride
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < Devise::SessionsController
-  skip_before_action :verify_authenticity_token, only: [:destroy], if: :json_request?
+  skip_before_action :verify_authenticity_token, 
+    if: -> { json_request? && action_name == "destroy" }
   after_action :set_csrf_headers, only: %i[create destroy]
   after_action :set_csrf_headers, only: :new, if: :json_request?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < Devise::SessionsController
   skip_before_action :verify_authenticity_token, only: [:destroy], if: :json_request?
-  after_filter :set_csrf_headers, only: [:create, :destroy]
-  after_filter :set_csrf_headers, only: :new, if: :json_request?
+  after_action :set_csrf_headers, only: [:create, :destroy]
+  after_action :set_csrf_headers, only: :new, if: :json_request?
 
   def new
     respond_to do |format|

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < Devise::SessionsController
-  skip_before_filter :verify_authenticity_token, only: [:destroy], if: :json_request?
+  skip_before_action :verify_authenticity_token, only: [:destroy], if: :json_request?
   after_filter :set_csrf_headers, only: [:create, :destroy]
   after_filter :set_csrf_headers, only: :new, if: :json_request?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < Devise::SessionsController
   skip_before_action :verify_authenticity_token, if: -> { json_request? && action_name == 'destroy' }
   after_action :set_csrf_headers, only: %i[create destroy]
-  after_action :set_csrf_headers, only: :new, if: :json_request?
+  after_action :set_csrf_headers, if: -> { :json_request? && action_name == 'new' }
 
   def new
     respond_to do |format|

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,5 @@
 class SessionsController < Devise::SessionsController
-  skip_before_action :verify_authenticity_token, 
-    if: -> { json_request? && action_name == "destroy" }
+  skip_before_action :verify_authenticity_token, if: -> { json_request? && action_name == 'destroy' }
   after_action :set_csrf_headers, only: %i[create destroy]
   after_action :set_csrf_headers, only: :new, if: :json_request?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < Devise::SessionsController
   skip_before_action :verify_authenticity_token, only: [:destroy], if: :json_request?
-  after_action :set_csrf_headers, only: [:create, :destroy]
+  after_action :set_csrf_headers, only: %i[create destroy]
   after_action :set_csrf_headers, only: :new, if: :json_request?
 
   def new

--- a/doc/pundit.md
+++ b/doc/pundit.md
@@ -58,7 +58,7 @@ controller actions suffixed with a question mark. The controller can then call
 *Note*: We don't currently use this. Nearly all actions will not be able to find
 any resource that the user isn't allowed to act upon. A good example of something
 that could use this would be `ProjectsController#create_classifications_export`
-which has this as a `before_filter`:
+which has this as a `before_action`:
 
 https://github.com/zooniverse/Panoptes/blob/fddc6e38dd4d1d61f3b767b2b3904d5496286a8a/app/controllers/api/v1/projects_controller.rb#L187
 


### PR DESCRIPTION
`DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.`
`DEPRECATION WARNING: skip_before_filter is deprecated and will be removed in Rails 5.1. Use skip_before_action instead.`
`DEPRECATION WARNING: prepend_before_filter is deprecated and will be removed in Rails 5.1. Use prepend_before_action instead.`
`DEPRECATION WARNING: after_filter is deprecated and will be removed in Rails 5.1. Use after_action instead.`



# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
