### PR TITLE
use ApplicationRecord as model inheritance base

### DIFF
--- a/app/models/access_control_list.rb
+++ b/app/models/access_control_list.rb
@@ -1,4 +1,4 @@
-class AccessControlList < ActiveRecord::Base
+class AccessControlList < ApplicationRecord
   belongs_to :user_group
   belongs_to :resource, polymorphic: true
 

--- a/app/models/access_control_list.rb
+++ b/app/models/access_control_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AccessControlList < ApplicationRecord
   belongs_to :user_group
   belongs_to :resource, polymorphic: true

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aggregation < ApplicationRecord
 
   belongs_to :workflow

--- a/app/models/aggregation.rb
+++ b/app/models/aggregation.rb
@@ -1,4 +1,4 @@
-class Aggregation < ActiveRecord::Base
+class Aggregation < ApplicationRecord
 
   belongs_to :workflow
   belongs_to :subject

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Authorization < ApplicationRecord
   belongs_to :user
 

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,4 +1,4 @@
-class Authorization < ActiveRecord::Base
+class Authorization < ApplicationRecord
   belongs_to :user
 
   validates_presence_of :provider, :uid, :token

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Classification < ApplicationRecord
   belongs_to :project
   belongs_to :user

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,4 +1,4 @@
-class Classification < ActiveRecord::Base
+class Classification < ApplicationRecord
   belongs_to :project
   belongs_to :user
   belongs_to :workflow

--- a/app/models/code_experiment_config.rb
+++ b/app/models/code_experiment_config.rb
@@ -1,4 +1,4 @@
-class CodeExperimentConfig < ActiveRecord::Base
+class CodeExperimentConfig < ApplicationRecord
   include Scientist::Experiment
   CACHE_TIME = 5.minutes
 

--- a/app/models/code_experiment_config.rb
+++ b/app/models/code_experiment_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CodeExperimentConfig < ApplicationRecord
   include Scientist::Experiment
   CACHE_TIME = 5.minutes

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Collection < ApplicationRecord
   include RoleControl::Owned
   include Activatable

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,4 +1,4 @@
-class Collection < ActiveRecord::Base
+class Collection < ApplicationRecord
   include RoleControl::Owned
   include Activatable
   include PgSearch::Model

--- a/app/models/collections_subject.rb
+++ b/app/models/collections_subject.rb
@@ -1,4 +1,4 @@
-class CollectionsSubject < ActiveRecord::Base
+class CollectionsSubject < ApplicationRecord
   belongs_to :collection
   belongs_to :subject
 

--- a/app/models/collections_subject.rb
+++ b/app/models/collections_subject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CollectionsSubject < ApplicationRecord
   belongs_to :collection
   belongs_to :subject

--- a/app/models/field_guide.rb
+++ b/app/models/field_guide.rb
@@ -1,4 +1,4 @@
-class FieldGuide < ActiveRecord::Base
+class FieldGuide < ApplicationRecord
   include Translatable
   include LanguageValidation
   include Versioning

--- a/app/models/field_guide.rb
+++ b/app/models/field_guide.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FieldGuide < ApplicationRecord
   include Translatable
   include LanguageValidation

--- a/app/models/field_guide_version.rb
+++ b/app/models/field_guide_version.rb
@@ -1,3 +1,3 @@
-class FieldGuideVersion < ActiveRecord::Base
+class FieldGuideVersion < ApplicationRecord
   belongs_to :field_guide
 end

--- a/app/models/field_guide_version.rb
+++ b/app/models/field_guide_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FieldGuideVersion < ApplicationRecord
   belongs_to :field_guide
 end

--- a/app/models/gold_standard_annotation.rb
+++ b/app/models/gold_standard_annotation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class contains the historical gold standard classification annotations.
 # They have been ported to this table as a read only resource, as they are
 # used to provide accuracy feedback for users in specific Zooniverse

--- a/app/models/gold_standard_annotation.rb
+++ b/app/models/gold_standard_annotation.rb
@@ -9,7 +9,7 @@
 #
 # Long term this can probably go, but please check that the projects have
 # been retired and don't need this data for the feedback mechanism.
-class GoldStandardAnnotation < ActiveRecord::Base
+class GoldStandardAnnotation < ApplicationRecord
   belongs_to :workflow
   belongs_to :subject
   belongs_to :project

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Medium < ApplicationRecord
   class MissingPutFilePath < StandardError; end
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,4 +1,4 @@
-class Medium < ActiveRecord::Base
+class Medium < ApplicationRecord
   class MissingPutFilePath < StandardError; end
 
   belongs_to :linked, polymorphic: true

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Membership < ApplicationRecord
   belongs_to :user_group
   belongs_to :user

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,4 @@
-class Membership < ActiveRecord::Base
+class Membership < ApplicationRecord
   belongs_to :user_group
   belongs_to :user
   enum state: [:active, :invited, :inactive]

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,4 @@
-class Organization < ActiveRecord::Base
+class Organization < ApplicationRecord
   include RoleControl::Owned
   include Activatable
   include SluggedName

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Organization < ApplicationRecord
   include RoleControl::Owned
   include Activatable

--- a/app/models/organization_page.rb
+++ b/app/models/organization_page.rb
@@ -1,4 +1,4 @@
-class OrganizationPage < ActiveRecord::Base
+class OrganizationPage < ApplicationRecord
   include Translatable
   include LanguageValidation
   include Versioning

--- a/app/models/organization_page.rb
+++ b/app/models/organization_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrganizationPage < ApplicationRecord
   include Translatable
   include LanguageValidation

--- a/app/models/organization_page_version.rb
+++ b/app/models/organization_page_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrganizationPageVersion < ApplicationRecord
   belongs_to :organization_page
 end

--- a/app/models/organization_page_version.rb
+++ b/app/models/organization_page_version.rb
@@ -1,3 +1,3 @@
-class OrganizationPageVersion < ActiveRecord::Base
+class OrganizationPageVersion < ApplicationRecord
   belongs_to :organization_page
 end

--- a/app/models/organization_version.rb
+++ b/app/models/organization_version.rb
@@ -1,3 +1,3 @@
-class OrganizationVersion < ActiveRecord::Base
+class OrganizationVersion < ApplicationRecord
   belongs_to :organization
 end

--- a/app/models/organization_version.rb
+++ b/app/models/organization_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrganizationVersion < ApplicationRecord
   belongs_to :organization
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,4 @@
-class Project < ActiveRecord::Base
+class Project < ApplicationRecord
   include RoleControl::Owned
   include Activatable
   include ExtendedCacheKey

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Project < ApplicationRecord
   include RoleControl::Owned
   include Activatable

--- a/app/models/project_page.rb
+++ b/app/models/project_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProjectPage < ApplicationRecord
   include Translatable
   include LanguageValidation

--- a/app/models/project_page.rb
+++ b/app/models/project_page.rb
@@ -1,4 +1,4 @@
-class ProjectPage < ActiveRecord::Base
+class ProjectPage < ApplicationRecord
   include Translatable
   include LanguageValidation
   include Versioning

--- a/app/models/project_page_version.rb
+++ b/app/models/project_page_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProjectPageVersion < ApplicationRecord
   belongs_to :project_page
 end

--- a/app/models/project_page_version.rb
+++ b/app/models/project_page_version.rb
@@ -1,3 +1,3 @@
-class ProjectPageVersion < ActiveRecord::Base
+class ProjectPageVersion < ApplicationRecord
   belongs_to :project_page
 end

--- a/app/models/project_version.rb
+++ b/app/models/project_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProjectVersion < ApplicationRecord
   belongs_to :project
 end

--- a/app/models/project_version.rb
+++ b/app/models/project_version.rb
@@ -1,3 +1,3 @@
-class ProjectVersion < ActiveRecord::Base
+class ProjectVersion < ApplicationRecord
   belongs_to :project
 end

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Recent < ApplicationRecord
   include OrderedLocations
 

--- a/app/models/recent.rb
+++ b/app/models/recent.rb
@@ -1,4 +1,4 @@
-class Recent < ActiveRecord::Base
+class Recent < ApplicationRecord
   include OrderedLocations
 
   belongs_to :classification

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -1,4 +1,4 @@
-require 'subjects/set_member_subject_selector'
+# frozen_string_literal: true
 
 class SetMemberSubject < ApplicationRecord
 

--- a/app/models/set_member_subject.rb
+++ b/app/models/set_member_subject.rb
@@ -1,6 +1,6 @@
 require 'subjects/set_member_subject_selector'
 
-class SetMemberSubject < ActiveRecord::Base
+class SetMemberSubject < ApplicationRecord
 
   belongs_to :subject_set
   belongs_to :subject

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,4 @@
-class Subject < ActiveRecord::Base
+class Subject < ApplicationRecord
   include Activatable
   include OrderedLocations
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Subject < ApplicationRecord
   include Activatable
   include OrderedLocations

--- a/app/models/subject_group.rb
+++ b/app/models/subject_group.rb
@@ -9,7 +9,7 @@
 # classifications, recents, seens data etc
 #
 # This class is not associated with the 'SubjectSet' class (a way to association subjects with a workflow)
-class SubjectGroup < ActiveRecord::Base
+class SubjectGroup < ApplicationRecord
   belongs_to :project
   has_many :subject_group_members, dependent: :destroy
   has_many :subjects, through: :subject_group_members

--- a/app/models/subject_group_member.rb
+++ b/app/models/subject_group_member.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubjectGroupMember < ActiveRecord::Base
+class SubjectGroupMember < ApplicationRecord
   belongs_to :subject
   belongs_to :subject_group
   has_one :project, through: :subject_group

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -1,4 +1,4 @@
-class SubjectSet < ActiveRecord::Base
+class SubjectSet < ApplicationRecord
 
   belongs_to :project
   has_many :subject_sets_workflows, dependent: :destroy

--- a/app/models/subject_set.rb
+++ b/app/models/subject_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SubjectSet < ApplicationRecord
 
   belongs_to :project

--- a/app/models/subject_set_import.rb
+++ b/app/models/subject_set_import.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubjectSetImport < ActiveRecord::Base
+class SubjectSetImport < ApplicationRecord
   belongs_to :subject_set
   belongs_to :user
 

--- a/app/models/subject_sets_workflow.rb
+++ b/app/models/subject_sets_workflow.rb
@@ -1,4 +1,4 @@
-class SubjectSetsWorkflow < ActiveRecord::Base
+class SubjectSetsWorkflow < ApplicationRecord
   belongs_to :workflow
   belongs_to :subject_set
 

--- a/app/models/subject_sets_workflow.rb
+++ b/app/models/subject_sets_workflow.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SubjectSetsWorkflow < ApplicationRecord
   belongs_to :workflow
   belongs_to :subject_set

--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -1,4 +1,4 @@
-class SubjectWorkflowStatus < ActiveRecord::Base
+class SubjectWorkflowStatus < ApplicationRecord
   self.table_name = 'subject_workflow_counts'
 
 

--- a/app/models/subject_workflow_status.rb
+++ b/app/models/subject_workflow_status.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 class SubjectWorkflowStatus < ApplicationRecord
   self.table_name = 'subject_workflow_counts'
-
 
   belongs_to :subject
   belongs_to :workflow

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ActiveRecord::Base
+class Tag < ApplicationRecord
   include PgSearch::Model
   has_many :tagged_resources
   has_many :projects, through: :tagged_resources, source: :resource, source_type: "Project"

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Tag < ApplicationRecord
   include PgSearch::Model
   has_many :tagged_resources

--- a/app/models/tagged_resource.rb
+++ b/app/models/tagged_resource.rb
@@ -1,4 +1,4 @@
-class TaggedResource < ActiveRecord::Base
+class TaggedResource < ApplicationRecord
   belongs_to :resource, polymorphic: true
   belongs_to :tag, counter_cache: true, dependent: :destroy
 end

--- a/app/models/tagged_resource.rb
+++ b/app/models/tagged_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TaggedResource < ApplicationRecord
   belongs_to :resource, polymorphic: true
   belongs_to :tag, counter_cache: true, dependent: :destroy

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Translation < ApplicationRecord
   include Versioning
 

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,4 +1,4 @@
-class Translation < ActiveRecord::Base
+class Translation < ApplicationRecord
   include Versioning
 
   belongs_to :translated, polymorphic: true, required: true

--- a/app/models/translation_version.rb
+++ b/app/models/translation_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TranslationVersion < ApplicationRecord
   belongs_to :translation
 end

--- a/app/models/translation_version.rb
+++ b/app/models/translation_version.rb
@@ -1,3 +1,3 @@
-class TranslationVersion < ActiveRecord::Base
+class TranslationVersion < ApplicationRecord
   belongs_to :translation
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,4 +1,4 @@
-class Tutorial < ActiveRecord::Base
+class Tutorial < ApplicationRecord
   include Translatable
   include Versioning
 

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Tutorial < ApplicationRecord
   include Translatable
   include Versioning

--- a/app/models/tutorial_version.rb
+++ b/app/models/tutorial_version.rb
@@ -1,3 +1,3 @@
-class TutorialVersion < ActiveRecord::Base
+class TutorialVersion < ApplicationRecord
   belongs_to :tutorial
 end

--- a/app/models/tutorial_version.rb
+++ b/app/models/tutorial_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TutorialVersion < ApplicationRecord
   belongs_to :tutorial
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 require "user_unsubscribe_message_verifier"
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   include Activatable
   include PgSearch::Model
   include ExtendedCacheKey

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-require "user_unsubscribe_message_verifier"
+# frozen_string_literal: true
 
 class User < ApplicationRecord
   include Activatable

--- a/app/models/user_collection_preference.rb
+++ b/app/models/user_collection_preference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserCollectionPreference < ApplicationRecord
   include Preferences
 

--- a/app/models/user_collection_preference.rb
+++ b/app/models/user_collection_preference.rb
@@ -1,4 +1,4 @@
-class UserCollectionPreference < ActiveRecord::Base
+class UserCollectionPreference < ApplicationRecord
   include Preferences
 
   preferences_for :collection

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserGroup < ApplicationRecord
   include Activatable
   include PgSearch::Model

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -1,4 +1,4 @@
-class UserGroup < ActiveRecord::Base
+class UserGroup < ApplicationRecord
   include Activatable
   include PgSearch::Model
 

--- a/app/models/user_project_preference.rb
+++ b/app/models/user_project_preference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserProjectPreference < ApplicationRecord
   include Preferences
 

--- a/app/models/user_project_preference.rb
+++ b/app/models/user_project_preference.rb
@@ -1,4 +1,4 @@
-class UserProjectPreference < ActiveRecord::Base
+class UserProjectPreference < ApplicationRecord
   include Preferences
 
   preferences_for :project

--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -1,4 +1,4 @@
-class UserSeenSubject < ActiveRecord::Base
+class UserSeenSubject < ApplicationRecord
   belongs_to :user
   belongs_to :workflow
 

--- a/app/models/user_seen_subject.rb
+++ b/app/models/user_seen_subject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserSeenSubject < ApplicationRecord
   belongs_to :user
   belongs_to :workflow

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Workflow < ApplicationRecord
   include Activatable
   include ExtendedCacheKey

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,4 +1,4 @@
-class Workflow < ActiveRecord::Base
+class Workflow < ApplicationRecord
   include Activatable
   include ExtendedCacheKey
   include RankedModel

--- a/app/models/workflow_tutorial.rb
+++ b/app/models/workflow_tutorial.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WorkflowTutorial < ApplicationRecord
   belongs_to :workflow
   belongs_to :tutorial

--- a/app/models/workflow_tutorial.rb
+++ b/app/models/workflow_tutorial.rb
@@ -1,4 +1,4 @@
-class WorkflowTutorial < ActiveRecord::Base
+class WorkflowTutorial < ApplicationRecord
   belongs_to :workflow
   belongs_to :tutorial
 end

--- a/app/models/workflow_version.rb
+++ b/app/models/workflow_version.rb
@@ -1,4 +1,4 @@
-class WorkflowVersion < ActiveRecord::Base
+class WorkflowVersion < ApplicationRecord
   belongs_to :workflow
 
   # These two aliases are used by Versioning because it doesn't support aliasing directly

--- a/app/models/workflow_version.rb
+++ b/app/models/workflow_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WorkflowVersion < ApplicationRecord
   belongs_to :workflow
 


### PR DESCRIPTION
https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-models-now-inherit-from-applicationrecord-by-default

Some background on why this change was made
- https://github.com/rails/rails/pull/22567#discussion-diff-47831156
- https://stackoverflow.com/questions/37359527/why-rails-5-uses-applicationrecord-instead-of-activerecordbase

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
