### PR TITLE
Querying Memberships Fix: ensure distinct memberships when querying for ones own public memberships

### DIFF
--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -20,7 +20,7 @@ class MembershipPolicy < ApplicationPolicy
       when :show, :index
         public_memberships = scope.where(identity: false, state: Membership.states[:active])
                                .joins(:user_group).merge(UserGroup.where(private: false))
-        Membership.union_all(query, public_memberships)
+        Membership.union_all(query, public_memberships).distinct
       else
         query
       end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -18,7 +18,7 @@ class WorkflowSerializer
 
   can_filter_by :active, :mobile_friendly
 
-  can_sort_by :completeness
+  can_sort_by :completeness, :id
 
   preload :subject_sets, :attached_images, :classifications_export, :published_version
 

--- a/spec/policies/membership_policy_spec.rb
+++ b/spec/policies/membership_policy_spec.rb
@@ -62,7 +62,14 @@ describe MembershipPolicy do
           group_admin_public_membership,
           group_admin_private_membership
         )
-        expect(scope.resolve(:show)).to contain_exactly(logged_in_user_public_membership, logged_in_user_private_membership, other_user_public_membership, other_user_private_membership, group_admin_public_membership, group_admin_private_membership)
+        expect(scope.resolve(:show)).to contain_exactly(
+          logged_in_user_public_membership,
+          logged_in_user_private_membership,
+          other_user_public_membership,
+          other_user_private_membership,
+          group_admin_public_membership,
+          group_admin_private_membership
+        )
       end
 
       it "cannot modify other user's memberships" do

--- a/spec/policies/membership_policy_spec.rb
+++ b/spec/policies/membership_policy_spec.rb
@@ -36,7 +36,7 @@ describe MembershipPolicy do
 
     context 'a normal user', :aggregate_failures do
       let(:api_user) { ApiUser.new(logged_in_user) }
-      let(:other_user) { create(:user)  }
+      let(:other_user) { create(:user) }
       let(:other_user_public_membership) { create(:membership, user: other_user, user_group: public_user_group) }
       let(:other_user_private_membership) { create(:membership, user: other_user, user_group: private_user_group) }
       let(:logged_in_user_public_membership) { create(:membership, user: logged_in_user, user_group: public_user_group) }

--- a/spec/policies/membership_policy_spec.rb
+++ b/spec/policies/membership_policy_spec.rb
@@ -54,7 +54,14 @@ describe MembershipPolicy do
       end
 
       it 'can see who are members of private groups they are in' do
-        expect(scope.resolve(:index)).to contain_exactly(logged_in_user_public_membership, logged_in_user_private_membership, other_user_public_membership, other_user_private_membership, group_admin_public_membership, group_admin_private_membership)
+        expect(scope.resolve(:index)).to contain_exactly(
+          logged_in_user_public_membership,
+          logged_in_user_private_membership,
+          other_user_public_membership,
+          other_user_private_membership,
+          group_admin_public_membership,
+          group_admin_private_membership
+        )
         expect(scope.resolve(:show)).to contain_exactly(logged_in_user_public_membership, logged_in_user_private_membership, other_user_public_membership, other_user_private_membership, group_admin_public_membership, group_admin_private_membership)
       end
 

--- a/spec/policies/membership_policy_spec.rb
+++ b/spec/policies/membership_policy_spec.rb
@@ -76,8 +76,18 @@ describe MembershipPolicy do
         expect(scope.resolve(:update)).to include(logged_in_user_public_membership, logged_in_user_private_membership)
         expect(scope.resolve(:destroy)).to include(logged_in_user_public_membership, logged_in_user_private_membership)
 
-        expect(scope.resolve(:update)).not_to include(other_user_private_membership, other_user_public_membership, group_admin_private_membership, group_admin_public_membership)
-        expect(scope.resolve(:destroy)).not_to include(other_user_private_membership, other_user_public_membership, group_admin_private_membership, group_admin_public_membership)
+        expect(scope.resolve(:update)).not_to include(
+          other_user_private_membership,
+          other_user_public_membership,
+          group_admin_private_membership,
+          group_admin_public_membership
+        )
+        expect(scope.resolve(:destroy)).not_to include(
+          other_user_private_membership,
+          other_user_public_membership,
+          group_admin_private_membership,
+          group_admin_public_membership
+        )
       end
     end
 
@@ -88,10 +98,30 @@ describe MembershipPolicy do
         membership1 = create :membership, user: logged_in_user, user_group: public_user_group
         membership2 = create :membership, user: logged_in_user, user_group: private_user_group
 
-        expect(scope.resolve(:index)).to contain_exactly(membership1, membership2, group_admin_private_membership, group_admin_public_membership)
-        expect(scope.resolve(:show)).to contain_exactly(membership1, membership2, group_admin_private_membership, group_admin_public_membership)
-        expect(scope.resolve(:update)).to include(membership1, membership2, group_admin_private_membership, group_admin_public_membership)
-        expect(scope.resolve(:destroy)).to include(membership1, membership2, group_admin_private_membership, group_admin_public_membership)
+        expect(scope.resolve(:index)).to contain_exactly(
+          membership1,
+          membership2,
+          group_admin_private_membership,
+          group_admin_public_membership
+        )
+        expect(scope.resolve(:show)).to contain_exactly(
+          membership1,
+          membership2,
+          group_admin_private_membership,
+          group_admin_public_membership
+        )
+        expect(scope.resolve(:update)).to include(
+          membership1,
+          membership2,
+          group_admin_private_membership,
+          group_admin_public_membership
+        )
+        expect(scope.resolve(:destroy)).to include(
+          membership1,
+          membership2,
+          group_admin_private_membership,
+          group_admin_public_membership
+        )
       end
     end
   end


### PR DESCRIPTION
Bug found while working on User Groups Features 

Correspondence on issue found in this Slack thread here: https://zooniverse.slack.com/archives/C010QAPB67J/p1715888434468079?thread_ts=1715813389.436219&cid=C010QAPB67J

**TL;DR; of the issue is that when doing a `GET` request to /memberships (either via `/memberships?user_id=_user_group_id=_` or  via `/memberships/id`) to one's own public membership, response responds with duplicates.** 

- The reason is that when querying memberships (in membership policy) we add a union of any public memberships. This leads to duplicates when one is querying one's own public membership. 
- Because of this duplicates issue, we cannot deactivate memberships through `DELETE` because `ETag` headers will never match the precondition (due to response of `GET` request having dupes). Which results in `412 Precondition Failed` error. 


Changes: 
- Ensure distinct memberships returned in query 
- Updating membership policy specs to ensure duplicates are not return using a `contains_exactly` rspec matching array method vs `includes`  match


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
