### PR TITLE
update minReplicas for sidekiq pods

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -419,7 +419,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: panoptes-production-sidekiq
-  minReplicas: 2
+  minReplicas: 5
   maxReplicas: 16
   targetCPUUtilizationPercentage: 95
 ---


### PR DESCRIPTION
Currently there is clog of UserSeenSubjectsWorker which is clogging up our sidekiq queues, as a quick remedy, we first will up minReplicas of sidekiq pods while more research on underlying queries is done. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
