### PR TITLE
avoid cloberring static assets from new pods only

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -195,7 +195,7 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
+                command: ["/bin/bash", "-c", "cp -Ru /rails_app/public/* /static-assets"]
         - name: panoptes-production-nginx
           image: zooniverse/nginx
           resources:

--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -58,7 +58,7 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
+                command: ["/bin/bash", "-c", "cp -Ru /rails_app/public/* /static-assets"]
         - name: panoptes-staging-nginx
           image: zooniverse/nginx
           resources:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -184,7 +184,7 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
+                command: ["/bin/bash", "-c", "cp -Ru /rails_app/public/* /static-assets"]
         - name: panoptes-staging-nginx
           image: zooniverse/nginx
           resources:


### PR DESCRIPTION
The `commit_id.txt` on some pod deploys was showing inconsistent results (i.e. old deploy sha values) even though the pod contained the new sha value in the commit_id.txt baked into the container. It appears the commit_id.txt file on the shared volume between nginx and panoptes api containers (panoptes api app pods) was sometimes being overwritten with a file from the old containers during deploys and thus leaving us with the possibly inconsistent state.

This PR attempts to fix this issue by now only copying the static assets to the shared nginx volume files system if they are newer, i.e. from the newer pod deployment and not a scaling / restart event.

This is achieved this by using the `cp -u` switch to avoid clobbering new pod static assets with old ones due to race condition on the pod lifecycle event hook runs https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution. 

> -u, --update                 copy only when the SOURCE file is newer than the destination file or when the destination file is missing

Note we don't control the number of times this hook can be called which may have been an oversight when setting this up
> Hook delivery is intended to be at least once, which means that a hook may be called multiple times for any given event, such as for PostStart or PreStop. It is up to the hook implementation to handle this correctly.

https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-delivery-guarantees


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
