### PR TITLE
update SMTP::MailerError.new with address param

### DIFF
--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -106,6 +106,7 @@ GEM
     crass (1.0.6)
     dalli (3.2.3)
     database_cleaner (1.99.0)
+    date (3.3.1)
     deep_cloneable (3.2.0)
       activerecord (>= 3.1.0, < 8)
     deprecate (0.0.0)
@@ -235,12 +236,15 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.19.0)
+    loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.2.8)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
     mime-types (3.4.1)
@@ -258,9 +262,18 @@ GEM
     nenv (0.3.0)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    net-imap (0.3.2)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     newrelic_rpm (8.6.0)
     nio4r (2.5.8)
-    nokogiri (1.13.9)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -309,7 +322,7 @@ GEM
     pundit (2.2.0)
       activesupport (>= 3.0.0)
     raabro (1.4.0)
-    racc (1.6.0)
+    racc (1.6.1)
     rack (2.2.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -333,8 +346,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
     railties (5.2.8.1)
       actionpack (= 5.2.8.1)
       activesupport (= 5.2.8.1)
@@ -446,6 +459,7 @@ GEM
       rainbow (~> 3.0.0)
     thor (1.2.1)
     thread_safe (0.3.6)
+    timeout (0.3.1)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
     uglifier (4.2.0)

--- a/spec/workers/dormant_user_mailer_worker_spec.rb
+++ b/spec/workers/dormant_user_mailer_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DormantUserMailerWorker do
       before do
         allow_any_instance_of(ActionMailer::MessageDelivery)
         .to receive(:deliver)
-        .and_raise(error_klass.new)
+        .and_raise(error_klass.new('invalid_email@test,'))
       end
 
       it 'should attempt to send an email' do

--- a/spec/workers/user_added_to_project_mailer_worker_spec.rb
+++ b/spec/workers/user_added_to_project_mailer_worker_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe UserAddedToProjectMailerWorker do
       before do
         allow_any_instance_of(ActionMailer::MessageDelivery)
           .to receive(:deliver)
-          .and_raise(error_klass.new)
+          .and_raise(error_klass.new('test@example.com,ox'))
         allow(user).to receive(:email).and_return('test@example.com,ox')
       end
 

--- a/spec/workers/user_info_changed_mailer_worker_spec.rb
+++ b/spec/workers/user_info_changed_mailer_worker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe UserInfoChangedMailerWorker do
       before(:each) do
         allow_any_instance_of(ActionMailer::MessageDelivery)
           .to receive(:deliver)
-          .and_raise(error_klass.new)
+          .and_raise(error_klass.new('test@example.com,ox'))
         allow(user).to receive("email").and_return("test@example.com,ox")
       end
 

--- a/spec/workers/user_welcome_mailer_worker_spec.rb
+++ b/spec/workers/user_welcome_mailer_worker_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe UserWelcomeMailerWorker do
       before(:each) do
         allow_any_instance_of(ActionMailer::MessageDelivery)
           .to receive(:deliver)
-          .and_raise(error_klass.new)
+          .and_raise(error_klass.new('test@example.com,ox'))
         allow(user).to receive(:email).and_return("test@example.com,ox")
       end
 


### PR DESCRIPTION
- Update Rails 5.2 dependencies on Gemfile.next.lock (did this by re-running `next bundle update rails` 
- Fix broken tests due to `mail` gem update (dependency of `actionmailer`).  [when testing rescue logic on invalid email, we raise `Net::SMTPSyntaxError` and `Net::SMTPFatalError` in tests eg. https://github.com/zooniverse/panoptes/blob/master/spec/workers/dormant_user_mailer_worker_spec.rb#L10-L16. `.new` expects an address param]

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
