### PR TITLE
Rails 6.1 spec fixes - change references to deprecated update_attributes to update in specs

### DIFF
--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -253,14 +253,14 @@ describe Api::V1::OrganizationsController, type: :controller do
         end
 
         it "touches listed_at if listed is true" do
-          organization.update_attributes({listed: false, listed_at: nil})
+          organization.update({listed: false, listed_at: nil})
           params = { organizations: { listed: true }, id: organization.id }
           run_update(params)
           expect(json_response["organizations"].first['listed_at']).to be_truthy
         end
 
         it "nulls listed_at if listed is false" do
-          organization.update_attributes({listed: true, listed_at: Time.now })
+          organization.update({listed: true, listed_at: Time.now })
           params = { organizations: { listed: false }, id: organization.id }
           run_update(params)
           expect(json_response["organizations"].first['listed_at']).to be_nil
@@ -268,7 +268,7 @@ describe Api::V1::OrganizationsController, type: :controller do
 
         it "updates the categories" do
           new_categories = %w(fish snails worms)
-          organization.update_attributes({listed: true, listed_at: Time.now })
+          organization.update({listed: true, listed_at: Time.now })
           params = {
             organizations: {
               categories: new_categories

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -253,14 +253,14 @@ describe Api::V1::OrganizationsController, type: :controller do
         end
 
         it "touches listed_at if listed is true" do
-          organization.update({listed: false, listed_at: nil})
+          organization.update({ listed: false, listed_at: nil })
           params = { organizations: { listed: true }, id: organization.id }
           run_update(params)
           expect(json_response["organizations"].first['listed_at']).to be_truthy
         end
 
         it "nulls listed_at if listed is false" do
-          organization.update({listed: true, listed_at: Time.now })
+          organization.update({ listed: true, listed_at: Time.zone.now })
           params = { organizations: { listed: false }, id: organization.id }
           run_update(params)
           expect(json_response["organizations"].first['listed_at']).to be_nil
@@ -268,7 +268,7 @@ describe Api::V1::OrganizationsController, type: :controller do
 
         it "updates the categories" do
           new_categories = %w(fish snails worms)
-          organization.update({listed: true, listed_at: Time.now })
+          organization.update({ listed: true, listed_at: Time.zone.now })
           params = {
             organizations: {
               categories: new_categories

--- a/spec/lib/formatter/csv/workflow_spec.rb
+++ b/spec/lib/formatter/csv/workflow_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Formatter::Csv::Workflow do
         tasks: tasks, pairwise: !workflow.pairwise,
         grouped: !workflow.grouped, prioritized: !workflow.prioritized
       }
-      workflow.update_attributes(updates)
+      workflow.update(updates)
     end
 
     describe "#to_rows on the latest version" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -81,7 +81,7 @@ describe Project, type: :model do
 
   describe "#live" do
     before(:each) do
-      project.update_attributes(live: nil)
+      project.update(live: nil)
     end
 
     it "should not accept nil values" do

--- a/spec/support/optimistic_locking.rb
+++ b/spec/support/optimistic_locking.rb
@@ -4,11 +4,11 @@ shared_examples "optimistically locked" do
     m1 = described_class.find(model_id)
     m2 = described_class.find(model_id)
 
-    m1.update_attributes(locked_update)
+    m1.update(locked_update)
     m1.save
 
     expect do
-      m2.update_attributes(locked_update)
+      m2.update(locked_update)
       m2.save
     end.to raise_error(ActiveRecord::StaleObjectError)
 


### PR DESCRIPTION

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
