### PR TITLE
Delete aggregations column from workflows table

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -8,8 +8,6 @@ class Workflow < ApplicationRecord
   include Translatable
   include Versioning
 
-  self.ignored_columns = ['aggregation']
-
   versioned association: :workflow_versions, attributes: %w(tasks first_task strings major_version minor_version)
 
   belongs_to :project

--- a/db/migrate/20240531184258_remove_aggregation_from_workflows.rb
+++ b/db/migrate/20240531184258_remove_aggregation_from_workflows.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveAggregationFromWorkflows < ActiveRecord::Migration[6.1]
   def change
     remove_column :workflows, :aggregation, :jsonb

--- a/db/migrate/20240531184258_remove_aggregation_from_workflows.rb
+++ b/db/migrate/20240531184258_remove_aggregation_from_workflows.rb
@@ -1,0 +1,5 @@
+class RemoveAggregationFromWorkflows < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :workflows, :aggregation, :jsonb
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1954,7 +1954,6 @@ CREATE TABLE public.workflows (
     retired_set_member_subjects_count integer DEFAULT 0,
     retirement jsonb DEFAULT '{}'::jsonb,
     active boolean DEFAULT true,
-    aggregation jsonb DEFAULT '{}'::jsonb NOT NULL,
     display_order integer,
     configuration jsonb DEFAULT '{}'::jsonb NOT NULL,
     public_gold_standard boolean DEFAULT false,
@@ -3713,13 +3712,6 @@ CREATE INDEX index_workflows_on_activated_state ON public.workflows USING btree 
 
 
 --
--- Name: index_workflows_on_aggregation; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_workflows_on_aggregation ON public.workflows USING btree (((aggregation ->> 'public'::text)));
-
-
---
 -- Name: index_workflows_on_display_order; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4605,6 +4597,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231025200957'),
 ('20240216142515'),
 ('20240216171653'),
-('20240216171937');
+('20240216171937'),
+('20240531184258');
 
 


### PR DESCRIPTION
Remove the deprecated `aggregation` column from the workflows table. The Aggregation model and associated other parts are being refactored by https://github.com/zooniverse/panoptes/pull/4303, and this fully frees up the association.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
