### PR TITLE
Add can_sort_bys to agg serializer

### DIFF
--- a/app/serializers/aggregation_serializer.rb
+++ b/app/serializers/aggregation_serializer.rb
@@ -5,5 +5,7 @@ class AggregationSerializer
   attributes :id, :href, :created_at, :updated_at, :uuid, :task_id, :status
   can_include :project, :workflow, :user
 
+  can_sort_by :id, :workflow_id, :project_id, :status, :created_at, :updated_at
+
   can_filter_by :project, :workflow
 end


### PR DESCRIPTION
Allows aggregations to be sorted via query param on: id, workflow_id, project_id, status, created_at,  and updated_at.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
