### PR TITLE
Remove memory-eating cache from iNat API interface

### DIFF
--- a/lib/inaturalist/api_interface.rb
+++ b/lib/inaturalist/api_interface.rb
@@ -7,12 +7,12 @@ module Inaturalist
     require 'json'
 
     # Set maximum imported subjects, or no limit with -1
-    attr_reader :taxon_id, :total_results, :observation_cache, :params
+    attr_reader :taxon_id, :total_results, :observation_count, :params
 
     def initialize(taxon_id:, updated_since: nil, max_observations: -1)
       @taxon_id = taxon_id
       @max_observations = max_observations
-      @observation_cache = []
+      @observation_count = 0
       @id_above = 0
       @params = { taxon_id: @taxon_id }
       @params[:updated_since] = updated_since unless updated_since.nil?
@@ -41,20 +41,20 @@ module Inaturalist
       # Stop if a) there are no more results
       #         b) the total number of desired subjects is hit
       #         c) the ID of the last seen observation is the same as the last result's id
-      @done = true if results.empty? || max_cache_hit? || @id_above == results.last['id']
+      @done = true if results.empty? || max_count_hit? || @id_above == results.last['id']
       return if @done
 
-      @observation_cache += results
+      @observation_count += 1
       @id_above = results.last['id']
       @params['id_above'] = @id_above
       results
     end
 
-    def max_cache_hit?
+    def max_count_hit?
       # Short circuit to turn off limit
       return false if @max_observations == -1
 
-      @observation_cache.size >= @max_observations
+      @observation_count >= @max_observations
     end
 
     def client


### PR DESCRIPTION
Keeping the observations cached seemed like a good idea at the time, but the iNat API responses are so huge that holding on to them was causing the memory usage to spike and `exit code 137` the pod. Tests showed that without the cache, mem usage plateaus around 400-500MB but still rises very slowly. Further testing with extremely large datasets (150k+) is required to make sure that it doesn't hit the 700MB limit on staging. If it does, options are "get better at ruby memory management" or "bump the staging dumpworker pod memory limit to compensate", depending on how egregious it is. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
