### PR TITLE
only update wf tasks when param is present

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -119,9 +119,12 @@ class Api::V1::WorkflowsController < Api::ApiController
   end
 
   def build_resource_for_create(create_params)
-    stripped_tasks, strings = extract_strings(create_params[:tasks])
-    create_params[:tasks] = stripped_tasks
-    create_params[:strings] = strings
+    if create_params.key? :tasks
+      stripped_tasks, strings = extract_strings(create_params[:tasks])
+      create_params[:tasks] = stripped_tasks
+      create_params[:strings] = strings
+    end
+
     create_params[:active] = false if project_live?
 
     super(create_params)

--- a/spec/controllers/api/v1/workflows_controller_spec.rb
+++ b/spec/controllers/api/v1/workflows_controller_spec.rb
@@ -616,6 +616,14 @@ describe Api::V1::WorkflowsController, type: :controller do
       it_behaves_like 'is creatable'
     end
 
+    context 'with a missing task attribute' do
+      it 'saves without setting tasks to nil and failing the non-null constraint in linked workflow_versions' do
+        default_request scopes: scopes, user_id: authorized_user.id
+        non_task_params = default_create_params[:workflows].except(*:tasks)
+        expect { post :create, params: { workflows: non_task_params } }.not_to raise_error
+      end
+    end
+
     context 'with an serialize_with_project attribute' do
       let(:create_params) do
         default_create_params.merge(serialize_with_project: false)


### PR DESCRIPTION
Follow up to #3978 and related to fixes in https://github.com/zooniverse/Panoptes-Front-End/pull/6217

This PR ensures we don't set tasks to a null value on create action as the `TasksVisitors::ExtractStrings` class returns nil if there is no task params to process. Instead of setting explicit values (even defaults) all the db defaults to kick in and avoid any possible incompatible states we have with the `workflow_versions` table (as it has a not null constraint on these fields).  

It seems the workflow db table is missing a lot of not null constraints but it does have column defaults which should take care of this issue. However explicitly setting values to nil will skip the db defaults so it's best to avoid setting missing values and allow the db defaults to kick in.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
