### PR TITLE
[issue-4364] add attached_images association to workflow copier

### DIFF
--- a/lib/workflow_copier.rb
+++ b/lib/workflow_copier.rb
@@ -10,13 +10,17 @@ class WorkflowCopier
     finished_at
   ].freeze
 
+  INCLUDE_ASSOCIATIONS = [
+    :attached_images
+  ].freeze
+
   def self.copy_by_id(workflow_id, target_project_id)
     source_workflow = Workflow.find(workflow_id)
     copy(source_workflow, target_project_id)
   end
 
   def self.copy(source_workflow, target_project_id)
-    copied_workflow = source_workflow.deep_clone(except: EXCLUDE_ATTRIBUTES)
+    copied_workflow = source_workflow.deep_clone(except: EXCLUDE_ATTRIBUTES, include: INCLUDE_ASSOCIATIONS)
     copied_workflow.project_id = target_project_id
     copied_workflow.active = false
     copied_workflow.display_name = "#{copied_workflow.display_name} (copy: #{Time.now.utc})"

--- a/spec/lib/workflow_copier_spec.rb
+++ b/spec/lib/workflow_copier_spec.rb
@@ -6,6 +6,7 @@ describe WorkflowCopier do
   let(:workflow) do
     create(:workflow, classifications_count: 100, retired_set_member_subjects_count: 10, real_set_member_subjects_count: 10, finished_at: Time.now.utc, completeness: 100.0, &:publish!)
   end
+  let(:media) { create(:medium, type: 'workflow_attached_image', linked: workflow) }
   let(:target_project) { create(:project) }
   let(:copier) { target_project.user }
   let(:copied_workflow) { described_class.copy(workflow, target_project.id) }
@@ -36,6 +37,10 @@ describe WorkflowCopier do
       %i[tasks primary_language pairwise grouped prioritized first_task retirement subject_selection_strategy mobile_friendly strings steps].each do |attribute|
         expect(copied_workflow.send(attribute)).to eq(workflow.send(attribute))
       end
+    end
+
+    it 'copies the attached_images' do
+      expect(copied_workflow.attached_images).to eq(workflow.attached_images)
     end
 
     it 'sets the workflow to inactive to avoid releasing these on live projects' do

--- a/spec/lib/workflow_copier_spec.rb
+++ b/spec/lib/workflow_copier_spec.rb
@@ -38,7 +38,7 @@ describe WorkflowCopier do
       end
     end
 
-    it 'copies the attached_images', focus: true do
+    it 'copies the attached_images' do
       create(:medium, type: 'workflow_attached_image', linked: workflow)
       expect(copied_workflow.attached_images.count).to eq(workflow.attached_images.count)
     end

--- a/spec/lib/workflow_copier_spec.rb
+++ b/spec/lib/workflow_copier_spec.rb
@@ -6,7 +6,6 @@ describe WorkflowCopier do
   let(:workflow) do
     create(:workflow, classifications_count: 100, retired_set_member_subjects_count: 10, real_set_member_subjects_count: 10, finished_at: Time.now.utc, completeness: 100.0, &:publish!)
   end
-  let(:media) { create(:medium, type: 'workflow_attached_image', linked: workflow) }
   let(:target_project) { create(:project) }
   let(:copier) { target_project.user }
   let(:copied_workflow) { described_class.copy(workflow, target_project.id) }
@@ -39,8 +38,9 @@ describe WorkflowCopier do
       end
     end
 
-    it 'copies the attached_images' do
-      expect(copied_workflow.attached_images).to eq(workflow.attached_images)
+    it 'copies the attached_images', focus: true do
+      create(:medium, type: 'workflow_attached_image', linked: workflow)
+      expect(copied_workflow.attached_images.count).to eq(workflow.attached_images.count)
     end
 
     it 'sets the workflow to inactive to avoid releasing these on live projects' do

--- a/spec/lib/workflow_copier_spec.rb
+++ b/spec/lib/workflow_copier_spec.rb
@@ -41,6 +41,7 @@ describe WorkflowCopier do
     it 'copies the attached_images' do
       create(:medium, type: 'workflow_attached_image', linked: workflow)
       expect(copied_workflow.attached_images.count).to eq(workflow.attached_images.count)
+      expect(copied_workflow.attached_images[0]).to be_valid
     end
 
     it 'sets the workflow to inactive to avoid releasing these on live projects' do


### PR DESCRIPTION
Describe your change here.
Solves for this [issue](https://github.com/zooniverse/panoptes/issues/4364)

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [x] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
