### PR TITLE
Allow admins to update settings in project preferences

### DIFF
--- a/app/controllers/api/v1/project_preferences_controller.rb
+++ b/app/controllers/api/v1/project_preferences_controller.rb
@@ -22,9 +22,11 @@ class Api::V1::ProjectPreferencesController < Api::ApiController
       user_id: params_for[:user_id],
       project_id: params_for[:project_id]
     )
-    unless @upp.project.owners_and_collaborators.include?(api_user.user)
-      raise Api::Unauthorized.new("You must be the project owner")
-    end
+    raise Api::Unauthorized, 'You must be the project owner or a collaborator' unless user_allowed?
+  end
+
+  def user_allowed?
+    @upp.project.owners_and_collaborators.include?(api_user.user) || api_user.user.is_admin?
   end
 
   def update_settings_response

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
     it_behaves_like 'is creatable'
   end
 
-  describe '#update_settings' do
+  describe '#update_settings', :focus, :focus do
     let!(:project) { create(:project, owner: authorized_user) }
     let!(:upp) { create(:user_project_preference, project: project) }
     let(:settings_params) do
@@ -165,6 +165,15 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
       it 'only updates settings of owned project' do
         run_update
         expect(response.status).to eq(403)
+      end
+    end
+
+    describe "updating a project as an admin" do
+      let(:admin_user) { create(:admin_user) }
+      it "lets the admin update UPP settings" do
+        default_request user_id: admin_user.id, scopes: scopes
+        run_update
+        expect(response.status).to eq(200)
       end
     end
 

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -168,9 +168,10 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
       end
     end
 
-    describe "updating a project as an admin" do
+    describe 'updating a project as an admin' do
       let(:admin_user) { create(:admin_user) }
-      it "lets the admin update UPP settings" do
+
+      it 'lets the admin update UPP settings' do
         default_request user_id: admin_user.id, scopes: scopes
         run_update
         expect(response.status).to eq(200)

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
     it_behaves_like 'is creatable'
   end
 
-  describe '#update_settings', :focus, :focus do
+  describe '#update_settings' do
     let!(:project) { create(:project, owner: authorized_user) }
     let!(:upp) { create(:user_project_preference, project: project) }
     let(:settings_params) do


### PR DESCRIPTION
Typical API auth is skipped for the ProjectPreferencesController's #update_settings method. It's done manually instead, checking a `project.owners_and_collaborators` includes the api_user. This also skips checking if a user is a global admin, though. This PR adds that check and allows admins to update any project's settings to allow them to assist with project building.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
