### PR TITLE
allow setting private attribute of user_groups on create and update

### DIFF
--- a/app/controllers/api/v1/user_groups_controller.rb
+++ b/app/controllers/api/v1/user_groups_controller.rb
@@ -9,8 +9,8 @@ class Api::V1::UserGroupsController < Api::ApiController
 
   alias_method :user_group, :controlled_resource
 
-  allowed_params :create, :name, :display_name, :stats_visibility, links: [users: []]
-  allowed_params :update, :name, :stats_visibility, :display_name
+  allowed_params :create, :name, :display_name, :private, :stats_visibility, links: [users: []]
+  allowed_params :update, :name, :private, :stats_visibility, :display_name
 
   search_by do |name, query|
     search_names = name.join(' ').downcase

--- a/spec/controllers/api/v1/user_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/user_groups_controller_spec.rb
@@ -106,7 +106,8 @@ describe Api::V1::UserGroupsController, type: :controller do
     let(:update_params) do
       {
         user_groups: {
-          display_name: 'A-Different-Name'
+          display_name: 'A-Different-Name',
+          private: false
         }
       }
     end
@@ -193,7 +194,7 @@ describe Api::V1::UserGroupsController, type: :controller do
   describe '#create' do
     let(:test_attr) { :name }
     let(:test_attr_value) { 'Zooniverse' }
-    let(:create_params) { { user_groups: { name: 'Zooniverse' } } }
+    let(:create_params) { { user_groups: { name: 'Zooniverse', private: false } } }
 
     it_behaves_like 'is creatable'
 


### PR DESCRIPTION
allow setting private attribute of user_groups on create and update

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
