### PR TITLE
Updating Restpack serializer panoptes-api-version to support up to activesupport/record 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ else
   gem 'rails', '~> 5.2'
 end
 gem 'ranked-model', '~> 0.4.8'
-gem 'restpack_serializer', git: 'https://github.com/zooniverse/restpack_serializer.git', branch: 'panoptes-api-version', ref: 'cef0969cef'
+gem 'restpack_serializer', git: 'https://github.com/zooniverse/restpack_serializer.git', branch: 'upgrade-activesupport-and-activerecord-to-allow-6.0', ref: 'babfd9e730'
 gem 'scientist', '~> 1.6.3'
 gem 'sidekiq', '< 7'
 gem 'sidekiq-congestion', '~> 0.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ else
   gem 'rails', '~> 5.2'
 end
 gem 'ranked-model', '~> 0.4.8'
-gem 'restpack_serializer', git: 'https://github.com/zooniverse/restpack_serializer.git', branch: 'upgrade-activesupport-and-activerecord-to-allow-6.0', ref: '5f1ef6c2b2'
+gem 'restpack_serializer', git: 'https://github.com/zooniverse/restpack_serializer.git', branch: 'panoptes-api-version', ref: '5f1ef6c2b2'
 gem 'scientist', '~> 1.6.3'
 gem 'sidekiq', '< 7'
 gem 'sidekiq-congestion', '~> 0.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ else
   gem 'rails', '~> 5.2'
 end
 gem 'ranked-model', '~> 0.4.8'
-gem 'restpack_serializer', git: 'https://github.com/zooniverse/restpack_serializer.git', branch: 'upgrade-activesupport-and-activerecord-to-allow-6.0', ref: 'babfd9e730'
+gem 'restpack_serializer', git: 'https://github.com/zooniverse/restpack_serializer.git', branch: 'upgrade-activesupport-and-activerecord-to-allow-6.0', ref: '5f1ef6c2b2'
 gem 'scientist', '~> 1.6.3'
 gem 'sidekiq', '< 7'
 gem 'sidekiq-congestion', '~> 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/zooniverse/restpack_serializer.git
-  revision: babfd9e730cf3b38e7db218b960522fe6424ed6a
-  ref: babfd9e730
+  revision: 5f1ef6c2b230f291dd3b30b9c213bbeb64617801
+  ref: 5f1ef6c2b2
   branch: upgrade-activesupport-and-activerecord-to-allow-6.0
   specs:
     restpack_serializer (0.5.9)
-      activerecord (>= 4.0.3, < 7.1)
-      activesupport (>= 4.0.3, < 7.1)
+      activerecord (>= 5.2, < 7.1)
+      activesupport (>= 5.2, < 7.1)
       kaminari (< 2.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/zooniverse/restpack_serializer.git
-  revision: cef0969cef79a31de774e71c63de2a934c9e9f7f
-  ref: cef0969cef
-  branch: panoptes-api-version
+  revision: babfd9e730cf3b38e7db218b960522fe6424ed6a
+  ref: babfd9e730
+  branch: upgrade-activesupport-and-activerecord-to-allow-6.0
   specs:
     restpack_serializer (0.5.9)
-      activerecord (>= 4.0.3, < 6.0)
-      activesupport (>= 4.0.3, < 6.0)
+      activerecord (>= 4.0.3, < 7.1)
+      activesupport (>= 4.0.3, < 7.1)
       kaminari (< 2.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GIT
   remote: https://github.com/zooniverse/restpack_serializer.git
   revision: 5f1ef6c2b230f291dd3b30b9c213bbeb64617801
   ref: 5f1ef6c2b2
-  branch: upgrade-activesupport-and-activerecord-to-allow-6.0
+  branch: panoptes-api-version
   specs:
     restpack_serializer (0.5.9)
       activerecord (>= 5.2, < 7.1)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/zooniverse/restpack_serializer.git
-  revision: cef0969cef79a31de774e71c63de2a934c9e9f7f
-  ref: cef0969cef
-  branch: panoptes-api-version
+  revision: 5f1ef6c2b230f291dd3b30b9c213bbeb64617801
+  ref: 5f1ef6c2b2
+  branch: upgrade-activesupport-and-activerecord-to-allow-6.0
   specs:
     restpack_serializer (0.5.9)
-      activerecord (>= 4.0.3, < 6.0)
-      activesupport (>= 4.0.3, < 6.0)
+      activerecord (>= 5.2, < 7.1)
+      activesupport (>= 5.2, < 7.1)
       kaminari (< 2.0)
 
 GEM

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -2,7 +2,7 @@ GIT
   remote: https://github.com/zooniverse/restpack_serializer.git
   revision: 5f1ef6c2b230f291dd3b30b9c213bbeb64617801
   ref: 5f1ef6c2b2
-  branch: upgrade-activesupport-and-activerecord-to-allow-6.0
+  branch: panoptes-api-version
   specs:
     restpack_serializer (0.5.9)
       activerecord (>= 5.2, < 7.1)


### PR DESCRIPTION
This is in preparation of moving next? dual boot to 6.0. Prior to this, restpack serializer was limited to support activesupport/record < 6. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
