### PR TITLE
remove rails-controller-testing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ group :test do
   gem 'guard-rspec', require: false
   gem 'listen', '~> 3.7'
   gem 'mock_redis'
-  gem 'rails-controller-testing' if next?
   gem 'rspec'
   gem 'rspec-its'
   gem 'rspec-rails'

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -323,10 +323,6 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7.2)
       sprockets-rails (>= 2.0.0)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -541,7 +537,6 @@ DEPENDENCIES
   pundit (~> 2.2.0)
   rack-cors (~> 1.0)
   rails (~> 5.0)
-  rails-controller-testing
   ranked-model (~> 0.4.8)
   restpack_serializer!
   rspec

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -6,10 +6,6 @@ shared_examples "restricted scopes" do
       req
       expect(response.status).to eq(200)
     end
-
-    it 'should render the approval page' do
-      expect(req).to render_template(:new)
-    end
   end
 
   context 'requesting greater scopes' do
@@ -52,7 +48,7 @@ describe AuthorizationsController, type: :controller do
     end
   end
 
-  context "an implicit grant by an insecure application", :focus do
+  context "an implicit grant by an insecure application" do
     let!(:app) { create(:application, owner: owner) }
     let(:req) { get :new, token_params }
 

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -48,7 +48,7 @@ describe AuthorizationsController, type: :controller do
     end
   end
 
-  context "an implicit grant by an insecure application" do
+  context 'with an insecure application using an implicit grant' do
     let!(:app) { create(:application, owner: owner) }
     let(:req) { get :new, token_params }
 

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -21,10 +21,12 @@ shared_examples "restricted scopes" do
   end
 
   context 'requesting no scopes' do
-    it 'should create a page with the apps default scopes' do
+    it 'uses the apps default scopes' do
       params.delete('scope')
+      allow(app).to receive(:default_scope).and_call_original
+      allow(controller).to receive(:client).and_return(app)
       req
-      expect(assigns(:pre_auth).scopes).to eq(['public', 'project', 'classification'])
+      expect(app).to have_received(:default_scope).at_least(1).time
     end
   end
 end
@@ -50,7 +52,7 @@ describe AuthorizationsController, type: :controller do
     end
   end
 
-  context "an implicit grant by an insecure application" do
+  context "an implicit grant by an insecure application", :focus do
     let!(:app) { create(:application, owner: owner) }
     let(:req) { get :new, token_params }
 


### PR DESCRIPTION
Remove the https://github.com/rails/rails-controller-testing gem

Avoid controller testing features removed in rails 5.0 that were re-added using this gem. Instead test the controller calls the relevant objects on state setup and avoid testing render template actions - instead test the controller response status.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
