### PR TITLE
Use 'priority' without hash in subject metadata. Update SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT.

### DIFF
--- a/app/workers/subject_metadata_worker.rb
+++ b/app/workers/subject_metadata_worker.rb
@@ -28,10 +28,10 @@ class SubjectMetadataWorker
       [
         <<-SQL.squish,
           UPDATE set_member_subjects
-          SET    priority = CAST(subjects.metadata->>'#priority' AS NUMERIC)
+          SET    priority = CAST(COALESCE(subjects.metadata->>'#priority', subjects.metadata->>'priority') AS NUMERIC)
           FROM   subjects
           WHERE  subjects.id = set_member_subjects.subject_id
-          AND    subjects.metadata ? '#priority'
+          AND    subjects.metadata ?| array['#priority', 'priority']
           AND    set_member_subjects.id IN (:sms_ids)
         SQL
         { sms_ids: sms_ids }

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -121,6 +121,7 @@ data:
   STORAGE_BUCKET: zooniverse-static
   STORAGE_PREFIX: panoptes-uploads.zooniverse.org/production/
   SUBJECT_GROUP_UPLOADER_ID: '1'
+  SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT: '100000'
   AZURE_STORAGE_ACCOUNT: panoptesuploads
   AZURE_STORAGE_CONTAINER_PUBLIC: public
   AZURE_STORAGE_CONTAINER_PRIVATE: private

--- a/spec/workers/subject_metadata_worker_spec.rb
+++ b/spec/workers/subject_metadata_worker_spec.rb
@@ -10,13 +10,16 @@ RSpec.describe SubjectMetadataWorker do
   let(:subject_two) do
     create(:subject, project: project, uploader: project.owner, metadata: {'#priority'=>'2'})
   end
+  let(:subject_three) do
+    create(:subject, project: project, uploader: project.owner, metadata: {'priority'=>'4'})
+  end
   let(:subject_set) do
     create(
       :subject_set_with_subjects,
-      num_subjects: 1,
+      num_subjects: 3,
       project: project,
       workflows: [workflow],
-      subjects: [subject_one, subject_two]
+      subjects: [subject_one, subject_two, subject_three]
     )
   end
   let(:set_member_subject_ids) do
@@ -44,7 +47,7 @@ RSpec.describe SubjectMetadataWorker do
       ).sort_by(&:id)
       expect(sms_one.priority).to eq(1/3.0)
       expect(sms_two.priority).to eq(2)
-      expect(sms_three.priority).to be_nil
+      expect(sms_three.priority).to eq(4)
     end
 
     it 'raises not found if the SMS resources do not exist' do


### PR DESCRIPTION
Allows for both `#priority` and `priority` to be valid metadata keys for copying the value into the SetMemberSubject. The priority metadata key is downcased when the subject is initially saved, so this will now work for all combinations of hash and case.

Also, this PR adds `SUBJECT_SET_IMPORT_MANIFEST_ROW_LIMIT` to the production deploy template. The new production limit for uploads via the subject set importer is 100,000 at a time. This will not trigger upload limit errors, but users who go over their limit in this way will be restricted from uploading normally until their limit is increased.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
