### PR TITLE
Use GHCR for staging nginx container

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -188,7 +188,7 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -Ru /rails_app/public/* /static-assets"]
         - name: panoptes-staging-nginx
-          image: zooniverse/nginx
+          image: ghcr.io/zooniverse/docker-nginx
           resources:
             requests:
               memory: "25Mi"


### PR DESCRIPTION
Points the sidecar nginx container to GHCR. The docker-nginx repo has been updated and the latest tag now is now nginx version 1.29, so this PR also updates the nginx version (from 1.20).

Only the staging deployment is affected. This is the second staging deployment I've updated, talk-staging is on 1.29 right now.

Once deployed, I should still be able to access everything served from panoptes.zooniverse.org (doorkeeper, login, etc) with all assets served. Also /commit_id.txt & /robots.txt will serve and the nginx config from within the updated container will validate. If successful, I'll update the production deploy.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
