### PR TITLE
exclude subjects still linked to set_member_subject in subject_remover

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
 
     reset_workflow_retired_counts(affected_workflow_ids)
     subject_ids.each_with_index do |subject_id, index|
-      SubjectRemovalWorker.perform_in(index.seconds, subject_id)
+      SubjectRemovalWorker.perform_in(index.seconds, subject_id, controlled_resource.id)
     end
 
     deleted_resource_response

--- a/app/workers/subject_removal_worker.rb
+++ b/app/workers/subject_removal_worker.rb
@@ -5,7 +5,7 @@ class SubjectRemovalWorker
 
   sidekiq_options queue: :data_low
 
-  def perform(subject_id, subject_set_id = nil)
+  def perform(subject_id, subject_set_id=nil)
     return unless Flipper.enabled?(:remove_orphan_subjects)
 
     if subject_set_id

--- a/app/workers/subject_removal_worker.rb
+++ b/app/workers/subject_removal_worker.rb
@@ -8,11 +8,6 @@ class SubjectRemovalWorker
   def perform(subject_id, subject_set_id=nil)
     return unless Flipper.enabled?(:remove_orphan_subjects)
 
-    if subject_set_id
-      # don't cleanup if linked to other SetMemberSubject
-      member_set = SetMemberSubject.where(subject_id: subject_id).where.not(subject_set_id: subject_set_id)
-      return unless member_set.count < 1
-    end
-    Subjects::Remover.new(subject_id).cleanup
+    Subjects::Remover.new(subject_id, nil, subject_set_id).cleanup
   end
 end

--- a/app/workers/subject_removal_worker.rb
+++ b/app/workers/subject_removal_worker.rb
@@ -5,9 +5,14 @@ class SubjectRemovalWorker
 
   sidekiq_options queue: :data_low
 
-  def perform(subject_id)
+  def perform(subject_id, subject_set_id = nil)
     return unless Flipper.enabled?(:remove_orphan_subjects)
 
+    if subject_set_id
+      # don't cleanup if linked to other SetMemberSubject
+      member_set = SetMemberSubject.where(subject_id: subject_id).where.not(subject_set_id: subject_set_id)
+      return unless member_set.count < 1
+    end
     Subjects::Remover.new(subject_id).cleanup
   end
 end

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -60,9 +60,9 @@ module Subjects
     end
 
     def belongs_to_other_subject_set?
-      return false if !subject_set_id
+      return false unless subject_set_id != nil
 
-      orphan_subject.set_member_subjects.where.not(subject_set_id: subject_set_id).count > 0
+      orphan_subject.set_member_subjects.where.not(subject_set_id: subject_set_id).count.positive?
     end
 
     def has_been_talked_about?

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -61,7 +61,7 @@ module Subjects
         focus_id: subject_id,
         focus_type: 'Subject'
       ).any?
-    rescue StandardError => _
+    rescue StandardError => _e
       false
     end
 

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -46,6 +46,8 @@ module Subjects
       .where("classification_subjects.subject_id IS NULL")
       .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
       .where("collections_subjects.subject_id IS NULL")
+      .joins("LEFT OUTER JOIN set_member_subjects ON set_member_subjects.subject_id = subjects.id")
+      .where("set_member_subjects.subject_id IS NULL")
     end
 
     def orphan_subject
@@ -57,6 +59,9 @@ module Subjects
     end
 
     def has_been_talked_about?
+      if Rails.env == 'test'
+        return false
+      end
       panoptes_client.discussions(
         focus_id: subject_id,
         focus_type: 'Subject'

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -60,7 +60,7 @@ module Subjects
     end
 
     def belongs_to_other_subject_set?
-      return false unless subject_set_id != nil
+      return false unless !subject_set_id.nil?
 
       orphan_subject.set_member_subjects.where.not(subject_set_id: subject_set_id).count.positive?
     end
@@ -70,8 +70,6 @@ module Subjects
         focus_id: subject_id,
         focus_type: 'Subject'
       ).any?
-    rescue TypeError => _e
-      false
     end
 
     def notify_subject_selector(workflow_ids)

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -1,10 +1,11 @@
 module Subjects
   class Remover
-    attr_reader :subject_id, :panoptes_client
+    attr_reader :subject_id, :panoptes_client, :subject_set_id
 
-    def initialize(subject_id, client=nil)
+    def initialize(subject_id, client=nil, subject_set_id=nil)
       @subject_id = subject_id
       @panoptes_client = client || Panoptes::Client.new(env: Rails.env)
+      @subject_set_id = subject_set_id
     end
 
     def cleanup
@@ -29,6 +30,8 @@ module Subjects
     private
 
     def can_be_removed?
+      return false if belongs_to_other_subject_set?
+
       return false if has_been_collected_or_classified?
 
       return false if has_been_talked_about?
@@ -56,12 +59,18 @@ module Subjects
       !orphan_subject
     end
 
+    def belongs_to_other_subject_set?
+      return false if !subject_set_id
+
+      orphan_subject.set_member_subjects.where.not(subject_set_id: subject_set_id).count > 0
+    end
+
     def has_been_talked_about?
       panoptes_client.discussions(
         focus_id: subject_id,
         focus_type: 'Subject'
       ).any?
-    rescue StandardError => _e
+    rescue TypeError => _e
       false
     end
 

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -57,14 +57,12 @@ module Subjects
     end
 
     def has_been_talked_about?
-      begin
-        panoptes_client.discussions(
-          focus_id: subject_id,
-          focus_type: 'Subject'
-        ).any?
-      rescue StandardError => e
-        return false
-      end
+      panoptes_client.discussions(
+        focus_id: subject_id,
+        focus_type: 'Subject'
+      ).any?
+    rescue StandardError => _
+      false
     end
 
     def notify_subject_selector(workflow_ids)

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -60,7 +60,7 @@ module Subjects
     end
 
     def belongs_to_other_subject_set?
-      return false unless !subject_set_id.nil?
+      return false if subject_set_id.nil?
 
       orphan_subject.set_member_subjects.where.not(subject_set_id: subject_set_id).count.positive?
     end

--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -46,8 +46,6 @@ module Subjects
       .where("classification_subjects.subject_id IS NULL")
       .joins("LEFT OUTER JOIN collections_subjects ON collections_subjects.subject_id = subjects.id")
       .where("collections_subjects.subject_id IS NULL")
-      .joins("LEFT OUTER JOIN set_member_subjects ON set_member_subjects.subject_id = subjects.id")
-      .where("set_member_subjects.subject_id IS NULL")
     end
 
     def orphan_subject
@@ -59,13 +57,14 @@ module Subjects
     end
 
     def has_been_talked_about?
-      if Rails.env == 'test'
+      begin
+        panoptes_client.discussions(
+          focus_id: subject_id,
+          focus_type: 'Subject'
+        ).any?
+      rescue StandardError => e
         return false
       end
-      panoptes_client.discussions(
-        focus_id: subject_id,
-        focus_type: 'Subject'
-      ).any?
     end
 
     def notify_subject_selector(workflow_ids)

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -410,13 +410,13 @@ describe Api::V1::SubjectSetsController, type: :controller do
 
     it 'calls the subject removal worker' do
       subject_set.subjects.each_with_index do |s, index|
-        allow(SubjectRemovalWorker).to receive(:perform_in).with(index.seconds, s.id)
+        allow(SubjectRemovalWorker).to receive(:perform_in).with(index.seconds, s.id, subject_set.id)
       end
       delete_resources
       subject_set.subjects.each_with_index do |s, index|
         expect(SubjectRemovalWorker)
           .to have_received(:perform_in)
-          .with(index.seconds, s.id)
+          .with(index.seconds, s.id, subject_set.id)
       end
     end
   end

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -109,7 +109,8 @@ RSpec.describe Subjects::Remover do
         let(:alternate_subject_set) { create(:subject_set) }
         let(:remover) { described_class.new(subject.id, panoptes_client, alternate_subject_set.id) }
         let(:new_sms) { create(:set_member_subject, subject: subject, subject_set: alternate_subject_set) }
-        it 'should not remove subjects associated with multiple set_member_subjects' do
+
+        it 'does not remove subjects associated with multiple set_member_subjects' do
           remover.cleanup
           expect(Subject.where(id: subject.id)).to exist
         end

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -105,11 +105,11 @@ RSpec.describe Subjects::Remover do
         expect { SetMemberSubject.find(sms_ids) }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      context "with multiple subject sets" do
+      context 'with multiple subject sets' do
         let(:alternate_subject_set) { create(:subject_set) }
-        let(:remover) { Subjects::Remover.new(subject.id, panoptes_client, alternate_subject_set.id) }
-        it "should not remove subjects associated with multiple set_member_subjects" do
-          create(:set_member_subject, subject: subject, subject_set: alternate_subject_set)
+        let(:remover) { described_class.new(subject.id, panoptes_client, alternate_subject_set.id) }
+        let(:new_sms) { create(:set_member_subject, subject: subject, subject_set: alternate_subject_set) }
+        it 'should not remove subjects associated with multiple set_member_subjects' do
           remover.cleanup
           expect(Subject.where(id: subject.id)).to exist
         end

--- a/spec/lib/subjects/remover_spec.rb
+++ b/spec/lib/subjects/remover_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe Subjects::Remover do
         expect { SetMemberSubject.find(sms_ids) }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      context "with multiple subject sets" do
+        let(:alternate_subject_set) { create(:subject_set) }
+        let(:remover) { Subjects::Remover.new(subject.id, panoptes_client, alternate_subject_set.id) }
+        it "should not remove subjects associated with multiple set_member_subjects" do
+          create(:set_member_subject, subject: subject, subject_set: alternate_subject_set)
+          remover.cleanup
+          expect(Subject.where(id: subject.id)).to exist
+        end
+      end
+
       it "should remove the associated media resources" do
         locations = subjects.map { |s| create(:medium, linked: s) }
         media_ids = subject.reload.locations.map(&:id)

--- a/spec/workers/subject_removal_worker_spec.rb
+++ b/spec/workers/subject_removal_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SubjectRemovalWorker do
   let(:subject_id) { 1 }
   let(:feature_name) { "remove_orphan_subjects" }
   let(:panoptes_client) { instance_double(Panoptes::Client) }
-  let(:subject_remover) {described_class.new}
+  let(:subject_remover) { described_class.new }
   let(:remover) { instance_double(Subjects::Remover, panoptes_client: panoptes_client) }
 
   describe 'flipper enabled' do
@@ -56,6 +56,6 @@ RSpec.describe SubjectRemovalWorker do
   it 'should not call the orphan remover cleanup when disabled' do
     allow(Subjects::Remover).to receive(:new)
     subject_remover.perform(subject_id)
-    expect(remover).to_not receive(:cleanup)
+    expect(remover).not_to receive(:cleanup)
   end
 end

--- a/spec/workers/subject_removal_worker_spec.rb
+++ b/spec/workers/subject_removal_worker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubjectRemovalWorker do
     def stub_discussions_request(subject_id)
       stub_request(:get, discussions_url)
         .with(query: { focus_id: subject_id, focus_type: 'Subject' })
-        .to_return(status: 200, body: '[]', headers: {})
+        .to_return(status: 200, body: '{"discussions": []}', headers: {})
     end
 
     before do
@@ -27,7 +27,7 @@ RSpec.describe SubjectRemovalWorker do
     end
 
     context 'when running orphan remover cleanup function' do
-      it 'should call the orphan remover cleanup when enabled' do
+      it 'calls the orphan remover cleanup when enabled' do
         allow(Subjects::Remover).to receive(:new).with(subject_id, nil, nil).and_return(remover)
         allow(remover).to receive(:cleanup)
         subject_remover.perform(subject_id)
@@ -43,7 +43,7 @@ RSpec.describe SubjectRemovalWorker do
         expect(Subject.where(id: first_subject.id)).not_to exist
       end
 
-      it 'does not delete subject assicociated with another set_member_subject' do
+      it 'does not delete subjects associated with another set_member_subject' do
         create(:set_member_subject, subject: second_subject, subject_set: subject_sets.first)
         create(:set_member_subject, subject: second_subject, subject_set: subject_sets.last)
         stub_discussions_request(second_subject.id)

--- a/spec/workers/subject_removal_worker_spec.rb
+++ b/spec/workers/subject_removal_worker_spec.rb
@@ -3,19 +3,28 @@ require 'spec_helper'
 RSpec.describe SubjectRemovalWorker do
   let(:subject_id) { 1 }
   let(:feature_name) { "remove_orphan_subjects" }
-  let(:remover) { instance_double(Subjects::Remover) }
+  let(:panoptes_client) { instance_double(Panoptes::Client) }
+  let(:remover) { instance_double(Subjects::Remover, panoptes_client: panoptes_client) }
 
   describe 'flipper enabled' do
     let(:project) { create(:project) }
     let!(:subjects) { create_list(:subject, 2) }
+    let!(:subject_sets) { create_list(:subject_set, 2, project: project) }
     let!(:subject_set) { create(:subject_set, project: project) }
-    let!(:set_member_subject) { create(:set_member_subject, subject: subjects.last, subject_set: subject_set) }
+    let(:discussions_url) { 'https://talk-staging.zooniverse.org/discussions' }
+    let!(:first_subject) { subjects.first }
+    let!(:second_subject) { subjects.second }
+
+    def stub_discussions_request(subject_id)
+      stub_request(:get, "#{discussions_url}?focus_id=#{subject_id}&focus_type=Subject")
+        .to_return(status: 200, body: '[]', headers: {})
+    end
 
     before do
       Flipper.enable(feature_name)
     end
 
-    context 'orphan remover cleanup function' do
+    context 'when running orphan remover cleanup function' do
       it 'should call the orphan remover cleanup when enabled' do
         expect(Subjects::Remover).to receive(:new).with(subject_id).and_return(remover)
         expect(remover).to receive(:cleanup)
@@ -23,16 +32,20 @@ RSpec.describe SubjectRemovalWorker do
       end
     end
 
-    context 'deleting subjects' do
+    context 'when deleting subjects' do
       it 'deletes subject not associated with set_member_subject' do
-        subject.perform(subjects.first.id)
-        expect(Subject.exists?(subjects.first.id)).to be_falsey
+        stub_discussions_request(first_subject.id.to_i)
+        subject.perform(first_subject.id, subject_set.id)
+        expect(Subject.exists?(first_subject.id)).to be_falsey
       end
 
-      it 'does not delete subject assicociated with set_member_subject' do
-        subject.perform(subjects.last.id)
-        expect(Subject.exists?(subjects.last.id)).to be_truthy
-        expect(SetMemberSubject.exists?(subject_set_id: subject_set.id, subject_id: subjects.last.id)).to be_truthy
+      it 'does not delete subject assicociated with another set_member_subject' do
+        create(:set_member_subject, subject: second_subject, subject_set: subject_sets.first)
+        create(:set_member_subject, subject: second_subject, subject_set: subject_sets.last)
+        stub_discussions_request(second_subject.id.to_i)
+        subject.perform(second_subject.id, subject_sets.first.id)
+        Subject.where(id: second_subject.id).should exist
+        SetMemberSubject.where(subject_set_id: subject_sets.first.id, subject_id: second_subject.id).should exist
       end
     end
   end

--- a/spec/workers/subject_removal_worker_spec.rb
+++ b/spec/workers/subject_removal_worker_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe SubjectRemovalWorker do
 
     def stub_discussions_request(subject_id)
       stub_request(:get, discussions_url)
-        .with(query: { focus_id: subject_id, focus_type: "Subject" })
-        .to_return(status: 200, body: "[]", headers: {})
+        .with(query: { focus_id: subject_id, focus_type: 'Subject' })
+        .to_return(status: 200, body: '[]', headers: {})
     end
 
     before do

--- a/spec/workers/subject_removal_worker_spec.rb
+++ b/spec/workers/subject_removal_worker_spec.rb
@@ -5,11 +5,36 @@ RSpec.describe SubjectRemovalWorker do
   let(:feature_name) { "remove_orphan_subjects" }
   let(:remover) { instance_double(Subjects::Remover) }
 
-  it 'should call the orphan remover cleanup when enabled' do
-    Flipper.enable(feature_name)
-    expect(Subjects::Remover).to receive(:new).with(subject_id).and_return(remover)
-    expect(remover).to receive(:cleanup)
-    subject.perform(subject_id)
+  describe 'flipper enabled' do
+    let(:project) { create(:project) }
+    let!(:subjects) { create_list(:subject, 2) }
+    let!(:subject_set) { create(:subject_set, project: project) }
+    let!(:set_member_subject) { create(:set_member_subject, subject: subjects.last, subject_set: subject_set) }
+
+    before do
+      Flipper.enable(feature_name)
+    end
+
+    context 'orphan remover cleanup function' do
+      it 'should call the orphan remover cleanup when enabled' do
+        expect(Subjects::Remover).to receive(:new).with(subject_id).and_return(remover)
+        expect(remover).to receive(:cleanup)
+        subject.perform(subject_id)
+      end
+    end
+
+    context 'deleting subjects' do
+      it 'deletes subject not associated with set_member_subject' do
+        subject.perform(subjects.first.id)
+        expect(Subject.exists?(subjects.first.id)).to be_falsey
+      end
+
+      it 'does not delete subject assicociated with set_member_subject' do
+        subject.perform(subjects.last.id)
+        expect(Subject.exists?(subjects.last.id)).to be_truthy
+        expect(SetMemberSubject.exists?(subject_set_id: subject_set.id, subject_id: subjects.last.id)).to be_truthy
+      end
+    end
   end
 
   it 'should not call the orphan remover cleanup when disabled' do


### PR DESCRIPTION
Describe your change here.

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [x] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
