### PR TITLE
Remove deprecation warning in ordered locations

### DIFF
--- a/app/models/concerns/ordered_locations.rb
+++ b/app/models/concerns/ordered_locations.rb
@@ -1,14 +1,15 @@
-module OrderedLocations
+# frozen_string_literal: true
 
+module OrderedLocations
   def ordered_locations
     if locations.loaded?
-      if locations.all? { |loc| loc.metadata&.key?("index") }
-        locations.sort_by { |loc| loc.metadata["index"] }
+      if locations.all? { |loc| loc.metadata&.key?('index') }
+        locations.sort_by { |loc| loc.metadata['index'] }
       else
         locations
       end
     else
-      locations.order("\"media\".\"metadata\"->'index' ASC")
+      locations.order(Arel.sql("media.metadata->'index' ASC"))
     end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-  ActiveSupport::Deprecation.silenced = true
+  # ActiveSupport::Deprecation.silenced = true
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/spec/support/ordered_locations.rb
+++ b/spec/support/ordered_locations.rb
@@ -1,28 +1,25 @@
 RSpec.shared_examples 'it has ordered locations' do
-
-  it "should sort the loaded locations by index" do
-    expected = resource.locations.sort_by { |loc| loc.metadata["index"] }
+  it 'sorts the loaded locations by index' do
+    expected = resource.locations.sort_by { |loc| loc.metadata['index'] }
     expect(expected.map(&:id)).to eq(resource.ordered_locations.map(&:id))
   end
 
-  it "should sort the non-loaded locations by db index" do
+  it 'sorts the non-loaded locations by db index', :aggregate_failures do
     lone_resource = klass.find(resource.id)
-    expect_any_instance_of(Medium::CollectionProxy)
-      .to receive(:order)
-      .with("\"media\".\"metadata\"->'index' ASC")
-      .and_call_original
-    expected = resource.locations.sort_by { |loc| loc.metadata["index"] }
+    expected = resource.locations.sort_by { |loc| loc.metadata['index'] }
+    allow(lone_resource.locations).to receive(:order).and_call_original
     expect(expected.map(&:id)).to eq(lone_resource.ordered_locations.map(&:id))
+    expect(lone_resource.locations).to have_received(:order).with("media.metadata->'index' ASC")
   end
 
-  context "resource without location metadata" do
+  context 'when the resource has no location metadata' do
     before do
       resource.locations.update_all(metadata: nil)
       resource.locations
     end
 
-    it "should mimic the database order by using the relation ordering" do
-      expected = resource.locations.order("\"media\".\"metadata\"->'index' ASC")
+    it 'mimics the database order by using the relation ordering' do
+      expected = resource.locations.order(Arel.sql("media.metadata->'index' ASC"))
       expect(expected.map(&:id)).to eq(resource.ordered_locations.map(&:id))
     end
   end


### PR DESCRIPTION
fixes a 5.2 -> 6.0 deprecation warning about sql code injection in order by clauses.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
