### PR TITLE
implement project preference read settings endpoint

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,7 @@ class Project < ApplicationRecord
   has_many :tutorials
   has_many :field_guides, dependent: :destroy
   belongs_to :organization
+  has_many :user_project_preference
   # uses the activated_state enum on the workflow
   has_many :workflows,
     -> { where(serialize_with_project: true).active},

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
       json_api_resources :project_preferences do
         collection do
           post :update_settings
+          get :read_settings
         end
       end
 

--- a/spec/controllers/api/v1/project_preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/project_preferences_controller_spec.rb
@@ -197,4 +197,45 @@ RSpec.describe Api::V1::ProjectPreferencesController, type: :controller do
       end
     end
   end
+
+  describe '#read_settings' do
+    let!(:project) { create(:project, owner: authorized_user) }
+    let!(:upp) { create(:user_project_preference, project: project) }
+    let(:run_generic_read) { get :read_settings, params: { project_id: project.id, format: :json } }
+    let(:unauthorised_user) { create(:user) }
+    let(:run_unauthorised_user_read) { get :read_settings, params: { project_id: project.id, user_id: unauthorised_user.id, format: :json } }
+
+    describe 'genetic preferences' do
+      before(:each) do
+        default_request user_id: authorized_user.id, scopes: scopes
+        run_generic_read
+      end
+
+      it 'responds with a 200' do
+        expect(response.status).to eq(200)
+      end
+  
+      it 'returns the correct response data' do
+        json_response = JSON.parse(response.body)
+        expect(json_response["project_preferences"]).to be_a(Array)
+        expect(json_response["project_preferences"].count).to eq(1)
+      end
+    end
+
+    describe 'user specific preferences' do
+      before(:each) do
+        default_request user_id: unauthorised_user.id, scopes: scopes
+        run_unauthorised_user_read
+      end
+
+      it 'responds with a 200' do
+        expect(response.status).to eq(200)
+      end
+  
+      it 'returns the correct response data' do
+        json_response = JSON.parse(response.body)
+        expect(json_response["project_preferences"].count).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Describe your change here.
Endpoint to expose read permissions for Project Preferences

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [x] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [x] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
