### PR TITLE
Use large iNaturalist photos in subject locations

### DIFF
--- a/lib/inaturalist/observation.rb
+++ b/lib/inaturalist/observation.rb
@@ -39,7 +39,7 @@ module Inaturalist
     def extract_locations(obs)
       locations = []
       obs['photos'].each do |p|
-        url = p['url'].sub('square', 'original')
+        url = p['url'].sub('square', 'large')
         mimetype = mime_type_from_file_extension(url)
         locations << { mimetype => url }
       end

--- a/spec/factories/observation.rb
+++ b/spec/factories/observation.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     metadata { { id: generate(:id_sequence) } }
     locations {
       [
-        { 'image/jpeg' => 'https://static.inaturalist.org/photos/12345/original.JPG' },
-        { 'image/jpeg' => 'https://static.inaturalist.org/photos/45678/original.JPG' }
+        { 'image/jpeg' => 'https://static.inaturalist.org/photos/12345/large.JPG' },
+        { 'image/jpeg' => 'https://static.inaturalist.org/photos/45678/large.JPG' }
       ]
     }
     initialize_with { new(**attributes) }

--- a/spec/lib/inaturalist/observation_spec.rb
+++ b/spec/lib/inaturalist/observation_spec.rb
@@ -22,8 +22,8 @@ describe Inaturalist::Observation do
   }
   let(:obs_locations) {
     [
-      { 'image/jpeg' => 'https://static.inaturalist.org/photos/12345/original.JPG' },
-      { 'image/jpeg' => 'https://static.inaturalist.org/photos/45678/original.JPG' }
+      { 'image/jpeg' => 'https://static.inaturalist.org/photos/12345/large.JPG' },
+      { 'image/jpeg' => 'https://static.inaturalist.org/photos/45678/large.JPG' }
     ]
   }
 

--- a/spec/lib/inaturalist/subject_importer_spec.rb
+++ b/spec/lib/inaturalist/subject_importer_spec.rb
@@ -7,8 +7,8 @@ describe Inaturalist::SubjectImporter do
   let(:importer) { described_class.new(subject_set.project.owner.id, subject_set.id) }
   let(:locations) {
     [
-      { 'image/jpeg' => 'https://static.inaturalist.org/photos/12345/original.JPG' },
-      { 'image/jpeg' => 'https://static.inaturalist.org/photos/45678/original.JPG' }
+      { 'image/jpeg' => 'https://static.inaturalist.org/photos/12345/large.JPG' },
+      { 'image/jpeg' => 'https://static.inaturalist.org/photos/45678/large.JPG' }
     ]
   }
 


### PR DESCRIPTION
iNaturalist observations come with photo URLs that end with "square.jpg". Previously, this square image was swapped for "original.jpg". These files are proving to be too massive, so the "large.jpg" should be used instead.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
