### PR TITLE
Rails 6.0 in Canary

### DIFF
--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: panoptes-staging-canary-app
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: panoptes-staging-canary-app


### PR DESCRIPTION
Update kubernetes template replicas to 1 for staging canary to test rails 6.0 on canary

Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
