### PR TITLE
Rails 5.2 deprecation fix use arel.sql in subjects controller

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -34,7 +34,7 @@ class Api::V1::SubjectsController < Api::ApiController
       .active
       .where(id: selected_subject_ids)
       .order(
-        "idx(array[#{selected_subject_ids.join(',')}], id)"
+        Arel.sql("idx(array[#{selected_subject_ids.join(',')}], id)")
       )
     end
 
@@ -73,7 +73,7 @@ class Api::V1::SubjectsController < Api::ApiController
       if selected_subject_ids.empty?
         Subject.none
       else
-        Subject.active.where(id: selected_subject_ids).order("idx(array[#{selected_subject_ids.join(',')}], id)") # guardrails-disable-line
+        Subject.active.where(id: selected_subject_ids).order(Arel.sql("idx(array[#{selected_subject_ids.join(',')}], id)")) # guardrails-disable-line
       end
 
     # create a special 'fake' selector for the serializer
@@ -119,7 +119,7 @@ class Api::V1::SubjectsController < Api::ApiController
     selected_subject_scope =
       Subject
       .where(id: group_subject_ids)
-      .order("idx(array[#{group_subject_ids.join(',')}], id)") # guardrails-disable-line
+      .order(Arel.sql("idx(array[#{group_subject_ids.join(',')}], id)")) # guardrails-disable-line
 
     selection_context = Subjects::SelectorContext.new(
       group_selection_result.subject_selector,


### PR DESCRIPTION

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
