### PR TITLE
Remove timeouts on doorkeeper cleanup

### DIFF
--- a/app/workers/doorkeeper_access_cleaner_worker.rb
+++ b/app/workers/doorkeeper_access_cleaner_worker.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 class DoorkeeperAccessCleanerWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :data_low
 
   def perform
-    Doorkeeper::AccessCleanup.new.cleanup!
+    DatabaseReplica.execute_without_timeout do
+      Doorkeeper::AccessCleanup.new.cleanup!
+    end
   end
 end

--- a/lib/database_replica.rb
+++ b/lib/database_replica.rb
@@ -33,5 +33,4 @@ class DatabaseReplica
       "SET statement_timeout = #{Panoptes.pg_statement_timeout}"
     )
   end
-  private_class_method :execute_without_timeout
 end


### PR DESCRIPTION
follow up to the work in #4062 - the worker queries are still timing out :( however we can wrap them in a block that sets the timeout to 0 (no timeout) for execution to allow this cleanup code to run.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
