### PR TITLE
Update inat import complete email

### DIFF
--- a/app/mailers/inat_import_completed_mailer.rb
+++ b/app/mailers/inat_import_completed_mailer.rb
@@ -12,6 +12,7 @@ class InatImportCompletedMailer < ApplicationMailer
     lab_url_prefix = "#{Panoptes.frontend_url}/lab/#{project_id}"
     @subject_set_lab_url = "#{lab_url_prefix}/subject-sets/#{ss_import.subject_set_id}"
     @subject_set_name = ss_import.subject_set.display_name
+    @failed_ids = ss_import.failed_uuids
 
     @no_errors = ss_import.failed_count.zero?
     import_status = @no_errors ? 'was successful!' : 'completed with errors'

--- a/app/views/inat_import_completed_mailer/inat_import_complete.text.erb
+++ b/app/views/inat_import_completed_mailer/inat_import_complete.text.erb
@@ -5,12 +5,17 @@ Your iNaturalist subject import has finished processing.
 <% if @no_errors %>
 The iNaturalist observations have been imported successfully.
 <% else %>
-There were some errors when importing your iNaturalist observations.
+Some observations could not be imported.
+Observations with the following iNaturalist IDs are not included in your subject set:
+
+<%= @failed_ids.join(', ') %>
 <% end %>
 
 <%= @imported_count %> subjects were imported into subject set '<%= @subject_set_name %>'.
 
 To view them, visit: <%= @subject_set_lab_url %>
+
+If you have questions or if there were any issues with your import, please email contact@zooniverse.org.
 
 Cheers,
 The Zooniverse Team

--- a/spec/mailers/inat_import_completed_mailer_spec.rb
+++ b/spec/mailers/inat_import_completed_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe InatImportCompletedMailer, type: :mailer do
     end
 
     context 'with a failed subject set import' do
-      let(:ss_import) { create(:subject_set_import, subject_set: subject_set, failed_count: 1) }
+      let(:ss_import) { create(:subject_set_import, subject_set: subject_set, failed_count: 3, failed_uuids: [111, 222, 333]) }
 
       it 'includes the failed subject suffix' do
         expect(mail.subject).to include('Your iNaturalist subject import completed with errors')
@@ -43,6 +43,10 @@ RSpec.describe InatImportCompletedMailer, type: :mailer do
 
       it 'reports the failures statement' do
         expect(mail.body.encoded).to include('There were some errors when importing your iNaturalist observations.')
+      end
+
+      it 'includes the failed ids' do
+        expect(mail.body.encoded).to include('111, 222, 333')
       end
     end
   end


### PR DESCRIPTION
When there are errors with an iNat import, use clearer language and include the observation IDs (SubjectSetImport.failed_uuids).

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
