### PR TITLE
isolate rails 5 staging deploy from prod deploys

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -12,7 +12,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
     with:
       repo_name: panoptes
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
       file: Dockerfile.rails-next
       latest: true
 
@@ -23,7 +23,7 @@ jobs:
     with:
       app_name: panoptes
       environment: staging
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
     secrets:
       creds: ${{ secrets.AZURE_AKS }}
 
@@ -34,7 +34,7 @@ jobs:
     with:
       app_name: panoptes
       repo_name: panoptes
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
       environment: staging
     secrets:
       creds: ${{ secrets.AZURE_AKS }}

--- a/.github/workflows/deploy_staging_canary.yml
+++ b/.github/workflows/deploy_staging_canary.yml
@@ -1,9 +1,6 @@
 name: Deploy Staging Canary
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:

--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: panoptes-staging-canary-app
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: panoptes-staging-canary-app


### PR DESCRIPTION
Follow up to #3911 - after more reflection on the staging rails 5 deploy changes I believe we introduced another possible deployment bug in #3911.

Re using the GH sha id after a production deploy would build a new image and update the container registry at that tag (prod would have a rails 4 gemfile build). The means that the existing staging deploy at the same sha id would be overwritten and would not include the rails 5 gem versions built for the staging deploy, rather it would have the production rails 4 versions :(

This would only happen if the production tag and the GH master branch head were the same (i.e. no changes on master) and the staging system redeployed to a node without the existing rails 5 staging image on it, thus it would pull down the prod rails 4 version and boot staging mode up. 

While this may not happen as the deploys are stable we run the risk of our staging testing env 'switching' out from under us which is not what we want. 

To avoid this scenario, this PR adds a tag suffix to the staging image builds and when we deploy production we don't overwrite the previously built staging rails 5 image tag. Specifically we add a tag suffix `-next` to the built staging images to isolate the staging rails 5 deploys from the prod rails 4 deploys.

Finally this PR also removes the staging canary setup from deploying / running as we no longer need this canary while we have the staging system running on rails next v5 version. I can extract this to it's own PR if folks want. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
