### PR TITLE
Bug Fix: Project Search needs longer string than expected  - update trigram search to use word similarity vs full word search similarity

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -75,7 +75,9 @@ class Project < ApplicationRecord
         dictionary: "english",
         tsvector_column: "tsv"
       },
-      trigram: {}
+      trigram: {
+        word_similarity: true
+      }
     },
     :ranked_by => ":tsearch + (0.25 * :trigram)"
 

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -67,6 +67,9 @@ describe Api::V1::ProjectsController, type: :controller do
         let(:new_project) do
           create(:full_project, display_name: 'Non-test project', owner: owner)
         end
+        let(:longer_substring_project) do
+          create(:full_project, display_name: 'Longer Display Name', owner: owner)
+        end
         let(:resource) { new_project }
         let(:ids) { json_response['projects'].map { |p| p['id'] } }
         let(:index_request) do
@@ -80,12 +83,23 @@ describe Api::V1::ProjectsController, type: :controller do
         describe 'search' do
           it_behaves_like 'filter by display_name'
 
-          describe 'filter by display_name substring' do
+          describe 'filter by display_name tsv substring' do
             let(:index_options) { { search: resource.display_name[0..2] } }
 
             it 'responds with the most relevant item first' do
               index_request
               expect(json_response[api_resource_name].length).to eq(1)
+              expect(ids[0].to_i).to eq(resource.id)
+            end
+          end
+
+          describe 'filter by display_name substring' do
+            let(:index_options) { { search: longer_substring_project.display_name[0..2] } }
+
+            it 'responds with the most relevant item first' do
+              index_request
+              expect(json_response[api_resource_name].length).to eq(1)
+              expect(ids[0].to_i).to eq(longer_substring_project.id)
             end
           end
         end


### PR DESCRIPTION
Fixes https://github.com/zooniverse/panoptes/issues/4549

Bug Fix: Project Search - update trigram search to use word similarity vs full word search similarity

Using SuperWASP Variable Stars project as an example : 
- When looking up `super`, `superw` will fail the first condition of the query -- the tsv vector search (https://github.com/zooniverse/panoptes/blob/master/app/models/project.rb#L74-L77), because it does not match the tsv vectors, 
- and it will fail the trigram search (https://github.com/zooniverse/panoptes/blob/master/app/models/project.rb#L78), because it does not have a similarity above the `pg_trgrm.similarity_threshold`. 

We can remedy this using pg_search's `word_similarity` option on trigram search (https://github.com/Casecommons/pg_search?tab=readme-ov-file#word_similarity).  [I.e. using the word similarity operator <% vs the similarity operator %]

Word similarity is most likely what was intended since similarity operator will fail for partial matches. 

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
