### PR TITLE
add sort functionality to subjects and sort by id default

### DIFF
--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -13,6 +13,10 @@ class Api::V1::SubjectsController < Api::ApiController
   before_action :check_subject_limit, only: :create
 
   def index
+    unless params[:sort]
+      params[:sort] = 'id'
+    end
+
     case params[:sort]
     when 'queued'
       queued

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::SubjectsController < Api::ApiController
   before_action :check_subject_limit, only: :create
 
   def index
-    params[:sort] = 'id' unless params[:sort].present?
+    params[:sort] = 'id' if params[:sort].blank?
 
     case params[:sort]
     when 'queued'

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -13,9 +13,7 @@ class Api::V1::SubjectsController < Api::ApiController
   before_action :check_subject_limit, only: :create
 
   def index
-    unless params[:sort]
-      params[:sort] = 'id'
-    end
+    params[:sort] = 'id' unless params[:sort].present?
 
     case params[:sort]
     when 'queued'

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -9,6 +9,8 @@ class SubjectSerializer
 
   preload :locations, :project, :collections, :subject_sets
 
+  can_sort_by :id
+
   def locations
     @model.ordered_locations.map do |loc|
       {

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -49,6 +49,10 @@ describe Api::V1::SubjectsController, type: :controller do
           get :index
         end
 
+        it 'should default sort parameter to id' do
+          expect(controller.params[:sort]).to eq('id')
+        end
+
         it_behaves_like "an api response"
 
         it "should return 200" do
@@ -83,6 +87,11 @@ describe Api::V1::SubjectsController, type: :controller do
           context "when firing the request before the test" do
             before(:each) do
               get :index, params: request_params
+            end
+
+            it 'should not default sort parameter to id', focus: true do
+              expect(controller.params[:sort]).to_not eq('id')
+              expect(controller.params[:sort]).to eq('queued')
             end
 
             it "should return 200" do

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -49,7 +49,7 @@ describe Api::V1::SubjectsController, type: :controller do
           get :index
         end
 
-        it 'should default sort parameter to id' do
+        it 'defaults sort parameter to id' do
           expect(controller.params[:sort]).to eq('id')
         end
 
@@ -89,9 +89,8 @@ describe Api::V1::SubjectsController, type: :controller do
               get :index, params: request_params
             end
 
-            it 'should not default sort parameter to id', focus: true do
-              expect(controller.params[:sort]).to_not eq('id')
-              expect(controller.params[:sort]).to eq('queued')
+            it 'does not default sort parameter to id' do
+              expect(controller.params[:sort]).not_to eq('id')
             end
 
             it "should return 200" do


### PR DESCRIPTION
Implement sort functionality to subjects index controller and make sort by id default

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
