### PR TITLE
Include Azure IPs as set_real_ip_from directives in sidecar nginx container

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -5,7 +5,7 @@ data:
 
     proxy_buffer_size 8k;
     proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $host;
 
     location = /commit_id.txt {
       root /static-assets/;
@@ -55,6 +55,8 @@ data:
     upstream docker-panoptes {
       server 127.0.0.1:81;
     }
+
+    include /etc/nginx/nginx-azure-ips.conf;
 
     server {
       server_name www.zooniverse.org;

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -5,7 +5,6 @@ data:
 
     proxy_buffer_size 8k;
     proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-Host $host;
 
     location = /commit_id.txt {
       root /static-assets/;
@@ -56,7 +55,16 @@ data:
       server 127.0.0.1:81;
     }
 
+    # set_real_ip_from for local and known Azure Front Door IPs
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
     include /etc/nginx/nginx-azure-ips.conf;
+
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     server {
       server_name www.zooniverse.org;


### PR DESCRIPTION
Traffic through the static proxy now Include the new conf file from the docker-nginx base image that contains a list of `set_real_ip_from` directives for all of Azure's Front Door IPs. Also set the correct headers to pass along the correct client IP. The staging backend isn't behind a FD, so it doesn't need this. 

The production API backend, however, is behind the main www-zooniverse-org FD and NOT behind the static proxy, so this allows the sidecar nginx container to include the same config as the static proxy, and for requests routed by the k8s ingress controller directly to the pod to utilize those directives.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
