### PR TITLE
fix strong params nested array objects being unpermitted

### DIFF
--- a/lib/gem_ext/gem_ext.rb
+++ b/lib/gem_ext/gem_ext.rb
@@ -1,3 +1,5 @@
 require_dependency 'gem_ext/doorkeeper/application'
 require 'gem_ext/doorkeeper/server'
 require 'gem_ext/doorkeeper/client_credentials_creator'
+
+require 'gem_ext/rails/strong_parameters'

--- a/lib/gem_ext/rails/strong_parameters.rb
+++ b/lib/gem_ext/rails/strong_parameters.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# backport the strong params nested array fix for permit!
+# that is fixed in 5.2+ https://github.com/rails/rails/pull/32593/
+# landed in https://github.com/rails/rails/blob/v5.2.8.1/actionpack/CHANGELOG.md#rails-521-august-07-2018
+if Gem::Version.new(Rails.version) < Gem::Version.new('5.2')
+  module ActionController
+    class Parameters
+      def permit!
+        each_pair do |key, value|
+          Array.wrap(value).flatten.each do |v|
+            v.permit! if v.respond_to? :permit!
+          end
+        end
+
+        @permitted = true
+        self
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -113,15 +113,27 @@ describe Api::V1::WorkflowsController, type: :controller do
              ]
            }
            },
-           steps: [],
+           steps: [['S0', { 'taskKeys' => ['T0', 'T1'] }]],
            display_order_position: 1,
            links: {
             subject_sets: [subject_set.id.to_s],
             tutorials: [tutorial.id.to_s]
           }
-
         }
       }
+    end
+
+    describe 'steps attribute with nested array objects' do
+      before do
+        default_request scopes: scopes, user_id: authorized_user.id
+        update_params[:id] = resource.id
+      end
+
+      it 'correctly handles steps attributes nested array objects' do
+        put :update, update_params
+        updated_resource = json_response['workflows'][0]
+        expect(updated_resource['steps']).to match(update_params.dig(:workflows, :steps))
+      end
     end
 
     it_behaves_like "is updatable"


### PR DESCRIPTION
related to #3113 and closes #3960 

The client payload for steps attribute contains nested arrays with json objects. Strong params fails to permit these via the explicit allowlist via `permit!` in our params validator in https://github.com/zooniverse/panoptes/blob/8cfcace49491a4017bfcd017cb95fa0a85f39bcd/lib/json_api_controller/json_schema_validator.rb#L42

This is a rails fraemwork issue that was fixed in 5.2+ https://github.com/rails/rails/pull/23650 so i've backported that fix and added specs on this. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
