### PR TITLE
Add infinite PG timeout to migrations

### DIFF
--- a/kubernetes/db-migrate-production.tmpl
+++ b/kubernetes/db-migrate-production.tmpl
@@ -9,6 +9,9 @@ spec:
       - name: panoptes-migrate-db-production
         image: ghcr.io/zooniverse/panoptes:__IMAGE_TAG__
         command: ["/rails_app/migrate.sh"]
+        env:
+        - name: PG_STATEMENT_TIMEOUT
+          value: '0'
         envFrom:
         - secretRef:
             name: panoptes-common-env-vars

--- a/kubernetes/db-migrate-staging.tmpl
+++ b/kubernetes/db-migrate-staging.tmpl
@@ -9,6 +9,9 @@ spec:
       - name: panoptes-migrate-db-staging
         image: ghcr.io/zooniverse/panoptes:__IMAGE_TAG__
         command: ["/rails_app/migrate.sh"]
+        env:
+        - name: PG_STATEMENT_TIMEOUT
+          value: '0'
         envFrom:
         - secretRef:
             name: panoptes-common-env-vars

--- a/kubernetes/job-task-production.tmpl
+++ b/kubernetes/job-task-production.tmpl
@@ -9,6 +9,9 @@ spec:
       - name: panoptes-rake-task-production
         image: ghcr.io/zooniverse/panoptes:__IMAGE_TAG__
         command: ["bundle",  "exec", "rake", __RAKE_TASK_NAME__]
+        env:
+        - name: PG_STATEMENT_TIMEOUT
+          value: '0'
         envFrom:
         - secretRef:
             name: panoptes-common-env-vars

--- a/kubernetes/job-task-staging.tmpl
+++ b/kubernetes/job-task-staging.tmpl
@@ -9,6 +9,9 @@ spec:
       - name: panoptes-rake-task-staging
         image: ghcr.io/zooniverse/panoptes:__IMAGE_TAG__
         command: ["bundle",  "exec", "rake", __RAKE_TASK_NAME__]
+        env:
+        - name: PG_STATEMENT_TIMEOUT
+          value: '0'
         envFrom:
         - secretRef:
             name: panoptes-common-env-vars


### PR DESCRIPTION
Allow extremely long running migrations to run extremely long. Current PG_STATEMENT_TIMEOUT is 65000, and the wait time on the job is set to 24h, but the PG statement should be allowed to run as long as necessary. Ideally not that long, but best to not time it out regardless.

Based on https://github.com/zooniverse/caesar/pull/1467/files. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
