### PR TITLE
Doorkeeper cleanup worker update to batch deletes

### DIFF
--- a/lib/gem_ext/doorkeeper/access_cleanup.rb
+++ b/lib/gem_ext/doorkeeper/access_cleanup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Doorkeeper
   class AccessCleanup
     def cleanup!(keep_old_refresh_tokens_for=14)
@@ -5,47 +7,37 @@ module Doorkeeper
       remove_revoked_grants
       remove_expired_tokens
       remove_revoked_tokens
-      remove_old_unused_refreshable_tokens
+      remove_old_unused_refreshable_tokens(keep_old_refresh_tokens_for)
     end
 
     def remove_expired_grants
-      Doorkeeper::AccessGrant.where(expired_clause).in_batches do |group|
-        group.delete_all
-      end
+      Doorkeeper::AccessGrant.where(expired_clause).in_batches(&:delete_all)
     end
 
     def remove_revoked_grants
-      Doorkeeper::AccessGrant.where(revoked_clause).in_batches do |group|
-        group.delete_all
-      end
+      Doorkeeper::AccessGrant.where(revoked_clause).in_batches(&:delete_all)
     end
 
     def remove_expired_tokens
-      Doorkeeper::AccessToken.where(refresh_token: nil).where(expired_clause).in_batches do |group|
-        group.delete_all
-      end
+      Doorkeeper::AccessToken.where(refresh_token: nil).where(expired_clause).in_batches(&:delete_all)
     end
 
     def remove_revoked_tokens
-      Doorkeeper::AccessToken.where(revoked_clause).in_batches do |group|
-        group.delete_all
-      end
+      Doorkeeper::AccessToken.where(revoked_clause).in_batches(&:delete_all)
     end
 
     def remove_old_unused_refreshable_tokens(keep_for)
       Doorkeeper::AccessToken
-      .where.not(refresh_token: nil)
-      .where(previous_refresh_token: nil)
-      .where("created_at < ?", Time.now - keep_for.days)
-      .in_batches do |group|
-        group.delete_all
-      end
+        .where.not(refresh_token: nil)
+        .where(previous_refresh_token: nil)
+        .where('created_at < ?', Time.zone.now - keep_for.days)
+        .in_batches(&:delete_all)
     end
 
     private
 
     def revoked_clause
-      "revoked_at IS NOT NULL"
+      'revoked_at IS NOT NULL'
     end
 
     def expired_clause

--- a/lib/gem_ext/doorkeeper/access_cleanup.rb
+++ b/lib/gem_ext/doorkeeper/access_cleanup.rb
@@ -1,34 +1,45 @@
 module Doorkeeper
   class AccessCleanup
     def cleanup!(keep_old_refresh_tokens_for=14)
-      expired_grants.delete_all
-      revoked_grants.delete_all
-      expired_tokens.delete_all
-      revoked_tokens.delete_all
-      old_unused_refreshable_tokens(keep_old_refresh_tokens_for).delete_all
+      remove_expired_grants
+      remove_revoked_grants
+      remove_expired_tokens
+      remove_revoked_tokens
+      remove_old_unused_refreshable_tokens
     end
 
-    def expired_grants
-      Doorkeeper::AccessGrant.where(expired_clause)
+    def remove_expired_grants
+      Doorkeeper::AccessGrant.where(expired_clause).in_batches do |group|
+        group.delete_all
+      end
     end
 
-    def revoked_grants
-      Doorkeeper::AccessGrant.where(revoked_clause)
+    def remove_revoked_grants
+      Doorkeeper::AccessGrant.where(revoked_clause).in_batches do |group|
+        group.delete_all
+      end
     end
 
-    def expired_tokens
-      Doorkeeper::AccessToken.where(refresh_token: nil).where(expired_clause)
+    def remove_expired_tokens
+      Doorkeeper::AccessToken.where(refresh_token: nil).where(expired_clause).in_batches do |group|
+        group.delete_all
+      end
     end
 
-    def revoked_tokens
-      Doorkeeper::AccessToken.where(revoked_clause)
+    def remove_revoked_tokens
+      Doorkeeper::AccessToken.where(revoked_clause).in_batches do |group|
+        group.delete_all
+      end
     end
 
-    def old_unused_refreshable_tokens(keep_for)
+    def remove_old_unused_refreshable_tokens(keep_for)
       Doorkeeper::AccessToken
       .where.not(refresh_token: nil)
       .where(previous_refresh_token: nil)
       .where("created_at < ?", Time.now - keep_for.days)
+      .in_batches do |group|
+        group.delete_all
+      end
     end
 
     private


### PR DESCRIPTION
Really tricky to see if this fixes `ActiveRecord::StatementInvalid: PG::QueryCanceled: ERROR: canceling statement due to statement timeout` errors  from cleanup worker. I believe it does (and we probably can be convinced more in staging). Reason why I believe it does: within local testing: with batching we split a longer query of DELETE query to chunks of a bit faster queries.

Testing locally with 4000 rows

**(without batching)**
`DEBUG -- : [primary]  Doorkeeper::AccessToken Destroy (37.4ms)  DELETE FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."refresh_token" IS NULL AND (created_at + interval '1 second' * expires_in < clock_timestamp())`
**37.4ms**

 **with batching** 

` DEBUG -- : [primary]   (1.4ms)  SELECT  "oauth_access_tokens"."id" FROM "oauth_access_tokens" WHERE (revoked_at IS NOT NULL) ORDER BY "oauth_access_tokens"."id" ASC LIMIT 1000`

` DEBUG -- : [primary]  Doorkeeper::AccessToken Destroy (6.0ms)  DELETE FROM "oauth_access_tokens" WHERE (revoked_at IS NOT NULL) AND "oauth_access_tokens"."id" IN (etc ids of the 1000 pulled from previous query)` 
**1.4 + 6.0 ms** about that * 4 

`



# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
