### PR TITLE
Revert "Revert "build staging with Dockerfile.rails-next to test rails 6 in staging (#4111)" (#4119)"

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -12,7 +12,8 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
     with:
       repo_name: panoptes
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
+      file: Dockerfile.rails-next
       latest: true
 
   db_migration_staging:
@@ -22,7 +23,7 @@ jobs:
     with:
       app_name: panoptes
       environment: staging
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
     secrets:
       creds: ${{ secrets.AZURE_AKS }}
 
@@ -33,7 +34,7 @@ jobs:
     with:
       app_name: panoptes
       repo_name: panoptes
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
       environment: staging
     secrets:
       creds: ${{ secrets.AZURE_AKS }}
@@ -44,7 +45,7 @@ jobs:
     needs: deploy_staging
     if: always()
     with:
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
       job_name: Build and Push Image / build_and_push_image
       status: ${{ needs.deploy_staging.result }}
       title: "Panoptes Staging deploy & migration complete"

--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: panoptes-staging-canary-app
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: panoptes-staging-canary-app


### PR DESCRIPTION
This reverts commit 0683d45acfda90f71f890457d894afd7632d4886.

Reverting back to Rails 6.0 because determined that Password Change issues were not due to the upgrade but due to how Panoptes JS Client was setting `withCredentials` on api call. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
