### PR TITLE
add cors block list mechanism

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,19 +9,44 @@ module Panoptes
       allows: [
         { origins: '*', resource: '/api/*' },
         { origins: '*', resource: '/graphql' },
-        { origins: cors_origins_regex, resource: '/users*', credentials: true },
-        { origins: cors_origins_regex, resource: '/oauth/*', credentials: true },
-        { origins: cors_origins_regex, resource: '/unsubscribe', credentials: true }
+        { origins: cors_origin_allowed, resource: '/users*', credentials: true },
+        { origins: cors_origin_allowed, resource: '/oauth/*', credentials: true },
+        { origins: cors_origin_allowed, resource: '/unsubscribe', credentials: true }
       ]
     )
   end
 
-  def self.cors_origins_regex
-    cors_origins = ENV.fetch(
-      'CORS_ORIGINS_REGEX',
-      '^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local)(:\d+)?$'
-    )
-    /#{cors_origins}/
+  # return a proc that can be used to configure the cors middleware
+  def self.cors_origin_allowed
+    proc do |source, _env|
+      # explictly set the allowed origin to false at start
+      allowed_origin = false
+
+      # allow to reject some domains - allows multiple values via comma delimited string
+      cors_origin_host_rejections = ENV.fetch('CORS_ORIGINS_REJECT_HOSTS', '').split(',')
+      reject_origin = cors_origin_host_rejections.map do |rejection_substring|
+        URI.parse(source).host == rejection_substring
+      end.any?
+
+      # NOTE: can't use return guard clause in this proc due to localJumpError
+      # https://ruby-doc.org/core-2.6/Proc.html#class-Proc-label-Lambda+and+non-lambda+semantics
+      # so we have to use control flow and boolean logic to determine if this origin is allowed
+
+      # test the origin via regex if not rejected
+      unless reject_origin
+        cors_origin_regex = ENV.fetch(
+          'CORS_ORIGINS_REGEX',
+          '^https?:\/\/(127\.0\.0\.1|localhost|[a-z0-9-]+\.local)(:\d+)?$'
+        )
+        allowed_origin = (source =~ /#{cors_origin_regex}/).present?
+      end
+
+      # allow the origin if:
+      # 1. it is not explicitly rejected
+      not_blocked_origin = !reject_origin
+      # 2. and if it matches the allowed regex
+      _allow_origin = not_blocked_origin && allowed_origin
+    end
   end
 end
 

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -87,6 +87,7 @@ data:
   ZOO_STREAM_SOURCE: panoptes
   CELLECT_HOST: http://cellect-production-app/
   CORS_ORIGINS_REGEX: '^https?:\/\/((www|staging)\.antislaverymanuscripts\.org|(www|relaunch|field-book)\.notesfromnature\.org|www\.scribesofthecairogeniza\.org|([a-z0-9-]+\.)?zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
+  CORS_ORIGINS_REJECT_HOSTS: 'panoptes-uploads.zooniverse.org,panoptes-uploads-staging.zooniverse.org'
   DESIGNATOR_API_HOST: http://designator-production-app/
   DESIGNATOR_API_USERNAME: production
   DUMP_WORKER_SIDEKIQ_QUEUE: dumpworker

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -75,6 +75,7 @@ data:
   ZOO_STREAM_SOURCE: panoptes
   CELLECT_HOST: http://cellect-staging-app/
   CORS_ORIGINS_REGEX: '^https?:\/\/([a-z0-9-]+\.zooniverse\.org|[a-z0-9-]+\.(pfe-)?preview\.zooniverse\.org)(:\d+)?$'
+  CORS_ORIGINS_REJECT_HOSTS: 'panoptes-uploads.zooniverse.org,panoptes-uploads-staging.zooniverse.org'
   DESIGNATOR_API_HOST: http://designator-staging-app/
   DESIGNATOR_API_USERNAME: staging
   DUMP_CONGESTION_OPTS_INTERVAL: "60"


### PR DESCRIPTION
allow us to block specific domains from CORS API access via a block list that checks against the origin domain host via the `CORS_ORIGIN_HOST_REJECTIONS` env var which takes a comma delimited list of domain hosts to block. 

This blocklist combines with existing behaviour of the explicity allow list in the `CORS_ORIGINS_REGEX` env var. 

Both the allow and block lists are setup at boot time by the env vars and don't change for the life of the server process.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
