### PR TITLE
Require prodution image to build & push before deploy

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -13,10 +13,11 @@ jobs:
       with:
         repo_name: panoptes
         commit_id: ${{ github.sha }}
-  
+
   deploy_production:
     name: Deploy to Production
     uses: zooniverse/ci-cd/.github/workflows/deploy_app.yaml@main
+    needs: build_and_push_image
     with:
       app_name: panoptes
       repo_name: panoptes

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,5 @@
 Rails.application.configure do
-  # ActiveSupport::Deprecation.silenced = ENV.fetch('DEPRECATION_WARNINGS_SILENCED', nil).present?
-  ActiveSupport::Deprecation.silenced = 1
+  ActiveSupport::Deprecation.silenced = ENV.fetch('DEPRECATION_WARNINGS_SILENCED', nil).present?
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
-  ActiveSupport::Deprecation.silenced = ENV.fetch('DEPRECATION_WARNINGS_SILENCED', nil).present?
+  # ActiveSupport::Deprecation.silenced = ENV.fetch('DEPRECATION_WARNINGS_SILENCED', nil).present?
+  ActiveSupport::Deprecation.silenced = 1
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's


### PR DESCRIPTION
If the image is going to be rebuilt after staging has presumably built the same one on the same sha, then we should at least wait until it finishes rebuilding before deploying. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
