### PR TITLE
disable the Gemfile.next CI tests when there is no upgrade happening

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         gemfile:
           - Gemfile
-          - Gemfile.next
+          # - Gemfile.next
         ruby:
           - 2.6
         spec-commands:


### PR DESCRIPTION
As we aren't testing any gem upgrades (e.g. rails 5.1) the Gemfile and Gemfile.next are the same - thus the CI tests for Gemfile.next don't need to be run. Lets save on GH compute and test CI runtime by not running these tests till we need them.

When we create a PR to upgrade a gem using the Gemfile.next technique (e.g. rails 5.1 in #3940) we will need to re-enable these CI Gemfile.next test runs by removing this commented line

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
