### PR TITLE
Add a worker that simulates a long running Sidekiq job

### DIFF
--- a/app/workers/simulate_long_job_worker.rb
+++ b/app/workers/simulate_long_job_worker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SimulateLongJobWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :dumpworker
+
+  def perform(duration_seconds)
+    sleep(duration_seconds)
+  end
+end

--- a/spec/workers/simulate_long_job_worker_spec.rb
+++ b/spec/workers/simulate_long_job_worker_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SimulateLongJobWorker do
+  describe '#perform' do
+    let(:worker_instance) { described_class.new }
+
+    it 'calls sleep with the specified duration' do
+      allow(worker_instance).to receive(:sleep).with(10)
+      worker_instance.perform(10)
+      expect(worker_instance).to have_received(:sleep).with(10)
+    end
+  end
+end


### PR DESCRIPTION
Our Sidekiq workers are very fast and rate limitedin a few ways, mostly by the congestion middleware. Makes it kind of hard to test scaling when the jobs complete instantly or are deduplicated and canceled on the way in. 

This PR adds an unexposed job that does nothing but `sleep` for the specified duration. This will facilitate testing (via the console) of scaling systems that use the redis queue length as the determining factor.

Might keep this after if it proves useful in other ways, or I can revert/remove after testing.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
