### PR TITLE
Require admin flag for admin UPP requests 

### DIFF
--- a/app/controllers/api/v1/project_preferences_controller.rb
+++ b/app/controllers/api/v1/project_preferences_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::ProjectPreferencesController < Api::ApiController
   end
 
   def user_allowed?
-    @upp.project.owners_and_collaborators.include?(api_user.user) || api_user.user.is_admin?
+    @upp.project.owners_and_collaborators.include?(api_user.user) || api_user.is_admin?
   end
 
   def update_settings_response

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
 
       it 'lets the admin update UPP settings' do
         default_request user_id: admin_user.id, scopes: scopes
+        settings_params[:admin] = true
         run_update
         expect(response.status).to eq(200)
       end


### PR DESCRIPTION
Admin UPP requests only reflect on whether a user is an admin in the database and does not check whether they included the admin flag in the request, signaling intention to act as one.

This PR uses the `api_user.is_admin?` method directly instead, which checks both `user.admin?` and whether the flag was set in the request. The spec needed just the flag set in the request params.

I though this would be a bigger lift so I started my own branch but it turned out to be as simple as https://github.com/zooniverse/panoptes/pull/4249 so this will supersede that one (thanks @lcjohnso!)

 
# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
