### PR TITLE
Filter upp for nonzero activity count

### DIFF
--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -31,7 +31,6 @@ class UserProjectPreferenceSerializer
         .order("projects.display_name #{display_sort[:display_name]}")
         .order(other_sorts)
     end
-
     super(options)
   end
 

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -1,35 +1,37 @@
+# frozen_string_literal: true
+
 class UserProjectPreferenceSerializer
   include Serialization::PanoptesRestpack
   include CachedSerializer
 
   attributes :id, :email_communication, :preferences, :href,
-    :activity_count, :activity_count_by_workflow, :settings,
-    :created_at, :updated_at
+             :activity_count, :activity_count_by_workflow, :settings,
+             :created_at, :updated_at
   can_include :user, :project
   can_sort_by :updated_at, :display_name
   can_filter_by :non_null_activity_count
 
-  CACHE_MINS = (ENV["UPP_ACTIVITY_COUNT_CACHE_MINS"] || 5).freeze
+  CACHE_MINS = (ENV['UPP_ACTIVITY_COUNT_CACHE_MINS'] || 5).freeze
 
   def self.key
-    "project_preferences"
+    'project_preferences'
   end
 
-  def self.page(params = {}, scope = nil, context = {})
+  def self.page(params={}, scope=nil, context={})
     page_with_options CustomScopeFilterOptions.new(self, params, scope, context)
   end
 
   def self.page_with_options(options)
     if options.sorting.key?(:display_name)
-      display_sort, other_sorts = options.sorting.partition do |field, direction|
+      display_sort, other_sorts = options.sorting.partition do |field, _direction|
         field.match(/display_name/)
       end.map(&:to_h)
       options.sorting = {}
       options.scope = options
-        .scope
-        .joins(:project)
-        .order("projects.display_name #{display_sort[:display_name]}")
-        .order(other_sorts)
+                      .scope
+                      .joins(:project)
+                      .order("projects.display_name #{display_sort[:display_name]}")
+                      .order(other_sorts)
     end
     super(options)
   end
@@ -53,9 +55,7 @@ class UserProjectPreferenceSerializer
   end
 
   def count_activity_by_workflow
-    unless project_workflows_ids.empty?
-      UserSeenSubject.activity_by_workflow(@model.user_id, project_workflows_ids)
-    end
+    UserSeenSubject.activity_by_workflow(@model.user_id, project_workflows_ids) unless project_workflows_ids.empty?
   end
 
   def project_workflows_ids
@@ -70,7 +70,7 @@ class UserProjectPreferenceSerializer
   end
 
   class CustomScopeFilterOptions < RestPack::Serializer::Options
-    CUSTOM_SCOPE_FILTERS = %i(non_null_activity_count).freeze
+    CUSTOM_SCOPE_FILTERS = %i[non_null_activity_count].freeze
 
     def scope_with_filters
       filtered_scope = apply_standard_filters
@@ -84,7 +84,7 @@ class UserProjectPreferenceSerializer
     def apply_standard_filters
       scope_filter = {}
       non_custom_filters = @filters.except(*CUSTOM_SCOPE_FILTERS)
-      non_custom_filters.keys.each do |filter|
+      non_custom_filters.each_key do |filter|
         value = query_to_array(@filters[filter])
         scope_filter[filter] = value
       end

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -91,7 +91,9 @@ class UserProjectPreferenceSerializer
     end
 
     def filter_non_null_activity_count(filtered)
-      non_null_activity_count_upp_ids = filtered.select { |upp| perform_cached_lookup(count_activity, upp).to_i.positive? }.map(&:id)
+      non_null_activity_count_upp_ids = filtered.select do |upp|
+        cached_activity_count(upp).to_i.positive?
+      end.map(&:id)
       @scope.where(id: non_null_activity_count_upp_ids)
     end
 
@@ -107,10 +109,10 @@ class UserProjectPreferenceSerializer
       Workflow.where(project_id: upp.project_id).pluck(:id)
     end
 
-    def perform_cached_lookup(method_to_send, upp)
-      cache_key = "#{upp.class}/#{upp.id}/#{method_to_send}"
+    def cached_activity_count(upp)
+      cache_key = "#{upp.class}/#{upp.id}/count_activity"
       Rails.cache.fetch(cache_key, expires_in: CACHE_MINS.minutes) do
-        send method_to_send
+        count_activity(upp)
       end
     end
   end

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -16,9 +16,6 @@ class UserProjectPreferenceSerializer
   end
 
   def self.page_with_options(options)
-    puts "MDY114 HITS OPTIONS NOW"
-    puts options.inspect
-
     if options.sorting.key?(:display_name)
       display_sort, other_sorts = options.sorting.partition do |field, direction|
         field.match(/display_name/)

--- a/app/serializers/user_project_preference_serializer.rb
+++ b/app/serializers/user_project_preference_serializer.rb
@@ -2,6 +2,9 @@ class UserProjectPreferenceSerializer
   include Serialization::PanoptesRestpack
   include CachedSerializer
 
+  attributes :id, :email_communication, :preferences, :href,
+    :activity_count, :activity_count_by_workflow, :settings,
+    :created_at, :updated_at
   can_include :user, :project
   can_sort_by :updated_at, :display_name
   can_filter_by :non_null_activity_count
@@ -72,7 +75,6 @@ class UserProjectPreferenceSerializer
 
     def scope_with_filters
       filtered_scope = apply_standard_filters
-
       return filtered_scope unless @filters.key?(:non_null_activity_count)
 
       filter_non_null_activity_count(filtered_scope)

--- a/spec/serializers/user_project_preference_serializer_spec.rb
+++ b/spec/serializers/user_project_preference_serializer_spec.rb
@@ -153,4 +153,37 @@ describe UserProjectPreferenceSerializer do
       end
     end
   end
+
+  describe 'filtering by non-zero activity count' do
+    let!(:upp_with_activity_count) { create(:user_project_preference) }
+    let!(:legacy_count_upp) { create(:legacy_user_project_preference) }
+    let(:project) { create(:project_with_workflow) }
+    let(:upp_with_count_from_uss) { create(:user_project_preference, project: project, activity_count: nil) }
+    let(:user) { upp_with_count_from_uss.user }
+    let(:workflow) { project.workflows.first }
+    let!(:user_seens) do
+      create(:user_seen_subject, user: user, workflow: workflow).tap do |uss|
+        create(:classification, user: user, workflow: workflow, subject_ids: uss.subject_ids)
+      end
+    end
+    let(:project2) { create :project }
+    let(:upp_with_no_activity) { create(:user_project_preference, project: project2, user: user, activity_count: nil)}
+    let(:params) { { non_null_activity_count: "true" } }
+    let(:serialized_page) do
+      UserProjectPreferenceSerializer.page(
+        params,
+        UserProjectPreference.all,
+        {}
+      )
+    end
+    let(:result_ids) do
+      serialized_page["project_preferences"].map{ |r| r[:id].to_i }
+    end
+
+    it 'filters out non-zero activity counts' do
+      expect(result_ids.length).to eq(3)
+      expect(result_ids).to contain_exactly(upp_with_count_from_uss.id, upp_with_activity_count.id, legacy_count_upp.id)
+      expect(result_ids).not_to include(upp_with_no_activity.id)
+    end
+  end
 end

--- a/spec/serializers/user_project_preference_serializer_spec.rb
+++ b/spec/serializers/user_project_preference_serializer_spec.rb
@@ -167,17 +167,17 @@ describe UserProjectPreferenceSerializer do
       end
     end
     let(:project2) { create :project }
-    let(:upp_with_no_activity) { create(:user_project_preference, project: project2, user: user, activity_count: nil)}
-    let(:params) { { non_null_activity_count: "true" } }
+    let(:upp_with_no_activity) { create(:user_project_preference, project: project2, user: user, activity_count: nil) }
+    let(:params) { { non_null_activity_count: 'true' } }
     let(:serialized_page) do
-      UserProjectPreferenceSerializer.page(
+      described_class.page(
         params,
         UserProjectPreference.all,
         {}
       )
     end
     let(:result_ids) do
-      serialized_page["project_preferences"].map{ |r| r[:id].to_i }
+      serialized_page['project_preferences'].map { |r| r[:id].to_i }
     end
 
     it 'filters out non-zero activity counts' do


### PR DESCRIPTION
Request by FE team to add a filter for non-zero activity count.  See Slack convo: https://zooniverse.slack.com/archives/C0DTP3L2K/p1745424531456379

Since activity_count is either calculated through UserSeenSubjects or through UPP for legacy projects (either as a column record or a summation of legacy_counts column values) on the UPP Serializer, we built a custom filter and override restpack serializer methods. 

### eg callout
Eg callout to get filter is 
```
 /api/project_preferences?user_id=1325361&http_cache=true&admin=true&sort=-updated_at&page=1&non_null_activity_count=true
```


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
