### PR TITLE
switch to proportional project completeness metric

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -42,11 +42,10 @@ class CalculateProjectCompletenessWorker
     # return the sum of the proportional completeness metrics
     project.active_workflows.sum(0.0) do |active_workflow|
       # as each workflow has a proportion of the total subjects
-      # we can use this proportion to weight the each workflow's completeness metric to the total for the project
+      # we can weight each workflow's completeness metric to the total for the project
       subject_proportion = active_workflow.subjects_count.to_d / project_subjects_count
 
-      # the summated proportion metrics will be clamped to the 0.0..1.0 range
-      # by the fraction of subjects / total subjects
+      # the summated proportion metrics will be clamped to the 0.0..1.0 range by subjects / total subjects fraction
       active_workflow.completeness * subject_proportion
     end
   end

--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -37,10 +37,18 @@ class CalculateProjectCompletenessWorker
   end
 
   def project_completeness
-    return 0.0 if no_active_workflows?
+    return 0.0 if no_active_workflows? || no_linked_subjects?
 
-    completenesses = project.active_workflows.pluck(:completeness)
-    completenesses.sum / completenesses.size.to_f
+    # return the sum of the proportional completeness metrics
+    project.active_workflows.sum(0.0) do |active_workflow|
+      # as each workflow has a proportion of the total subjects
+      # we can use this proportion to weight the each workflow's completeness metric to the total for the project
+      subject_proportion = active_workflow.subjects_count.to_d / project_subjects_count
+
+      # the summated proportion metrics will be clamped to the 0.0..1.0 range
+      # by the fraction of subjects / total subjects
+      active_workflow.completeness * subject_proportion
+    end
   end
 
   def workflow_completeness(workflow)
@@ -50,7 +58,7 @@ class CalculateProjectCompletenessWorker
 
     retired_subjects = workflow.retired_subjects_count
     total_subjects = workflow_subjects_count
-    (0.0..1.0).clamp(retired_subjects / total_subjects.to_f)
+    (0.0..1.0).clamp(retired_subjects / total_subjects.to_d)
   end
 
   def project_columns_to_update
@@ -70,10 +78,14 @@ class CalculateProjectCompletenessWorker
   end
 
   def no_active_workflows?
-    project.active_workflows.empty?
+    @no_active_workflows ||= project.active_workflows.empty?
+  end
+
+  def project_subjects_count
+    @project_subjects_count ||= project.active_workflows.sum(&:subjects_count)
   end
 
   def no_linked_subjects?
-    project.active_workflows.all? { |workflow| workflow.subjects_count.zero? }
+    @no_linked_subjects ||= project_subjects_count.zero?
   end
 end

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -198,10 +198,8 @@ describe CalculateProjectCompletenessWorker do
     context "when the project is active and complete" do
       before do
         allow(project)
-        .to receive(:active_workflows)
-        .and_return(
-          [build_stubbed(:workflow, completeness: 1.0, real_set_member_subjects_count: 10, retired_set_member_subjects_count: 10)]
-        )
+          .to receive(:active_workflows)
+          .and_return([build_stubbed(:workflow, completeness: 1.0, real_set_member_subjects_count: 10, retired_set_member_subjects_count: 10)])
       end
 
       it "should move it to paused" do


### PR DESCRIPTION
linked to #2492 

this PR switches the project completeness metric from the average of all workflow completion metrics to a proportional metric derived from the number of subjects in a workflow. 

```
E.g. for a project with 2 active workflows this new behaviour results in 
workflow_1 = { completeness: 0.5, subjects_count 100, retired_subjects: 50 } 
workflow_2 = { completeness: 0.9, subjects_count 900, retired_subjects: 810 } 

workflow_1.proportional_completeness = 0.5 (100 / 1000) = 0.05
workflow_2.proportional_completeness = 0.9 * (900 / 1000) = 0.81
project.completeness = 0.86 - more accurate

# under the old average metric we would have
(0.5 + 0.9) / 2 = 0.7 
project.completeness = 0.7 - not accurate
```

This is because the average metric doesn't factor the proportion of the subjects that each workflow is responsible for and can return inaccurate values depending on how workflows and subject sets are setup across the project. 

switching to a proportional metric that factors in the number of subjects each workflow has to ensure we have a more accurate completeness metric as we take the subject proportions into account as well. 

Not only that but we cover edge cases as reported on talk https://www.zooniverse.org/talk/17/2614180?comment=4277958 This project had a completed workflow(s) and one training workflow with 0 subjects (training subjects don't count) but a derived completeness metric of 0.5 `((1.0 + 0.0) / 2.0)` where the average calculation failed and thus this project would never 'pause'. 

With this new calculation this project would have a completeness calculation of 1.0 `1.0 + 0.0` where the training workflow has a 0.0 proportional value so no effect on the overall completeness of the project. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
