### PR TITLE
disable deprecation warnings in CI

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -61,3 +61,4 @@ jobs:
         env:
            RAILS_ENV: test
            DISABLE_TEST_LOGGING: 1
+           DEPRECATION_WARNINGS_SILENCED: 1

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-  # ActiveSupport::Deprecation.silenced = true
+  ActiveSupport::Deprecation.silenced = ENV.fetch('DEPRECATION_WARNINGS_SILENCED', nil).present?
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's


### PR DESCRIPTION
avoid logging deprecation warnings in CI system but keep them in local dev for visibility.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
