### PR TITLE
Run iNat imports on the dumpworker sidekiq queue

### DIFF
--- a/app/workers/inat_import_worker.rb
+++ b/app/workers/inat_import_worker.rb
@@ -4,7 +4,7 @@ class InatImportWorker
   include Sidekiq::Worker
 
   # skip retries for this job to avoid re-running imports with errors
-  sidekiq_options retry: 0, queue: :data_medium
+  sidekiq_options retry: 0, queue: :dumpworker
   sidekiq_options lock: :until_and_while_executing
 
   def perform(user_id, taxon_id, subject_set_id, updated_since=nil)


### PR DESCRIPTION
Imports should be isolated from the main sidekiq queue.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
