### PR TITLE
Fix failing organizations GIN trigram migration

### DIFF
--- a/db/migrate/20260323120100_add_index_tsv_to_organizations.rb
+++ b/db/migrate/20260323120100_add_index_tsv_to_organizations.rb
@@ -4,19 +4,24 @@ class AddIndexTsvToOrganizations < ActiveRecord::Migration[7.2]
   disable_ddl_transaction!
 
   def up
-    add_index :organizations, :tsv, using: 'gin', algorithm: :concurrently
-    add_index(
-      :organizations,
-      "coalesce(display_name, '')",
-      using: 'gin',
-      opclass: :gin_trgm_ops,
-      name: 'index_organizations_display_name_trgrm',
-      algorithm: :concurrently
-    )
+    add_index :organizations, :tsv, using: 'gin', algorithm: :concurrently, if_not_exists: true
+
+    safety_assured do
+      execute <<~SQL.squish
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS index_organizations_display_name_trgrm
+        ON organizations
+        USING gin (coalesce(display_name::text, '') gin_trgm_ops);
+      SQL
+    end
   end
 
   def down
-    remove_index :organizations, name: 'index_organizations_display_name_trgrm'
-    remove_index :organizations, :tsv
+    safety_assured do
+      execute <<~SQL.squish
+        DROP INDEX CONCURRENTLY IF EXISTS index_organizations_display_name_trgrm;
+      SQL
+    end
+
+    remove_index :organizations, :tsv, algorithm: :concurrently, if_exists: true
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3013,6 +3013,13 @@ CREATE INDEX index_organization_versions_on_organization_id ON public.organizati
 
 
 --
+-- Name: index_organizations_display_name_trgrm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_organizations_display_name_trgrm ON public.organizations USING gin (COALESCE((display_name)::text, ''::text) public.gin_trgm_ops);
+
+
+--
 -- Name: index_organizations_on_activated_state; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
Describe your change here.

## Summary

Fix the `organizations` search index migration so it works.

Staging failed with:

`PG::UndefinedObject: data type character varying has no default operator class for access method "gin"`

The failing index was on `coalesce(display_name, '')` using a GIN trigram index. PostgreSQL needs the expression to be typed appropriately for `gin_trgm_ops`, so the migration now creates:

`coalesce(display_name::text, '') gin_trgm_ops`

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
