### PR TITLE
turn off CI tests for next rails version

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         gemfile:
           - Gemfile
-          - Gemfile.next
+          # - Gemfile.next
         ruby:
           - 2.7
         spec-commands:


### PR DESCRIPTION
follow up to #4121  

as we don't have a next rails version ready let's avoid the CI running the same tests for Gemfile.next as we're just wasting compute time / CI system resources

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
