### PR TITLE
Add safety_assured to migration

### DIFF
--- a/db/migrate/20240531184258_remove_aggregation_from_workflows.rb
+++ b/db/migrate/20240531184258_remove_aggregation_from_workflows.rb
@@ -2,6 +2,6 @@
 
 class RemoveAggregationFromWorkflows < ActiveRecord::Migration[6.1]
   def change
-    remove_column :workflows, :aggregation, :jsonb
+    safety_assured { remove_column :workflows, :aggregation, :jsonb }
   end
 end


### PR DESCRIPTION
Strong migrations needs safety_assured to remove the aggregation column from workflows table.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
