### PR TITLE
Import Subjects recursively to include locations as Media

### DIFF
--- a/app/workers/inat_import_worker.rb
+++ b/app/workers/inat_import_worker.rb
@@ -5,7 +5,8 @@ class InatImportWorker
 
   # skip retries for this job to avoid re-running imports with errors
   sidekiq_options retry: 0, queue: :dumpworker
-  sidekiq_options lock: :until_and_while_executing
+  sidekiq_options lock: :until_and_while_executing,
+                  on_conflict: { client: :log, server: :reject }
 
   def perform(user_id, taxon_id, subject_set_id, updated_since=nil)
     @inat = Inaturalist::ApiInterface.new(taxon_id: taxon_id, updated_since: updated_since)

--- a/lib/inaturalist/subject_importer.rb
+++ b/lib/inaturalist/subject_importer.rb
@@ -23,7 +23,7 @@ module Inaturalist
     end
 
     def import_subjects(subjects_to_import)
-      Subject.import subjects_to_import, on_duplicate_key_update: %i[metadata updated_at]
+      Subject.import subjects_to_import, recursive: true, on_duplicate_key_update: %i[metadata updated_at]
     end
 
     def import_smses(smses_to_import)


### PR DESCRIPTION
The activerecord-import call needs to include `recursive: true` in order to include the unsaved Media that are built as each subject's location.

Also includes a fix to reject duplicate Sidekiq jobs based on attribute signature to prevent running multiple simultaneous import jobs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
