### PR TITLE
ignore duplicate subjects records when linking to a subject set

### DIFF
--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -219,6 +219,14 @@ describe Api::V1::SubjectSetsController, type: :controller do
           expect(response).to have_http_status(:unprocessable_entity)
         end
       end
+
+      context 'when the subjects already existin in the set' do
+        it 'does not raise a duplicate key error' do
+          SetMemberSubject.create!(subject_id: subjects.first.id, subject_set_id: resource.id)
+          run_update_links
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     context 'with illegal link properties' do


### PR DESCRIPTION
This PR changes how we bulk insert / link subjects to a subject set to ignore duplicates when importing. 

Currently when a subject already is linked to a subject set then re-adding the subject via update_links causes a `PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint` error as the `subject_id` and `subject_set_id` have a unique compound index that errors when linking subjects that already exist in the subject set.

With the PR change we now ignore the duplicate record via the AR import `on_duplicate_key_ignore: true` setting which does a sql `ON CONFLICT DO NOTHING` insert statement to avoid the insert errors. 

see https://github.com/zdennis/activerecord-import#duplicate-key-ignore for more details.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
