### PR TITLE
Email verification

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ConfirmationsController < Devise::ConfirmationsController
+  protected
+
+  def after_confirmation_path_for(resource_name, resource)
+    'https://www.zooniverse.org'
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   attr_accessor :minor_age
 
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :trackable, :validatable,
+    :recoverable, :rememberable, :trackable, :validatable, :confirmable,
     :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
 
   has_many :classifications, dependent: :restrict_with_exception
@@ -56,14 +56,12 @@ class User < ApplicationRecord
   validates_with IdentityGroupNameValidator
 
   after_create :set_zooniverse_id
-  after_create :send_welcome_email, unless: :migrated
   before_create :set_ouroboros_api_key
 
   delegate :projects, to: :identity_group
   delegate :collections, to: :identity_group
   delegate :subjects, to: :identity_group
   delegate :owns?, to: :identity_group
-
 
   pg_search_scope :search_name,
     against: [:login],
@@ -202,6 +200,10 @@ class User < ApplicationRecord
 
   def self.find_by_lower_login(login)
     find_by("lower(login) = ?", login.downcase)
+  end
+
+  def after_confirmation
+    send_welcome_email
   end
 
   def subject_limit

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   config.strip_whitespace_keys = [ :email ]
   config.skip_session_storage = [:http_auth]
   config.stretches = Rails.env.test? ? 1 : 10
-  config.reconfirmable = true
+  config.reconfirmable = false
   config.password_length = 8..128
   config.reset_password_within = 6.hours
   config.paranoid = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,6 +9,7 @@ Devise.setup do |config|
   config.skip_session_storage = [:http_auth]
   config.stretches = Rails.env.test? ? 1 : 10
   config.reconfirmable = false
+  config.allow_unconfirmed_access_for = nil
   config.password_length = 8..128
   config.reset_password_within = 6.hours
   config.paranoid = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :users,
-    controllers: { omniauth_callbacks: 'omniauth_callbacks', passwords: 'passwords' },
+    controllers: { confirmations: 'confirmations', omniauth_callbacks: 'omniauth_callbacks', passwords: 'passwords' },
     skip: [ :sessions, :registrations ]
 
   as :user do

--- a/db/migrate/20231025200957_add_confirmable_to_devise.rb
+++ b/db/migrate/20231025200957_add_confirmable_to_devise.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddConfirmableToDevise < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+
+    add_index :users, :confirmation_token, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_column :users, :confirmation_token
+    remove_column :users, :confirmed_at
+    remove_column :users, :confirmation_sent_at
+
+    remove_index :users, :confirmation_token
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -53,8 +53,6 @@ COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
-
 --
 -- Name: access_control_lists; Type: TABLE; Schema: public; Owner: -
 --
@@ -1802,7 +1800,10 @@ CREATE TABLE public.users (
     upload_whitelist boolean DEFAULT false NOT NULL,
     ux_testing_email_communication boolean DEFAULT false,
     intervention_notifications boolean DEFAULT true,
-    nasa_email_communication boolean DEFAULT false
+    nasa_email_communication boolean DEFAULT false,
+    confirmation_token character varying,
+    confirmed_at timestamp without time zone,
+    confirmation_sent_at timestamp without time zone
 );
 
 
@@ -3569,6 +3570,13 @@ CREATE INDEX index_users_on_beta_email_communication ON public.users USING btree
 
 
 --
+-- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_confirmation_token ON public.users USING btree (confirmation_token);
+
+
+--
 -- Name: index_users_on_display_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4576,6 +4584,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211124175756'),
 ('20211201164326'),
 ('20221018032140'),
-('20230613165746');
+('20230613165746'),
+('20231025200957');
 
 

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -48,6 +48,18 @@ namespace :user do
     end
   end
 
+  desc 'Backfill confirmed_at in batches (restartable)'
+  task backfill_confirmed_at: :environment do
+    mass_confirmed_at = Time.current.to_s(:db)
+    User.select(:id).find_in_batches do |users|
+      null_confirmed_at_user_scope = User.where(
+        id: users.map(&:id),
+        confirmed_at: nil
+      )
+      null_confirmed_at_user_scope.update_all(confirmed_at: mass_confirmed_at)
+    end
+  end
+
   namespace :limit do
 
     class UpdateUserLimitArgsError < StandardError; end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -72,8 +72,9 @@ describe PasswordsController, type: [ :controller, :mailer ] do
           expect(response.status).to eq(200)
         end
 
-        it "should not send an email to the account email address" do
-          expect(ActionMailer::Base.deliveries).to be_empty
+        it 'should send confirmation instructions to the account email address' do
+          expect(ActionMailer::Base.deliveries).not_to be_empty
+          expect(ActionMailer::Base.deliveries.first.body).to include('confirm your account')
         end
       end
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -149,8 +149,8 @@ describe RegistrationsController, type: :controller do
           post :create, params: { user: user_attributes }
         end
 
-        it "should queue a welcome worker to send an email" do
-          expect(UserWelcomeMailerWorker).to receive(:perform_async)
+        it "should send a confirmation instructions email" do
+          expect_any_instance_of(User).to receive(:send_confirmation_instructions).once
           post :create, params: { user: user_attributes }
         end
 
@@ -212,8 +212,8 @@ describe RegistrationsController, type: :controller do
           end
         end
 
-        it "should not queue a welcome worker to send an email" do
-          expect(UserWelcomeMailerWorker).to_not receive(:perform_async)
+        it "should not send a confirmation instructions email" do
+          expect_any_instance_of(User).to_not receive(:send_confirmation_instructions)
           post :create, params: { user: user_attributes }
         end
       end
@@ -279,8 +279,8 @@ describe RegistrationsController, type: :controller do
           post :create, params: { user: user_attributes }
         end
 
-        it "should queue a welcome worker to send an email" do
-          expect(UserWelcomeMailerWorker).to receive(:perform_async)
+        it "should send a confirmation instructions email" do
+          expect_any_instance_of(User).to receive(:send_confirmation_instructions).once
           post :create, params: { user: user_attributes }
         end
       end
@@ -313,8 +313,8 @@ describe RegistrationsController, type: :controller do
           expect(User.where(login: user_attributes[:login])).to_not exist
         end
 
-        it "should not queue a welcome worker to send an email" do
-          expect(UserWelcomeMailerWorker).to_not receive(:perform_async)
+        it "should not send a confirmation instructions email" do
+          expect_any_instance_of(User).to_not receive(:send_confirmation_instructions)
           post :create, params: { user: user_attributes }
         end
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     sequence(:email) {|n| "example#{n}@example.com"}
     password { 'password' }
     encrypted_password { User.new.send(:password_digest, 'password') }
-    confirmed_at { Time.now }
-    confirmation_sent_at { Time.now }
+    confirmed_at { Time.current }
+    confirmation_sent_at { Time.current }
     credited_name { 'Dr User' }
     activated_state { :active }
     sequence(:login) { |n| "new_user_#{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     sequence(:email) {|n| "example#{n}@example.com"}
     password { 'password' }
     encrypted_password { User.new.send(:password_digest, 'password') }
+    confirmed_at { Time.now }
+    confirmation_sent_at { Time.now }
     credited_name { 'Dr User' }
     activated_state { :active }
     sequence(:login) { |n| "new_user_#{n}" }


### PR DESCRIPTION
Adds the Confirmable module for Devise along with the requisite database attributes. A "please confirm your email address" email is now sent to the user on account creation. That email is using the default template ([located here](https://github.com/zooniverse/panoptes/blob/email-verification/app/views/devise/mailer/confirmation_instructions.html.erb#L6)) and can be updated if desired. 

When a user creates a new account, the front end should inform them that they will receive a confirmation email (this currently happens on Panoptes' own reg page, but no one uses it). The link in that email will point to Panoptes directly so that the API can process the user's confirmation token. That "thank you for confirming" event will likely have to be updated to redirect to wherever makes the most sense since that form currently just refreshes the [panoptes API home page](https://panoptes.zooniverse.org/). Right now, successful I am redirecting successful confirmations to the zooniverse.org (production) home page. Is there a way to ensure the registration modal opens on PFE? I can include a query param that can trigger a "thank you for confirming your email address!" welcome flash message. Is that worth integrating into PFE, or should that wait until FEM is at the site root? **This is a todo and should be figured out & updated before this deploys to production.**

Also, when the user is confirmed they will then receive the standard Zooniverse welcome email. For reference, that template is [located here](https://github.com/zooniverse/panoptes/blob/email-verification/app/views/user_welcome_mailer/welcome_user.html.erb#L111) and hasn't needed to be updated in a while. 

Finally: there's a rake task to backfill all existing users with a `confirmed_at` value. This field is going to be used by Talk in order to prevent unconfirmed users from interacting with Talk beyond viewing public posts. This PR must be merged and this backfill run before the Talk PR merges.

This is gonna need a bit of hands on testing on staging, so once this and the Talk PR merge, that'll be the focus till production can be deployed safely.  

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
