### PR TITLE
remove gem update step on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-# Newest versions of rubygems-update is not compatible with Ruby2.7 (Only compatible with Ruby 3+)
-RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install --without development test
 
 ADD ./ /rails_app

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-RUN gem update --system
+RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install --without development test
 
 ADD ./ /rails_app

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+# Newest versions of rubygems-update is not compatible with Ruby2.7 (Only compatible with Ruby 3+)
 RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install --without development test
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,7 +19,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-RUN gem update --system
+RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install
 
 ADD ./ /rails_app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,8 +19,6 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-# Newest versions of rubygems-update is not compatible with Ruby2.7 (Only compatible with Ruby 3+)
-RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install
 
 ADD ./ /rails_app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,6 +19,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+# Newest versions of rubygems-update is not compatible with Ruby2.7 (Only compatible with Ruby 3+)
 RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install
 


### PR DESCRIPTION
Fixes broken Docker builds due to newest version of [gem update compatible with Ruby 3.0](https://github.com/zooniverse/panoptes/issues/4271) and we're on 2.7. 

I don't think we need this step until we go from 2.7 -> 3.0 (See [Slack thread](https://zooniverse.slack.com/archives/C01M8PJGLR5/p1704216465080689?thread_ts=1703798315.916799&cid=C01M8PJGLR5) )

Looking at diffs/git blame that step was added when we bumped from  2.6 -> 2.7. 

**ERROR ON CURRENT DOCKER BUILD**
```
 > [ 7/10] RUN gem i "rubygems-update:<3.5.3" --no-document && update_rubygems:                                                                 
#11 35.12 ERROR:  Error installing rubygems-update:                                                                                             
#11 35.12       The last version of rubygems-update (< 3.5.3) to support your Ruby & RubyGems was 3.4.22. Try installing it with `gem install rubygems-update -v 3.4.22`
#11 35.12       rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```

- As opposed to going to 3.0 willy nilly, I'm pretty sure we as a team would want to do a Dual boot of current app on 2.7 and then dual booted app on 3.0 to see if there are any breaking changes. 


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
