### PR TITLE
Update prod template with new aggregation host

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -120,7 +120,7 @@ data:
   TALK_API_USER: '1'
   TALK_API_APPLICATION: '1'
   USER_SUBJECT_LIMIT: '10000'
-  AGGREGATION_HOST: http://aggregation-caesar/
+  AGGREGATION_HOST: http://aggregation-production-app/
   AGGREGATION_STORAGE_BASE_URL: https://aggregationdata.blob.core.windows.net
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
The internal kubernetes aggregation service name was changed from `aggregation-caesar` to `aggregation-production-app` to reflect the existence of the staging deploy and multiple services that make up the full deployment. This PR updates the env var that points to that service.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
