### PR TITLE
Remove redundant nginx directives

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -60,9 +60,6 @@ data:
     set_real_ip_from 172.16.0.0/12;
     include /etc/nginx/nginx-azure-ips.conf;
 
-    real_ip_header X-Forwarded-For;
-    real_ip_recursive on;
-
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 


### PR DESCRIPTION
The base docker-nginx image's nginx.conf file that already includes these two directives. The naming of the files/configmaps  and the chain of inclusion is confusing, something to come back and sort.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
