### PR TITLE
Rails 5.1 update failing update_links tests with params key

### DIFF
--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -761,7 +761,7 @@ describe Api::V1::ProjectsController, type: :controller do
         end
 
         it "does not clobber the project's existing workflow links" do
-          post :update_links, params
+          post :update_links, params: params
           response_wf_ids = json_response['projects'][0]['links']['workflows']
           expect(response_wf_ids).to include(linked_resource.id.to_s)
         end

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -130,7 +130,7 @@ describe Api::V1::WorkflowsController, type: :controller do
       end
 
       it 'correctly handles steps attributes nested array objects' do
-        put :update, update_params
+        put :update, params: update_params
         updated_resource = json_response['workflows'][0]
         expect(updated_resource['steps']).to match(update_params.dig(:workflows, :steps))
       end
@@ -456,7 +456,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
       it_behaves_like 'supports update_links' do
         it 'links the tutorial to the workflow' do
-          post :update_links, params
+          post :update_links, params: params
           expect(updated_resource.tutorial_ids.map(&:to_s)).to eq(test_relation_ids)
         end
       end
@@ -479,7 +479,7 @@ describe Api::V1::WorkflowsController, type: :controller do
 
       it_behaves_like 'supports update_links' do
         it 'marks the subject as retired' do
-          post :update_links, params
+          post :update_links, params: params
           expect(linked_resource.retired_for_workflow?(resource)).to be(true)
         end
       end

--- a/spec/support/updatable.rb
+++ b/spec/support/updatable.rb
@@ -94,19 +94,19 @@ RSpec.shared_examples "supports update_links" do
   end
 
   it 'updates any included links' do
-    post :update_links, params
+    post :update_links, params: params
     updated_relation_ids = UpdatableResource.extract_linked_resource_ids(linked_resources)
     expect(updated_relation_ids).to include(*stringified_test_relation_ids)
   end
 
   it 'retains pre-existing links' do
-    post :update_links, params
+    post :update_links, params: params
     expect(linked_resources.map(&:id)).to include(*old_ids)
   end
 
   it 'updates the cache key on the resource' do
     # this is so the serializer response cache is busted and the links includes the newly added resource
-    expect { post :update_links, params }.to change { resource.reload.cache_key }
+    expect { post :update_links, params: params }.to change { resource.reload.cache_key }
   end
 end
 


### PR DESCRIPTION

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
