### PR TITLE
BatchAgg: update filenames for mailer

### DIFF
--- a/app/mailers/aggregation_completed_mailer.rb
+++ b/app/mailers/aggregation_completed_mailer.rb
@@ -7,8 +7,8 @@ class AggregationCompletedMailer < ApplicationMailer
     @user = User.find(agg.user_id)
     @email_to = @user.email
     base_url = ENV.fetch('AGGREGATION_STORAGE_BASE_URL', '')
-    @zip_url = "#{base_url}/#{agg.uuid}/#{agg.uuid}.zip"
-    @reductions_url = "#{base_url}/#{agg.uuid}/reductions.csv"
+    @zip_url = "#{base_url}/#{agg.uuid}/#{agg.workflow_id}_aggregation.zip"
+    @reductions_url = "#{base_url}/#{agg.uuid}/#{agg.workflow_id}_reductions.csv"
 
     @success = agg.completed?
     agg_status = @success ? 'was successful!' : 'failed'

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -121,7 +121,7 @@ data:
   TALK_API_APPLICATION: '1'
   USER_SUBJECT_LIMIT: '10000'
   AGGREGATION_HOST: http://aggregation-production-app/
-  AGGREGATION_STORAGE_BASE_URL: https://aggregationdata.blob.core.windows.net
+  AGGREGATION_STORAGE_BASE_URL: https://aggregationdata.blob.core.windows.net/production
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -110,7 +110,7 @@ data:
   TALK_API_APPLICATION: '1'
   USER_SUBJECT_LIMIT: '100'
   AGGREGATION_HOST: http://aggregation-staging-app/
-  AGGREGATION_STORAGE_BASE_URL: https://aggregationdata.blob.core.windows.net
+  AGGREGATION_STORAGE_BASE_URL: https://aggregationdata.blob.core.windows.net/staging
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/spec/mailers/aggregation_completed_mailer_spec.rb
+++ b/spec/mailers/aggregation_completed_mailer_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe AggregationCompletedMailer, type: :mailer do
     let(:mail) { described_class.aggregation_complete(aggregation) }
 
     context 'with a successful aggregation' do
-      let(:aggregation) { create(:aggregation, status: 'completed', uuid: 'asdf123asdf', workflow_id: 1) }
+      let(:aggregation) { create(:aggregation, status: 'completed', uuid: 'asdf123asdf') }
       let(:uuid) { aggregation.uuid }
-      let(:workflow_id) { aggregation.workflow_id }
+      let(:workflow) { aggregation.workflow }
 
       it 'mails the user' do
         expect(mail.to).to match_array([aggregation.user.email])
@@ -26,11 +26,11 @@ RSpec.describe AggregationCompletedMailer, type: :mailer do
       end
 
       it 'includes the zip file link' do
-        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/#{workflow_id}_aggregation.zip")
+        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/#{workflow.id}_aggregation.zip")
       end
 
       it 'includes the reductions file link' do
-        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/#{workflow_id}_reductions.csv")
+        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/#{workflow.id}_reductions.csv")
       end
 
       it 'comes from no-reply@zooniverse.org' do

--- a/spec/mailers/aggregation_completed_mailer_spec.rb
+++ b/spec/mailers/aggregation_completed_mailer_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe AggregationCompletedMailer, type: :mailer do
     let(:mail) { described_class.aggregation_complete(aggregation) }
 
     context 'with a successful aggregation' do
-      let(:aggregation) { create(:aggregation, status: 'completed', uuid: 'asdf123asdf') }
+      let(:aggregation) { create(:aggregation, status: 'completed', uuid: 'asdf123asdf', workflow_id: 1) }
       let(:uuid) { aggregation.uuid }
+      let(:workflow_id) { aggregation.workflow_id }
 
       it 'mails the user' do
         expect(mail.to).to match_array([aggregation.user.email])
@@ -25,11 +26,11 @@ RSpec.describe AggregationCompletedMailer, type: :mailer do
       end
 
       it 'includes the zip file link' do
-        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/#{uuid}.zip")
+        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/#{workflow_id}_aggregation.zip")
       end
 
       it 'includes the reductions file link' do
-        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/reductions.csv")
+        expect(mail.body.encoded).to include("#{base_url}/#{uuid}/#{workflow_id}_reductions.csv")
       end
 
       it 'comes from no-reply@zooniverse.org' do


### PR DESCRIPTION
As part of May 2025 updates to Batch Aggregation, edit the mailer to use updated URLs for output files.

Linked to: https://github.com/zooniverse/aggregation-for-caesar/pull/821, https://github.com/zooniverse/panoptes-python-client/pull/328