### PR TITLE
avoid clobbering a project's existing workflows when updating links

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -102,6 +102,17 @@ class Api::V1::ProjectsController < Api::ApiController
     created_resource_response(copied_project)
   end
 
+  # ensure we avoid clobbering the workflow relations on a project via the
+  # relation manager when the workflow id is not in the array form, i.e. is singular
+  def update_links
+    # using an array form param ensures we use the concat form of relation adding vs overwriting the relation
+    # this is important for the project -> workflow relation
+    # as we never want to unlink a workflow when handling project links
+    # instead force the clients to explicitly delete workflows from the project
+    params[:workflows] = Array.wrap(params[:workflows])
+    super
+  end
+
   private
 
   def create_response(project_scope)

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -752,6 +752,26 @@ describe Api::V1::ProjectsController, type: :controller do
           end
         end
       end
+
+      context 'with linkable workflow id not in array form' do
+        let(:params) do
+          {
+            link_relation: test_relation.to_s,
+            workflows: linked_resource.id.to_s,
+            project_id: resource.id
+          }
+        end
+
+        before do
+          default_request scopes: scopes, user_id: authorized_user.id
+        end
+
+        it "does not clobber the project's existing workflow links" do
+          post :update_links, params
+          response_wf_ids = json_response['projects'][0]['links']['workflows']
+          expect(response_wf_ids).to include(linked_resource.id.to_s)
+        end
+      end
     end
 
     describe "linking a subject_set" do


### PR DESCRIPTION
related to https://github.com/zooniverse/Panoptes-Front-End/pull/6212#discussion_r994067886

This PR ensures we use an array form for the project's workflow links when using the `update_links` controller paths and the relation manager. Thus we avoid clobbering a project's existing workflow links as we never want to lose existing workflows on a project. 

FWIW - I can't see a use case where a client would want to clobber the existing workflow links but we will see if any bug reports come in and Hyrum's law kicks in https://www.hyrumslaw.com/

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
