### PR TITLE
update sql schema post rails 5 upgrade

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.11 (Debian 11.11-1.pgdg90+1)
--- Dumped by pg_dump version 11.14
+-- Dumped from database version 11.15 (Debian 11.15-1.pgdg90+1)
+-- Dumped by pg_dump version 11.15
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -127,6 +127,18 @@ CREATE SEQUENCE public.aggregations_id_seq
 --
 
 ALTER SEQUENCE public.aggregations_id_seq OWNED BY public.aggregations.id;
+
+
+--
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
 
 
 --
@@ -2358,6 +2370,14 @@ ALTER TABLE ONLY public.aggregations
 
 
 --
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
 -- Name: authorizations authorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4300,523 +4320,266 @@ ALTER TABLE ONLY public.users
 
 SET search_path TO "$user", public;
 
-INSERT INTO schema_migrations (version) VALUES ('20150210025312');
+INSERT INTO "schema_migrations" (version) VALUES
+('20150210025312'),
+('20150216192914'),
+('20150216192936'),
+('20150220000430'),
+('20150223194424'),
+('20150223200017'),
+('20150224161921'),
+('20150224211450'),
+('20150224223657'),
+('20150225181828'),
+('20150227223423'),
+('20150309171224'),
+('20150317180911'),
+('20150318132024'),
+('20150318174012'),
+('20150318221605'),
+('20150327184058'),
+('20150406095027'),
+('20150409130306'),
+('20150421161901'),
+('20150421191603'),
+('20150427171257'),
+('20150427181152'),
+('20150427204917'),
+('20150429163442'),
+('20150430084746'),
+('20150430132128'),
+('20150501162020'),
+('20150504171133'),
+('20150504185433'),
+('20150504193426'),
+('20150505181642'),
+('20150506195759'),
+('20150506195817'),
+('20150507120651'),
+('20150507212315'),
+('20150511151058'),
+('20150512012101'),
+('20150512123559'),
+('20150512223346'),
+('20150517015229'),
+('20150521160726'),
+('20150522155815'),
+('20150523190207'),
+('20150526180444'),
+('20150527200052'),
+('20150527223732'),
+('20150602140836'),
+('20150602160633'),
+('20150604214129'),
+('20150605103339'),
+('20150610200133'),
+('20150615153138'),
+('20150616113453'),
+('20150616113526'),
+('20150616113559'),
+('20150616155130'),
+('20150622085848'),
+('20150624131746'),
+('20150624135643'),
+('20150624155122'),
+('20150625043821'),
+('20150625045214'),
+('20150625160224'),
+('20150629192248'),
+('20150630144332'),
+('20150706100343'),
+('20150706133624'),
+('20150706185722'),
+('20150709191011'),
+('20150710184447'),
+('20150715134211'),
+('20150716161318'),
+('20150717123631'),
+('20150721221349'),
+('20150722180408'),
+('20150727212724'),
+('20150729165415'),
+('20150730160541'),
+('20150811202500'),
+('20150817145756'),
+('20150827124834'),
+('20150901222924'),
+('20150902000226'),
+('20150908162042'),
+('20150908193654'),
+('20150916161203'),
+('20150916162320'),
+('20150921130111'),
+('20151005093746'),
+('20151007161139'),
+('20151007193849'),
+('20151009145251'),
+('20151012162248'),
+('20151013181750'),
+('20151023103228'),
+('20151024080849'),
+('20151026142554'),
+('20151027134345'),
+('20151106172531'),
+('20151110101156'),
+('20151110135415'),
+('20151111154310'),
+('20151116143407'),
+('20151117154126'),
+('20151120104454'),
+('20151120161458'),
+('20151125153712'),
+('20151127150019'),
+('20151201102135'),
+('20151207111508'),
+('20151207145728'),
+('20151210134819'),
+('20151231123306'),
+('20160103142817'),
+('20160104131622'),
+('20160106120927'),
+('20160107143209'),
+('20160111112417'),
+('20160113120732'),
+('20160113132540'),
+('20160113133848'),
+('20160113143609'),
+('20160114135531'),
+('20160114141909'),
+('20160202155708'),
+('20160303163658'),
+('20160323101942'),
+('20160329144922'),
+('20160330142609'),
+('20160406151657'),
+('20160408104326'),
+('20160412125332'),
+('20160414151041'),
+('20160425190129'),
+('20160427150421'),
+('20160506182308'),
+('20160512181921'),
+('20160525103520'),
+('20160527140046'),
+('20160527162831'),
+('20160601162035'),
+('20160613074506'),
+('20160613074514'),
+('20160613074521'),
+('20160613074534'),
+('20160613074550'),
+('20160613074559'),
+('20160613074613'),
+('20160613074625'),
+('20160613074633'),
+('20160613074640'),
+('20160613074658'),
+('20160613074711'),
+('20160613074718'),
+('20160613074730'),
+('20160613074745'),
+('20160613074746'),
+('20160613074754'),
+('20160613074924'),
+('20160613074934'),
+('20160613075003'),
+('20160628165038'),
+('20160630150419'),
+('20160630170502'),
+('20160810140805'),
+('20160810195152'),
+('20160819134413'),
+('20160824101413'),
+('20160901100944'),
+('20160901141903'),
+('20161017135917'),
+('20161017141439'),
+('20161125123824'),
+('20161128193435'),
+('20161205203956'),
+('20161207111319'),
+('20161212205412'),
+('20161221203241'),
+('20170112163747'),
+('20170113113532'),
+('20170116134142'),
+('20170118141452'),
+('20170202200131'),
+('20170202202724'),
+('20170206161946'),
+('20170210163241'),
+('20170215105309'),
+('20170215151802'),
+('20170310131642'),
+('20170316170501'),
+('20170320203350'),
+('20170325135953'),
+('20170403194826'),
+('20170420095703'),
+('20170425110939'),
+('20170426162708'),
+('20170519181110'),
+('20170523135118'),
+('20170524205300'),
+('20170524210302'),
+('20170525151142'),
+('20170727142122'),
+('20170808130619'),
+('20170824165411'),
+('20171019115705'),
+('20171120222438'),
+('20171121120455'),
+('20171208141841'),
+('20171208142645'),
+('20171213144807'),
+('20171214121332'),
+('20180110133833'),
+('20180115214144'),
+('20180119110708'),
+('20180122134607'),
+('20180207120238'),
+('20180403150901'),
+('20180404144354'),
+('20180404144531'),
+('20180510100328'),
+('20180510121206'),
+('20180614131933'),
+('20180710151618'),
+('20180724112620'),
+('20180726133210'),
+('20180730133806'),
+('20180730150333'),
+('20180808140938'),
+('20180821125430'),
+('20180821151555'),
+('20181001154345'),
+('20181002145749'),
+('20181015112421'),
+('20181022172507'),
+('20181023130028'),
+('20181203164038'),
+('20190220114950'),
+('20190220155414'),
+('20190220161628'),
+('20190222121420'),
+('20190307114830'),
+('20190307121801'),
+('20190307141138'),
+('20190411125709'),
+('20190507103007'),
+('20190524111214'),
+('20190624094308'),
+('20200513124310'),
+('20200714191914'),
+('20200716170833'),
+('20200717155424'),
+('20200720125246'),
+('20201113151433'),
+('20210226173243'),
+('20210602210437'),
+('20210729152047'),
+('20211007125705'),
+('20211124175756'),
+('20211201164326');
 
-INSERT INTO schema_migrations (version) VALUES ('20150216192914');
-
-INSERT INTO schema_migrations (version) VALUES ('20150216192936');
-
-INSERT INTO schema_migrations (version) VALUES ('20150220000430');
-
-INSERT INTO schema_migrations (version) VALUES ('20150223194424');
-
-INSERT INTO schema_migrations (version) VALUES ('20150223200017');
-
-INSERT INTO schema_migrations (version) VALUES ('20150224161921');
-
-INSERT INTO schema_migrations (version) VALUES ('20150224211450');
-
-INSERT INTO schema_migrations (version) VALUES ('20150224223657');
-
-INSERT INTO schema_migrations (version) VALUES ('20150225181828');
-
-INSERT INTO schema_migrations (version) VALUES ('20150227223423');
-
-INSERT INTO schema_migrations (version) VALUES ('20150309171224');
-
-INSERT INTO schema_migrations (version) VALUES ('20150317180911');
-
-INSERT INTO schema_migrations (version) VALUES ('20150318132024');
-
-INSERT INTO schema_migrations (version) VALUES ('20150318174012');
-
-INSERT INTO schema_migrations (version) VALUES ('20150318221605');
-
-INSERT INTO schema_migrations (version) VALUES ('20150327184058');
-
-INSERT INTO schema_migrations (version) VALUES ('20150406095027');
-
-INSERT INTO schema_migrations (version) VALUES ('20150409130306');
-
-INSERT INTO schema_migrations (version) VALUES ('20150421161901');
-
-INSERT INTO schema_migrations (version) VALUES ('20150421191603');
-
-INSERT INTO schema_migrations (version) VALUES ('20150427171257');
-
-INSERT INTO schema_migrations (version) VALUES ('20150427181152');
-
-INSERT INTO schema_migrations (version) VALUES ('20150427204917');
-
-INSERT INTO schema_migrations (version) VALUES ('20150429163442');
-
-INSERT INTO schema_migrations (version) VALUES ('20150430084746');
-
-INSERT INTO schema_migrations (version) VALUES ('20150430132128');
-
-INSERT INTO schema_migrations (version) VALUES ('20150501162020');
-
-INSERT INTO schema_migrations (version) VALUES ('20150504171133');
-
-INSERT INTO schema_migrations (version) VALUES ('20150504185433');
-
-INSERT INTO schema_migrations (version) VALUES ('20150504193426');
-
-INSERT INTO schema_migrations (version) VALUES ('20150505181642');
-
-INSERT INTO schema_migrations (version) VALUES ('20150506195759');
-
-INSERT INTO schema_migrations (version) VALUES ('20150506195817');
-
-INSERT INTO schema_migrations (version) VALUES ('20150507120651');
-
-INSERT INTO schema_migrations (version) VALUES ('20150507212315');
-
-INSERT INTO schema_migrations (version) VALUES ('20150511151058');
-
-INSERT INTO schema_migrations (version) VALUES ('20150512012101');
-
-INSERT INTO schema_migrations (version) VALUES ('20150512123559');
-
-INSERT INTO schema_migrations (version) VALUES ('20150512223346');
-
-INSERT INTO schema_migrations (version) VALUES ('20150517015229');
-
-INSERT INTO schema_migrations (version) VALUES ('20150521160726');
-
-INSERT INTO schema_migrations (version) VALUES ('20150522155815');
-
-INSERT INTO schema_migrations (version) VALUES ('20150523190207');
-
-INSERT INTO schema_migrations (version) VALUES ('20150526180444');
-
-INSERT INTO schema_migrations (version) VALUES ('20150527200052');
-
-INSERT INTO schema_migrations (version) VALUES ('20150527223732');
-
-INSERT INTO schema_migrations (version) VALUES ('20150602140836');
-
-INSERT INTO schema_migrations (version) VALUES ('20150602160633');
-
-INSERT INTO schema_migrations (version) VALUES ('20150604214129');
-
-INSERT INTO schema_migrations (version) VALUES ('20150605103339');
-
-INSERT INTO schema_migrations (version) VALUES ('20150610200133');
-
-INSERT INTO schema_migrations (version) VALUES ('20150615153138');
-
-INSERT INTO schema_migrations (version) VALUES ('20150616113453');
-
-INSERT INTO schema_migrations (version) VALUES ('20150616113526');
-
-INSERT INTO schema_migrations (version) VALUES ('20150616113559');
-
-INSERT INTO schema_migrations (version) VALUES ('20150616155130');
-
-INSERT INTO schema_migrations (version) VALUES ('20150622085848');
-
-INSERT INTO schema_migrations (version) VALUES ('20150624131746');
-
-INSERT INTO schema_migrations (version) VALUES ('20150624135643');
-
-INSERT INTO schema_migrations (version) VALUES ('20150624155122');
-
-INSERT INTO schema_migrations (version) VALUES ('20150625043821');
-
-INSERT INTO schema_migrations (version) VALUES ('20150625045214');
-
-INSERT INTO schema_migrations (version) VALUES ('20150625160224');
-
-INSERT INTO schema_migrations (version) VALUES ('20150629192248');
-
-INSERT INTO schema_migrations (version) VALUES ('20150630144332');
-
-INSERT INTO schema_migrations (version) VALUES ('20150706100343');
-
-INSERT INTO schema_migrations (version) VALUES ('20150706133624');
-
-INSERT INTO schema_migrations (version) VALUES ('20150706185722');
-
-INSERT INTO schema_migrations (version) VALUES ('20150709191011');
-
-INSERT INTO schema_migrations (version) VALUES ('20150710184447');
-
-INSERT INTO schema_migrations (version) VALUES ('20150715134211');
-
-INSERT INTO schema_migrations (version) VALUES ('20150716161318');
-
-INSERT INTO schema_migrations (version) VALUES ('20150717123631');
-
-INSERT INTO schema_migrations (version) VALUES ('20150721221349');
-
-INSERT INTO schema_migrations (version) VALUES ('20150722180408');
-
-INSERT INTO schema_migrations (version) VALUES ('20150727212724');
-
-INSERT INTO schema_migrations (version) VALUES ('20150729165415');
-
-INSERT INTO schema_migrations (version) VALUES ('20150730160541');
-
-INSERT INTO schema_migrations (version) VALUES ('20150811202500');
-
-INSERT INTO schema_migrations (version) VALUES ('20150817145756');
-
-INSERT INTO schema_migrations (version) VALUES ('20150827124834');
-
-INSERT INTO schema_migrations (version) VALUES ('20150901222924');
-
-INSERT INTO schema_migrations (version) VALUES ('20150902000226');
-
-INSERT INTO schema_migrations (version) VALUES ('20150908162042');
-
-INSERT INTO schema_migrations (version) VALUES ('20150908193654');
-
-INSERT INTO schema_migrations (version) VALUES ('20150916161203');
-
-INSERT INTO schema_migrations (version) VALUES ('20150916162320');
-
-INSERT INTO schema_migrations (version) VALUES ('20150921130111');
-
-INSERT INTO schema_migrations (version) VALUES ('20151005093746');
-
-INSERT INTO schema_migrations (version) VALUES ('20151007161139');
-
-INSERT INTO schema_migrations (version) VALUES ('20151007193849');
-
-INSERT INTO schema_migrations (version) VALUES ('20151009145251');
-
-INSERT INTO schema_migrations (version) VALUES ('20151012162248');
-
-INSERT INTO schema_migrations (version) VALUES ('20151013181750');
-
-INSERT INTO schema_migrations (version) VALUES ('20151023103228');
-
-INSERT INTO schema_migrations (version) VALUES ('20151024080849');
-
-INSERT INTO schema_migrations (version) VALUES ('20151026142554');
-
-INSERT INTO schema_migrations (version) VALUES ('20151027134345');
-
-INSERT INTO schema_migrations (version) VALUES ('20151106172531');
-
-INSERT INTO schema_migrations (version) VALUES ('20151110101156');
-
-INSERT INTO schema_migrations (version) VALUES ('20151110135415');
-
-INSERT INTO schema_migrations (version) VALUES ('20151111154310');
-
-INSERT INTO schema_migrations (version) VALUES ('20151116143407');
-
-INSERT INTO schema_migrations (version) VALUES ('20151117154126');
-
-INSERT INTO schema_migrations (version) VALUES ('20151120104454');
-
-INSERT INTO schema_migrations (version) VALUES ('20151120161458');
-
-INSERT INTO schema_migrations (version) VALUES ('20151125153712');
-
-INSERT INTO schema_migrations (version) VALUES ('20151127150019');
-
-INSERT INTO schema_migrations (version) VALUES ('20151201102135');
-
-INSERT INTO schema_migrations (version) VALUES ('20151207111508');
-
-INSERT INTO schema_migrations (version) VALUES ('20151207145728');
-
-INSERT INTO schema_migrations (version) VALUES ('20151210134819');
-
-INSERT INTO schema_migrations (version) VALUES ('20151231123306');
-
-INSERT INTO schema_migrations (version) VALUES ('20160103142817');
-
-INSERT INTO schema_migrations (version) VALUES ('20160104131622');
-
-INSERT INTO schema_migrations (version) VALUES ('20160106120927');
-
-INSERT INTO schema_migrations (version) VALUES ('20160107143209');
-
-INSERT INTO schema_migrations (version) VALUES ('20160111112417');
-
-INSERT INTO schema_migrations (version) VALUES ('20160113120732');
-
-INSERT INTO schema_migrations (version) VALUES ('20160113132540');
-
-INSERT INTO schema_migrations (version) VALUES ('20160113133848');
-
-INSERT INTO schema_migrations (version) VALUES ('20160113143609');
-
-INSERT INTO schema_migrations (version) VALUES ('20160114135531');
-
-INSERT INTO schema_migrations (version) VALUES ('20160114141909');
-
-INSERT INTO schema_migrations (version) VALUES ('20160202155708');
-
-INSERT INTO schema_migrations (version) VALUES ('20160303163658');
-
-INSERT INTO schema_migrations (version) VALUES ('20160323101942');
-
-INSERT INTO schema_migrations (version) VALUES ('20160329144922');
-
-INSERT INTO schema_migrations (version) VALUES ('20160330142609');
-
-INSERT INTO schema_migrations (version) VALUES ('20160406151657');
-
-INSERT INTO schema_migrations (version) VALUES ('20160408104326');
-
-INSERT INTO schema_migrations (version) VALUES ('20160412125332');
-
-INSERT INTO schema_migrations (version) VALUES ('20160414151041');
-
-INSERT INTO schema_migrations (version) VALUES ('20160425190129');
-
-INSERT INTO schema_migrations (version) VALUES ('20160427150421');
-
-INSERT INTO schema_migrations (version) VALUES ('20160506182308');
-
-INSERT INTO schema_migrations (version) VALUES ('20160512181921');
-
-INSERT INTO schema_migrations (version) VALUES ('20160525103520');
-
-INSERT INTO schema_migrations (version) VALUES ('20160527140046');
-
-INSERT INTO schema_migrations (version) VALUES ('20160527162831');
-
-INSERT INTO schema_migrations (version) VALUES ('20160601162035');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074506');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074514');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074521');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074534');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074550');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074559');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074613');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074625');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074633');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074640');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074658');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074711');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074718');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074730');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074745');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074746');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074754');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074924');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613074934');
-
-INSERT INTO schema_migrations (version) VALUES ('20160613075003');
-
-INSERT INTO schema_migrations (version) VALUES ('20160628165038');
-
-INSERT INTO schema_migrations (version) VALUES ('20160630150419');
-
-INSERT INTO schema_migrations (version) VALUES ('20160630170502');
-
-INSERT INTO schema_migrations (version) VALUES ('20160810140805');
-
-INSERT INTO schema_migrations (version) VALUES ('20160810195152');
-
-INSERT INTO schema_migrations (version) VALUES ('20160819134413');
-
-INSERT INTO schema_migrations (version) VALUES ('20160824101413');
-
-INSERT INTO schema_migrations (version) VALUES ('20160901100944');
-
-INSERT INTO schema_migrations (version) VALUES ('20160901141903');
-
-INSERT INTO schema_migrations (version) VALUES ('20161017135917');
-
-INSERT INTO schema_migrations (version) VALUES ('20161017141439');
-
-INSERT INTO schema_migrations (version) VALUES ('20161125123824');
-
-INSERT INTO schema_migrations (version) VALUES ('20161128193435');
-
-INSERT INTO schema_migrations (version) VALUES ('20161205203956');
-
-INSERT INTO schema_migrations (version) VALUES ('20161207111319');
-
-INSERT INTO schema_migrations (version) VALUES ('20161212205412');
-
-INSERT INTO schema_migrations (version) VALUES ('20161221203241');
-
-INSERT INTO schema_migrations (version) VALUES ('20170112163747');
-
-INSERT INTO schema_migrations (version) VALUES ('20170113113532');
-
-INSERT INTO schema_migrations (version) VALUES ('20170116134142');
-
-INSERT INTO schema_migrations (version) VALUES ('20170118141452');
-
-INSERT INTO schema_migrations (version) VALUES ('20170202200131');
-
-INSERT INTO schema_migrations (version) VALUES ('20170202202724');
-
-INSERT INTO schema_migrations (version) VALUES ('20170206161946');
-
-INSERT INTO schema_migrations (version) VALUES ('20170210163241');
-
-INSERT INTO schema_migrations (version) VALUES ('20170215105309');
-
-INSERT INTO schema_migrations (version) VALUES ('20170215151802');
-
-INSERT INTO schema_migrations (version) VALUES ('20170310131642');
-
-INSERT INTO schema_migrations (version) VALUES ('20170316170501');
-
-INSERT INTO schema_migrations (version) VALUES ('20170320203350');
-
-INSERT INTO schema_migrations (version) VALUES ('20170325135953');
-
-INSERT INTO schema_migrations (version) VALUES ('20170403194826');
-
-INSERT INTO schema_migrations (version) VALUES ('20170420095703');
-
-INSERT INTO schema_migrations (version) VALUES ('20170425110939');
-
-INSERT INTO schema_migrations (version) VALUES ('20170426162708');
-
-INSERT INTO schema_migrations (version) VALUES ('20170519181110');
-
-INSERT INTO schema_migrations (version) VALUES ('20170523135118');
-
-INSERT INTO schema_migrations (version) VALUES ('20170524205300');
-
-INSERT INTO schema_migrations (version) VALUES ('20170524210302');
-
-INSERT INTO schema_migrations (version) VALUES ('20170525151142');
-
-INSERT INTO schema_migrations (version) VALUES ('20170727142122');
-
-INSERT INTO schema_migrations (version) VALUES ('20170808130619');
-
-INSERT INTO schema_migrations (version) VALUES ('20170824165411');
-
-INSERT INTO schema_migrations (version) VALUES ('20171019115705');
-
-INSERT INTO schema_migrations (version) VALUES ('20171120222438');
-
-INSERT INTO schema_migrations (version) VALUES ('20171121120455');
-
-INSERT INTO schema_migrations (version) VALUES ('20171208141841');
-
-INSERT INTO schema_migrations (version) VALUES ('20171208142645');
-
-INSERT INTO schema_migrations (version) VALUES ('20171213144807');
-
-INSERT INTO schema_migrations (version) VALUES ('20171214121332');
-
-INSERT INTO schema_migrations (version) VALUES ('20180110133833');
-
-INSERT INTO schema_migrations (version) VALUES ('20180115214144');
-
-INSERT INTO schema_migrations (version) VALUES ('20180119110708');
-
-INSERT INTO schema_migrations (version) VALUES ('20180122134607');
-
-INSERT INTO schema_migrations (version) VALUES ('20180207120238');
-
-INSERT INTO schema_migrations (version) VALUES ('20180403150901');
-
-INSERT INTO schema_migrations (version) VALUES ('20180404144354');
-
-INSERT INTO schema_migrations (version) VALUES ('20180404144531');
-
-INSERT INTO schema_migrations (version) VALUES ('20180510100328');
-
-INSERT INTO schema_migrations (version) VALUES ('20180510121206');
-
-INSERT INTO schema_migrations (version) VALUES ('20180614131933');
-
-INSERT INTO schema_migrations (version) VALUES ('20180710151618');
-
-INSERT INTO schema_migrations (version) VALUES ('20180724112620');
-
-INSERT INTO schema_migrations (version) VALUES ('20180726133210');
-
-INSERT INTO schema_migrations (version) VALUES ('20180730133806');
-
-INSERT INTO schema_migrations (version) VALUES ('20180730150333');
-
-INSERT INTO schema_migrations (version) VALUES ('20180808140938');
-
-INSERT INTO schema_migrations (version) VALUES ('20180821125430');
-
-INSERT INTO schema_migrations (version) VALUES ('20180821151555');
-
-INSERT INTO schema_migrations (version) VALUES ('20181001154345');
-
-INSERT INTO schema_migrations (version) VALUES ('20181002145749');
-
-INSERT INTO schema_migrations (version) VALUES ('20181015112421');
-
-INSERT INTO schema_migrations (version) VALUES ('20181022172507');
-
-INSERT INTO schema_migrations (version) VALUES ('20181023130028');
-
-INSERT INTO schema_migrations (version) VALUES ('20181203164038');
-
-INSERT INTO schema_migrations (version) VALUES ('20190220114950');
-
-INSERT INTO schema_migrations (version) VALUES ('20190220155414');
-
-INSERT INTO schema_migrations (version) VALUES ('20190220161628');
-
-INSERT INTO schema_migrations (version) VALUES ('20190222121420');
-
-INSERT INTO schema_migrations (version) VALUES ('20190307114830');
-
-INSERT INTO schema_migrations (version) VALUES ('20190307121801');
-
-INSERT INTO schema_migrations (version) VALUES ('20190307141138');
-
-INSERT INTO schema_migrations (version) VALUES ('20190411125709');
-
-INSERT INTO schema_migrations (version) VALUES ('20190507103007');
-
-INSERT INTO schema_migrations (version) VALUES ('20190524111214');
-
-INSERT INTO schema_migrations (version) VALUES ('20190624094308');
-
-INSERT INTO schema_migrations (version) VALUES ('20200513124310');
-
-INSERT INTO schema_migrations (version) VALUES ('20200714191914');
-
-INSERT INTO schema_migrations (version) VALUES ('20200716170833');
-
-INSERT INTO schema_migrations (version) VALUES ('20200717155424');
-
-INSERT INTO schema_migrations (version) VALUES ('20200720125246');
-
-INSERT INTO schema_migrations (version) VALUES ('20201113151433');
-
-INSERT INTO schema_migrations (version) VALUES ('20210226173243');
-
-INSERT INTO schema_migrations (version) VALUES ('20210602210437');
-
-INSERT INTO schema_migrations (version) VALUES ('20210729152047');
-
-INSERT INTO schema_migrations (version) VALUES ('20211007125705');
-
-INSERT INTO schema_migrations (version) VALUES ('20211124175756');
-
-INSERT INTO schema_migrations (version) VALUES ('20211201164326');
 


### PR DESCRIPTION
This PR udpates the DB's sql representation after the rails 5 upgrade. We need to adopt and isolate these changes so future migrations only have the relevant changes.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
