### PR TITLE
touch the resource we are linking to on update_links

### DIFF
--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -27,9 +27,14 @@ module JsonApiController
     def update_links
       check_relation
       resource = controlled_resources.first
+
       resource_class.transaction(requires_new: true) do
         add_relation(resource, relation, params[relation])
-        resource.save!
+        if resource.changed?
+          resource.save!
+        else
+          resource.touch
+        end
       end
 
       yield resource if block_given?

--- a/lib/json_api_controller/updatable_resource.rb
+++ b/lib/json_api_controller/updatable_resource.rb
@@ -27,7 +27,6 @@ module JsonApiController
     def update_links
       check_relation
       resource = controlled_resources.first
-
       resource_class.transaction(requires_new: true) do
         add_relation(resource, relation, params[relation])
         if resource.changed?

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -446,7 +446,6 @@ describe Api::V1::WorkflowsController, type: :controller do
     end
 
     context 'linking a tutorial' do
-
       let(:tutorial_project) { project }
       let(:linked_resource) { create(:tutorial, project: tutorial_project) }
       let(:resource) { workflow }
@@ -456,9 +455,9 @@ describe Api::V1::WorkflowsController, type: :controller do
 
       it_behaves_like "supports update_links" do
         it 'links the tutorial to the workflow' do
-          expect(updated_resource.tutorials.pluck(:id).map(&:to_s)).to eq(test_relation_ids)
+          post :update_links, params
+          expect(updated_resource.tutorial_ids.map(&:to_s)).to eq(test_relation_ids)
         end
-
       end
     end
 
@@ -479,7 +478,8 @@ describe Api::V1::WorkflowsController, type: :controller do
 
       it_behaves_like "supports update_links" do
         it 'marks the subject as retired' do
-          expect(linked_resource.retired_for_workflow?(resource)).to be_truthy
+          post :update_links, params
+          expect(linked_resource.retired_for_workflow?(resource)).to be(true)
         end
       end
 

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -105,7 +105,7 @@ RSpec.shared_examples "supports update_links" do
   end
 
   it 'updates the cache key on the resource' do
-    # this is so the serializer resonse cache is busted and the links includes the newly added resource
+    # this is so the serializer response cache is busted and the links includes the newly added resource
     expect { post :update_links, params }.to change { resource.reload.cache_key }
   end
 end

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -140,7 +140,7 @@ RSpec.shared_examples "supports update_links via a copy of the original" do
   end
 
   it 'updates the cache key on the original resource' do
-    # this is so the serializer resonse cache is busted and the links includes the newly added resource
+    # this is so the serializer response cache is busted and the links includes the newly added resource
     expect { update_via_links }.to change { resource.reload.cache_key }
   end
 end


### PR DESCRIPTION
This PR introduces a change to controller `update_links` behaviours where we ensure always modify the `resource.updated_at` value. 

When we `save` the resource we need to ensure we modify the cache key (cache bust) on the linking resource so we generate a new serialization response that includes the update_link operations results. As such we run `resource.touch` if the save operation had no changes (no update issued) and we modify the `updated_at`.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
