### PR TITLE
Rails 5.2 - deprecation fix : Add Arel.sql around query  in create.rb

### DIFF
--- a/app/operations/subject_groups/create.rb
+++ b/app/operations/subject_groups/create.rb
@@ -92,7 +92,7 @@ module SubjectGroups
         .active
         .where(id: subject_ids)
         .order(
-          "idx(array[#{subject_ids.join(',')}], id)"
+          Arel.sql("idx(array[#{subject_ids.join(',')}], id)")
         )
         .load
     end

--- a/spec/operations/subject_groups/create_spec.rb
+++ b/spec/operations/subject_groups/create_spec.rb
@@ -15,7 +15,7 @@ describe SubjectGroups::Create do
     operation.run!(params)
   end
 
-  it 'creates creates a valid subject_group' do
+  it 'creates a valid subject_group' do
     expect(created_subject_group).to be_valid
   end
 


### PR DESCRIPTION
Adding raw sql to query methods will be disallowed in Rails 6.0

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
