### PR TITLE
fix docker builds to run gem update system with gem-update pinned to specific version that is compatible with ruby 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+
 # run gem update system so installation of mini_racer does not fail
 # See: https://github.com/rubyjs/mini_racer/issues/289#issuecomment-1823077560
 # pinning gem update to 3.4.22 since anything higher requires updating Ruby version to 3+

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+# run gem update system so installation of mini_racer does not fail
+# See: https://github.com/rubyjs/mini_racer/issues/289#issuecomment-1823077560
+# pinning gem update to 3.4.22 since anything higher requires updating Ruby version to 3+
+RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install --without development test
 
 ADD ./ /rails_app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,6 +19,10 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+# run gem update system so installation of mini_racer does not fail
+# pinning gem update to 3.4.22 since anything higher requires updating Ruby version to 3+
+# https://github.com/rubyjs/mini_racer/issues/289#issuecomment-1823077560
+RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install
 
 ADD ./ /rails_app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,9 +19,10 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+
 # run gem update system so installation of mini_racer does not fail
-# pinning gem update to 3.4.22 since anything higher requires updating Ruby version to 3+
 # https://github.com/rubyjs/mini_racer/issues/289#issuecomment-1823077560
+# pinning gem update to 3.4.22 since anything higher requires updating Ruby version to 3+
 RUN gem i "rubygems-update:~>3.4.22" --no-document && update_rubygems
 RUN bundle install
 


### PR DESCRIPTION
run `gem update system` so installation of mini_racer does not fail
 pinning gem update to 3.4.22 since using default gem-update requires updating Ruby version to 3+. See: https://github.com/zooniverse/panoptes/issues/4271

Describe your change here.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
