### PR TITLE
Add uniqueness constraint to iNatImportWorker jobs

### DIFF
--- a/app/workers/inat_import_worker.rb
+++ b/app/workers/inat_import_worker.rb
@@ -5,6 +5,7 @@ class InatImportWorker
 
   # skip retries for this job to avoid re-running imports with errors
   sidekiq_options retry: 0, queue: :data_medium
+  sidekiq_options lock: :until_and_while_executing
 
   def perform(user_id, taxon_id, subject_set_id, updated_since=nil)
     inat = Inaturalist::ApiInterface.new(taxon_id: taxon_id, updated_since: updated_since)

--- a/spec/controllers/api/v1/inaturalist_controller_spec.rb
+++ b/spec/controllers/api/v1/inaturalist_controller_spec.rb
@@ -28,6 +28,12 @@ describe Api::V1::InaturalistController, type: :controller do
         response = post :import, params: import_params
         expect(response).to have_http_status(:not_found)
       end
+
+      it 'includes updated_since' do
+        import_params[:updated_since] = '2022-10-31'
+        expect { post :import, params: import_params }
+          .to change(InatImportWorker.jobs, :size).by(1)
+      end
     end
 
     context 'with an unauthorized user' do


### PR DESCRIPTION
More than one job per set of args shouldn't be allowed to run at once. This is difficult behavior to spec, see https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness

> It is recommended to leave the uniqueness testing to the gem maintainers. 

Because of how the controller gives back a 200 immediately and the job is queued, SubjectSetImport is created, all in the background with no ability to track progress at the moment, so it's important that that request is idempotent. I'll give it a spin with a small set on staging to make sure.

also included an unrelated extra spec I thought of 🙃

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
