### PR TITLE
Create subject counts on collection

### DIFF
--- a/db/migrate/20260520193213_add_subjects_count_to_collections.rb
+++ b/db/migrate/20260520193213_add_subjects_count_to_collections.rb
@@ -1,0 +1,8 @@
+class AddSubjectsCountToCollections < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :collections, :subjects_count, :integer, default: 0
+    add_index :collections, :subjects_count, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -234,7 +234,8 @@ CREATE TABLE public.collections (
     slug character varying DEFAULT ''::character varying,
     favorite boolean DEFAULT false NOT NULL,
     default_subject_id integer,
-    description text DEFAULT ''::text
+    description text DEFAULT ''::text,
+    subjects_count integer DEFAULT 0
 );
 
 
@@ -2824,6 +2825,13 @@ CREATE INDEX index_collections_on_slug ON public.collections USING btree (slug);
 
 
 --
+-- Name: index_collections_on_subjects_count; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_collections_on_subjects_count ON public.collections USING btree (subjects_count);
+
+
+--
 -- Name: index_collections_projects_on_collection_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4240,6 +4248,7 @@ ALTER TABLE ONLY public.users
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260520193213'),
 ('20260323120200'),
 ('20260323120100'),
 ('20260323120000'),

--- a/lib/tasks/collections.rake
+++ b/lib/tasks/collections.rake
@@ -4,7 +4,7 @@ namespace :collections do
     Collection.in_batches(of: 1_000) do |batch|
       collection_ids = batch.pluck(:id)
 
-      counts = CollectionSubject
+      counts = CollectionsSubject
                .where(collection_id: collection_ids)
                .group(:collection_id)
                .count

--- a/lib/tasks/collections.rake
+++ b/lib/tasks/collections.rake
@@ -5,9 +5,9 @@ namespace :collections do
       collection_ids = batch.pluck(:id)
 
       counts = CollectionSubject
-              .where(collection_id: collection_ids)
-              .group(:collection_id)
-              .count
+               .where(collection_id: collection_ids)
+               .group(:collection_id)
+               .count
 
       collections_to_update = collection_ids.map do |id|
         [id, counts[id] || 0]

--- a/lib/tasks/collections.rake
+++ b/lib/tasks/collections.rake
@@ -1,0 +1,22 @@
+namespace :collections do
+  desc "Backfill subjects_count on collections"
+  task backfill_subjects_count: :environment do
+    Collection.in_batches(of: 1_000) do |batch|
+      collection_ids = batch.pluck(:id)
+
+      counts = CollectionSubject
+        .where(collection_id: collection_ids)
+        .group(:collection_id)
+        .count
+
+      collections_to_update = collection_ids.map do |id|
+        [id, counts[id] || 0]
+      end
+
+      collections_to_update.each do |id, count|
+        Collection.where(id: id)
+                  .update_all(subjects_count: count)
+      end
+    end
+  end
+end

--- a/lib/tasks/collections.rake
+++ b/lib/tasks/collections.rake
@@ -1,5 +1,5 @@
 namespace :collections do
-  desc "Backfill subjects_count on collections"
+  desc 'Backfill subjects_count on collections'
   task backfill_subjects_count: :environment do
     Collection.in_batches(of: 1_000) do |batch|
       collection_ids = batch.pluck(:id)

--- a/lib/tasks/collections.rake
+++ b/lib/tasks/collections.rake
@@ -5,9 +5,9 @@ namespace :collections do
       collection_ids = batch.pluck(:id)
 
       counts = CollectionSubject
-        .where(collection_id: collection_ids)
-        .group(:collection_id)
-        .count
+              .where(collection_id: collection_ids)
+              .group(:collection_id)
+              .count
 
       collections_to_update = collection_ids.map do |id|
         [id, counts[id] || 0]


### PR DESCRIPTION
Create a counter_cache column (`subjects_count`) in order to filter out collections by number of subjects.
https://github.com/zooniverse/panoptes/issues/4577

TODO after merge, deploy, migration 

- [ ] Follow up PR to filter collections by min_subjects (PR: #4634)
- [ ] Run Rake task to backfill collections subjects_count

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
