### PR TITLE
Ensure commit id is in public dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN bundle install --without development test
 
 ADD ./ /rails_app
 
-RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt)
+RUN (cd /rails_app && git log --format="%H" -n 1 > public/commit_id.txt)
 RUN (cd /rails_app && mkdir -p tmp/pids && rm -f tmp/pids/*.pid)
 RUN (cd /rails_app && SECRET_KEY_BASE=1a bundle exec rake assets:precompile)
 

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -12,9 +12,4 @@ tmpreaper 6h --mtime /tmp/
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 
-if [ -f "commit_id.txt" ]
-then
-  cp commit_id.txt public/
-fi
-
 exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
follow up to #4042 - our pre start container hook expects the `commit_id.txt` to be in public but we only cp it there on the container entrypoint execution, this can lead to a race condition where the prestart hooks runs and copies static assets to shared pod's nginx container file system before the `commit_id.txt` has been moved there, i.e. a race condition.

This PR now creates the `commit_id.txt` in the public dir to avoid the race condition.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
