### PR TITLE
Bug Fix -- ensure orphan_subject existence in remover before referring to its attributes

### DIFF
--- a/lib/subjects/remover.rb
+++ b/lib/subjects/remover.rb
@@ -30,9 +30,9 @@ module Subjects
     private
 
     def can_be_removed?
-      return false if belongs_to_other_subject_set?
-
       return false if has_been_collected_or_classified?
+
+      return false if belongs_to_other_subject_set?
 
       return false if has_been_talked_about?
 


### PR DESCRIPTION
Bug fix of https://github.com/zooniverse/panoptes/pull/4306 

Bug description: When attempting to delete a subject set (and its corresponding subjects) that has subjects with classifications, we receive the following error: https://app.honeybadger.io/projects/40595/faults/106293131 (`NoMethodError`). This is because `orphan_subject` queried is `nil`. 

- switched order within `can_be_removed` to ensure we have orphan subject before querying for attributes of orphan subject
- Added positive and negative specs (i.e. specs where we expect subject removal vs not) for the case when sending over `subject_set_id` to `remover.rb`. 



# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
