### PR TITLE
allow unknown user ids to trigger the congestion rate limiter

### DIFF
--- a/app/workers/concerns/rate_limit_dump_worker.rb
+++ b/app/workers/concerns/rate_limit_dump_worker.rb
@@ -22,17 +22,17 @@ module RateLimitDumpWorker
   module ClassMethods
     def congestion_enabled?(requester_id)
       # if the user is missing, should only happen via the rails console
-      return false if requester_id.blank?
+      # false if the user is a special skip rate limit user
+      return false if requester_id.blank? || Panoptes::RateLimitDumpWorker.skip_rate_limit_user_ids.include?(requester_id)
 
-      skip_user_ids = Panoptes::RateLimitDumpWorker.skip_rate_limit_user_ids
-
-      if skip_user_ids.include?(requester_id)
-        # false if the user is a special skip rate limit user
-        false
-      else
-        # false if user is admin, true if not admin
-        !User.find(requester_id).is_admin?
-      end
+      user = User.find(requester_id)
+      # false - disable congestion if user is admin
+      # true - emable congestion if they are a normal user
+      user.is_admin? ? false : true
+    rescue ActiveRecord::RecordNotFound
+      # if the user ID can't then enable congestion rate limiting
+      # this may be the special case of a 'fake' internal user, e.g. -1
+      true
     end
   end
 end

--- a/app/workers/concerns/rate_limit_dump_worker.rb
+++ b/app/workers/concerns/rate_limit_dump_worker.rb
@@ -27,7 +27,7 @@ module RateLimitDumpWorker
 
       user = User.find(requester_id)
       # false - disable congestion if user is admin
-      # true - emable congestion if they are a normal user
+      # true - enable congestion if they are a normal user
       user.is_admin? ? false : true
     rescue ActiveRecord::RecordNotFound
       # if the user ID can't then enable congestion rate limiting

--- a/spec/support/rate_limit_dump_worker.rb
+++ b/spec/support/rate_limit_dump_worker.rb
@@ -4,42 +4,49 @@ RSpec.shared_examples 'rate limit dump worker' do
   let(:enabled_lambda) do
     described_class.sidekiq_options.dig('congestion', :enabled)
   end
-  let(:user_double) { instance_double(User) }
 
-  before do
-    allow(User).to receive(:find).and_return(user_double)
+  it 'enables congestion for unknown requesters' do
+    expect(enabled_lambda.call(nil, nil, nil, -11)).to eq(true)
   end
 
-  it 'enables congestion for non-admin requesters' do
-    allow(user_double).to receive(:is_admin?).and_return(false)
-    expect(enabled_lambda.call(nil, nil, nil, 1)).to eq(true)
-  end
+  context 'with a known user' do
+    let(:user_double) { instance_double(User) }
 
-  it 'disables congestion if no requester_id is passed' do
-    expect(enabled_lambda.call(nil, nil, nil, nil)).to eq(false)
-  end
+    before do
+      allow(User).to receive(:find).and_return(user_double)
+    end
 
-  it 'disables congestion for admin requesters' do
-    allow(user_double).to receive(:is_admin?).and_return(true)
-    expect(enabled_lambda.call(nil, nil, nil, 1)).to eq(false)
-  end
-
-  describe 'skip congestions for special requester ids' do
-    it 'handles no configured skip ids' do
+    it 'enables congestion for non-admin requesters' do
       allow(user_double).to receive(:is_admin?).and_return(false)
-      expect(enabled_lambda.call(nil, nil, nil, 23)).to eq(true)
+      expect(enabled_lambda.call(nil, nil, nil, 1)).to eq(true)
     end
 
-    it 'disables congestion if matching skip ids' do
-      ENV['SKIP_DUMP_RATE_LIMIT_USER_IDS'] = '1,2,23,55'
-      expect(enabled_lambda.call(nil, nil, nil, 23)).to eq(false)
-      ENV.delete('SKIP_DUMP_RATE_LIMIT_USER_IDS')
+    it 'disables congestion if no requester_id is passed' do
+      expect(enabled_lambda.call(nil, nil, nil, nil)).to eq(false)
     end
 
-    it 'handles spaces in skip id inputs' do
-      ENV['SKIP_DUMP_RATE_LIMIT_USER_IDS'] = '23,   55'
-      expect(enabled_lambda.call(nil, nil, nil, 55)).to eq(false)
-      ENV.delete('SKIP_DUMP_RATE_LIMIT_USER_IDS')
+    it 'disables congestion for admin requesters' do
+      allow(user_double).to receive(:is_admin?).and_return(true)
+      expect(enabled_lambda.call(nil, nil, nil, 1)).to eq(false)
+    end
+
+    describe 'skip congestions for special requester ids' do
+      it 'handles no configured skip ids' do
+        allow(user_double).to receive(:is_admin?).and_return(false)
+        expect(enabled_lambda.call(nil, nil, nil, 23)).to eq(true)
+      end
+
+      it 'disables congestion if matching skip ids' do
+        ENV['SKIP_DUMP_RATE_LIMIT_USER_IDS'] = '1,2,23,55'
+        expect(enabled_lambda.call(nil, nil, nil, 23)).to eq(false)
+        ENV.delete('SKIP_DUMP_RATE_LIMIT_USER_IDS')
+      end
+
+      it 'handles spaces in skip id inputs' do
+        ENV['SKIP_DUMP_RATE_LIMIT_USER_IDS'] = '23,   55'
+        expect(enabled_lambda.call(nil, nil, nil, 55)).to eq(false)
+        ENV.delete('SKIP_DUMP_RATE_LIMIT_USER_IDS')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is a fix for the automated subject set export functionality added in #3714

Specifically the issue is the congestion rate limiter raises an error when running and stops all jobs linked to it. this issue is due to the special internal user id in https://github.com/zooniverse/panoptes/blob/581ad45e99bc88826dba32aa4978533c21a6d8c9/app/operations/subject_sets/run_completion_events.rb#L26-L29

As we use a special internal user (id=-1) to internally trigger the classification so we can't raise and AR not found error, rather in this PR we catch this error and use the special id to setup congestion rate limiter key and carry on with the rate limiter middleware / job. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
