### PR TITLE
Bump active-model-serializers to 0.10.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 source 'https://rubygems.org'
 
 gem 'active_interaction', '~> 3.8.3'
-gem 'active_model_serializers', '0.10.0.rc2' # Event stream
+gem 'active_model_serializers' # Event stream
 gem 'activerecord-import', '~> 1.4'
 gem 'active_record_union', '~> 1.3.0'
 gem 'aws-sdk', '~> 2.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,11 @@ GEM
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_interaction (3.8.3)
       activemodel (>= 4, < 7)
-    active_model_serializers (0.10.0.rc2)
-      activemodel (>= 4.0)
+    active_model_serializers (0.10.13)
+      actionpack (>= 4.1, < 7.1)
+      activemodel (>= 4.1, < 7.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     active_record_union (1.3.0)
       activerecord (>= 4.0)
     activejob (5.0.7.2)
@@ -90,6 +93,8 @@ GEM
       nokogiri (~> 1.6, >= 1.6.8)
     bcrypt (3.1.17)
     builder (3.2.4)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.1.10)
@@ -188,6 +193,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    jsonapi-renderer (0.2.2)
     jwt (1.5.6)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -472,7 +478,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_interaction (~> 3.8.3)
-  active_model_serializers (= 0.10.0.rc2)
+  active_model_serializers
   active_record_union (~> 1.3.0)
   activerecord-import (~> 1.4)
   aws-sdk (~> 2.10)

--- a/app/serializers/event_stream_serializers/classification_serializer.rb
+++ b/app/serializers/event_stream_serializers/classification_serializer.rb
@@ -7,6 +7,8 @@ module EventStreamSerializers
 
     attributes :id, :created_at, :updated_at, :user_ip, :workflow_version, :gold_standard,
                :expert_classifier, :annotations, :metadata
+    
+    type :classifications
 
     belongs_to :project,          serializer: EventStreamSerializers::ProjectSerializer
     belongs_to :user,             serializer: EventStreamSerializers::UserSerializer

--- a/app/serializers/event_stream_serializers/project_serializer.rb
+++ b/app/serializers/event_stream_serializers/project_serializer.rb
@@ -1,5 +1,6 @@
 module EventStreamSerializers
   class ProjectSerializer < ActiveModel::Serializer
     attributes :id, :display_name, :created_at, :updated_at
+    type :projects
   end
 end

--- a/app/serializers/event_stream_serializers/subject_serializer.rb
+++ b/app/serializers/event_stream_serializers/subject_serializer.rb
@@ -1,6 +1,7 @@
 module EventStreamSerializers
   class SubjectSerializer < ActiveModel::Serializer
     attributes :id, :locations, :metadata, :created_at, :updated_at
+    type :subjects
 
     def locations
       object.ordered_locations.map do |loc|

--- a/app/serializers/event_stream_serializers/user_serializer.rb
+++ b/app/serializers/event_stream_serializers/user_serializer.rb
@@ -1,5 +1,6 @@
 module EventStreamSerializers
   class UserSerializer < ActiveModel::Serializer
     attributes :id, :login
+    type :users
   end
 end

--- a/app/serializers/event_stream_serializers/workflow_serializer.rb
+++ b/app/serializers/event_stream_serializers/workflow_serializer.rb
@@ -1,5 +1,6 @@
 module EventStreamSerializers
   class WorkflowSerializer < ActiveModel::Serializer
     attributes :id, :display_name, :retirement, :created_at, :updated_at
+    type :workflows
   end
 end

--- a/spec/fixtures/files/example_event_stream_serializer_classification.json
+++ b/spec/fixtures/files/example_event_stream_serializer_classification.json
@@ -1,0 +1,135 @@
+{
+    "source": "panoptes",
+    "type": "classification",
+    "version": "1.0.0",
+    "timestamp": "2022-09-12T19:51:17Z",
+    "data": {
+        "id": "110709",
+        "created_at": "2022-09-12T19:51:17.680Z",
+        "updated_at": "2022-09-12T19:51:17.755Z",
+        "user_ip": "12.157.174.6",
+        "workflow_version": "4.8",
+        "gold_standard": null,
+        "expert_classifier": null,
+        "annotations": [
+            {
+                "task": "T0",
+                "value": [
+                    {
+                        "r": 128.8813503413908,
+                        "x": 427.69921875,
+                        "y": 127.0078125,
+                        "tool": 0,
+                        "angle": -52.83905177255981,
+                        "frame": 0,
+                        "details": []
+                    },
+                    {
+                        "r": 123.9794215692921,
+                        "x": 203.734375,
+                        "y": 235.6640625,
+                        "tool": 0,
+                        "angle": -38.182777356943184,
+                        "frame": 0,
+                        "details": []
+                    }
+                ]
+            }
+        ],
+        "metadata": {
+            "source": "api",
+            "session": "e39e2ece29af8bd9fedc4fcea4515b92406c30e5f0e16c1d157d2a5a52f4a52d",
+            "viewport": {
+                "width": 1792,
+                "height": 986
+            },
+            "started_at": "2022-09-12T19:51:12.898Z",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
+            "utc_offset": "18000",
+            "finished_at": "2022-09-12T19:51:17.601Z",
+            "live_project": false,
+            "interventions": {
+                "opt_in": true,
+                "messageShown": false
+            },
+            "user_language": "en",
+            "user_group_ids": [],
+            "subject_dimensions": [
+                {
+                    "clientWidth": 690,
+                    "clientHeight": 682,
+                    "naturalWidth": 690,
+                    "naturalHeight": 682
+                }
+            ],
+            "subject_selection_state": {
+                "retired": false,
+                "selected_at": "2022-09-12T19:49:44.897Z",
+                "already_seen": false,
+                "selection_state": "internal_fallback",
+                "finished_workflow": false,
+                "user_has_finished_workflow": false
+            },
+            "workflow_translation_id": "1945",
+            "workflow_version": "4.8"
+        },
+        "href": "/classifications/110709",
+        "links": {
+            "project": "1663",
+            "user": "1325837",
+            "workflow": "2660",
+            "subjects": [
+                "48746"
+            ]
+        }
+    },
+    "linked": {
+        "projects": [
+            {
+                "id": "1663",
+                "display_name": "Wildcam Illuminati Zoo Watch!",
+                "created_at": "2016-10-05T20:04:50.297Z",
+                "updated_at": "2022-09-12T19:20:27.869Z",
+                "href": "/projects/1663"
+            }
+        ],
+        "users": [
+            {
+                "id": "1325837",
+                "login": "zwolf",
+                "href": "/users/1325837"
+            }
+        ],
+        "workflows": [
+            {
+                "id": "2660",
+                "display_name": "Triangle Spotter",
+                "retirement": {
+                    "options": {
+                        "count": 26
+                    },
+                    "criteria": "classification_count"
+                },
+                "created_at": "2016-10-05T20:07:36.544Z",
+                "updated_at": "2021-05-17T19:07:52.784Z",
+                "href": "/workflows/2660"
+            }
+        ],
+        "subjects": [
+            {
+                "id": "48746",
+                "locations": [
+                    {
+                        "image/jpeg": "https://panoptes-uploads-staging.zooniverse.org/subject_location/029ec528-87f7-4e47-b643-d6276854aeee.jpeg"
+                    }
+                ],
+                "metadata": {
+                    "Filename": "Cassidy-Bloomberg-Presidential-Trial-Balloon-690x682-1453648495.jpg"
+                },
+                "created_at": "2016-11-18T16:53:57.782Z",
+                "updated_at": "2016-11-18T16:53:57.782Z",
+                "href": "/subjects/48746"
+            }
+        ]
+    }
+}

--- a/spec/serializers/event_stream_serializers/classification_serializer_spec.rb
+++ b/spec/serializers/event_stream_serializers/classification_serializer_spec.rb
@@ -11,4 +11,19 @@ describe EventStreamSerializers::ClassificationSerializer do
     adapter = described_class.serialize(classification, include: ['subjects'])
     expect(adapter.as_json[:linked]['subjects'].size).to eq(1)
   end
+
+  describe 'serialize for kinesis stream' do
+    it 'follows format of kinesis stream' do
+      serialized_data = described_class
+                        .serialize(classification, include: %w[project workflow user subjects])
+                        .as_json
+                        .with_indifferent_access
+
+      sample_kinesis_json = JSON.parse(file_fixture('example_event_stream_serializer_classification.json').read)
+
+      expect(serialized_data.keys).to match_array(%w[classifications linked])
+      expect(serialized_data[:classifications][0].keys).to match_array(sample_kinesis_json['data'].keys)
+      expect(serialized_data[:linked].keys).to match_array(sample_kinesis_json['linked'].keys)
+    end
+  end
 end


### PR DESCRIPTION
Related to https://github.com/zooniverse/panoptes/pull/3947/files

Pulling out logic related to dual boot to separate concerns. 

### Changes:
 From AMS 0.10.0rc2 to 0.10.13, serializer.each_asociation as well as serializer.type has been removed. Replaced with .associations and .json_key respectively.
Serializer.associations returns association instance which is an enumerable that can be iterated. .json_key returns in our case ._type defined in each serializer class.

Defining `type` attr for each serializer that extends ActiveModel::Serializer.

Adding fixture based on what was received when tailing kinesis stream and adding appropriate test on classification_serializer_spec.rb to test output of .serialize comes out in the expected format of our kinesis stream.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
