### PR TITLE
remove docker build caching

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,9 +2,7 @@ FROM ruby:2.5-slim-buster
 
 WORKDIR /rails_app
 
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,id=panoptes-apt-cache,target=/var/cache/apt --mount=type=cache,id=panoptes-apt-lib,target=/var/lib/apt \
-    apt-get update && apt-get -y upgrade && \
+RUN apt-get update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y \
       build-essential \
       # git is required for installing gems from git repos
@@ -18,7 +16,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-RUN --mount=type=cache,id=panoptes-gems,target=/usr/local/bundle/cache bundle install
+RUN bundle install
 
 ADD ./ /rails_app
 


### PR DESCRIPTION
remove the docker build caching - this was added to speed up builds but we don't need it.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
