### PR TITLE
Add first task default

### DIFF
--- a/db/migrate/20221018032140_update_workflows_add_first_task_default_value.rb
+++ b/db/migrate/20221018032140_update_workflows_add_first_task_default_value.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateWorkflowsAddFirstTaskDefaultValue < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default(:workflows, :first_task, from: nil, to: '')
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1950,7 +1950,7 @@ CREATE TABLE public.workflows (
     grouped boolean DEFAULT false NOT NULL,
     prioritized boolean DEFAULT false NOT NULL,
     primary_language character varying,
-    first_task character varying,
+    first_task character varying DEFAULT ''::character varying,
     tutorial_subject_id integer,
     lock_version integer DEFAULT 0,
     retired_set_member_subjects_count integer DEFAULT 0,
@@ -4580,6 +4580,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210729152047'),
 ('20211007125705'),
 ('20211124175756'),
-('20211201164326');
+('20211201164326'),
+('20221018032140');
 
 


### PR DESCRIPTION
related to the changes in https://github.com/zooniverse/Panoptes-Front-End/pull/6217 

This PR ensures that the workflow's `first_task` attribute is always set to a default, not null value, i.e. ''. 

I've included the changes in #3977 here and once that is in i'll isolate the changes to only include the relevant migration commit and decrease the noise in the `structure.sql` file to only include the changes this migration brings in. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
