### PR TITLE
update active_interaction to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ end
 
 source 'https://rubygems.org'
 
-gem 'active_interaction', '~> 3.8.3'
+gem 'active_interaction'
 gem 'active_model_serializers' # Event stream
 gem 'active_record_extended'
 gem 'activerecord-import', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_interaction (3.8.3)
-      activemodel (>= 4, < 7)
+    active_interaction (5.2.0)
+      activemodel (>= 5.2, < 8)
+      activesupport (>= 5.2, < 8)
     active_model_serializers (0.10.13)
       actionpack (>= 4.1, < 7.1)
       activemodel (>= 4.1, < 7.1)
@@ -520,7 +521,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_interaction (~> 3.8.3)
+  active_interaction
   active_model_serializers
   active_record_extended
   activerecord-import (~> 1.4)


### PR DESCRIPTION
See: https://github.com/AaronLasseigne/active_interaction/blob/main/CHANGELOG.md#upgrading-1
There's been some breaking changes from 3.8.3 -> 4.0 which will affect our Operations. 

FWIW, I did some testing on local and things look fine. The change is tiny, but I wanted a second or third set of eyes to ensure I'm not missing anything. Or if anyone had context on why we had a pinned version for this. (I'm assuming its because we were on Rails 4 for a while). 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
