### PR TITLE
Update HPAs to v2 and add memory metrics

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -262,7 +262,7 @@ spec:
           secret:
             secretName: panoptes-doorkeeper-jwt-production
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: panoptes-production-app
@@ -273,7 +273,19 @@ spec:
     name: panoptes-production-app
   minReplicas: 3
   maxReplicas: 16
-  targetCPUUtilizationPercentage: 80
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -247,7 +247,7 @@ spec:
           secret:
             secretName: panoptes-doorkeeper-jwt-staging
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: panoptes-staging-app
@@ -258,7 +258,19 @@ spec:
     name: panoptes-staging-app
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 95
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 90
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 70
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Update to the newer `metrics` annotation. Add the memory metric to upscale on memory pressure.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
