### PR TITLE
allow setting and updating stats_visibility on update and create

### DIFF
--- a/app/controllers/api/v1/user_groups_controller.rb
+++ b/app/controllers/api/v1/user_groups_controller.rb
@@ -9,8 +9,8 @@ class Api::V1::UserGroupsController < Api::ApiController
 
   alias_method :user_group, :controlled_resource
 
-  allowed_params :create, :name, :display_name, links: [ users: [] ]
-  allowed_params :update, :name, :display_name
+  allowed_params :create, :name, :display_name, :stats_visibility, links: [ users: [] ]
+  allowed_params :update, :name, :stats_visibility, :display_name
 
   search_by do |name, query|
     query.search_name(name.join(" "))

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -31,13 +31,20 @@ class UserGroup < ApplicationRecord
   #
   # public_show_all: Anyone can view aggregate stats of the user group and can view individual stats of the user group.
   ##
-  enum stats_visibility: {
+  STATS_VISIBILITY_LEVELS = {
     private_agg_only: 0,
     private_show_agg_and_ind: 1,
     public_agg_only: 2,
     public_agg_show_ind_if_member: 3,
     public_show_all: 4
   }
+  enum stats_visibility: STATS_VISIBILITY_LEVELS
+
+  validate do
+    if @invalid_stats_visibility
+      errors.add(:stats_visibility, "Not stats_visibility type, please select from the list: #{STATS_VISIBILITY_LEVELS.keys}")
+    end
+  end
 
   validates :display_name, presence: true
   validates :name, presence: true,
@@ -84,6 +91,14 @@ class UserGroup < ApplicationRecord
 
   def verify_join_token(token_to_verify)
     join_token.present? && join_token == token_to_verify
+  end
+
+  def stats_visibility=(value)
+    if !STATS_VISIBILITY_LEVELS.stringify_keys.keys.include?(value) && !STATS_VISIBILITY_LEVELS.values.include?(value)
+      @invalid_stats_visibility = true
+    else
+      super value
+    end
   end
 
   private

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -71,6 +71,32 @@ describe UserGroup, :type => :model do
     end
   end
 
+  describe '#stats_visibility' do
+    it 'validates that it is one of the STATS_VISIBILITY levels' do
+      ug = build(:user_group, name: "abc")
+      ug.stats_visibility = 'public_agg_only'
+      expect(ug).to be_valid
+    end
+
+    it 'allows stats_visibility to be integer corresponding to STATS_VISIBILITY level' do
+      ug = build(:user_group, name: "abc")
+      ug.stats_visibility = 4
+      expect(ug).to be_valid
+    end
+
+    it 'does not allow stats_visibility to be outside STATS_VISIBILITY levels' do
+      ug = build(:user_group, name: "abc")
+      ug.stats_visibility = 'fake_stats_level'
+      expect(ug).to_not be_valid
+    end
+
+    it 'does not allow stats_visibility to be outside STATS_VISIBILITY range' do
+      ug = build(:user_group, name: "abc")
+      ug.stats_visibility = 9
+      expect(ug).to_not be_valid
+    end
+  end
+
   describe "#users" do
     let(:user_group) { create(:user_group_with_users) }
 


### PR DESCRIPTION
also adding error if `stats_visibility` is invalid to bypass Rails enum attribute validation that gives an `ArgumentError`. 
Per: 
https://stackoverflow.com/a/67090071


Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
