### PR TITLE
Project copying fixes: Talk roles and field guide images

### DIFF
--- a/lib/project_copier.rb
+++ b/lib/project_copier.rb
@@ -36,6 +36,9 @@ class ProjectCopier
       # to keep the translations system working with these copied resources
       setup_associated_primary_language_translations(copied_project)
 
+      # Creates Talk roles via background worker
+      TalkAdminCreateWorker.perform_async(copied_project.id)
+
       # return the newly copied project
       copied_project
     end

--- a/lib/project_copier.rb
+++ b/lib/project_copier.rb
@@ -23,7 +23,7 @@ class ProjectCopier
     # Should this all be wrapped in a transaction?
     # to ensure we rollback an sub resource creations,
     # e.g. inband primary lang strings for the associated resources....
-    Project.transaction(requires_new: true) do
+    copied_project = Project.transaction(requires_new: true) do
       copied_project = copy_project
 
       # save the project and create the project versions for use in translation strings
@@ -36,12 +36,14 @@ class ProjectCopier
       # to keep the translations system working with these copied resources
       setup_associated_primary_language_translations(copied_project)
 
-      # Creates Talk roles via background worker
-      TalkAdminCreateWorker.perform_async(copied_project.id)
-
-      # return the newly copied project
       copied_project
     end
+
+    # Creates Talk roles via background worker
+    TalkAdminCreateWorker.perform_async(copied_project.id)
+
+    # return the newly copied project
+    copied_project
   end
 
   private

--- a/lib/project_copier.rb
+++ b/lib/project_copier.rb
@@ -4,7 +4,6 @@ class ProjectCopier
   EXCLUDE_ATTRIBUTES = %i[classifications_count launched_row_order beta_row_order].freeze
   INCLUDE_ASSOCIATIONS = [
     :tutorials,
-    :field_guides,
     :pages,
     :tags,
     :tagged_resources,

--- a/lib/project_copier.rb
+++ b/lib/project_copier.rb
@@ -10,7 +10,8 @@ class ProjectCopier
     :tagged_resources,
     :avatar,
     :background,
-    { active_workflows: %i[tutorials attached_images] }
+    { active_workflows: %i[tutorials attached_images] },
+    { field_guides: %i[attached_images] }
   ].freeze
 
   def initialize(project_id, user_id)

--- a/spec/lib/project_copier_spec.rb
+++ b/spec/lib/project_copier_spec.rb
@@ -39,6 +39,13 @@ describe ProjectCopier do
       expect(copied_project.configuration['source_project_id']).to be(project.id)
     end
 
+    it 'creates Talk roles for the new project and its owner' do
+      expect(TalkAdminCreateWorker)
+        .to receive(:perform_async)
+        .with(be_kind_of(Integer))
+      copied_project
+    end
+
     context 'when a project has active_worklfows' do
       it 'creates a valid workflow copy' do
         expect(copied_project.active_workflows.first).to be_valid

--- a/spec/lib/project_copier_spec.rb
+++ b/spec/lib/project_copier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe ProjectCopier do
@@ -40,10 +42,11 @@ describe ProjectCopier do
     end
 
     it 'creates Talk roles for the new project and its owner' do
-      expect(TalkAdminCreateWorker)
-        .to receive(:perform_async)
-        .with(be_kind_of(Integer))
+      allow(TalkAdminCreateWorker).to receive(:perform_async)
       copied_project
+      expect(TalkAdminCreateWorker)
+        .to have_received(:perform_async)
+        .with(be_kind_of(Integer))
     end
 
     context 'when a project has active_worklfows' do
@@ -94,7 +97,7 @@ describe ProjectCopier do
 
       it 'copies the field guide attached images' do
         fg = create(:field_guide, project: project)
-        fg.attached_images << create(:medium, type: "field_guide_attached_image", linked: fg)
+        fg.attached_images << create(:medium, type: 'field_guide_attached_image', linked: fg)
         expect(copied_project.field_guides.first.attached_images[0]).to be_valid
       end
     end

--- a/spec/lib/project_copier_spec.rb
+++ b/spec/lib/project_copier_spec.rb
@@ -84,6 +84,12 @@ describe ProjectCopier do
         field_guide = copied_project.field_guides.first
         expect(field_guide.translations.first.language).to eq(project.primary_language)
       end
+
+      it 'copies the field guide attached images' do
+        fg = create(:field_guide, project: project)
+        fg.attached_images << create(:medium, type: "field_guide_attached_image", linked: fg)
+        expect(copied_project.field_guides.first.attached_images[0]).to be_valid
+      end
     end
 
     context 'when a project has a project page' do


### PR DESCRIPTION
Fixes a couple project copying bugs. 

* Includes Field Guide attached images in project deep copies.
* Creates Talk admin roles for copied projects. Uses the same TalkAdminCreateWorker that fires on project creation.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
