### PR TITLE
Run RecentsCleanupWorker as a cronjob

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -34,3 +34,8 @@ requeue_export_job_worker:
   class: "RequeueExportJobWorker"
   queue: "data_medium"
   description: "Checks, updates and requeues export jobs"
+recents_cleanup_worker:
+  cron: "0 */3 * * *"
+  class: "RecentsCleanupWorker"
+  queue: "data_medium"
+  description: "Cleans up recents, removes entries older than 90 days and more than 20 per user/project. Runs every 3 hours."


### PR DESCRIPTION
Run the RecentsCleanupWorker every three hours. It will clean up the new three hours' worth of now 90 day old recents as well as the recents of active users who have more than 20 for a given project.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
