### PR TITLE
update middleman to 1.3.0 on publish_docs gh action

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -13,4 +13,4 @@ jobs:
           REMOTE_BRANCH: gh-pages
           SITE_LOCATION: docs
           BUILD_LOCATION: build
-        uses: zooniverse/middleman-gh-pages-action@v1.2.0
+        uses: zooniverse/middleman-gh-pages-action@v1.3.0


### PR DESCRIPTION
update to middleman version without git diff check

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
