### PR TITLE
Upgrade ruby to 2.7 and jemalloc to v5

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -27,7 +27,7 @@ jobs:
           - Gemfile
           - Gemfile.next
         ruby:
-          - 2.6
+          - 2.7
         spec-commands:
           - 'spec/controllers/api/v1/[a-m]*.rb spec/counters spec/operations spec/serializers spec/workers'
           - 'spec/controllers/api/v1/[n-s]*.rb'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update && apt-get -y upgrade && \
         build-essential \
         # git is required for installing gems from git repos
         git \
-        # libjemalloc1 (v3) provides big memory savings vs jemalloc v5+ (default on debian buster)
-        libjemalloc1 \
+        # install jemalloc (v5) for memory savings
+        libjemalloc2 \
         libpq-dev \
         nodejs \
         tmpreaper \
         && \
         apt-get clean
 
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 # set a default RAILS_ENV for the build scripts
 # this is required for the `rake assets:precompile` script

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN apt-get update && apt-get -y upgrade && \
         && \
         apt-get clean
 
+# configure jemalloc v5 with v3 behaviours (trade ram usage over performance)
+# https://twitter.com/nateberkopec/status/1442894624935137288
+# https://github.com/code-dot-org/code-dot-org/blob/5c8b24674d1c2f7e51e85dd32124e113dc423d84/cookbooks/cdo-jemalloc/attributes/default.rb#L10
+ENV MALLOC_CONF="narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:0"
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 # set a default RAILS_ENV for the build scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# debian stretch has libjemalloc1 https://packages.debian.org/stretch/libjemalloc1
-FROM ruby:2.6-slim-stretch
+FROM ruby:2.7-slim
 
 WORKDIR /rails_app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+RUN gem update --system
 RUN bundle install --without development test
 
 ADD ./ /rails_app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim-buster
+FROM ruby:2.7-slim-buster
 
 WORKDIR /rails_app
 
@@ -8,14 +8,18 @@ RUN apt-get update && apt-get -y upgrade && \
       # git is required for installing gems from git repos
       git \
       libpq-dev \
-      # debian buster has v11 by default
+      # debian buster and comes with pg client v11 by default
       postgresql-client-11 \
       tmpreaper
+
+# set MRI memory allocator to mimic jemalloc memory savings
+ENV MALLOC_ARENA_MAX=2
 
 ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+RUN gem update --system
 RUN bundle install
 
 ADD ./ /rails_app


### PR DESCRIPTION
This PR is related to the change in #4023 that switched to v2 bundler version

This is due to the CD system using our ruby2.6 docker image which doesn't have the v2 version of bundler available. 

The bad news is our ruby 2.6 docker image is more than 1 year old and unsupported both in terms of the underlying OS debian version (stretch) and the ruby version. 
https://www.ruby-lang.org/en/downloads/releases/
https://hub.docker.com/_/ruby/tags?page=1&name=2.6-slim-stretch

Sadly we can't rely on this image anymore and it's time to upgrade it. 

The good news is we have an easy upgrade to ruby 2.7 though that too is on the way to EOL https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/

The only tricky part here is the upgrade to 2.7 means we are now on debian bullseye which installs v5 of the jemalloc memory allocator. I've included a `MALLOC_CONF` env var config to make jemalloc v5 behave like v3 in terms of memory savings vs raw performance so we shouldn't see big changes in overall RAM use on our systems. 

Once approved we can get this deployed to staging for testing and monitoring via new relic ruby vm memory use graphs to determine if we see unacceptable changes. 

As some background - i looked into fullstaq ruby which comes with v3 jemalloc built into ruby via the docker images supplied by https://github.com/evilmartians/fullstaq-ruby-docker. However it appears that they believe v5 is ok once configured properly, https://github.com/fullstaq-ruby/server-edition/issues/98 so we can easily construct those images ourselves and use LD_PRELOAD to inject the upgraded jemalloc system. 

I prefer this as it frees us from relying on other folks building our base images and ensures we are flexible with the underlying image variations. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
