### PR TITLE
Finish update before enqueueing worker

### DIFF
--- a/app/controllers/api/v1/aggregations_controller.rb
+++ b/app/controllers/api/v1/aggregations_controller.rb
@@ -24,8 +24,7 @@ class Api::V1::AggregationsController < Api::ApiController
   end
 
   def update
-    super do |agg|
-      AggregationCompletedMailerWorker.perform_async(agg.id) if update_params[:status]
-    end
+    super
+    AggregationCompletedMailerWorker.perform_async(params['id']) if update_params[:status]
   end
 end

--- a/spec/controllers/api/v1/aggregations_controller_spec.rb
+++ b/spec/controllers/api/v1/aggregations_controller_spec.rb
@@ -111,14 +111,14 @@ RSpec.describe Api::V1::AggregationsController, type: :controller do
     context 'with the mailer worker' do
       before do
         default_request scopes: scopes, user_id: authorized_user.id
-        allow(AggregationCompletedMailerWorker).to receive(:perform_async).with(resource.id)
+        allow(AggregationCompletedMailerWorker).to receive(:perform_async).with(resource.id.to_s)
       end
 
-      let(:params) { update_params.merge(id: resource.id) }
+      let(:params) { update_params.merge(id: resource.id.to_s) }
 
       it 'calls the mailer worker' do
         put :update, params: params
-        expect(AggregationCompletedMailerWorker).to have_received(:perform_async).with(resource.id)
+        expect(AggregationCompletedMailerWorker).to have_received(:perform_async).with(resource.id.to_s)
       end
 
       it 'does not call the mailer if status is not an updated param' do

--- a/spec/workers/aggregation_completed_mailer_worker_spec.rb
+++ b/spec/workers/aggregation_completed_mailer_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AggregationCompletedMailerWorker do
   let(:aggregation) { create(:aggregation) }
 
   it 'delivers the mail' do
-    expect { described_class.new.perform(aggregation.id) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect { described_class.new.perform(aggregation.id.to_s) }.to change { ActionMailer::Base.deliveries.count }.by(1)
   end
 
   context 'with missing attributes' do


### PR DESCRIPTION
The `AggregationCompletedMailerWorker` is sending failure emails for successful runs. Instead of passing a block to `super`, the AggregationsController should finish the update first so that the resource has its new status saved before enqueueing the mailer. Also, let's assume params are strings in the specs.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
