### PR TITLE
Clear unsubscribe token on user deactivation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
   validates :login, presence: true, format: { with: USER_LOGIN_REGEX }
   validates_uniqueness_of :login, case_sensitive: false
   validates :display_name, presence: true
-  validates :unsubscribe_token, presence: true, uniqueness: true
+  validates :unsubscribe_token, presence: true, uniqueness: true, on: :create
   validates_inclusion_of :valid_email, in: [true, false], message: "must be true or false"
 
   validates_with IdentityGroupNameValidator

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -11,6 +11,14 @@ namespace :user do
     end
   end
 
+  desc 'Scrub unsubscribe_token of deactivated users'
+  task scrub_inactive_user_unsubscribe_token: :environment do
+    User.where(activated_state: 'inactive').select(:id).find_in_batches do |users|
+      ids = users.map(&:id)
+      User.where(id: ids).update_all(unsubscribe_token: nil)
+    end
+  end
+
   desc 'Backfill UX testing emails comms field in batches'
   task backfill_ux_testing_email_field: :environment do
     User.select(:id).find_in_batches do |users|

--- a/lib/user_info_scrubber.rb
+++ b/lib/user_info_scrubber.rb
@@ -29,6 +29,7 @@ class UserInfoScrubber
     user.valid_email = false
     user.private_profile = true
     user.api_key = nil
+    user.unsubscribe_token = nil
     user.tsv = nil
     user.save!
     user

--- a/spec/lib/user_info_scrubber_spec.rb
+++ b/spec/lib/user_info_scrubber_spec.rb
@@ -33,6 +33,10 @@ describe UserInfoScrubber do
         expect { described_class.scrub_personal_info!(user) }.to change(user, :credited_name).to(nil)
       end
 
+      it 'scrubs the unsubscribe_token' do
+        expect { described_class.scrub_personal_info!(user) }.to change(user, :unsubscribe_token).to(nil)
+      end
+
       it 'scrubs the encrypted_password' do
         expect { described_class.scrub_personal_info!(user) }.to change(user, :encrypted_password)
       end


### PR DESCRIPTION
Follow up on conversation on Slack thread found here: https://zooniverse.slack.com/archives/C06DCM0V9/p1713893304800329

Scrubbing unsubscribe_token on user deactivation . 

 - Also added rake task to scrub unsubscribe_token for already deactivated users

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
