### PR TITLE
round the project completeness metric to avoid FP precision issues

### DIFF
--- a/app/workers/calculate_project_completeness_worker.rb
+++ b/app/workers/calculate_project_completeness_worker.rb
@@ -1,9 +1,11 @@
-require 'retirement_schemes'
+# frozen_string_literal: true
 
 class CalculateProjectCompletenessWorker
   include Sidekiq::Worker
   using Refinements::RangeClamping
   attr_reader :project
+
+  COMPLETENESS_ROUNDING_PRECISION = ENV.fetch('COMPLETENESS_ROUNDING_PRECISION', 4).to_i
 
   sidekiq_options congestion: {
     interval: 300,
@@ -40,14 +42,23 @@ class CalculateProjectCompletenessWorker
     return 0.0 if no_active_workflows? || no_linked_subjects?
 
     # return the sum of the proportional completeness metrics
-    project.active_workflows.sum(0.0) do |active_workflow|
+    proportional_completeness = project.active_workflows.sum do |active_workflow|
       # as each workflow has a proportion of the total subjects
       # we can weight each workflow's completeness metric to the total for the project
       subject_proportion = active_workflow.subjects_count.to_f / project_subjects_count
-
-      # the summated proportion metrics will be clamped to the 0.0..1.0 range by subjects / total subjects fraction
       active_workflow.completeness * subject_proportion
     end
+
+    # avoid the loss of precision for small / recurring float values
+    # that under certain conditions can cause the per workflow subject_proportion values not to summate to 1.0
+    # that in turn cause the project completion metric not to summate to 1.0
+    #
+    # this due to the loss of precision when doing floating point calculations
+    # even with the use of the BigDecimal library as some recurring values fail with this class
+    #
+    # round the summated values to the desired significant digits
+    # to avoid the loss of precision on this metric calculation
+    proportional_completeness.round(COMPLETENESS_ROUNDING_PRECISION)
   end
 
   def workflow_completeness(workflow)
@@ -57,7 +68,7 @@ class CalculateProjectCompletenessWorker
 
     retired_subjects = workflow.retired_subjects_count
     total_subjects = workflow_subjects_count
-    (0.0..1.0).clamp(retired_subjects / total_subjects.to_f)
+    (0.0..1.0).clamp(retired_subjects / total_subjects.to_d)
   end
 
   def project_columns_to_update


### PR DESCRIPTION
Follow up to #3950 and #3952 and specifically https://github.com/zooniverse/panoptes/pull/3950#issuecomment-1263051646

This PR changes the way we summate project completeness metrics to avoid issues with FP precision. 

Sometimes the calculation loses / accretes precision due to floating point arithmetic. To avoid this issue we can simple round the summated value to a significant  number of digits (4 by default). This PR provides an env var to change the rounding precision at runtime as needed to avoid code changes.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
