### PR TITLE
update azure_adapter default expires in 5 mins to match Panoptes cache 

### DIFF
--- a/app/services/media_storage/azure_adapter.rb
+++ b/app/services/media_storage/azure_adapter.rb
@@ -4,7 +4,7 @@ module MediaStorage
   class AzureAdapter < AbstractAdapter
     attr_reader :url_prefix, :public_container, :private_container, :storage_account_name, :get_expiration, :put_expiration, :client, :signer
 
-    DEFAULT_EXPIRES_IN = 3 # time in minutes, see get_expiry_time(expires_in)
+    DEFAULT_EXPIRES_IN = 5 # time in minutes, see get_expiry_time(expires_in)
 
     def initialize(opts={})
       @storage_account_name = opts[:azure_storage_account]


### PR DESCRIPTION
Update azure_adapter default expires in 5 mins to match Panoptes cache 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
