### PR TITLE
remove uglifier gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ gem 'sidekiq-unique-jobs'
 gem 'standby'
 gem 'stringex', '~> 2.8'
 gem 'strong_migrations'
-gem 'uglifier', '~> 4.2'
 gem 'versionist', '~> 2.0'
 gem 'zoo_stream', '~> 1.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,6 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
-    execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -495,8 +494,6 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -591,7 +588,6 @@ DEPENDENCIES
   stringex (~> 2.8)
   strong_migrations
   ten_years_rails
-  uglifier (~> 4.2)
   versionist (~> 2.0)
   webmock
   zoo_stream (~> 1.0.1)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -145,7 +145,6 @@ GEM
     erubi (1.11.0)
     et-orbi (1.2.7)
       tzinfo
-    execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -497,8 +496,6 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -594,7 +591,6 @@ DEPENDENCIES
   stringex (~> 2.8)
   strong_migrations
   ten_years_rails
-  uglifier (~> 4.2)
   versionist (~> 2.0)
   webmock
   zoo_stream (~> 1.0.1)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,10 +22,6 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.public_file_server.enabled = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true, mangle: false)
-  # config.assets.css_compressor = :sass
-
   # use a non-default path to provide unique paths for use behind CDNs
   # E.g. avoid clashes with the PFE UI code uses as it uses '/assets'
   config.assets.prefix = '/api-assets'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -22,8 +22,6 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.public_file_server.enabled = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true, mangle: false)
   # config.assets.css_compressor = :sass
 
   # use a non-default path to provide unique paths for use behind CDNs


### PR DESCRIPTION
Rails 6 uses ES6 as a standard and no longer supports Uglifier. See: https://www.mintbit.com/blog/rails-5-6-upgrade-es6-uglifier-bug. 
https://github.com/zooniverse/panoptes/actions/runs/4577101400
With Rails 6, default compiler is Webpacker, so it probably is safe to drop uglifier altogether. Why this didn't get caught in building staging Canary...is a mystery. :/ 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
