### PR TITLE
SLTP - Subject Ancillary Data Creation

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -14,6 +14,7 @@ class Api::V1::MediaController < Api::ApiController
     avatar: :avatar,
     background: :background,
     attached_images: :attached_images,
+    attached_media: :attached_media
     classifications_export: :classifications_export,
     subjects_export: :subjects_export,
     workflows_export: :workflows_export,

--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::MediaController < Api::ApiController
     avatar: :avatar,
     background: :background,
     attached_images: :attached_images,
-    attached_media: :attached_media
+    attached_media: :attached_media,
     classifications_export: :classifications_export,
     subjects_export: :subjects_export,
     workflows_export: :workflows_export,

--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -14,7 +14,6 @@ class Api::V1::MediaController < Api::ApiController
     avatar: :avatar,
     background: :background,
     attached_images: :attached_images,
-    attached_media: :attached_media,
     classifications_export: :classifications_export,
     subjects_export: :subjects_export,
     workflows_export: :workflows_export,

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -16,8 +16,8 @@ class Subject < ApplicationRecord
     -> { where(type: 'subject_location') },
     class_name: "Medium",
     as: :linked
-  has_many :attached_media,
-    -> { where(type: 'subject_attached_media') },
+  has_many :attached_images,
+    -> { where(type: 'subject_attached_image') },
     class_name: "Medium",
     as: :linked
   has_many :recents, dependent: :destroy

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -16,6 +16,10 @@ class Subject < ApplicationRecord
     -> { where(type: 'subject_location') },
     class_name: "Medium",
     as: :linked
+  has_many :attached_media,
+    -> { where(type: 'subject_attached_media') },
+    class_name: "Medium",
+    as: :linked
   has_many :recents, dependent: :destroy
   has_many :tutorial_workflows,
     class_name: 'Workflow',

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -1,13 +1,16 @@
 class SubjectSerializer
   include Serialization::PanoptesRestpack
   include FilterHasMany
+  include MediaLinksSerializer
+
 
   attributes :id, :metadata, :locations, :zooniverse_id, :external_id,
     :created_at, :updated_at, :href
 
   can_include :project, :collections, :subject_sets
+  media_include :attached_images
 
-  preload :locations, :project, :collections, :subject_sets
+  preload :locations, :project, :collections, :subject_sets, :attached_images
 
   can_sort_by :id
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
           get :grouped # SubjectGroup selection end point
           get :selection # Subject selection by subject ids end point
         end
+        media_resources :attached_media
       end
 
       json_api_resources :users, except: [:new, :edit, :create], links: [:user_groups] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
           get :grouped # SubjectGroup selection end point
           get :selection # Subject selection by subject ids end point
         end
-        media_resources :attached_media
+        media_resources :attached_images
       end
 
       json_api_resources :users, except: [:new, :edit, :create], links: [:user_groups] do

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::SubjectsController, type: :controller do
     [ "id", "metadata", "locations", "zooniverse_id", "created_at", "updated_at" ]
   end
   let(:api_resource_links) do
-    [ "subjects.project","subjects.collections", "subjects.subject_sets" ]
+    [ "subjects.project","subjects.collections", "subjects.subject_sets", 'subjects.attached_images' ]
   end
 
   describe "#index" do

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -9,7 +9,7 @@ describe SubjectSerializer do
   it_should_behave_like "a panoptes restpack serializer" do
     let(:resource) { subject }
     let(:includes) { %i(project collections subject_sets) }
-    let(:preloads) { %i(locations project collections subject_sets) }
+    let(:preloads) { %i(locations project collections subject_sets attached_images) }
   end
 
   it_should_behave_like "a filter has many serializer" do


### PR DESCRIPTION
Part of SLTP Effort: 
Allow to create and get subject ancillary data through new subjects endpoint attached_images. 

Add `/attached_images` route to `/subjects` to allow subject ancillary data media to be inserted and associated to subject. 

Works similar to  `/:resource/:id/attached_images`,  where resource is either organizations, projects, workflows, tutorials, field guides

Eg requests: re @mcbouslog 

### POST subjects/:id/attached_images

```
curl --location --request POST 'localhost:3000/api/subjects/:id/attached_images' \
--header 'Accept: application/vnd.api+json; version=1' \
--header 'Content-Type: application/json' \
--header 'Authorization: BLAH' \
--data '{"http_cache":true,"admin":true,"media":{"content_type":"image/png","metadata":{"filename":"your_image.png","size":606805}}}
```
**RESPONSE**
```
{
    "media": [
        {
            "id": "6",
            "href": "/subjects/1/attached_images/6",
            "src": "https://subject_attached_image/a4bfaca3-2a62-4499-8823-5141b42bae39.png",
            "content_type": "image/png",
            "media_type": "subject_attached_image",
            "external_link": false,
            "created_at": "2025-09-19T22:50:10.613Z",
            "metadata": {
                "size": 606805,
                "filename": "609780764988425780_gri_17.8096.png"
            },
            "updated_at": "2025-09-19T22:50:10.613Z",
            "links": {
                "linked": {
                    "href": "/subjects/1",
                    "id": "1",
                    "type": "subjects"
                }
            }
        }
    ],
    "meta": {
        "media": {
            "page": 1,
            "page_size": 20,
            "count": 1,
            "include": [],
            "page_count": 1,
            "previous_page": null,
            "next_page": null,
            "first_href": "/media",
            "previous_href": null,
            "next_href": null,
            "last_href": "/media"
        }
    }
}
```


### **GET from /subjects/:id/attached_images**
```
curl --location 'localhost:3000/api/subjects/1/attached_images' \
--header 'Accept: application/vnd.api+json; version=1' \
--header 'Content-Type: application/json' 
```

**RESPONSE:** 
```
{
    "media": [
        {
            "id": "4",
            "href": "/subjects/1/attached_images/4",
            "src": "https://subject_attached_image/79526b51-c1c3-4e9e-9afe-bd24f380228b.png",
            "content_type": "image/png",
            "media_type": "subject_attached_image",
            "external_link": false,
            "created_at": "2025-09-19T01:12:08.736Z",
            "metadata": {
                "size": 606805,
                "filename": "sketch-20250910-ai-coding-assistants.png"
            },
            "updated_at": "2025-09-19T01:12:08.736Z",
            "links": {
                "linked": {
                    "href": "/subjects/1",
                    "id": "1",
                    "type": "subjects"
                }
            }
        }
    ],
    "meta": {
        "media": {
            "page": 1,
            "page_size": 20,
            "count": 2,
            "include": [],
            "page_count": 1,
            "previous_page": null,
            "next_page": null,
            "first_href": "/media",
            "previous_href": null,
            "next_href": null,
            "last_href": "/media"
        }
    }
}
```

You could also get `subject_attached_images` from `/subjects/:id?include=attached_images` as well. 

### GET from /api/subjects/:id?include=attached_images
```
curl --location --request GET 'localhost:3000/api/subjects/2?include=attached_images' \
--header 'Accept: application/vnd.api+json; version=1' \
--header 'Content-Type: application/json' 
```

**RESPONSE**
```
{
    "subjects": [
        {
            "id": "2",
            "metadata": {
                "loudness": 11,
                "brightness": -20,
                "distance_from_earth": "42 light years"
            },
            "locations": [],
            "zooniverse_id": "TES00000002",
            "external_id": null,
            "created_at": "2025-09-19T00:45:42.814Z",
            "updated_at": "2025-09-19T00:45:42.814Z",
            "href": "/subjects/2",
            "links": {
                "project": "1",
                "collections": [],
                "subject_sets": [
                    "1"
                ],
                "attached_images": {
                    "href": "/subjects/2/attached_images",
                    "type": "attached_images",
                    "ids": [
                        "5"
                    ]
                }
            }
        }
    ],
    "linked": {
        "media": [
            {
                "id": "5",
                "href": "/subjects/2/attached_images/5",
                "src": "https://subject_attached_image/99d9c1f2-4a62-4400-be59-1c590ddca193.png",
                "content_type": "image/png",
                "media_type": "subject_attached_image",
                "external_link": false,
                "created_at": "2025-09-19T01:53:14.955Z",
                "metadata": {
                    "size": 606805,
                    "filename": "sketch-20250910-ai-coding-assistants.png"
                },
                "updated_at": "2025-09-19T01:53:14.955Z",
                "links": {
                    "linked": {
                        "href": "/subjects/2",
                        "id": "2",
                        "type": "subjects"
                    }
                }
            }
        ]
    },
    "links": {
        "subjects.project": {
            "href": "/projects/{subjects.project}",
            "type": "projects"
        },
        "subjects.collections": {
            "href": "/collections?subject_id={subjects.id}",
            "type": "collections"
        },
        "subjects.subject_sets": {
            "href": "/subject_sets?subject_id={subjects.id}",
            "type": "subject_sets"
        },
        "subjects.attached_images": {
            "href": "/subjects/{subjects.id}/attached_images",
            "type": "media"
        }
    },
    "meta": {
        "subjects": {
            "page": 1,
            "page_size": 20,
            "count": 1,
            "include": [
                "attached_images"
            ],
            "page_count": 1,
            "previous_page": null,
            "next_page": null,
            "first_href": "/subjects?include=attached_images&id=2",
            "previous_href": null,
            "next_href": null,
            "last_href": "/subjects?include=attached_images&id=2"
        },
        "media": {
            "page": 1,
            "page_size": 20,
            "count": 1,
            "include": [],
            "page_count": 1,
            "previous_page": null,
            "next_page": null,
            "first_href": "/media?linked_id=2",
            "previous_href": null,
            "next_href": null,
            "last_href": "/media?linked_id=2"
        }
    }
}
```

This will be added in our docs as a follow up PR post approval. Mainly doing a followup PR for documentation because I also would like to do add documentation for /:resource/:media_type for all our resources and media types that have a media_resources endpoint.  



# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
