### PR TITLE
explicit avoid code injection via media_route params

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -17,7 +17,8 @@ class Api::V1::MediaController < Api::ApiController
     classifications_export: :classifications_export,
     subjects_export: :subjects_export,
     workflows_export: :workflows_export,
-    workflow_contents_export: :workflow_contents_export
+    workflow_contents_export: :workflow_contents_export,
+    profile_header: :profile_header
   }.freeze
 
   def schema_class(action)


### PR DESCRIPTION
media routes declare allowed polymorphic resources for use in routes and these are constrained to certain resource names, https://github.com/zooniverse/panoptes/blob/5b0cbf938e1e33830ec4204778aa0c6c9f5030bc/lib/routes/json_api_routes.rb#L34

This PR avoids any possible code injection we avoid using those params and instead rely on an allow list in the media controller. 

Longer term that means if we add new media resources in routes we have to declare them in this controller file as well to ensure they work and not error. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
