### PR TITLE
bump middleman-gh-pages-action version

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -13,4 +13,4 @@ jobs:
           REMOTE_BRANCH: gh-pages
           SITE_LOCATION: docs
           BUILD_LOCATION: build
-        uses: zooniverse/middleman-gh-pages-action@v1.4.0
+        uses: zooniverse/middleman-gh-pages-action@v1.4.1


### PR DESCRIPTION
Bumping action version -- see https://github.com/zooniverse/middleman-gh-pages-action/releases/tag/v1.4.1
Related to failed docs deploy from https://github.com/zooniverse/panoptes/pull/4591 after bumping to Ruby 3.2.

Note: The Panoptes publish_docs.yml uses a forked action script (see https://github.com/zooniverse/middleman-gh-pages-action), which is a different strategy from that used for Caesar (see its [publish_docs](https://github.com/zooniverse/caesar/blob/master/.github/workflows/publish_docs.yml) action), which has an otherwise identical docs site setup.