### PR TITLE
[issue-4336] halt launch requested notifications on projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -118,8 +118,6 @@ class Project < ApplicationRecord
     if Panoptes.project_request.recipients
       request_type = if saved_change_to_beta_requested? && beta_requested
                        "beta"
-                     elsif saved_change_to_launch_requested? && launch_requested
-                       "launch"
                      end
       ProjectRequestEmailWorker.perform_async(request_type, id) if request_type
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -483,25 +483,6 @@ describe Project, type: :model do
           end
         end
       end
-
-      context "when launch_requested changed" do
-        let(:field) { "launch_requested" }
-
-        context "when true" do
-          let(:value) { true }
-          it 'should queue the worker' do
-            expect(ProjectRequestEmailWorker).to receive(:perform_async).with("launch", project.id)
-          end
-        end
-
-        context "when false" do
-          let(:value) { false }
-
-          it 'should not queue the worker' do
-            expect(ProjectRequestEmailWorker).not_to receive(:perform_async)
-          end
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Describe your change here.

Remove launch email notifications from Projects

# Review checklist

- [x] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [x] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
