### PR TITLE
switch to fatal log level to avoid IO in CI

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,6 +54,6 @@ Rails.application.configure do
     puts 'Logs are being suppressed to speed up the test suite. ' \
          'Remove DISABLE_TEST_LOGGING env var to add logging back.'
     # rubocop:enable Rails/Output
-    config.log_level = :warn
+    config.log_level = :fatal
   end
 end


### PR DESCRIPTION
log less data with less IO work should speedup the CI suite runs - https://guides.rubyonrails.org/debugging_rails_applications.html#log-levels

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
