### PR TITLE
Update Dockerfile.rails-next to use 2.7

### DIFF
--- a/Dockerfile.rails-next
+++ b/Dockerfile.rails-next
@@ -12,6 +12,9 @@ RUN apt-get update && apt-get -y upgrade && \
     && \
     apt-get clean
 
+# set MRI memory allocator to mimic jemalloc memory savings
+ENV MALLOC_ARENA_MAX=2
+
 # set a default RAILS_ENV for the build scripts
 # this is required for the `rake assets:precompile` script
 # to write assets to target dir set in `config.assets.prefix`

--- a/Dockerfile.rails-next
+++ b/Dockerfile.rails-next
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim-buster
+FROM ruby:2.7-slim-buster
 
 WORKDIR /rails_app
 


### PR DESCRIPTION
in order to keep next version of app consistent with ruby upgrade in our app, i think we should update the dockerfile.rails-next to use 2.7 as well

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
