### PR TITLE
switch dumpworkers to 2 replica pods deployment with more RAM

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -308,10 +308,10 @@ spec:
           image: ghcr.io/zooniverse/panoptes:__IMAGE_TAG__
           resources:
             requests:
-              memory: "2000Mi"
+              memory: "4000Mi"
               cpu: "250m"
             limits:
-              memory: "8000Mi"
+              memory: "10000Mi"
               cpu: "2000m"
           livenessProbe:
             exec:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -294,7 +294,7 @@ metadata:
   labels:
     app: panoptes-production-sidekiq-dumpworker
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: panoptes-production-sidekiq-dumpworker
@@ -321,9 +321,9 @@ spec:
           args: ["/rails_app/scripts/docker/start-sidekiq.sh"]
           env:
           - name: RAILS_MAX_THREADS
-            value: '2'
+            value: '1'
           - name: SIDEKIQ_CONCURRENCY
-            value: '2'
+            value: '1'
           - name: SIDEKIQ_ARGS
             value: '-q dumpworker -q really_high -q high -q data_high -q data_medium -q default -q data_low'
           - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED


### PR DESCRIPTION
This PR modifies the way the panoptes dump worker pods are deployed. Instead of running 2 possible concurrent exports (2 sidekiq threads per pod) we switch to 1 thread per pod but run 2 pods. This is an attempt to avoid 2 exports running at once and using more RAM than the limit of the pod the exports dying with OOM errors. 

We also increase the required RAM request and limits for each dump worker pod, and allow pods to schedule where a node has at least 4GB up front but set RAM limit to 10GB per pod to avoid overwhelming the node (or try to) but let the exports use more RAM as needed.

This new deployment setup will use more RAM as we run 2 sidekiq pods / processes but it should improve the behaviors of the data exports while still allowing 2 concurrent exports to run. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
