### PR TITLE
Rails 6.0 issues on Signing out from PFE

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,8 +19,8 @@ class SessionsController < Devise::SessionsController
 
   def destroy
     respond_to do |format|
-      format.html { super }
       format.json { destroy_from_json }
+      format.html { super }
     end
   end
 


### PR DESCRIPTION
change order of `format` `respond_to` on session destroy. (PFE uses `Accept */*` header when calling `session_controller`'s `destroy` via `DELETE` which causes `ActionController::RespondToMismatchError` errors, since in Rails `respond_to` will take the first format as priority. https://github.com/rails/rails/issues/40023#issuecomment-673675138). 

it seem we have done this in other controllers (i.e. prioritizing format.json vs format.html), eg. `passwords_controller`.

but still worth checking to see if we hit this error elsewhere. 

(EDIT: Testing  if there are still similar issues: Will append below as I test/see issues)

**RELATED ISSUES FOUND WHILE TESTING** 
- [ ] It does look like updating password from profile settings page also has issues. 

it does look like https://github.com/zooniverse/panoptes/issues/4096 this deprecation warning might have something to do with these issues. 




# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
