### PR TITLE
switch back to float calculation for completeness metrics

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -43,7 +43,7 @@ class CalculateProjectCompletenessWorker
     project.active_workflows.sum(0.0) do |active_workflow|
       # as each workflow has a proportion of the total subjects
       # we can weight each workflow's completeness metric to the total for the project
-      subject_proportion = active_workflow.subjects_count.to_d / project_subjects_count
+      subject_proportion = active_workflow.subjects_count.to_f / project_subjects_count
 
       # the summated proportion metrics will be clamped to the 0.0..1.0 range by subjects / total subjects fraction
       active_workflow.completeness * subject_proportion
@@ -57,7 +57,7 @@ class CalculateProjectCompletenessWorker
 
     retired_subjects = workflow.retired_subjects_count
     total_subjects = workflow_subjects_count
-    (0.0..1.0).clamp(retired_subjects / total_subjects.to_d)
+    (0.0..1.0).clamp(retired_subjects / total_subjects.to_f)
   end
 
   def project_columns_to_update

--- a/spec/workers/calculate_project_completeness_worker_spec.rb
+++ b/spec/workers/calculate_project_completeness_worker_spec.rb
@@ -81,7 +81,7 @@ describe CalculateProjectCompletenessWorker do
       it 'returns the proportional scaled completeness metric' do
         # 0.5 * (100 / 1000) + 0.9 * (900 / 1000)
         # 0.05 + 0.81
-        expect(worker.project_completeness).to eq(0.86)
+        expect(worker.project_completeness.to_d).to eq(0.86)
       end
     end
   end


### PR DESCRIPTION
related to the changes in #3950 switch back to `.to_f` metric representation for the workflow completion and the summed metric to avoid loss of precision via `.to_d`

This fixes the issue with completed projects not moving to the paused state as reported in https://www.zooniverse.org/talk/14/2620044?comment=4287231&page=1

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
