### PR TITLE
Rails 5.1 (test fixes) update user_spec with update_ouroboros_created with stubs 

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -569,9 +569,12 @@ describe User, type: :model do
     let(:user) { create(:user) }
 
     it "should call update_ouroboros_created on the model" do
-      expect(user).to receive(:update_ouroboros_created)
-      expect(user).not_to receive(:save)
-      user.active_for_authentication?
+      stubbed_user = build_stubbed(:user)
+      allow(stubbed_user).to receive(:update_ouroboros_created)
+      allow(stubbed_user).to receive(:save)
+      stubbed_user.active_for_authentication?
+      expect(stubbed_user).to have_received(:update_ouroboros_created)
+      expect(stubbed_user).not_to have_received(:save)
     end
 
     it "should return true for an active user" do


### PR DESCRIPTION
 update user_spec with update_ouroboros_created with stubs to test if method gets called instead of using db transaction checks due to issues testing active record callbacks


Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
