### PR TITLE
add check to prevent soft deleted subject added to subject set

### DIFF
--- a/app/controllers/api/v1/subject_sets_controller.rb
+++ b/app/controllers/api/v1/subject_sets_controller.rb
@@ -112,7 +112,7 @@ class Api::V1::SubjectSetsController < Api::ApiController
     if relation == :subjects && value.is_a?(Array)
       #ids is returning duplicates even though the AR Relations were uniq
       subject_ids_to_link = new_items(resource, relation, value).distinct.ids
-      unless Subject.where(id: subject_ids_to_link).count == value.count
+      unless Subject.where(id: subject_ids_to_link, activated_state: 'active').count == value.count
         raise BadLinkParams.new("Error: check the subject set and all the subjects exist.")
       end
       new_sms_values = subject_ids_to_link.map do |subject_id|

--- a/spec/controllers/api/v1/subject_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/subject_sets_controller_spec.rb
@@ -227,6 +227,15 @@ describe Api::V1::SubjectSetsController, type: :controller do
           expect(response).to have_http_status(:ok)
         end
       end
+
+      context 'when a linking resource has been soft deleted' do
+        it 'returns a 422 with a missing subject' do
+          last_subject = subjects.last
+          last_subject.update(activated_state: 'inactive')
+          run_update_links
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
     end
 
     context 'with illegal link properties' do


### PR DESCRIPTION
Describe your change here.
Added a check to make sure only active subjects are added to subject_sets. 
Solves for this [issue](https://github.com/zooniverse/panoptes/issues/4281)
# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [x] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
