### PR TITLE
iNat: don't cut off the last batch

### DIFF
--- a/app/workers/inat_import_worker.rb
+++ b/app/workers/inat_import_worker.rb
@@ -43,7 +43,9 @@ class InatImportWorker
   end
 
   def process_batch?(index)
-    (index % import_batch_size).zero? && index.positive?
+    index.positive? &&
+    # Catch the end of the last batch, but trim total_results to account for 0-indexing
+    ((index % import_batch_size).zero? || index == (@inat.total_results - 1))
   end
 
   def ss_import

--- a/app/workers/inat_import_worker.rb
+++ b/app/workers/inat_import_worker.rb
@@ -44,8 +44,7 @@ class InatImportWorker
 
   def process_batch?(index)
     index.positive? &&
-    # Catch the end of the last batch, but trim total_results to account for 0-indexing
-    ((index % import_batch_size).zero? || index == (@inat.total_results - 1))
+      ((index % import_batch_size).zero? || index == (@inat.total_results - 1))
   end
 
   def ss_import

--- a/lib/inaturalist/subject_importer.rb
+++ b/lib/inaturalist/subject_importer.rb
@@ -33,7 +33,7 @@ module Inaturalist
     def build_smses(subject_import_results)
       subject_import_results.ids.map do |subject_id|
         sms = SetMemberSubject.find_or_initialize_by(subject_set_id: @subject_set.id, subject_id: subject_id)
-        sms.random = rand unless sms.random?
+        sms.random ||= rand
         sms
       end
     end


### PR DESCRIPTION
When importing iNat observations, the calculation that determined whether a batch of subjects/smses needed to be inserted only checked the modulo-batch size and was cutting off the last x (where x is less than the batch size) records. It now also checks the enumerable's index against the API responses total_results metadata attr (and subtracts one to account for 0-indexing) so it can finish.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
