### PR TITLE
add new drawing annotation for exports

### DIFF
--- a/lib/formatter/csv/v2/annotation.rb
+++ b/lib/formatter/csv/v2/annotation.rb
@@ -27,6 +27,8 @@ module Formatter
           case task_info['type']
           when 'dropdown'
             DropdownAnnotation.new(task_info, current_annotation, workflow_information).format
+          when 'drawing'
+            DrawingAnnotation.new(task_info, current_annotation, workflow_information).format
           else
             # use the default formatter (v1) for non v2 specific task types
             # as time goes on behaviour will eventually move from default formatter

--- a/lib/formatter/csv/v2/drawing_annotation.rb
+++ b/lib/formatter/csv/v2/drawing_annotation.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Formatter
+  module Csv
+    module V2
+      class DrawingAnnotation
+        attr_reader :task_info, :annotation, :workflow_information
+
+        def initialize(task_info, annotation, workflow_information)
+          @task_info = task_info
+          @annotation = annotation
+          @workflow_information = workflow_information
+        end
+
+        def format
+          {
+            'task' => annotation['task'],
+            'task_label' => task_label,
+            'value' => drawing_values
+          }
+        end
+
+        private
+
+        def drawing_values
+          Array.wrap(annotation['value']).map do |drawn_item|
+            next drawn_item unless drawn_item.is_a?(Hash)
+
+            drawn_item.merge('tool_label' => tool_label(drawn_item))
+          end
+        end
+
+        def task_label
+          workflow_information.string(task_info['question'] || task_info['instruction'])
+        end
+
+        def tool_label(drawn_item)
+          tool_index = drawn_item['toolIndex'] || drawn_item['tool_index']
+          return unless tool_index
+
+          known_tool = task_info['tools'] && task_info['tools'][tool_index]
+          workflow_information.string(known_tool['label']) if known_tool
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/formatter/csv/v2/annotation_spec.rb
+++ b/spec/lib/formatter/csv/v2/annotation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Formatter::Csv::V2::Annotation do
   end
 
   context 'with a non-dropdown task workflow and annotation' do
-    let(:workflow) { build_stubbed(:workflow) }
+    let(:workflow) { build_stubbed(:workflow, :question_task) }
     let(:annotation) { { 'task' => 'interest', 'value' => {} } }
     let(:default_formatter) { formatter.default_formatter }
 
@@ -54,6 +54,30 @@ RSpec.describe Formatter::Csv::V2::Annotation do
     it 'uses the dropdown annotation formatter' do
       formatter.to_h
       expect(dropdown_formatter).to have_received(:format)
+    end
+  end
+
+  context 'with a v2 drawing task' do
+    let(:workflow) { build_stubbed(:workflow) }
+    let(:annotation) do
+      {
+        'task' => 'interest',
+        'value' => [
+          { 'x' => 1, 'y' => 2, 'toolIndex' => 1 },
+          { 'x' => 3, 'y' => 4, 'toolIndex' => 2 }
+        ]
+      }
+    end
+    let(:drawing_formatter) { instance_double(Formatter::Csv::V2::DrawingAnnotation) }
+
+    before do
+      allow(Formatter::Csv::V2::DrawingAnnotation).to receive(:new).and_return(drawing_formatter)
+      allow(drawing_formatter).to receive(:format)
+    end
+
+    it 'uses the drawing annotation formatter' do
+      formatter.to_h
+      expect(drawing_formatter).to have_received(:format)
     end
   end
 end

--- a/spec/lib/formatter/csv/v2/drawing_annotation_spec.rb
+++ b/spec/lib/formatter/csv/v2/drawing_annotation_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Formatter::Csv::V2::DrawingAnnotation do
+  let(:workflow_version) { build_stubbed(:workflow_version, workflow: workflow, tasks: workflow.tasks, strings: workflow.strings) }
+  let(:workflow) { build_stubbed(:workflow) }
+  let(:cache) { instance_double('ClassificationDumpCache') }
+  let(:workflow_information) { Formatter::Csv::WorkflowInformation.new(cache, workflow, '1.1') }
+  let(:task_info) { workflow_information.task('interest') }
+  let(:annotation) do
+    {
+      'task' => 'interest',
+      'value' => [
+        { 'x' => 1, 'y' => 2, 'toolIndex' => 1 },
+        { 'x' => 3, 'y' => 4, 'toolIndex' => 2 },
+        { 'x' => 5, 'y' => 6, 'toolIndex' => 1 }
+      ]
+    }
+  end
+
+  before do
+    allow(cache).to receive(:workflow_at_version).with(workflow, 1, 1).and_return(workflow_version)
+  end
+
+  it 'adds the task label' do
+    formatted = described_class.new(task_info, annotation, workflow_information).format
+    expect(formatted['task_label']).to eq('Draw a circle')
+  end
+
+  it 'adds the tool labels for drawing tasks', :aggregate_failures do
+    formatted = described_class.new(task_info, annotation, workflow_information).format
+    expect(formatted['value'][0]['tool_label']).to eq('Green')
+    expect(formatted['value'][1]['tool_label']).to eq('Blue')
+    expect(formatted['value'][2]['tool_label']).to eq('Green')
+  end
+
+  it 'has a nil label when the tool is not found in the workflow' do
+    annotation['value'] = [{ 'x' => 1, 'y' => 2, 'toolIndex' => 1000 }]
+
+    formatted = described_class.new(task_info, annotation, workflow_information).format
+    expect(formatted['value'][0]['tool_label']).to be_nil
+  end
+
+  it 'adds the tool label when the tool index uses the previous snake-case key' do
+    annotation['value'] = [{ 'x' => 1, 'y' => 2, 'tool_index' => 1 }]
+
+    formatted = described_class.new(task_info, annotation, workflow_information).format
+    expect(formatted['value'][0]['tool_label']).to eq('Green')
+  end
+
+  it 'has a nil label when the tool index is missing' do
+    annotation['value'] = [{ 'x' => 1, 'y' => 2 }]
+
+    formatted = described_class.new(task_info, annotation, workflow_information).format
+    expect(formatted['value'][0]['tool_label']).to be_nil
+  end
+
+  it 'returns the raw value if it is in an unexpected format' do
+    annotation['value'] = 0
+
+    formatted = described_class.new(task_info, annotation, workflow_information).format
+    expect(formatted['value']).to eq(Array.wrap(annotation['value']))
+  end
+
+  it 'returns an empty list of values when annotation itself has no value' do
+    annotation.delete('value')
+
+    formatted = described_class.new(task_info, annotation, workflow_information).format
+    expect(formatted['value']).to be_empty
+  end
+end


### PR DESCRIPTION
Describe your change here.
Adds  drawing annotation export support for drawing annotations  in classification exports.

## Changes

- Added `Formatter::Csv::V2::DrawingAnnotation`
- Updated the v2 annotation dispatcher to handle workflow tasks with `type: "drawing"`
- Uses `toolIndex` to look up the workflow tool label
 
# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.