### PR TITLE
update project completeness worker, set completeness to be of decimal for precisness

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -61,7 +61,7 @@ class CalculateProjectCompletenessWorker
   end
 
   def project_columns_to_update
-    completeness = project_completeness
+    completeness = project_completeness.to_d
     columns_to_update = { completeness: completeness }
 
     # avoid the overriden project.finished? method


### PR DESCRIPTION
Due to floating point operations being inexact, when project_completeness gets calculated to `0.9999999999999999.to_f` (with 16 9s) will keep it as is, but  `0.99999999999999999.to_f` will return to `1.0`.  However, `0.9_w/_16_9s.to_f.to_i` will return 0 and cause a small number of paused projects to become active. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
