### PR TITLE
AggClient already returns the parsed response body

### DIFF
--- a/app/controllers/api/v1/aggregations_controller.rb
+++ b/app/controllers/api/v1/aggregations_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::AggregationsController < Api::ApiController
       create_params['links']['user']
     )
     super do |agg|
-      agg.update({ task_id: response.body[:task_id], status: 'pending' })
+      agg.update({ task_id: response[:task_id], status: 'pending' })
     end
   rescue AggregationClient::ConnectionError
     json_api_render(:service_unavailable, 'The aggregation service is unavailable or not responding')

--- a/spec/controllers/api/v1/aggregations_controller_spec.rb
+++ b/spec/controllers/api/v1/aggregations_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
   describe 'create' do
     let(:test_attr) { :workflow_id }
     let(:test_attr_value) { workflow.id }
-    let(:fake_response) { double }
+    let(:fake_response) { { 'task_id': 'asdf-1234-asdf' } }
     let(:mock_agg) { instance_double(AggregationClient) }
 
     let(:create_params) do
@@ -48,7 +48,6 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
 
     before do
       allow(AggregationClient).to receive(:new).and_return(mock_agg)
-      allow(fake_response).to receive(:body).and_return({ 'task_id': 'asdf-1234-asdf' })
       allow(mock_agg).to receive(:send_aggregation_request).and_return(fake_response)
       default_request scopes: scopes, user_id: authorized_user.id
     end


### PR DESCRIPTION
The AggregationClient already returns the body and Faraday already parses it. Just need to pull out what's needed for the update.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
