### PR TITLE
Sign out revoke tokens in a worker

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -61,6 +61,7 @@ class SessionsController < Devise::SessionsController
     # revoke all tokens that this user owns for the client application this token is linked to, e.g. PFE, FEM, classrooms etc.
     RevokeTokensWorker.perform_async(
       application_id_to_revoke,
-      doorkeeper_token.resource_owner_id)
+      doorkeeper_token.resource_owner_id
+    )
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -59,10 +59,8 @@ class SessionsController < Devise::SessionsController
     return unless application_id_to_revoke
 
     # revoke all tokens that this user owns for the client application this token is linked to, e.g. PFE, FEM, classrooms etc.
-    user = User.find(doorkeeper_token.resource_owner_id)
-    Doorkeeper::AccessToken.revoke_all_for(
+    RevokeTokensWorker.perform_async(
       application_id_to_revoke,
-      user
-    )
+      doorkeeper_token.resource_owner_id)
   end
 end

--- a/app/workers/revoke_tokens_worker.rb
+++ b/app/workers/revoke_tokens_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RevokeTokensWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :data_low
+
+  def perform(application_id_to_revoke, user_id)
+    user = User.find(user_id)
+    Doorkeeper::AccessToken.revoke_all_for(
+      application_id_to_revoke,
+      user
+    )
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -63,8 +63,6 @@ describe SessionsController, type: :controller do
       describe 'revoking access tokens' do
         let(:oauth_app) { create(:non_confidential_first_party_app, owner: user) }
         let(:user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
-        let(:user_other_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
-        let(:user_revoked_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
         let(:another_user) { create(:user) }
         let(:other_user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: another_user.id) }
         let(:other_oauth_app) { create(:non_confidential_first_party_app, owner: user) }
@@ -72,8 +70,6 @@ describe SessionsController, type: :controller do
 
         before do
           user_token
-          user_other_token
-          user_revoked_token.revoke
           other_user_token
           other_app_token
           request.env['devise.user'] = user

--- a/spec/workers/revoke_tokens_worker_spec.rb
+++ b/spec/workers/revoke_tokens_worker_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RevokeTokensWorker do
+  let(:worker) { described_class.new }
+  let(:user) { create(:user) }
+  let(:oauth_app) { create(:non_confidential_first_party_app, owner: user) }
+  let(:user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
+  let(:user_other_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
+  let(:user_revoked_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
+  let(:another_user) { create(:user) }
+  let(:other_user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: another_user.id) }
+  let(:other_oauth_app) { create(:non_confidential_first_party_app, owner: user) }
+  let(:other_app_token) { create(:access_token, application_id: other_oauth_app.id, resource_owner_id: user.id) }
+
+  before do
+    user_token
+    user_other_token
+    user_revoked_token.revoke
+    other_user_token
+    other_app_token
+  end
+
+  it { is_expected.to be_a Sidekiq::Worker }
+
+  describe 'perform' do
+    it 'revokes all access tokens for the relevant client app' do
+      expect {
+        worker.perform(oauth_app.id, user.id)
+      }.to change {
+        Doorkeeper::AccessToken.where(application_id: oauth_app.id, resource_owner_id: user.id, revoked_at: nil).count
+      }.from(2).to(0)
+    end
+
+    it 'does not revoke access token for another user' do
+      expect {
+        worker.perform(oauth_app.id, user.id)
+      }.not_to change {
+        Doorkeeper::AccessToken.where(application_id: oauth_app.id, resource_owner_id: another_user.id, revoked_at: nil).count
+      }
+    end
+
+    it 'does not revoke access token for other client apps' do
+      expect {
+        worker.perform(oauth_app.id, user.id)
+      }.not_to change {
+        Doorkeeper::AccessToken.where(application_id: other_oauth_app.id, resource_owner_id: user.id, revoked_at: nil).count
+      }
+    end
+  end
+end

--- a/spec/workers/revoke_tokens_worker_spec.rb
+++ b/spec/workers/revoke_tokens_worker_spec.rb
@@ -4,15 +4,15 @@ require 'spec_helper'
 
 describe RevokeTokensWorker do
   let(:worker) { described_class.new }
-  let(:user) { create(:user) }
-  let(:oauth_app) { create(:non_confidential_first_party_app, owner: user) }
-  let(:user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
-  let(:user_other_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
-  let(:user_revoked_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
-  let(:another_user) { create(:user) }
-  let(:other_user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: another_user.id) }
-  let(:other_oauth_app) { create(:non_confidential_first_party_app, owner: user) }
-  let(:other_app_token) { create(:access_token, application_id: other_oauth_app.id, resource_owner_id: user.id) }
+  let!(:user) { create(:user) }
+  let!(:oauth_app) { create(:non_confidential_first_party_app, owner: user) }
+  let!(:user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
+  let!(:user_other_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
+  let!(:user_revoked_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: user.id) }
+  let!(:another_user) { create(:user) }
+  let!(:other_user_token) { create(:access_token, application_id: oauth_app.id, resource_owner_id: another_user.id) }
+  let!(:other_oauth_app) { create(:non_confidential_first_party_app, owner: user) }
+  let!(:other_app_token) { create(:access_token, application_id: other_oauth_app.id, resource_owner_id: user.id) }
 
   before do
     user_token


### PR DESCRIPTION
Related to latency in sign out. Newly added revoking all user's relevant client app tokens, cause slow sign out (especially if user has many tokens...eg. opening up many tabs of the same client). We move the revoking to a worker to hopefully speed up the process. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
