### PR TITLE
use v2.3.26 bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,4 +575,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0.1)
 
 BUNDLED WITH
-   1.17.3
+   2.3.26

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -568,4 +568,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0.1)
 
 BUNDLED WITH
-   1.17.3
+   2.3.26


### PR DESCRIPTION
We don't need to be on v1 of bundler anymore so we can use the latest v2 version.

This shouldn't impact on any CI systems to install ruby and setup gems via `bundle install` etc but it will fix the issue of some libs compiling natively, e.g. https://github.com/zooniverse/panoptes/actions/runs/3511260107/jobs/5881865785

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
