### PR TITLE
ensure we deploy the staging canary on merges to master

### DIFF
--- a/.github/workflows/deploy_staging_canary.yml
+++ b/.github/workflows/deploy_staging_canary.yml
@@ -1,6 +1,9 @@
 name: Deploy Staging Canary
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Make sure we keep the canary deploy up to date - it's just like staging but uses the Next gemfile to install libs and boot.

I'm not sure why this was set to manual deploys...that seems like an oversight and would have kept possible insecure / broken code running on the canary system.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
