### PR TITLE
Format sidecar nginx logs in JSON

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -62,20 +62,41 @@ data:
       default $http_x_azure_clientip;
     }
 
+    log_format json_main escape=json
+      '{'
+        '"timestamp":"$time_iso8601",'
+        '"client_ip":"$resolved_client_ip",'
+        '"host":"$host",'
+        '"remote_addr":"$remote_addr",'
+        '"request":"$request",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"upstream_time":"$upstream_response_time",'
+        '"http_referer":"$http_referer",'
+        '"http_user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for",'
+        '"http_x_real_ip":"$http_x_real_ip",'
+        '"request_id":"$request_id"'
+      '}';
+
     server {
       server_name www.zooniverse.org;
+      access_log /dev/stdout json_main;
       include /etc/nginx/ssl.default.conf;
       include /etc/nginx/shared/panoptes-nginx-common.conf;
     }
 
     server {
       server_name panoptes.zooniverse.org;
+      access_log /dev/stdout json_main;
       include /etc/nginx/ssl.default.conf;
       include /etc/nginx/shared/panoptes-nginx-common.conf;
     }
 
     server {
       server_name signin.zooniverse.org;
+      access_log /dev/stdout json_main;
       include /etc/nginx/ssl.default.conf;
       include /etc/nginx/shared/panoptes-nginx-common.conf;
     }

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -58,10 +58,29 @@ data:
       server 127.0.0.1:81;
     }
 
+    log_format json_main escape=json
+      '{'
+        '"timestamp":"$time_iso8601",'
+        '"client_ip":"$http_x_forwarded_for",'
+        '"host":"$host",'
+        '"remote_addr":"$remote_addr",'
+        '"request":"$request",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"upstream_time":"$upstream_response_time",'
+        '"http_referer":"$http_referer",'
+        '"http_user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for",'
+        '"http_x_real_ip":"$http_x_real_ip",'
+        '"request_id":"$request_id"'
+      '}';
+
     set_real_ip_from 172.16.0.0/12;
 
     server {
       server_name panoptes-staging.zooniverse.org;
+      access_log /dev/stdout json_main;
       include /etc/nginx/ssl.default.conf;
       include /etc/nginx/shared/panoptes-nginx-common.conf;
     }


### PR DESCRIPTION
Format the sidecar nginx container's logs in structured JSON. This will make ingestion by any service easier. I also added the new $resolved_client_ip to the production log so that I can compare to $http_x_forwarded_for and ensure we're getting the correct client IP.


# Review checklist

- [ ] First, the most important one: is this PR small enough that you can actually review it? Feel free to just reject a branch if the changes are hard to review due to the length of the diff.
- [ ] If there are any migrations, will they the previous version of the app work correctly after they've been run (e.g. the don't remove columns still known about by ActiveRecord).
- [ ] If anything changed with regards to the public API, are those changes also documented in the `apiary.apib` file?
- [ ] Are all the changes covered by tests? Think about any possible edge cases that might be left untested.
