### PR TITLE
Tweak admin permissions for ProjectPreferences update_settings

### DIFF
--- a/app/controllers/api/v1/project_preferences_controller.rb
+++ b/app/controllers/api/v1/project_preferences_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::ProjectPreferencesController < Api::ApiController
   end
 
   def user_allowed?
-    @upp.project.owners_and_collaborators.include?(api_user.user) || api_user.user.is_admin?
+    @upp.project.owners_and_collaborators.include?(api_user.user) || api_user.is_admin?
   end
 
   def update_settings_response


### PR DESCRIPTION
Tweaking https://github.com/zooniverse/panoptes/pull/4218 -- run `is_admin?` check on `api_user` instead of `user` so that an admin flag is required in the request, not just that the user has admin privlidges.  This allows for non-admin use of API endpoint by Zoo team members. 

My initial commit is going to break the spec, and I could use assistance in correcting the test.  Not sure if there's a standard case / method of testing for admin flag use.
