### PR TITLE
Refactor pg selection code to use CTEs instead of subqueries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gem 'active_interaction', '~> 3.8.3'
 gem 'active_model_serializers' # Event stream
 gem 'activerecord-import', '~> 1.4'
-gem 'active_record_union', '~> 1.3.0'
+gem 'active_record_extended'
 gem 'aws-sdk', '~> 2.10'
 gem 'azure-storage'
 gem 'azure-storage-blob'

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ source 'https://rubygems.org'
 
 gem 'active_interaction', '~> 3.8.3'
 gem 'active_model_serializers' # Event stream
-gem 'activerecord-import', '~> 1.4'
 gem 'active_record_extended'
+gem 'activerecord-import', '~> 1.4'
 gem 'aws-sdk', '~> 2.10'
 gem 'azure-storage'
 gem 'azure-storage-blob'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,10 @@ GEM
       activemodel (>= 4.1, < 7.1)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
-    active_record_union (1.3.0)
-      activerecord (>= 4.0)
+    active_record_extended (1.4.0)
+      activerecord (>= 5.0, < 6.1)
+      ar_outer_joins (~> 0.2)
+      pg (< 2.0)
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
@@ -63,6 +65,8 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aggregate (0.2.3)
+    ar_outer_joins (0.2.0)
+      activerecord (>= 3.2)
     arel (7.1.4)
     ast (2.4.2)
     aws-eventstream (1.2.0)
@@ -479,7 +483,7 @@ PLATFORMS
 DEPENDENCIES
   active_interaction (~> 3.8.3)
   active_model_serializers
-  active_record_union (~> 1.3.0)
+  active_record_extended
   activerecord-import (~> 1.4)
   aws-sdk (~> 2.10)
   azure-storage

--- a/app/policies/aggregation_policy.rb
+++ b/app/policies/aggregation_policy.rb
@@ -5,9 +5,8 @@ class AggregationPolicy < ApplicationPolicy
       updatable_parents = policy_for(Workflow).scope_for(:update)
       updatable_scope = scope.joins(:workflow).merge(updatable_parents)
 
-      scope.joins(:workflow)
-        .where("workflows.aggregation ->> 'public' = 'true'")
-        .union(updatable_scope)
+      public_aggregations = scope.joins(:workflow).where("workflows.aggregation ->> 'public' = 'true'")
+      Aggregation.union(updatable_scope, public_aggregations)
     end
   end
 

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -20,7 +20,7 @@ class MembershipPolicy < ApplicationPolicy
       when :show, :index
         public_memberships = scope.where(identity: false, state: Membership.states[:active])
                                .joins(:user_group).merge(UserGroup.where(private: false))
-        query.union_all(public_memberships)
+        Membership.union_all(query, public_memberships)
       else
         query
       end

--- a/lib/subjects/postgresql_in_order_selection.rb
+++ b/lib/subjects/postgresql_in_order_selection.rb
@@ -7,14 +7,17 @@ module Subjects
       @limit = limit
     end
 
-    # ensure the order runs outside the subselect here
-    # otherwise it attemps to sort the whole available complex joinsed scope
+    # ensure the order does not run on the available query
+    # use a CTE with the available subquery
+    # to resolve the ordering to be applied to the joined result set
+    # otherwise it attemps to sort the whole available query scope which can be large
     def select
       SetMemberSubject
-      .where(id: available)
-      .order(priority: :asc)
-      .limit(limit)
-      .pluck(:subject_id)
+        .with(available_ids: available)
+        .joins('INNER JOIN available_ids ON available_ids.id = set_member_subjects.id')
+        .order(priority: :asc)
+        .limit(limit)
+        .pluck(:subject_id)
     end
   end
 end

--- a/lib/subjects/postgresql_random_selection.rb
+++ b/lib/subjects/postgresql_random_selection.rb
@@ -36,7 +36,11 @@ module Subjects
     # to resolve the ordering to be applied to the joined result set
     # otherwise it attemps to sort the whole available query scope which can be large
     def focus_window_random_sample
-      SetMemberSubject.with(available_ids: available).joins('INNER JOIN available_ids ON available_ids.id = set_member_subjects.id').order(random: %i[asc desc].sample).limit(focus_set_window_size)
+      SetMemberSubject
+        .with(available_ids: available)
+        .joins('INNER JOIN available_ids ON available_ids.id = set_member_subjects.id')
+        .order(random: %i[asc desc].sample)
+        .limit(focus_set_window_size)
     end
 
     def focus_set_window_size

--- a/lib/subjects/postgresql_random_selection.rb
+++ b/lib/subjects/postgresql_random_selection.rb
@@ -31,13 +31,12 @@ module Subjects
       @available_count ||= available.except(:select).count
     end
 
-    # ensure the order runs outside the subselect here
-    # otherwise it attemps to sort the whole available complex joinsed scope
+    # ensure the order does not run on the available query
+    # use a CTE with the available subquery
+    # to resolve the ordering to be applied to the joined result set
+    # otherwise it attemps to sort the whole available query scope which can be large
     def focus_window_random_sample
-      SetMemberSubject
-      .where(id: available)
-      .order(random: %i(asc desc).sample)
-      .limit(focus_set_window_size)
+      SetMemberSubject.with(available_ids: available).joins('INNER JOIN available_ids ON available_ids.id = set_member_subjects.id').order(random: %i[asc desc].sample).limit(focus_set_window_size)
     end
 
     def focus_set_window_size

--- a/lib/subjects/postgresql_selection.rb
+++ b/lib/subjects/postgresql_selection.rb
@@ -22,55 +22,20 @@ module Subjects
 
     def available
       query = Subjects::SetMemberSubjectSelector.new(workflow, user).set_member_subjects
-      subject_set_ids = if workflow.grouped
-                          # respect the user if they want to select from a training set
-                          Array.wrap(opts[:subject_set_id])
-                        else
-                          # default mode: do not select from training sets
-                          workflow.non_training_subject_sets.pluck(:id)
-                        end
-      if Gem::Version.new(Rails.version) > Gem::Version.new('5.0') && Gem::Version.new(Rails.version) < Gem::Version.new('5.1')
-        # Handle a bug when the rails 5.0 AR scope bind params merge in rails 5.0 (works fine in 4.2)
-        #
-        # failed fix 1 - ensure the subject_set_id param clause is before the id clause
-        #
-        # SetMemberSubject.where(subject_set_id: subject_set_ids, id: query).select(:id)
-        #
-        # as that fixes the incorrect subject_set_id bind param - fails to bind limit correctly later on :(
-        #
-        # failed fix 2 - leave as is but wrap subject set ids in array
-        #
-        # query.where(subject_set_id: subject_set_ids)
-        #
-        # duplicate query clauses which make no sense and can be cleaned up
-        # but it still fails on the limit bind param fails later on :(
-        #
-        # failed fix 3 - tried to merge the AR queries manually
-        #
-        # query.merge(SetMemberSubject.where(subject_set_id: subject_set_ids))
-        #
-        # fixes the duplicate query clause but still fails on the limit bind param later on :(
-        #
-        # failed fix 4 - use an explicit sub query
-        #
-        # SetMemberSubject.where(subject_set_id: subject_set_ids, id: SetMemberSubject.select('id').from(query)).select(:id)
-        #
-        # fixes the subject set id bind param but still fails on the limit bind param later on :(
-
-        # Working solution
-        #
-        # run two queries
-        # one with with a pluck on the query select to pull the avaialble SMS IDs
-        # and then apply the subject set id filter to create a new simple scope
-        # that we pass onto to the selector strategy class which then applies the limit bind params etc
-        SetMemberSubject.where(id: query.pluck(:id), subject_set_id: subject_set_ids).select(:id)
-      else
-        query.merge(SetMemberSubject.where(subject_set_id: subject_set_ids))
-      end
+      # use a rewhere in case we've applied this clause before
+      query.rewhere(subject_set_id: subject_set_ids)
     end
 
     def limit
       opts.fetch(:limit, 20).to_i
+    end
+
+    def subject_set_ids
+      # respect the user if they want to select from a training set
+      return Array.wrap(opts[:subject_set_id]) if workflow.grouped
+
+      # default mode: do not select from training sets
+      workflow.non_training_subject_sets.pluck(:id)
     end
   end
 end


### PR DESCRIPTION
This PR switches the pg subject selection code** from using nested subqueries to find the available pools of subjects to using postgres [CTE](https://www.postgresql.org/docs/current/queries-with.html) queries. This removes the need for custom AR version scoping code and should be faster (benchmarks needed!)

It uses a new PG query [extensions gem ](https://github.com/georgekaraszi/ActiveRecordExtended#common-table-expressions-cte) in place of an older union query gem - it provides a suite of new features and is compatible with rails 5+ and is maintained. 

**used when external subject selector service ([designator](https://github.com/zooniverse/designator/)) is not available

In the benchmarking below it appears that the CTE version is slightly quicker (use total not real values) but there doesn't seem to be a decrease in performance which is key for me. 

### Benchmarks (to be take with a grain of salt)

*All queries were run with subject data loaded already, i.e. i removed the results that loaded the ~225K subjects from disk*

#### Current deployed version
```
##### Current master with hot data paths
### WF: 2363
# usual priority project wf subjects (~2K)
# with priority selection

### logged in user with no seen subjects
#       user     system      total        real
#  0.073161   0.010550   0.083711 (  1.018071)

### user with some seen subjects
#       user     system      total        real
#  0.014965   0.000000   0.014965 (  0.370547)

### no user
#       user     system      total        real
#  0.017332   0.002949   0.020281 (  0.386075)

### WF: 13693
# good sized wf subjects (~225K)
# with random selection

### user with no seen subjects
#       user     system      total        real
#  0.462185   0.020308   0.482493 (  3.011191)

### user with some seen subjects
#       user     system      total        real
#  0.347239   0.003387   0.350626 (  2.128591)

### user with seens subjects
#       user     system      total        real
#  0.330617   0.011642   0.342259 (  2.019306)

### no user
#       user     system      total        real
#  0.330270   0.007683   0.337953 (  2.114776)
```

#### Refactored branch
```
## Refactor branch with hot data paths
### WF: 2363
# usual priority project wf subjects (~2K)
# with priority selection

### logged in user with no seen subjects
#       user     system      total        real
#  0.053747   0.003275   0.057022 (  0.779420)

### user with some seen subjects
#       user     system      total        real
#  0.005348   0.000000   0.005348 (  0.168495)

### no user
#       user     system      total        real
#  0.002275   0.000134   0.002409 (  0.165507)

### WF: 13693
# good sized wf subjects (~225K)
# with random selection

### user with no seen subjects
#       user     system      total        real
#  0.032827   0.006103   0.038930 (  1.355070)

### user with some seen subejcts
#       user     system      total        real
#  0.006971   0.000000   0.006971 (  0.810077)
 
### user with seens subjects
#       user     system      total        real
#  0.010655   0.000000   0.010655 (  0.790179)

### no user
#       user     system      total        real
#  0.006159   0.000000   0.006159 (  0.780472)
```

## TODO 
- [x] Run benchmark test queries on new and old code

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
