### PR TITLE
fix project filtering bug and add multi org projects to documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -889,7 +889,8 @@ Resources related to _Panoptes Projects_.
 ## Project [/projects/{id}{?include,display_name,approved,beta,live}]
 A Project is a collection of subjects and task workflows that a
 volunteer performs on subjects. The project also holds supplementary
-text describing the tasks volunteers perform.
+text describing the tasks volunteers perform. A project can be linked to
+multiple organizations.
 
 It has the following attributes:
 
@@ -946,6 +947,10 @@ It has the following attributes:
                     "projects.owner": {
                         "href": "/{projects.owner.href}",
                         "type": "owners"
+                    },
+                    "projects.organizations": {
+                        "href": "/organizations/{projects.organizations}",
+                        "type": "organizations"
                     }
                 },
                 "projects": [{
@@ -1097,7 +1102,7 @@ this action.
 
 + Response 204
 
-## Project Collection [/projects{?page,page_size,sort,owner,include}]
+## Project Collection [/projects{?page,page_size,sort,owner,organization_id,include}]
 A collection of _Panotpes Project_ resources.
 
 All collections add a *meta* attribute hash containing
@@ -1132,6 +1137,10 @@ Projects are returned as an array under the _projects_ key.
                     "projects.owner": {
                         "href": "/{projects.owner.href}",
                         "type": "owners"
+                    },
+                    "projects.organizations": {
+                        "href": "/organizations/{projects.organizations}",
+                        "type": "organizations"
                     }
                 },
                 "meta": {
@@ -1222,6 +1231,7 @@ Projects are returned as an array under the _projects_ key.
   + page_size (optional, integer) ... number of items to include on a page default is 20
   + sort (optional, string) ... field to sort by
   + owner (optional, string) ... string owner name of either a user or a user group to filter by.
+  + organization_id (optional, integer or comma-separated integers) ... return projects linked to one or more organizations.
   + include (optional, string) ... comma separated list of linked resources to include in the response
 
 + Request
@@ -1276,7 +1286,8 @@ returned.
 Resources related to _Panoptes Organizations_.
 
 ## Organization [/organizations/{id}{?include,display_name}]
-An Organization is a collection of projects that are related by dicipline, research group
+An Organization is a collection of projects that are related by dicipline or
+research group. Projects can be linked to multiple organizations.
 
 It has the following attributes:
 
@@ -1452,7 +1463,9 @@ A user may destroy a Organization they own or have destroy permissions for.
 ## Organization Create Links [/Organization/{id}/links/{link_type}]
 
 ### Add a Link [POST]
-The body key must match the link_type parameter. Po
+The body key must match the link_type parameter. Use this endpoint to link one
+or more projects to an organization. A project may be linked to multiple
+organizations.
 
 + Parameters
   + id (required, integer) - the id of the project to add

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -211,9 +211,8 @@ class Api::V1::ProjectsController < Api::ApiController
     organization_ids = params.delete(:organization_id)&.split(',')
     return if organization_ids.blank?
 
-    project_ids = OrganizationProject
-      .where(organization_id: organization_ids)
-      .select(:project_id)
+    project_ids = OrganizationProject.where(organization_id: organization_ids)
+                                     .select(:project_id)
 
     @controlled_resources = controlled_resources.where(id: project_ids)
   end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -211,8 +211,10 @@ class Api::V1::ProjectsController < Api::ApiController
     organization_ids = params.delete(:organization_id)&.split(',')
     return if organization_ids.blank?
 
-    @controlled_resources = controlled_resources.joins(:organizations).where(
-      organizations: { id: organization_ids }
-    ).distinct
+    project_ids = OrganizationProject
+      .where(organization_id: organization_ids)
+      .select(:project_id)
+
+    @controlled_resources = controlled_resources.where(id: project_ids)
   end
 end

--- a/docs/source/includes/_organizations.md
+++ b/docs/source/includes/_organizations.md
@@ -113,7 +113,8 @@
 }
 ```
 
-An Organization is a collection of projects that are related by dicipline, research group
+An Organization is a collection of projects that are related by dicipline or
+research group. Projects can be linked to multiple organizations.
 
 It has the following attributes:
 
@@ -233,6 +234,8 @@ Content-Type: application/json
 }
 ```
 The body key must match the link_type parameter.
+Use this endpoint to link one or more projects to an organization. A project may
+be linked to multiple organizations.
 
 + Parameters
   + id (required, integer) - the id of the project to add
@@ -250,7 +253,7 @@ Content-Type: application/json
 ```
 The recommended way to destroy Organization links.
 Will destroy the comma separated list of link ids for the given link
-type. 
+type.
 
 + Parameters
   + id (required, integer) ... the id of the project to modify

--- a/docs/source/includes/_projects.md
+++ b/docs/source/includes/_projects.md
@@ -63,6 +63,10 @@
         "projects.owner": {
             "href": "/{projects.owner.href}",
             "type": "owners"
+        },
+        "projects.organizations": {
+            "href": "/organizations/{projects.organizations}",
+            "type": "organizations"
         }
     }
 }
@@ -70,7 +74,8 @@
 
 A Project is a collection of subjects and task workflows that a
 volunteer performs on subjects. The project also holds supplementary
-text describing the tasks volunteers perform.
+text describing the tasks volunteers perform. A project can be linked to
+multiple organizations.
 
 It has the following attributes:
 
@@ -114,6 +119,8 @@ live | boolean |
 - subjects (read-only)
 - classifications (read-only)
 - owner (read-only)
+- `organizations` (read-only) - Projects may be linked to multiple organizations.
+  Add or remove these links through the organization project link endpoints.
 
 ## List All Projects
 
@@ -132,6 +139,7 @@ Content-Type: application/json
   + page_size (optional, integer) ... number of items to include on a page default is 20
   + sort (optional, string) ... field to sort by
   + owner (optional, string) ... string owner name of either a user or a user group to filter by.
+  + organization_id (optional, integer or comma-separated integers) ... return projects linked to one or more organizations.
   + include (optional, string) ... comma separated list of linked resources to include in the response
 
 ## Retrieve a single Project

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -303,6 +303,15 @@ describe Api::V1::ProjectsController, type: :controller do
               index_request
               expect(ids).not_to include(project_for_other_organization.id.to_s)
             end
+
+            context 'with sorting' do
+              let(:index_options) { { organization_id: organization.id.to_s, sort: 'display_name' } }
+
+              it 'returns projects linked to the requested organization' do
+                index_request
+                expect(ids).to include(project_for_organization.id.to_s)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Describe your change here.

## Summary

- Filter projects by `organization_id` through the new `organization_projects` join table
- Avoid `DISTINCT` on the projects index query so `organization_id` filtering works with sorting
- Document that projects can be linked to multiple organizations
- Add project docs for the `organizations` link and `organization_id` filter

## Why

Projects can now belong to multiple organizations through `organization_projects`. The previous project filter joined organizations and used `DISTINCT`, which caused PostgreSQL errors when sorting project results:

Error from staging logs
```
[3c3f403e-85c1-4b2b-adba-916f6e09322a] PG::InvalidColumnReference (ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1: ..._state" = 0 AND "organizations"."id" = 3 ORDER BY "projects"...
```

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
