### PR TITLE
Rails 6.1 spec fixes- update error messages assertion when an invalid put operation

### DIFF
--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -569,8 +569,8 @@ describe Api::V1::UsersController, type: :controller do
         expect(response.status).to eq(422)
       end
 
-      it "should return a specific error message in the response body" do
-        error_message = "param is missing or the value is empty: users"
+      it 'returns a specific error message in the response body' do
+        error_message = 'param is missing or the value is empty: users'
         errors = JSON.parse(response.body)['errors']
         expect(errors).not_to be_empty
         expect(errors[0]['message']).to include(error_message)

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -561,7 +561,7 @@ describe Api::V1::UsersController, type: :controller do
       it_behaves_like "an api response"
     end
 
-    context "with a an invalid put operation" do
+    context 'with an invalid put operation' do
       before(:each) { update_request }
       let(:put_operations) { {} }
 
@@ -570,8 +570,10 @@ describe Api::V1::UsersController, type: :controller do
       end
 
       it "should return a specific error message in the response body" do
-        error_message = json_error_message("param is missing or the value is empty: users")
-        expect(response.body).to eq(error_message)
+        error_message = "param is missing or the value is empty: users"
+        errors = JSON.parse(response.body)['errors']
+        expect(errors).not_to be_empty
+        expect(errors[0]['message']).to include(error_message)
       end
 
       it "should not updated the resource attribute" do


### PR DESCRIPTION
error message on an invalid put operation for users includes rails generated message 
`\nDid you mean?  controller\n               action\n               id` (in 6.1) vs  just

`"param is missing or the value is empty: users"` 
# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
