### PR TITLE
Conditionally set IP headers in nginx sidecar conf

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -42,8 +42,8 @@ data:
       # avoid attacker setting the host value for links in rails_app
       # https://github.com/rails/rails/issues/29893
       proxy_set_header X-Forwarded-Host $server_name;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Real-IP $resolved_client_ip;
+      proxy_set_header X-Forwarded-For $resolved_client_ip;
       proxy_pass http://docker-panoptes;
     }
 kind: ConfigMap
@@ -57,12 +57,10 @@ data:
       server 127.0.0.1:81;
     }
 
-    # set_real_ip_from for local and known Azure Front Door IPs
-    set_real_ip_from 172.16.0.0/12;
-    include /etc/nginx/nginx-azure-ips.conf;
-
-    real_ip_header X-Forwarded-For;
-    real_ip_recursive on;
+    map $http_x_azure_clientip $resolved_client_ip {
+      ""      $http_x_forwarded_for;
+      default $http_x_azure_clientip;
+    }
 
     server {
       server_name www.zooniverse.org;


### PR DESCRIPTION
Azure Front Door sets a header on requests that pass through it called `X-Azure-Clientip` that stores the original client IP. So instead of keeping a list of Azure IPs, if that header exists, use `proxy_set_header` to set  `X-Forwarded-For` to its value. If it doesn't, pass along the standard `x-forwarded-for`. 

This should allow for both cases: traffic that comes through the AFD via www will have its `x-forwarded-for` header overwritten by `x-azure-clientip`, giving you the real client IP. If it doesn't, it passes along `x-forwarded-for` as is.

# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
